### PR TITLE
Update discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@ _from Xiq's [Towards data sovereignty, and a backup of the twitter canon](https:
 
 The goals of this project are (1) create a public domain dataset so that we can analyze & build apps on top of our own data, commercial or otherwise (2) develop an open workflow for archival that people can self host or create private archives for their communities if they wish.
 
-## Join our Discord
-
-https://discord.gg/5mbWEfVrqw
-
 ## App showcase
 
 |  | | |

--- a/src/app/data-policy/page.tsx
+++ b/src/app/data-policy/page.tsx
@@ -114,7 +114,7 @@ export default function DataPolicyPage() {
         >
           @exgenesis
         </a>
-        . Or find us on <a href="https://discord.gg/5mbWEfVrqw" className="text-blue-500 hover:underline">Discord</a> or <a href="https://github.com/TheExGenesis/community-archive" className="text-blue-500 hover:underline">GitHub</a>  
+        . Or find us on <a href="https://discord.gg/RArTGrUawX" className="text-blue-500 hover:underline">Discord</a> or <a href="https://github.com/TheExGenesis/community-archive" className="text-blue-500 hover:underline">GitHub</a>  
       </p>
 
       <p className="mb-8">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -251,7 +251,7 @@ export default async function Homepage() {
           </div>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6 md:gap-8">
             <InfoPanel icon={<FaGithub />} title="GitHub Repository" description="Access the full source code, contribute to the project, and track issues." href="https://github.com/TheExGenesis/community-archive" />
-            <InfoPanel icon={<FaDiscord />} title="Join our Discord" description="Connect with the community, ask questions, and share your projects." href="https://discord.gg/5mbWEfVrqw" />
+            <InfoPanel icon={<FaDiscord />} title="Join our Discord" description="Connect with the community, ask questions, and share your projects." href="https://discord.gg/RArTGrUawX" />
             <InfoPanel icon={<FaBook />} title="Documentation & API" description="Explore our API, download data, and find examples to build your own apps." href="https://github.com/TheExGenesis/community-archive/tree/main/docs" />
           </div>
         </div>


### PR DESCRIPTION
We have invalidated the previous Discord invite because it makes the server too easy to find (it shows up as the first search result in some search engines, specifically Brave)

This new link is now only present in one place on the internet.

I wrote this "artist statement" here (partially to see if this will show up on google search results instead): https://github.com/DefenderOfBasic/open-memetics-institute/blob/main/discord.md