### PR TITLE
Fix exgenesis twitter profile link

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -148,7 +148,7 @@ export default async function Homepage() {
         <br />
         <p>
           Maintained & developed by{' '}
-          <a href="@https://x.com/exgenesis" className="hover:underline">
+          <a href="https://x.com/exgenesis" className="hover:underline">
             Xiq (@exgenesis)
           </a>{' '}
           & contributors.


### PR DESCRIPTION
Previously, went to `https://www.community-archive.org/@https:/x.com/exgenesis` which is a 404