### PR TITLE
Add jupyter notebook links

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ https://discord.gg/5mbWEfVrqw
 
 See [API docs](docs/api-doc.md) for how to access the archive's supabase DB.
 
+See also this [Google colab notebook](https://colab.research.google.com/drive/109XOgTWj-sajpAYhDCNPfts5zvdkpi_s) for an example you can run in your browser that fetches tweets from the archive for a specific user and runs some basic analysis.
+
 ## Development Instructions
 
 See [local setup](docs/local-setup.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,4 @@
+# Docs
+
+- [API docs](./api-doc.md) how to download raw JSON data from storage, or query the database through the Supabase API.
+- [Quickstart Jupyter notebook](https://colab.research.google.com/drive/109XOgTWj-sajpAYhDCNPfts5zvdkpi_s) that you can run in your browser. Shows how to fetch all tweets for a given user in Python, and do some basic analysis like find the most common used phrases, and plot the amount of likes over time.

--- a/docs/api-doc.md
+++ b/docs/api-doc.md
@@ -1,4 +1,4 @@
-# How to use the API (from your own app)
+# API doc
 
 There are two ways to access the Community Archive's data: (1) Download a JSON file with an individual user's data from blob storage (2) query the DB through the Supabase API
 


### PR DESCRIPTION
- add link to jupyter notebook in main README
- added a `docs/README.md` link where we can start to add all links to the various example code/snippets/tutorials over time

should eventually add a link to these docs from the homepage I think