### PR TITLE
Fix supabase SQL migration errors

### DIFF
--- a/supabase/migrations/20250307144041_views.sql
+++ b/supabase/migrations/20250307144041_views.sql
@@ -27,6 +27,4 @@ LEFT JOIN LATERAL (
     LIMIT 1
 ) p ON true;
 
-CREATE INDEX IF NOT EXISTS idx_profile_account_id_archive_upload_id ON profile(account_id, archive_upload_id DESC);
 CREATE INDEX IF NOT EXISTS idx_conversations_tweet_id ON conversations(tweet_id);
-CREATE INDEX IF NOT EXISTS idx_quote_tweets_tweet_id ON quote_tweets(tweet_id);

--- a/supabase/migrations/20250317220509_rls.sql
+++ b/supabase/migrations/20250317220509_rls.sql
@@ -35,8 +35,10 @@ BEGIN
         )', schema_name, table_name);
 END;
 $$ LANGUAGE plpgsql;
-
-PERFORM public.apply_public_rls_policies('public', 'tweets');
-PERFORM public.apply_public_rls_policies('public', 'likes');
-PERFORM public.apply_public_rls_policies('public', 'followers');
-PERFORM public.apply_public_rls_policies('public', 'following');
+DO $$
+BEGIN
+    PERFORM public.apply_public_rls_policies('public', 'tweets');
+    PERFORM public.apply_public_rls_policies('public', 'likes');
+    PERFORM public.apply_public_rls_policies('public', 'followers');
+    PERFORM public.apply_public_rls_policies('public', 'following');
+END $$;


### PR DESCRIPTION
Attempting dev setup with local supabase, I'm getting a series of errors which seem related to the circles mitigation https://github.com/TheExGenesis/community-archive/commit/a0eefce2b978b199f98d0f054cf9fa1e5414e84f:

```
❯ pnpm supabase start --debug
...
2025/03/29 15:04:57 PG Recv: {"Type":"ErrorResponse","Severity":"ERROR","SeverityUnlocalized":"ERROR","Code":"42809","Message":"cannot create index on relation \"profile\"","Detail":"This operation is not supported for views.","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"indexcmds.c","Line":679,"Routine":"DefineIndex","UnknownFields":null}
...
ERROR: cannot create index on relation "profile" (SQLSTATE 42809) At statement 1: CREATE INDEX IF NOT EXISTS idx_profile_account_id_archive_upload_id ON profile(account_id, archive_upload_id DESC)
```

and

```
ERROR: cannot create index on relation "quote_tweets" (SQLSTATE 42809) At statement 2: CREATE INDEX IF NOT EXISTS idx_quote_tweets_tweet_id ON quote_tweets(tweet_id)
```

and

```
...
2025/03/29 15:11:13 PG Recv: {"Type":"ErrorResponse","Severity":"ERROR","SeverityUnlocalized":"ERROR","Code":"42601","Message":"syntax error at or near \"PERFORM\"","Detail":"","Hint":"","Position":1,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"scan.l","Line":1188,"Routine":"scanner_yyerror","UnknownFields":null}
...
ERROR: syntax error at or near "PERFORM" (SQLSTATE 42601) At statement 1: PERFORM public.apply_public_rls_policies('public', 'tweets')
```

Attempting to fix these in this PR. I'm not sure if (or how to test) whether this impacts the circles mitigation.

Also running into another one which I don't yet have a fix for:

```
2025/03/29 15:25:36 PG Recv: {"Type":"ErrorResponse","Severity":"ERROR","SeverityUnlocalized":"ERROR","Code":"42703","Message":"column \"account_id\" does not exist","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"SQL statement \"\n        CREATE POLICY \"Data is modifiable by their users\" ON public.tweet_media TO authenticated \n        USING (\n            account_id = (SELECT auth.jwt()) -\u003e 'app_metadata' -\u003e\u003e 'provider_id'\n        ) \n        WITH CHECK (\n            account_id = (SELECT auth.jwt()) -\u003e 'app_metadata' -\u003e\u003e 'provider_id'\n        )\"\nPL/pgSQL function apply_public_rls_policies(text,text) line 27 at EXECUTE\nSQL statement \"SELECT public.apply_public_rls_policies('public', 'tweet_media')\"\nPL/pgSQL function inline_code_block line 4 at PERFORM","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"parse_relation.c","Line":3656,"Routine":"errorMissingColumn","UnknownFields":null}
...
ERROR: column "account_id" does not exist (SQLSTATE 42703)
At statement 1: -- Apply similar policy to tweet_media
DO $$
BEGIN
  -- Remove existing policies
  PERFORM public.apply_public_rls_policies('public', 'tweet_media');

  -- Add quarantine policy for tweet media based on tweet creation date
  CREATE POLICY "Quarantine media from tweets between Aug 2022 and Nov 2023" ON public.tweet_media
  FOR SELECT
  USING (
    NOT EXISTS (
      SELECT 1 FROM public.tweets t
      WHERE t.tweet_id = tweet_media.tweet_id
      AND t.created_at >= '2022-08-01'::timestamp
      AND t.created_at <= '2023-11-30'::timestamp
    )
    OR auth.role() IN ('service_role', 'postgres')
  );
END
$$
```