### PR TITLE
Add better intro examples to api doc

### DIFF
--- a/scripts/get_all_tweets_paginated.mts
+++ b/scripts/get_all_tweets_paginated.mts
@@ -1,0 +1,40 @@
+import { createClient } from '@supabase/supabase-js'
+const supabaseUrl = 'https://fabxmporizzqflnftavs.supabase.co'
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+const supabase = createClient(supabaseUrl, supabaseKey!)
+
+const allTweets = await getTweetsPaginated('1680757426889342977')
+console.log("Total tweets fetched:", allTweets.length);
+console.log(allTweets);
+
+async function getTweetsPaginated(accountId:string) {
+    let allTweets:any = [];
+    let batchSize = 1000;
+    let offset = 0;
+    let done = false;
+  
+    while (!done) {
+      const { data, error } = await supabase
+        .schema('public')
+        .from('tweets')
+        .select('*')
+        .eq('account_id', accountId)
+        .range(offset, offset + batchSize - 1); // Fetch a batch of 1000
+  
+      if (error) {
+        console.error("Error fetching tweets:", error);
+        return { error };
+      }
+  
+      if (data.length === 0) {
+        done = true; // If no data is returned, we are done
+      } else {
+        console.log(`Got ${data.length} tweets, fetching another page...`)
+        allTweets = allTweets.concat(data); // Accumulate tweets
+        offset += batchSize; // Move to the next batch
+      }
+    }
+  
+    return allTweets; // Return the accumulated results
+  }
+  


### PR DESCRIPTION
Preview: https://github.com/TheExGenesis/community-archive/blob/api-docs-tweak/docs/api-doc.md

This documents how to get the raw JSONs from blob storage. This gives users a path to get the data just by opening a URL in their browser. This is great for people who just want to download a user's data and run some local analysis or open it in a text file etc.

The other big thing is adding an example for how to fetch tweets for a particular user with curl (thanks [@dpinkshadow](https://x.com/dpinkshadow/status/1847973253567930685/photo/1) on twitter for the tip). I added both a curl example, a JS example, and a more fleshed out JS example that does pagination. 