### PR TITLE
Add an "ecosystem" section to the doc

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,14 @@
  
 ## Ecosystem
 
-- [Tweetback](https://github.com/tweetback/tweetback) given a twitter archive, generates a simple static site you can self host. [Live demo](https://www.zachleat.com/twitter/) 
+Static site generators
+
+- [Tweetback](https://github.com/tweetback/tweetback) given a twitter archive, generates a simple static site you can self host. [Live demo](https://www.zachleat.com/twitter/)
+- [helgridly/canonize](https://github.com/helgridly/canonize) generate a static site as a "personal canon"
+
+Misc
+
 - [deepfates's python script](https://gist.github.com/deepfates/78c9515ec2c2f263d6a65a19dd10162d) to preprocess a twitter archive for LLM fine-tuning, or just viewing as markdown/in Obsidian. See [twitter thread on it](https://x.com/deepfates/status/1858234863587049678)
 - [DefenderOfBasic/twitter-semantic-search](https://github.com/DefenderOfBasic/twitter-semantic-search) with CloudFlare backend. Given a twitter archive, generate embeddings, insert them into a cloud vector DB, and a simple frontend to search.
+
+[Nitter](https://github.com/zedeus/nitter) is an open source twitter frontend. It doesn't host data but can be used to access twitter without being rate limited (how? because they cache stuff?) 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,3 +7,9 @@
 
 - Fetch a tweet by ID & display it
   - https://codepen.io/DefenderOfBasic/pen/OJKGdPx?editors=1010
+ 
+## Ecosystem
+
+- [Tweetback](https://github.com/tweetback/tweetback) given a twitter archive, generates a simple static site you can self host. [Live demo](https://www.zachleat.com/twitter/) 
+- [deepfates's python script](https://gist.github.com/deepfates/78c9515ec2c2f263d6a65a19dd10162d) to preprocess a twitter archive for LLM fine-tuning, or just viewing as markdown/in Obsidian. See [twitter thread on it](https://x.com/deepfates/status/1858234863587049678)
+- [DefenderOfBasic/twitter-semantic-search](https://github.com/DefenderOfBasic/twitter-semantic-search) with CloudFlare backend. Given a twitter archive, generate embeddings, insert them into a cloud vector DB, and a simple frontend to search.


### PR DESCRIPTION
cc @ri72miieop 

Adding a section for tools that work on top of twitter archives, to start collecting things in one place. This was the list shared on discord:

https://sotwe.com/
https://instalker.org/
https://www.muskviewer.com/
https://twstalker.com/

https://nitter.privacydev.net/
https://syndication.twitter.com/srv/timeline-profile/screen-name/iaimforgoat

---

archives:

https://archive.org/details/twitterarchive
https://archive.org/details/twitterstream