### PR TITLE
Fix import of tweet_urls for RTs

### DIFF
--- a/src/lib-server/db_insert.ts
+++ b/src/lib-server/db_insert.ts
@@ -150,7 +150,7 @@ const processAndInsertTweetEntities = async (
   const tweetUrls = tweets.flatMap((tweet) =>
     tweet.entities.urls.map((url: any) => ({
       url: url.url,
-      expanded_url: url.expanded_url || '',
+      expanded_url: url.expanded_url,
       display_url: url.display_url || '',
       tweet_id: tweet.id_str,
     })),

--- a/supabase/migrations/20250128204847_fix_import_tweet_urls.sql
+++ b/supabase/migrations/20250128204847_fix_import_tweet_urls.sql
@@ -1,0 +1,4 @@
+--RTs apparently have no expanded_url
+
+ALTER TABLE public.tweet_urls
+ALTER COLUMN expanded_url DROP NOT NULL;


### PR DESCRIPTION
For RTs twitter doesn't send the data of expanded_urls, because of this while importing the data into the tables we were having errors because the schema forced expanded_url to not be null, this PR fixes that by allowing it to be null.