### PR TITLE
Cleaner homepage with clear action items + donation link

### DIFF
--- a/docs/apps.md
+++ b/docs/apps.md
@@ -1,0 +1,7 @@
+# Apps
+
+Applications running on top of the community archive.
+
+|  | | |
+| ------------- | ------------- | ------------- |
+| <a href="https://labs-community-archive.streamlit.app/"><img src="https://github.com/user-attachments/assets/39269a8e-e675-4040-9b71-f04c811ca304" width="350" /></a>  | - [app](https://labs-community-archive.streamlit.app/) <br/> - [source code](https://github.com/TheExGenesis/community-archive-apps/tree/main) | "google trends" like app but for twitter data

--- a/src/app/data-policy/page.tsx
+++ b/src/app/data-policy/page.tsx
@@ -8,7 +8,7 @@ export default function DataPolicyPage() {
       </h1>
 
       <p>
-        At the Community Archive, we are committed to preserving the public
+        We are committed to preserving the public
         history of Twitter conversations while respecting your privacy. This
         policy outlines how we handle your data and the options available to
         you.
@@ -51,6 +51,10 @@ export default function DataPolicyPage() {
           anthropology research and fine-tuning language models.
         </li>
       </ul>
+      <br/>
+      <p>
+        API docs & instructions for downloading the data <a href='https://github.com/TheExGenesis/community-archive/tree/main/docs#docs' className='text-blue-500 hover:underline'>are in the GitHub repo.</a>
+      </p>
 
       <h2 className="mt-6 text-2xl font-semibold">Important Considerations</h2>
 
@@ -73,22 +77,6 @@ export default function DataPolicyPage() {
 
       <ol className="list-inside list-decimal space-y-2">
         <li>
-          <strong>Private Archive</strong>: You can choose to make your archive
-          private. In this case:
-          <ul className="ml-5 mt-2 list-inside list-disc space-y-1">
-            <li>
-              Only you and Community Archive stewards will have access to your
-              full data.
-            </li>
-            <li>
-              Your tweets may still appear in search results or aggregated data.
-            </li>
-            <li>
-              We may use your data for research and to improve our services.
-            </li>
-          </ul>
-        </li>
-        <li>
           <strong>Exclude Likes</strong>: You can opt to leave out your likes
           when uploading your archive.
         </li>
@@ -103,14 +91,6 @@ export default function DataPolicyPage() {
         </li>
       </ol>
 
-      <h2 className="mt-6 text-2xl font-semibold">Data Access</h2>
-
-      <p>
-        We provide a full dump of the public database for easier data science
-        use. This allows researchers and developers to work with the collective
-        data more efficiently.
-      </p>
-
       <h2 className="mt-6 text-2xl font-semibold">Contact Us</h2>
 
       <p>
@@ -124,11 +104,11 @@ export default function DataPolicyPage() {
           href="https://x.com/exgenesis"
           target="_blank"
           rel="noopener noreferrer"
-          className="text-blue-600 hover:underline"
+          className="text-blue-500 hover:underline"
         >
           @exgenesis
         </a>
-        .
+        . Or find us on <a href="https://discord.gg/5mbWEfVrqw" className="text-blue-500 hover:underline">Discord</a> or <a href="https://github.com/TheExGenesis/community-archive" className="text-blue-500 hover:underline">GitHub</a>  
       </p>
 
       <p>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -73,20 +73,20 @@ export default function RootLayout({
                     </Link>
                   </NavigationMenuItem>
                   <NavigationMenuItem>
-                    <Link href="/mission-control" legacyBehavior passHref>
-                      <NavigationMenuLink
-                        className={navigationMenuTriggerStyle()}
-                      >
-                        Mission Control
-                      </NavigationMenuLink>
-                    </Link>
-                  </NavigationMenuItem>
-                  <NavigationMenuItem>
                     <Link href="/search" legacyBehavior passHref>
                       <NavigationMenuLink
                         className={navigationMenuTriggerStyle()}
                       >
                         Advanced Search
+                      </NavigationMenuLink>
+                    </Link>
+                  </NavigationMenuItem>
+                  <NavigationMenuItem>
+                    <Link href="https://github.com/TheExGenesis/community-archive/blob/main/docs/apps.md" legacyBehavior passHref>
+                      <NavigationMenuLink
+                        className={navigationMenuTriggerStyle()}
+                      >
+                        Apps
                       </NavigationMenuLink>
                     </Link>
                   </NavigationMenuItem>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -66,9 +66,9 @@ export default async function Homepage() {
         )}
 
         <br/>
-        <h1 className="mb-4 text-2xl">
+        <h2 className="mb-4 text-xl">
           📤 Upload your data
-        </h1>
+        </h2>
 
         <p>
           Export your data from twitter:{' '}
@@ -84,9 +84,9 @@ export default async function Homepage() {
         <UploadTwitterArchive supabase={null} />
         <br />
 
-        <h1 className="mb-4 text-2xl my-10">
+        <h2 className="mb-4 text-xl my-10">
           💻 Data & source code
-        </h1>
+        </h2>
 
         <p>
           You can download any individual user&apos;s data (includes all tweets, followers, following, etc) as one big JSON file, or query our API, <a href='https://github.com/TheExGenesis/community-archive/tree/main/docs#docs' className='text-blue-500 hover:underline'>see documentation here</a>.
@@ -120,18 +120,23 @@ export default async function Homepage() {
           </li>
         </ul>
 
-        <h1 className="mb-4 text-2xl my-10">
+        <h2 className="mb-4 text-xl my-10">
           📖 About this project
-        </h1>
+        </h2>
  
         <p>
           We believe there is immense cultural, historical, and economic value in our data. We&apos;re building open source public infrastructure to collect, host, and serve this data for whatever purpose communities choose to use it for.
         </p>
 
         <br/>
-        <a href="https://opencollective.com/community-archive/donate" target="_blank">
-          <img src="https://opencollective.com/community-archive/donate/button@2x.png?color=blue" width="300" />
+        <ul className='list-disc pl-4'>
+          <li>
+          <a href="https://opencollective.com/community-archive/donate" className='text-blue-500 hover:underline' target="_blank">
+          Donate to our Open Collective
         </a>
+          </li>
+        </ul>
+        
         <br/>
         <p>
           Maintained & developed by <a href="@https://x.com/exgenesis" className='hover:underline'>Xiq (@exgeneis)</a> & contributors.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -89,7 +89,7 @@ export default async function Homepage() {
         </h1>
 
         <p>
-          You can download any individual user's data (includes all tweets, followers, following, etc) as one big JSON file, or query our API, <a href='https://github.com/TheExGenesis/community-archive/tree/main/docs#docs' className='text-blue-500 hover:underline'>see documentation here</a>.
+          You can download any individual user&apos;s data (includes all tweets, followers, following, etc) as one big JSON file, or query our API, <a href='https://github.com/TheExGenesis/community-archive/tree/main/docs#docs' className='text-blue-500 hover:underline'>see documentation here</a>.
         </p>
 
         <br/>
@@ -125,7 +125,7 @@ export default async function Homepage() {
         </h1>
  
         <p>
-          We believe there is immense cultural, historical, and economic value in our data. We're building open source public infrastructure to collect, host, and serve this data for whatever purpose communities choose to use it for.
+          We believe there is immense cultural, historical, and economic value in our data. We&apos;re building open source public infrastructure to collect, host, and serve this data for whatever purpose communities choose to use it for.
         </p>
 
         <br/>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,19 +45,14 @@ export default async function Homepage() {
   return (
     <div className="relative mx-auto flex min-h-screen w-full max-w-3xl flex-col bg-white px-4 dark:bg-gray-800 sm:px-6 lg:px-24">
       {/* Main content */}
-      <div className="mt-8 bg-white dark:bg-gray-800">
-        {' '}
-        <h1 className="mb-0 text-4xl font-bold text-zinc-400 dark:text-zinc-500 md:text-4xl">
-          Upload to the
-        </h1>
+      <div className="mt-8 bg-white dark:bg-gray-800 pb-16">
         <h1 className="mt-0 text-4xl font-bold text-black dark:text-white md:text-4xl">
-          Community Archive!
+          Community Archive
         </h1>
-        <br />
         <h2 className="mb-4 text-xl text-zinc-600 dark:text-zinc-300">
-          {`An open database and API anyone can build on.`}
+          {`An open database and API anyone can build on`}
         </h2>
-        <br />
+        <CommunityStats />
         <h3 className="mb-4 text-sm">Featuring archives uploaded by:</h3>
         {mostFollowed ? (
           <AvatarList
@@ -69,82 +64,79 @@ export default async function Homepage() {
             Failed to load most followed accounts.
           </p>
         )}
-        <br />
-        <CommunityStats />
-        <br />
-        <div className="text-sm">
-          <p className="mb-4 leading-relaxed">
-            {`Powered by your tweet history, the community archive lets anyone build things like:`}
-          </p>
-          <div className="mb-4 space-y-2 pl-4">
-            <p>🔎 Search that really knows what you mean</p>
-            <p>✨ AI apps with context on you and your friends</p>
-            <p>📚 Make artifacts like books based on your tweets</p>
-            <p>And more!</p>
-          </div>
-          <br />
-        </div>
-        <p className="mb-4 text-sm font-bold">{`How can I contribute?`}</p>
-        <ul className="mb-4 list-disc space-y-2 pl-6 text-sm">
-          <li>
-            {`If you don't have an archive yet, `}
-            <strong>
-              <a
-                href="https://x.com/settings/download_your_data"
-                className="text-blue-500 hover:underline"
-              >
-                request it here
-              </a>
-            </strong>
-            {` now!`}
-          </li>
-          <li className="dark:text-gray-300">{`If you do have an archive... `}</li>
-        </ul>
+
+        <br/>
+        <h1 className="mb-4 text-2xl">
+          📤 Upload your data
+        </h1>
+
+        <p>
+          Export your data from twitter:{' '}
+            <a
+              href="https://x.com/settings/download_your_data"
+              className="text-blue-500 hover:underline"
+            >
+              https://x.com/settings/download_your_data
+            </a>
+        </p>
+        <br/>
         <DynamicSignIn />
         <UploadTwitterArchive supabase={null} />
         <br />
-        <div className="mb-4 text-sm">
-          Useful links:
-          <ul className="mb-4 list-disc pl-6">
-            <li>
-              <a
-                href="https://github.com/TheExGenesis/community-archive/blob/main/docs/archive_data.md"
-                className="text-blue-500 hover:underline"
-              >
-                {`What data from the archive do we use, and why?`}
-              </a>
-            </li>
-            <li>
-              Want to build on the project? Check out our{' '}
-              <a
-                href="https://github.com/TheExGenesis/community-archive"
-                className="mr-2 inline-flex items-center text-blue-500 hover:underline"
-              >
-                <FaGithub className="mr-1" /> GitHub repo
-              </a>{' '}
-              and{' '}
-              <a
+
+        <h1 className="mb-4 text-2xl my-10">
+          💻 Data & source code
+        </h1>
+
+        <p>
+          You can download any individual user's data (includes all tweets, followers, following, etc) as one big JSON file, or query our API, <a href='https://github.com/TheExGenesis/community-archive/tree/main/docs#docs' className='text-blue-500 underline'>see documentation here</a>.
+        </p>
+
+        <br/>
+        <ul className='list-disc pl-4'>
+          <li>
+          <a
+            href="https://github.com/TheExGenesis/community-archive"
+            className="mr-2 inline-flex items-center text-blue-500 underline"
+          >
+            <FaGithub className="mr-1" /> GitHub repo
+          </a>
+          </li>
+          <li>
+          <a
                 href="https://discord.gg/5mbWEfVrqw"
-                className="inline-flex items-center text-blue-500 hover:underline"
+                className="inline-flex items-center text-blue-500 underline"
               >
                 <FaDiscord className="mr-1" /> Discord
               </a>
-            </li>
-            <li>
-              {`Want to know more? `}
-              <a
-                href="https://substack.com/@xiqo/p-148517224"
-                className="text-blue-500 hover:underline"
+          </li>
+          <li>
+          <a
+                href="https://github.com/TheExGenesis/community-archive/tree/main/docs"
+                className="inline-flex items-center text-blue-500 underline"
               >
-                {`Here's our FAQ`}
+                Docs & code examples
               </a>
-            </li>
-          </ul>
-          <br />
-          <br />
-        </div>
-        <div className="mb-4"></div>
-        <br />
+          </li>
+        </ul>
+
+        <h1 className="mb-4 text-2xl my-10">
+          📖 About this project
+        </h1>
+ 
+        <p>
+          We believe there is immense cultural, historical, and economic value in our data. We're building open source public infrastructure to collect, host, and serve this data for whatever purpose communities choose to use it for.
+        </p>
+
+        <br/>
+        <a href="https://opencollective.com/community-archive/donate" target="_blank">
+          <img src="https://opencollective.com/community-archive/donate/button@2x.png?color=blue" width="300" />
+        </a>
+        <br/>
+        <p>
+          Maintained & developed by <a href="@https://x.com/exgenesis" className='hover:underline'>Xiq (@exgeneis)</a> & contributors.
+        </p>
+
       </div>
 
       {/* Add Footer component */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -89,7 +89,7 @@ export default async function Homepage() {
         </h1>
 
         <p>
-          You can download any individual user's data (includes all tweets, followers, following, etc) as one big JSON file, or query our API, <a href='https://github.com/TheExGenesis/community-archive/tree/main/docs#docs' className='text-blue-500 underline'>see documentation here</a>.
+          You can download any individual user's data (includes all tweets, followers, following, etc) as one big JSON file, or query our API, <a href='https://github.com/TheExGenesis/community-archive/tree/main/docs#docs' className='text-blue-500 hover:underline'>see documentation here</a>.
         </p>
 
         <br/>
@@ -97,7 +97,7 @@ export default async function Homepage() {
           <li>
           <a
             href="https://github.com/TheExGenesis/community-archive"
-            className="mr-2 inline-flex items-center text-blue-500 underline"
+            className="mr-2 inline-flex items-center text-blue-500 hover:underline"
           >
             <FaGithub className="mr-1" /> GitHub repo
           </a>
@@ -105,7 +105,7 @@ export default async function Homepage() {
           <li>
           <a
                 href="https://discord.gg/5mbWEfVrqw"
-                className="inline-flex items-center text-blue-500 underline"
+                className="inline-flex items-center text-blue-500 hover:underline"
               >
                 <FaDiscord className="mr-1" /> Discord
               </a>
@@ -113,7 +113,7 @@ export default async function Homepage() {
           <li>
           <a
                 href="https://github.com/TheExGenesis/community-archive/tree/main/docs"
-                className="inline-flex items-center text-blue-500 underline"
+                className="inline-flex items-center text-blue-500 hover:underline"
               >
                 Docs & code examples
               </a>

--- a/src/components/file-upload-dialog.tsx
+++ b/src/components/file-upload-dialog.tsx
@@ -285,8 +285,9 @@ export function FileUploadDialog({
               <Link
                 href="/data-policy"
                 className="text-primary hover:underline"
+                target='_blank'
               >
-                Read our Privacy Policy
+                Read our Data Policy
               </Link>
             </div>
           </div>


### PR DESCRIPTION
- make the call to actions clearer (1) how to upload (2) how to access the data & discord & github (3) how to donate, and who is developing & maintaining this
- Add "Apps" instead of "Mission control". It goes to `app.md` on github so we can rapidly iterate/add more apps here (I'm thinking we should just do title + little description + gifs for each app, since we don't have that many right now and it helps to explain them a bit more. As we got more apps we can put it into a table)
  - I can put back mission control if we think it's important, I think apps is way more important & the tabs don't collapse/look good on mobile so I didn't want to keep adding more

## TODO

needs to be tested with real data. In my local instance I still don't have the DB correctly setup, so I tested just the HTML with mock data/zero archives.

## Preview

<img width="925" alt="Screenshot 2024-12-03 at 10 12 44 PM" src="https://github.com/user-attachments/assets/629bd171-2a98-4e93-a879-7725ef2a2131">

<img width="926" alt="Screenshot 2024-12-03 at 10 12 51 PM" src="https://github.com/user-attachments/assets/468e0862-59c5-4501-8bdc-11b12e13c8dd">
