### PR TITLE
Fix tweet_media row-level security policy migration

### DIFF
--- a/supabase/migrations/20250317220509_rls.sql
+++ b/supabase/migrations/20250317220509_rls.sql
@@ -24,15 +24,35 @@ BEGIN
         FOR SELECT
         USING (true)', schema_name, table_name);
 
-    -- The modification policy remains unchanged
-    EXECUTE format('
-        CREATE POLICY "Data is modifiable by their users" ON %I.%I TO authenticated 
-        USING (
-            account_id = (SELECT auth.jwt()) -> ''app_metadata'' ->> ''provider_id''
-        ) 
-        WITH CHECK (
-            account_id = (SELECT auth.jwt()) -> ''app_metadata'' ->> ''provider_id''
-        )', schema_name, table_name);
+    -- Special case for tweet_media table which needs to join with tweets table
+    IF table_name = 'tweet_media' THEN
+        EXECUTE format('
+            CREATE POLICY "Data is modifiable by their users" ON %I.%I TO authenticated 
+            USING (
+                EXISTS (
+                    SELECT 1 FROM public.tweets t
+                    WHERE t.tweet_id = tweet_media.tweet_id
+                    AND t.account_id = (SELECT auth.jwt()) -> ''app_metadata'' ->> ''provider_id''
+                )
+            ) 
+            WITH CHECK (
+                EXISTS (
+                    SELECT 1 FROM public.tweets t
+                    WHERE t.tweet_id = tweet_media.tweet_id
+                    AND t.account_id = (SELECT auth.jwt()) -> ''app_metadata'' ->> ''provider_id''
+                )
+            )', schema_name, table_name);
+    ELSE
+        -- The modification policy remains unchanged for other tables
+        EXECUTE format('
+            CREATE POLICY "Data is modifiable by their users" ON %I.%I TO authenticated 
+            USING (
+                account_id = (SELECT auth.jwt()) -> ''app_metadata'' ->> ''provider_id''
+            ) 
+            WITH CHECK (
+                account_id = (SELECT auth.jwt()) -> ''app_metadata'' ->> ''provider_id''
+            )', schema_name, table_name);
+    END IF;
 END;
 $$ LANGUAGE plpgsql;
 DO $$
@@ -41,4 +61,5 @@ BEGIN
     PERFORM public.apply_public_rls_policies('public', 'likes');
     PERFORM public.apply_public_rls_policies('public', 'followers');
     PERFORM public.apply_public_rls_policies('public', 'following');
+    PERFORM public.apply_public_rls_policies('public', 'tweet_media');
 END $$;


### PR DESCRIPTION
As described in #240, there was an error applying the `20250317225419_circle_quarantine.sql` migration:

```
❯ pnpm supabase start --debug
Applying migration 20250317225419_circle_quarantine.sql...
...
2025/03/29 15:25:36 PG Recv: {"Type":"ErrorResponse","Severity":"ERROR","SeverityUnlocalized":"ERROR","Code":"42703","Message":"column \"account_id\" does not exist","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"SQL statement \"\n        CREATE POLICY \"Data is modifiable by their users\" ON public.tweet_media TO authenticated \n        USING (\n            account_id = (SELECT auth.jwt()) -\u003e 'app_metadata' -\u003e\u003e 'provider_id'\n        ) \n        WITH CHECK (\n            account_id = (SELECT auth.jwt()) -\u003e 'app_metadata' -\u003e\u003e 'provider_id'\n        )\"\nPL/pgSQL function apply_public_rls_policies(text,text) line 27 at EXECUTE\nSQL statement \"SELECT public.apply_public_rls_policies('public', 'tweet_media')\"\nPL/pgSQL function inline_code_block line 4 at PERFORM","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"parse_relation.c","Line":3656,"Routine":"errorMissingColumn","UnknownFields":null}
2025/03/29 15:25:36 PG Recv: {"Type":"ReadyForQuery","TxStatus":"I"}
2025/03/29 15:25:36 PG Send: {"Type":"Terminate"}
Stopping containers...
Pruned containers: [2c2d14eafd8c2b1970946d1c0649144f3e88648eefcae2b547896c8c9776de9f]
Pruned volumes: [supabase_db_canonball supabase_config_canonball]
Pruned network: [supabase_network_canonball]
ERROR: column "account_id" does not exist (SQLSTATE 42703)
At statement 1: -- Apply similar policy to tweet_media
DO $$
BEGIN
  -- Remove existing policies
  PERFORM public.apply_public_rls_policies('public', 'tweet_media');

  -- Add quarantine policy for tweet media based on tweet creation date
  CREATE POLICY "Quarantine media from tweets between Aug 2022 and Nov 2023" ON public.tweet_media
  FOR SELECT
  USING (
    NOT EXISTS (
      SELECT 1 FROM public.tweets t
      WHERE t.tweet_id = tweet_media.tweet_id
      AND t.created_at >= '2022-08-01'::timestamp
      AND t.created_at <= '2023-11-30'::timestamp
    )
    OR auth.role() IN ('service_role', 'postgres')
  );
END
$$
```

This is due to the `tweet_media` table missing an `account_id` column.

Using Cursor:

> I'll search through the migrations to find any references to the `tweet_media` table and `account_id` column.
> 
> Read file: sql/tables/08_tweet_media.sql
> 
> I can see the issue now. The `tweet_media` table does not have an `account_id` column, but the RLS policy in `20250317220509_rls.sql` is trying to use it. This is causing the error.
> 
> Looking at the table definition, the `tweet_media` table has these columns:
> - `media_id` (BIGINT, PRIMARY KEY)
> - `tweet_id` (TEXT, NOT NULL)
> - `media_url` (TEXT, NOT NULL)
> - `media_type` (TEXT, NOT NULL)
> - `width` (INTEGER, NOT NULL)
> - `height` (INTEGER, NOT NULL)
> - `archive_upload_id` (BIGINT)
> - `updated_at` (TIMESTAMP WITH TIME ZONE)
> 
> The RLS policy is trying to check against an `account_id` column that doesn't exist. This is likely because the policy was copied from another table that does have an `account_id` column.
> 
> To fix this, you'll need to modify the RLS policy for the `tweet_media` table to use a different column for access control. Since `tweet_media` is related to tweets through the `tweet_id` foreign key, you might want to join with the `tweets` table to get the `account_id` from there.
> 
> Would you like me to help you modify the RLS policy to work correctly with the `tweet_media` table?

> Yes.

> I'll help you modify the RLS policy for the `tweet_media` table. Since `tweet_media` is related to tweets through the `tweet_id` foreign key, we should join with the `tweets` table to get the `account_id` for access control.
> 
> Let me create a new migration to fix this:
> 
> ```
> (updated supabase/migrations/20250317220509_rls.sql)
> ```
> 
> I've made the following changes to fix the RLS policy for the `tweet_media` table:
> 
> 1. Added a special case in the `apply_public_rls_policies` function to handle the `tweet_media` table differently
> 2. For `tweet_media`, the policy now:
>    - Uses an `EXISTS` subquery to join with the `tweets` table
>    - Checks if the `account_id` in the related tweet matches the user's `provider_id`
>    - This ensures users can only modify media associated with their own tweets
> 3. Added `tweet_media` to the list of tables that the policies are applied to
> 
> The new policy will:
> - Allow users to modify media only if they own the associated tweet
> - Keep the same security model as before, but now properly handles the relationship between tweets and their media
> - Fix the "column account_id does not exist" error since we're now getting the `account_id` from the related `tweets` table
> 
> This change maintains the same security model while properly handling the relationship between tweets and their media attachments. Users can only modify media that belongs to their own tweets.

---

Now:

```
❯ pnpm supabase start
...
Started supabase local development setup.

         API URL: http://127.0.0.1:54321
     GraphQL URL: http://127.0.0.1:54321/graphql/v1
  S3 Storage URL: http://127.0.0.1:54321/storage/v1/s3
          DB URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
      Studio URL: http://127.0.0.1:54323
    Inbucket URL: http://127.0.0.1:54324
...
```