### PR TITLE
user page accessed by user_id or username

### DIFF
--- a/src/lib-server/user.ts
+++ b/src/lib-server/user.ts
@@ -75,7 +75,7 @@ export const getUserData = async (account_id: string) => {
       archive_upload:archive_upload(archive_at)
     `,
     )
-    .eq('account_id', account_id)
+    .or(`account_id.eq.${account_id},username.ilike.${account_id}`)
     .single()
 
   if (!data) {


### PR DESCRIPTION
As of right now if one wants to check an user one must open https://www.community-archive.org/user/<user_id> this change makes it possible to open directly the page with the username instead (case insensitive) so both https://www.community-archive.org/user/345709253 and https://www.community-archive.org/user/IaimforGOAT work.