### PR TITLE
Permit pnpm to run lifecycle scripts for dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,5 +125,13 @@
     "workerDirectory": [
       "public"
     ]
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@swc/core",
+      "esbuild",
+      "msw",
+      "supabase"
+    ]
   }
 }


### PR DESCRIPTION
Problem: in pnpm v10, [lifecycle scripts of dependencies are not executed by default](https://github.com/pnpm/pnpm/releases/tag/v10.0.0):

```
❯ pnpm i
Lockfile is up to date, resolution step is skipped
Already up to date
 WARN  Failed to create bin at /Users/spencerelliott/Dev/elliottsj/community-archive/node_modules/.bin/supabase. ENOENT: no such file or directory, open '/Users/spencerelliott/Dev/elliottsj/community-archive/node_modules/.pnpm/supabase@1.226.4/node_modules/supabase/bin/supabase'

╭ Warning ───────────────────────────────────────────────────────────────────────────────────╮
│                                                                                            │
│   Ignored build scripts: @swc/core, esbuild, msw, supabase.                                │
│   Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.   │
│                                                                                            │
╰────────────────────────────────────────────────────────────────────────────────────────────╯
```

As a result, `pnpm supabase` does not work.

I ran `pnpm approve-builds`, which adds packages to `pnpm.onlyBuildDependencies`:

```
❯ pnpm approve-builds
✔ Choose which packages to build (Press <space> to select, <a> to toggle all, <i> to invert selection) · @swc/core, esbuild, msw, supabase
✔ The next packages will now be built: @swc/core, esbuild, msw, supabase.
Do you approve? (y/N) · true
node_modules/.pnpm/@swc+core@1.10.12_@swc+helpers@0.5.15/node_modules/@swc/core: Running postinstall script, done in 532ms
node_modules/.pnpm/supabase@1.226.4/node_modules/supabase: Running postinstall script, done in 3.9s
node_modules/.pnpm/esbuild@0.23.1/node_modules/esbuild: Running postinstall script, done in 766ms
node_modules/.pnpm/msw@2.7.0_@types+node@20.3.1_typescript@5.1.3/node_modules/msw: Running postinstall script, done in 134ms
```

Now `pnpm supabase start` works again.