### PR TITLE
Add "app showcase" to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ https://discord.gg/AStSQj6ugq
 
 |  | | |
 | ------------- | ------------- | ------------- |
-| <a href="https://labs-community-archive.streamlit.app/"><img src="https://github.com/user-attachments/assets/39269a8e-e675-4040-9b71-f04c811ca304" width="350" /></a>  | [link](https://labs-community-archive.streamlit.app/)  | "google trends" like app but for twitter data
+| <a href="https://labs-community-archive.streamlit.app/"><img src="https://github.com/user-attachments/assets/39269a8e-e675-4040-9b71-f04c811ca304" width="350" /></a>  | - [app](https://labs-community-archive.streamlit.app/) <br/> - [source code](https://github.com/TheExGenesis/community-archive-apps/tree/main) | "google trends" like app but for twitter data
 
 
 ## How to use the API (from your own app)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ The goals of this project are (1) create a public domain dataset so that we can 
 
 https://discord.gg/AStSQj6ugq
 
+## App showcase
+
+|  | | |
+| ------------- | ------------- | ------------- |
+| <a href="https://labs-community-archive.streamlit.app/"><img src="https://github.com/user-attachments/assets/39269a8e-e675-4040-9b71-f04c811ca304" width="350" /></a>  | [link](https://labs-community-archive.streamlit.app/)  | "google trends" like app but for twitter data
+
+
 ## How to use the API (from your own app)
 
 See [API docs](docs/api-doc.md) for how to access the archive's supabase DB.


### PR DESCRIPTION
Added a section to the README where we can start collecting links to apps as examples for users, and inspiration for developers? I made it a little grid so we can add image + description for each entry and make it look nice

Live preview: https://github.com/TheExGenesis/community-archive/blob/app-showcase-readme/README.md#app-showcase

![firefox_FfdHXj2UW0](https://github.com/user-attachments/assets/a69345dc-af08-445d-a327-64e5318240a4)