### PR TITLE
feat: Add download archive button to user profile page

### DIFF
--- a/src/app/user/[account_id]/DownloadArchiveButton.tsx
+++ b/src/app/user/[account_id]/DownloadArchiveButton.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { FileDown } from 'lucide-react'
+import { useEffect, useState } from 'react'
+
+function formatFileSize(bytes: number) {
+  if (bytes === 0) return '0 Bytes'
+  
+  const k = 1024
+  const sizes = ['Bytes', 'KB', 'MB', 'GB']
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`
+}
+
+export function DownloadArchiveButton({ username }: { username: string }) {
+  const archiveUrl = `https://fabxmporizzqflnftavs.supabase.co/storage/v1/object/public/archives/${username.toLowerCase()}/archive.json`
+
+  return (
+    <div className="mt-4">
+      <Button 
+        variant="outline" 
+        onClick={() => window.open(archiveUrl, '_blank')}
+        className="flex items-center gap-2"
+      >
+        <FileDown size={16} />
+        Download Raw Archive
+      </Button>
+      <p className="mt-1 text-xs text-gray-500">
+        Downloads the complete Twitter archive in JSON format
+      </p>
+    </div>
+  )
+} 

--- a/src/app/user/[account_id]/DownloadArchiveButton.tsx
+++ b/src/app/user/[account_id]/DownloadArchiveButton.tsx
@@ -2,26 +2,39 @@
 
 import { Button } from '@/components/ui/button'
 import { FileDown } from 'lucide-react'
-import { useEffect, useState } from 'react'
-
-function formatFileSize(bytes: number) {
-  if (bytes === 0) return '0 Bytes'
-  
-  const k = 1024
-  const sizes = ['Bytes', 'KB', 'MB', 'GB']
-  const i = Math.floor(Math.log(bytes) / Math.log(k))
-  
-  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`
-}
 
 export function DownloadArchiveButton({ username }: { username: string }) {
   const archiveUrl = `https://fabxmporizzqflnftavs.supabase.co/storage/v1/object/public/archives/${username.toLowerCase()}/archive.json`
+
+  const handleDownload = async () => {
+    try {
+      // Fetch the file
+      const response = await fetch(archiveUrl)
+      const blob = await response.blob()
+      
+      // Create a temporary link element
+      const downloadUrl = window.URL.createObjectURL(blob)
+      const link = document.createElement('a')
+      link.href = downloadUrl
+      link.download = `${username}_twitter_archive.json` // Set filename
+      
+      // Trigger download
+      document.body.appendChild(link)
+      link.click()
+      
+      // Cleanup
+      document.body.removeChild(link)
+      window.URL.revokeObjectURL(downloadUrl)
+    } catch (error) {
+      console.error('Download failed:', error)
+    }
+  }
 
   return (
     <div className="mt-4">
       <Button 
         variant="outline" 
-        onClick={() => window.open(archiveUrl, '_blank')}
+        onClick={handleDownload}
         className="flex items-center gap-2"
       >
         <FileDown size={16} />

--- a/src/app/user/[account_id]/page.tsx
+++ b/src/app/user/[account_id]/page.tsx
@@ -11,6 +11,7 @@ import { devLog } from '@/lib-client/devLog'
 import { cookies } from 'next/headers'
 import { getUserData } from '@/lib-server/queries/fetchUsers'
 import { formatNumber } from '@/lib-client/formatNumber'
+import { DownloadArchiveButton } from './DownloadArchiveButton'
 
 const UserProfile = ({ userData }: { userData: FormattedUser }) => {
   const account = userData
@@ -46,6 +47,7 @@ const UserProfile = ({ userData }: { userData: FormattedUser }) => {
           <p>{formatNumber(account.num_following)} Following</p>
           <p>{formatNumber(account.num_likes)} Likes</p>
         </div>
+        <DownloadArchiveButton username={account.username} />
       </div>
     </div>
   )


### PR DESCRIPTION
![37535](https://github.com/user-attachments/assets/11d5faca-2820-4ef3-aefd-2c62ce78a0b9)

https://github.com/user-attachments/assets/dd79ff8b-d509-4d3f-a4c5-ec5513199c0d

future ideas
- add button to the user directory page too (maybe it's fine to just click on profile)
- add download size (maybe use a server action to read the metadata since it might be large, haven't really used it much so didn't add it to this)