### PR TITLE
Fix: Make stream-monitor and opt-in pages always accessible

### DIFF
--- a/src/app/opt-in/page.tsx
+++ b/src/app/opt-in/page.tsx
@@ -1,13 +1,7 @@
 import { requireAuth, getOptInStatus } from '@/lib/auth-utils'
 import OptInForm from '@/components/OptInForm'
-import { notFound } from 'next/navigation'
 
 export default async function OptInPage() {
-  // Check if streaming features are enabled
-  if (process.env.NEXT_PUBLIC_ENABLE_STREAMING_FEATURES !== 'true') {
-    notFound()
-  }
-
   const { user } = await requireAuth()
   const { data: optInData } = await getOptInStatus(user.id)
 

--- a/src/app/stream-monitor/page.tsx
+++ b/src/app/stream-monitor/page.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import React, { useState, useEffect } from 'react'
-import { useRouter } from 'next/navigation'
 import { useQuery } from '@tanstack/react-query'
 import { createBrowserClient } from '@/utils/supabase'
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from '@/components/ui/chart'
@@ -45,7 +44,6 @@ interface Tweet {
 }
 
 const StreamMonitor = () => {
-  const router = useRouter()
   const [viewMode, setViewMode] = useState<'24h' | '7d' | '1y'>('24h')
   const [timeOffset, setTimeOffset] = useState(0)
   const [showStreamedOnly, setShowStreamedOnly] = useState(true)
@@ -54,13 +52,6 @@ const StreamMonitor = () => {
   const tweetsPerPage = 20
   
   const supabase = createBrowserClient()
-
-  // Check if streaming features are enabled
-  useEffect(() => {
-    if (process.env.NEXT_PUBLIC_ENABLE_STREAMING_FEATURES !== 'true') {
-      router.push('/404')
-    }
-  }, [router])
 
   // Query for scraping stats based on view mode and offset
   const { data: scrapingStats, isLoading: statsLoading, error: statsError } = useQuery({


### PR DESCRIPTION
## Summary
Fixes 404 errors on stream-monitor and opt-in pages when feature flag is disabled. Pages should always be accessible via direct URL, with only navigation visibility controlled by the feature flag.

## Problem
- Stream monitor and opt-in pages were returning 404 when `NEXT_PUBLIC_ENABLE_STREAMING_FEATURES` was false
- This prevented direct access to these pages even when users had the URL

## Solution
- Removed feature flag checks from page components
- Pages now always render when accessed directly
- Navigation visibility still controlled by feature flag (working as intended)
- Cleaned up unused imports

## Changes
- Removed `router.push('/404')` redirect from `/stream-monitor/page.tsx`
- Removed `notFound()` call from `/opt-in/page.tsx`
- Removed unused imports (`useRouter`, `notFound`)

## Testing
Pages now load successfully regardless of feature flag setting:
- `/stream-monitor` - ✅ Always accessible
- `/opt-in` - ✅ Always accessible
- Navigation links - Still hidden when flag is false

🤖 Generated with [Claude Code](https://claude.ai/code)