### PR TITLE
Add guarded staging login bypass

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,17 @@ NEXT_PUBLIC_LOCAL_SERVICE_ROLE=<your-service-role-key(from pnpm supabase start)>
 SUPABASE_SERVICE_ROLE=<> #same as above, is needed for vercel in the server
 NODE_ENV=development
 
+# Staging-only login bypass.
+# Use this with a separate Supabase project loaded with mock data, never with prod data.
+NEXT_PUBLIC_ENABLE_STAGING_DEV_LOGIN=false
+ENABLE_STAGING_DEV_LOGIN=false
+STAGING_DEV_LOGIN_EMAIL=staging-dev@example.com
+STAGING_DEV_LOGIN_PASSWORD=<strong-staging-password>
+STAGING_DEV_LOGIN_USERNAME=alice_dev
+STAGING_DEV_LOGIN_PROVIDER_ID=mock_alice
+STAGING_DEV_LOGIN_DISPLAY_NAME=Alice Staging
+ALLOW_STAGING_DEV_LOGIN_ON_PROD_SUPABASE=false
+
 ARCHIVE_PATH=<path_to_archive_folder>
 
 NEXT_PUBLIC_USER_ID=<>

--- a/.github/workflows/sync-staging-db.yaml
+++ b/.github/workflows/sync-staging-db.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   sync:
     runs-on: ubuntu-latest
-    environment: staging
+    environment: Preview
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/sync-staging-db.yaml
+++ b/.github/workflows/sync-staging-db.yaml
@@ -1,0 +1,42 @@
+name: Sync staging database
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'supabase/**'
+      - 'scripts/sync-staging-db.sh'
+
+concurrency:
+  group: sync-staging-db
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+          run_install: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Sync staging database
+        env:
+          SUPABASE_STAGING_PROJECT_REF: ${{ secrets.SUPABASE_STAGING_PROJECT_REF }}
+          STAGING_DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+        run: ./scripts/sync-staging-db.sh

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ yarn-error.log*
 # local env files
 .env*.local
 .env
+.env.staging.generated
 
 # vercel
 .vercel

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -30,9 +30,47 @@ STAGING_DEV_LOGIN_DISPLAY_NAME=Alice Staging
 ALLOW_STAGING_DEV_LOGIN_ON_PROD_SUPABASE=false
 ```
 
+The default staging login identity is:
+
+- Email: value of `STAGING_DEV_LOGIN_EMAIL`
+- Password: value of `STAGING_DEV_LOGIN_PASSWORD`
+- Mock Twitter username: value of `STAGING_DEV_LOGIN_USERNAME`
+- Mock Twitter account id: value of `STAGING_DEV_LOGIN_PROVIDER_ID`
+
+Do not commit the real password. The bootstrap script below writes it to an ignored `.env.staging.generated` file so it can be copied into Vercel's Preview environment.
+
 The server route refuses staging dev login against the known production Supabase host unless `ALLOW_STAGING_DEV_LOGIN_ON_PROD_SUPABASE=true`. Do not set that override for normal staging.
 
-## Database Setup
+## Programmatic Database Setup
+
+If `SUPABASE_ACCESS_TOKEN` has organization/project management permissions, the repository can create and seed staging automatically.
+
+Required local environment:
+
+```env
+SUPABASE_ACCESS_TOKEN=<valid Supabase management token>
+SUPABASE_STAGING_ORG_ID=<Supabase org id>
+SUPABASE_STAGING_DB_PASSWORD=<new staging database password>
+SUPABASE_STAGING_REGION=eu-central-1
+```
+
+Then run:
+
+```bash
+./scripts/bootstrap-staging-supabase.sh
+```
+
+The script will:
+
+- create a `community-archive-staging` Supabase project if `SUPABASE_STAGING_PROJECT_REF` is not set
+- link the project locally
+- run `supabase db push --include-all`
+- load `supabase/seed.sql`
+- write Preview environment values to `.env.staging.generated`
+
+If you create the Supabase project manually, set `SUPABASE_STAGING_PROJECT_REF` and rerun the same script to apply schema, seed data, and generate the Vercel env file.
+
+## Manual Database Setup
 
 1. Create a new Supabase project.
 2. Link the project locally:
@@ -54,6 +92,24 @@ psql '<staging-db-connection-string>' -f supabase/seed.sql
 ```
 
 The default staging login identity maps to `mock_alice` / `alice_dev`, which exists in the seed data and has a multi-tweet thread.
+
+## Vercel Preview Setup
+
+For PR-created Vercel Preview deployments, add the values from `.env.staging.generated` to the Vercel project's Preview environment. At minimum:
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `SUPABASE_SERVICE_ROLE`
+- `NEXT_PUBLIC_ENABLE_STAGING_DEV_LOGIN=true`
+- `ENABLE_STAGING_DEV_LOGIN=true`
+- `STAGING_DEV_LOGIN_EMAIL`
+- `STAGING_DEV_LOGIN_PASSWORD`
+- `STAGING_DEV_LOGIN_USERNAME`
+- `STAGING_DEV_LOGIN_PROVIDER_ID`
+- `STAGING_DEV_LOGIN_DISPLAY_NAME`
+- `ALLOW_STAGING_DEV_LOGIN_ON_PROD_SUPABASE=false`
+
+After updating Preview env vars, redeploy the PR preview so the new values are picked up.
 
 ## What To Verify Before Privacy PRs
 

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -1,0 +1,69 @@
+# Staging Environment
+
+Staging should be safe enough to exercise login, upload, opt-in, explicit opt-out, deletion, admin tools, and thread rendering without touching production data.
+
+## Target Shape
+
+- Separate Supabase project from production.
+- Same schema as production.
+- Mock seed data from `supabase/seed.sql`.
+- Email/password staging login bypass instead of Twitter OAuth.
+- No production archive storage files.
+- No production service role key.
+
+## Required Environment Variables
+
+Set these in the staging deployment, for example a Vercel preview/staging environment:
+
+```env
+NEXT_PUBLIC_SUPABASE_URL=<staging-supabase-url>
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<staging-anon-key>
+SUPABASE_SERVICE_ROLE=<staging-service-role-key>
+
+NEXT_PUBLIC_ENABLE_STAGING_DEV_LOGIN=true
+ENABLE_STAGING_DEV_LOGIN=true
+STAGING_DEV_LOGIN_EMAIL=staging-dev@example.com
+STAGING_DEV_LOGIN_PASSWORD=<strong-staging-password>
+STAGING_DEV_LOGIN_USERNAME=alice_dev
+STAGING_DEV_LOGIN_PROVIDER_ID=mock_alice
+STAGING_DEV_LOGIN_DISPLAY_NAME=Alice Staging
+ALLOW_STAGING_DEV_LOGIN_ON_PROD_SUPABASE=false
+```
+
+The server route refuses staging dev login against the known production Supabase host unless `ALLOW_STAGING_DEV_LOGIN_ON_PROD_SUPABASE=true`. Do not set that override for normal staging.
+
+## Database Setup
+
+1. Create a new Supabase project.
+2. Link the project locally:
+
+```bash
+supabase link --project-ref <staging-project-ref>
+```
+
+3. Apply the schema:
+
+```bash
+supabase db push
+```
+
+4. Load mock data:
+
+```bash
+psql '<staging-db-connection-string>' -f supabase/seed.sql
+```
+
+The default staging login identity maps to `mock_alice` / `alice_dev`, which exists in the seed data and has a multi-tweet thread.
+
+## What To Verify Before Privacy PRs
+
+- Staging login creates/signs in the configured mock user.
+- `/profile` resolves the mock account and shows archive state.
+- Upload and opt-in flows mutate only the staging database.
+- Explicit opt-out/deletion removes or hides the mock user's public data.
+- Thread pages still render acceptably when one account in the thread has been deleted or blocked.
+- Public pages do not show opted-out account data after deletion/hiding.
+
+## Thread Rendering TODO
+
+When an opted-out account's tweets are removed from local tables, thread views can become incomplete. The intended follow-up is to add a thread fallback that can hydrate missing public tweets through the Twitter/X syndication API, while still respecting local opt-out/block state for any account that requested removal.

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -37,6 +37,8 @@ The default staging login identity is:
 - Mock Twitter username: value of `STAGING_DEV_LOGIN_USERNAME`
 - Mock Twitter account id: value of `STAGING_DEV_LOGIN_PROVIDER_ID`
 
+The staging UI does not ask for these credentials. When `NEXT_PUBLIC_ENABLE_STAGING_DEV_LOGIN=true`, the sign-in button calls the server-side staging login route with no client-side password. The server uses `STAGING_DEV_LOGIN_PASSWORD` from the staging environment.
+
 Do not commit the real password. The bootstrap script below writes it to an ignored `.env.staging.generated` file so it can be copied into Vercel's Preview environment.
 
 The server route refuses staging dev login against the known production Supabase host unless `ALLOW_STAGING_DEV_LOGIN_ON_PROD_SUPABASE=true`. Do not set that override for normal staging.
@@ -110,6 +112,22 @@ For PR-created Vercel Preview deployments, add the values from `.env.staging.gen
 - `ALLOW_STAGING_DEV_LOGIN_ON_PROD_SUPABASE=false`
 
 After updating Preview env vars, redeploy the PR preview so the new values are picked up.
+
+## Keeping Staging Schema Current
+
+The `Sync staging database` GitHub Action resets staging from the repo schema and mock seed data:
+
+- It runs manually via `workflow_dispatch`.
+- It runs on pushes to `main` that touch `supabase/**` or `scripts/sync-staging-db.sh`.
+- It refuses to run if `STAGING_DATABASE_URL` does not include `SUPABASE_STAGING_PROJECT_REF`.
+- It refuses the production project ref.
+
+Required GitHub repository secrets:
+
+- `SUPABASE_STAGING_PROJECT_REF`
+- `STAGING_DATABASE_URL`
+
+Use the Supabase Dashboard connection string for `STAGING_DATABASE_URL`. Prefer the session pooler connection string if direct database connections fail locally or in GitHub Actions because of IPv6 routing.
 
 ## What To Verify Before Privacy PRs
 

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -122,7 +122,7 @@ The `Sync staging database` GitHub Action resets staging from the repo schema an
 - It refuses to run if `STAGING_DATABASE_URL` does not include `SUPABASE_STAGING_PROJECT_REF`.
 - It refuses the production project ref.
 
-Required GitHub repository secrets:
+Required GitHub repository secrets (configured on the `Preview` GitHub Environment):
 
 - `SUPABASE_STAGING_PROJECT_REF`
 - `STAGING_DATABASE_URL`

--- a/scripts/bootstrap-staging-supabase.sh
+++ b/scripts/bootstrap-staging-supabase.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if [[ -f ".env" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  . ./.env
+  set +a
+fi
+
+PROJECT_NAME="${SUPABASE_STAGING_PROJECT_NAME:-community-archive-staging}"
+REGION="${SUPABASE_STAGING_REGION:-eu-central-1}"
+GENERATED_ENV_FILE="${SUPABASE_STAGING_ENV_FILE:-.env.staging.generated}"
+
+require_env() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "Missing required env var: $name" >&2
+    exit 1
+  fi
+}
+
+urlencode() {
+  node -e "process.stdout.write(encodeURIComponent(process.argv[1]))" "$1"
+}
+
+require_env SUPABASE_ACCESS_TOKEN
+require_env SUPABASE_STAGING_DB_PASSWORD
+
+export SUPABASE_ACCESS_TOKEN
+
+PROJECT_REF="${SUPABASE_STAGING_PROJECT_REF:-}"
+
+if [[ -z "$PROJECT_REF" ]]; then
+  require_env SUPABASE_STAGING_ORG_ID
+  echo "Creating Supabase project '$PROJECT_NAME' in org '$SUPABASE_STAGING_ORG_ID' ($REGION)..."
+  CREATE_OUTPUT="$(pnpm supabase projects create "$PROJECT_NAME" \
+    --org-id "$SUPABASE_STAGING_ORG_ID" \
+    --db-password "$SUPABASE_STAGING_DB_PASSWORD" \
+    --region "$REGION" \
+    --output json)"
+
+  PROJECT_REF="$(node -e '
+    const input = JSON.parse(process.argv[1]);
+    const ref = input.ref || input.id || input.project_ref || input.projectRef;
+    if (!ref) {
+      console.error("Could not find project ref in Supabase CLI output:");
+      console.error(JSON.stringify(input, null, 2));
+      process.exit(1);
+    }
+    process.stdout.write(ref);
+  ' "$CREATE_OUTPUT")"
+
+  echo "Created project ref: $PROJECT_REF"
+  echo "Waiting 90 seconds for the database to become reachable..."
+  sleep 90
+fi
+
+ENCODED_PASSWORD="$(urlencode "$SUPABASE_STAGING_DB_PASSWORD")"
+DB_URL="postgresql://postgres:${ENCODED_PASSWORD}@db.${PROJECT_REF}.supabase.co:5432/postgres"
+
+echo "Linking Supabase project $PROJECT_REF..."
+pnpm supabase link --project-ref "$PROJECT_REF" --password "$SUPABASE_STAGING_DB_PASSWORD"
+
+echo "Applying migrations to staging..."
+pnpm supabase db push --password "$SUPABASE_STAGING_DB_PASSWORD" --include-all
+
+echo "Loading mock seed data from supabase/seed.sql..."
+psql "$DB_URL" -v ON_ERROR_STOP=1 -f supabase/seed.sql
+
+echo "Fetching staging API keys..."
+KEYS_JSON="$(pnpm supabase projects api-keys --project-ref "$PROJECT_REF" --output json)"
+ANON_KEY="$(node -e '
+  const keys = JSON.parse(process.argv[1]);
+  const key = keys.find((item) => item.name === "anon" || item.name === "anon key" || item.api_key === "anon");
+  process.stdout.write(key?.api_key || key?.key || "");
+' "$KEYS_JSON")"
+SERVICE_ROLE_KEY="$(node -e '
+  const keys = JSON.parse(process.argv[1]);
+  const key = keys.find((item) => item.name === "service_role" || item.name === "service_role key" || item.api_key === "service_role");
+  process.stdout.write(key?.api_key || key?.key || "");
+' "$KEYS_JSON")"
+
+if [[ -z "$ANON_KEY" || -z "$SERVICE_ROLE_KEY" ]]; then
+  echo "Could not parse Supabase API keys. Raw key metadata:" >&2
+  echo "$KEYS_JSON" >&2
+  exit 1
+fi
+
+cat > "$GENERATED_ENV_FILE" <<EOF
+NEXT_PUBLIC_SUPABASE_URL=https://${PROJECT_REF}.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=${ANON_KEY}
+SUPABASE_SERVICE_ROLE=${SERVICE_ROLE_KEY}
+
+NEXT_PUBLIC_ENABLE_STAGING_DEV_LOGIN=true
+ENABLE_STAGING_DEV_LOGIN=true
+STAGING_DEV_LOGIN_EMAIL=${STAGING_DEV_LOGIN_EMAIL:-staging-dev@example.com}
+STAGING_DEV_LOGIN_PASSWORD=${STAGING_DEV_LOGIN_PASSWORD:-$(openssl rand -base64 30 | tr -d '\n')}
+STAGING_DEV_LOGIN_USERNAME=${STAGING_DEV_LOGIN_USERNAME:-alice_dev}
+STAGING_DEV_LOGIN_PROVIDER_ID=${STAGING_DEV_LOGIN_PROVIDER_ID:-mock_alice}
+STAGING_DEV_LOGIN_DISPLAY_NAME=${STAGING_DEV_LOGIN_DISPLAY_NAME:-Alice Staging}
+ALLOW_STAGING_DEV_LOGIN_ON_PROD_SUPABASE=false
+EOF
+
+echo
+echo "Staging Supabase is ready."
+echo "Project ref: $PROJECT_REF"
+echo "Mock data loaded from supabase/seed.sql."
+echo "Generated Vercel env file: $GENERATED_ENV_FILE"
+echo
+echo "Add those values to Vercel's Preview environment for this project."

--- a/scripts/sync-staging-db.sh
+++ b/scripts/sync-staging-db.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if [[ -f ".env" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  . ./.env
+  set +a
+fi
+
+require_env() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "Missing required env var: $name" >&2
+    exit 1
+  fi
+}
+
+require_env SUPABASE_STAGING_PROJECT_REF
+require_env STAGING_DATABASE_URL
+
+if [[ "$STAGING_DATABASE_URL" != *"$SUPABASE_STAGING_PROJECT_REF"* ]]; then
+  echo "Refusing to sync: STAGING_DATABASE_URL does not contain SUPABASE_STAGING_PROJECT_REF." >&2
+  exit 1
+fi
+
+if [[ "$STAGING_DATABASE_URL" == *"fabxmporizzqflnftavs"* ]]; then
+  echo "Refusing to sync: STAGING_DATABASE_URL appears to point at production." >&2
+  exit 1
+fi
+
+if [[ "$SUPABASE_STAGING_PROJECT_REF" == "fabxmporizzqflnftavs" ]]; then
+  echo "Refusing to sync: SUPABASE_STAGING_PROJECT_REF is production." >&2
+  exit 1
+fi
+
+echo "Resetting staging database and loading repo migrations + supabase/seed.sql..."
+yes | pnpm supabase db reset --db-url "$STAGING_DATABASE_URL"
+echo "Staging database is in sync with the current repo schema and mock seed data."

--- a/src/app/api/auth/dev-login/route.ts
+++ b/src/app/api/auth/dev-login/route.ts
@@ -15,7 +15,7 @@ const isKnownProductionSupabase = () =>
 
 const getStagingLoginConfig = () => ({
   email: process.env.STAGING_DEV_LOGIN_EMAIL ?? 'dev@example.com',
-  password: process.env.STAGING_DEV_LOGIN_PASSWORD ?? 'devpassword123',
+  password: process.env.STAGING_DEV_LOGIN_PASSWORD,
   username: process.env.STAGING_DEV_LOGIN_USERNAME ?? 'alice_dev',
   providerId: process.env.STAGING_DEV_LOGIN_PROVIDER_ID ?? 'mock_alice',
   displayName: process.env.STAGING_DEV_LOGIN_DISPLAY_NAME ?? 'Staging User',
@@ -52,11 +52,19 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json().catch(() => ({}))
     const stagingConfig = getStagingLoginConfig()
+
+    if (!isDevelopment() && !stagingConfig.password) {
+      return NextResponse.json(
+        { error: 'STAGING_DEV_LOGIN_PASSWORD must be set for staging login' },
+        { status: 500 },
+      )
+    }
+
     const email = isDevelopment()
       ? (body.email ?? stagingConfig.email)
       : stagingConfig.email
     const password = isDevelopment()
-      ? (body.password ?? stagingConfig.password)
+      ? (body.password ?? stagingConfig.password ?? 'devpassword123')
       : stagingConfig.password
     const username = stagingConfig.username.toLowerCase()
 

--- a/src/app/api/auth/dev-login/route.ts
+++ b/src/app/api/auth/dev-login/route.ts
@@ -1,74 +1,125 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createServerClient } from '@/utils/supabase'
+import { createServerAdminClient, createServerClient } from '@/utils/supabase'
 import { cookies } from 'next/headers'
 
+const PRODUCTION_SUPABASE_HOST = 'fabxmporizzqflnftavs.supabase.co'
+
+const isDevelopment = () => process.env.NODE_ENV === 'development'
+
+const isStagingDevLoginEnabled = () =>
+  process.env.ENABLE_STAGING_DEV_LOGIN === 'true'
+
+const isKnownProductionSupabase = () =>
+  process.env.NEXT_PUBLIC_SUPABASE_URL?.includes(PRODUCTION_SUPABASE_HOST) ??
+  false
+
+const getStagingLoginConfig = () => ({
+  email: process.env.STAGING_DEV_LOGIN_EMAIL ?? 'dev@example.com',
+  password: process.env.STAGING_DEV_LOGIN_PASSWORD ?? 'devpassword123',
+  username: process.env.STAGING_DEV_LOGIN_USERNAME ?? 'alice_dev',
+  providerId: process.env.STAGING_DEV_LOGIN_PROVIDER_ID ?? 'mock_alice',
+  displayName: process.env.STAGING_DEV_LOGIN_DISPLAY_NAME ?? 'Staging User',
+})
+
 export async function POST(request: NextRequest) {
-  // Only allow in development mode
-  if (process.env.NODE_ENV !== 'development') {
+  const allowDevLogin = isDevelopment() || isStagingDevLoginEnabled()
+
+  if (!allowDevLogin) {
     return NextResponse.json(
-      { error: 'Dev login is only available in development mode' },
-      { status: 403 }
+      { error: 'Dev login is disabled for this environment' },
+      { status: 403 },
+    )
+  }
+
+  if (
+    !isDevelopment() &&
+    isKnownProductionSupabase() &&
+    process.env.ALLOW_STAGING_DEV_LOGIN_ON_PROD_SUPABASE !== 'true'
+  ) {
+    return NextResponse.json(
+      {
+        error:
+          'Refusing staging dev login against the production Supabase project',
+      },
+      { status: 500 },
     )
   }
 
   const cookieStore = await cookies()
   const supabase = createServerClient(cookieStore)
+  const adminSupabase = createServerAdminClient(cookieStore)
 
   try {
-    const body = await request.json()
-    const { email = 'dev@example.com', password = 'devpassword123' } = body
+    const body = await request.json().catch(() => ({}))
+    const stagingConfig = getStagingLoginConfig()
+    const email = isDevelopment()
+      ? (body.email ?? stagingConfig.email)
+      : stagingConfig.email
+    const password = isDevelopment()
+      ? (body.password ?? stagingConfig.password)
+      : stagingConfig.password
+    const username = stagingConfig.username.toLowerCase()
 
     // Try to sign in first
-    const { data: signInData, error: signInError } = await supabase.auth.signInWithPassword({
-      email,
-      password,
-    })
+    const { data: signInData, error: signInError } =
+      await supabase.auth.signInWithPassword({
+        email,
+        password,
+      })
 
     if (signInError) {
       // If sign in fails, try to create the account
       if (signInError.message.includes('Invalid login credentials')) {
-        // First, sign up the user
-        const { data: signUpData, error: signUpError } = await supabase.auth.signUp({
-          email,
-          password,
-          options: {
-            data: {
-              full_name: 'Dev User',
-              user_name: 'devuser',
-              provider: 'email',
-            }
-          }
-        })
+        const { error: createError } =
+          await adminSupabase.auth.admin.createUser({
+            email,
+            password,
+            email_confirm: true,
+            user_metadata: {
+              full_name: stagingConfig.displayName,
+              user_name: username,
+              provider_id: stagingConfig.providerId,
+              provider: isDevelopment() ? 'email' : 'staging',
+            },
+            app_metadata: {
+              provider_id: stagingConfig.providerId,
+              user_name: username,
+              provider: isDevelopment() ? 'email' : 'staging',
+            },
+          })
 
-        if (signUpError) {
+        if (createError) {
           return NextResponse.json(
-            { error: `Failed to create dev account: ${signUpError.message}` },
-            { status: 400 }
+            { error: `Failed to create dev account: ${createError.message}` },
+            { status: 400 },
           )
         }
 
         // Try to sign in again after creating the account
-        const { data: retryData, error: retryError } = await supabase.auth.signInWithPassword({
-          email,
-          password,
-        })
+        const { data: retryData, error: retryError } =
+          await supabase.auth.signInWithPassword({
+            email,
+            password,
+          })
 
         if (retryError) {
           return NextResponse.json(
-            { error: `Failed to sign in after creating account: ${retryError.message}` },
-            { status: 400 }
+            {
+              error: `Failed to sign in after creating account: ${retryError.message}`,
+            },
+            { status: 400 },
           )
         }
 
         return NextResponse.json({
           success: true,
           message: 'Dev account created and signed in successfully',
-          user: retryData.user
+          user: retryData.user,
         })
       } else {
         return NextResponse.json(
           { error: signInError.message },
-          { status: 400 }
+          { status: 400 },
         )
       }
     }
@@ -76,13 +127,13 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({
       success: true,
       message: 'Signed in successfully',
-      user: signInData.user
+      user: signInData.user,
     })
   } catch (error: any) {
     console.error('Dev login error:', error)
     return NextResponse.json(
       { error: error.message || 'Internal server error' },
-      { status: 500 }
+      { status: 500 },
     )
   }
 }

--- a/src/components/SignIn.tsx
+++ b/src/components/SignIn.tsx
@@ -11,6 +11,9 @@ export default function SignIn() {
   const isDevLoginEnabled =
     process.env.NODE_ENV === 'development' ||
     process.env.NEXT_PUBLIC_ENABLE_STAGING_DEV_LOGIN === 'true'
+  const isStagingLogin =
+    process.env.NODE_ENV !== 'development' &&
+    process.env.NEXT_PUBLIC_ENABLE_STAGING_DEV_LOGIN === 'true'
 
   const signIn = async () => {
     const supabase = createBrowserClient()
@@ -28,10 +31,14 @@ export default function SignIn() {
           headers: {
             'Content-Type': 'application/json',
           },
-          body: JSON.stringify({
-            email: 'dev@example.com',
-            password: 'devpassword123',
-          }),
+          body: JSON.stringify(
+            isStagingLogin
+              ? {}
+              : {
+                  email: 'dev@example.com',
+                  password: 'devpassword123',
+                },
+          ),
         })
 
         const result = await response.json()
@@ -108,7 +115,11 @@ export default function SignIn() {
               : 'bg-green-600 hover:bg-green-700 focus:ring-green-500 dark:bg-green-500 dark:hover:bg-green-600'
           }`}
         >
-          {isDevLoginEnabled ? 'Sign in (Staging)' : 'Sign in with Twitter'}
+          {isStagingLogin
+            ? 'Sign in as Alice Staging'
+            : isDevLoginEnabled
+              ? 'Sign in (Dev Mode)'
+              : 'Sign in with Twitter'}
         </button>
       </form>
     </div>

--- a/src/components/SignIn.tsx
+++ b/src/components/SignIn.tsx
@@ -8,6 +8,9 @@ export default function SignIn() {
   const searchParams = useSearchParams()
   const redirectTo = searchParams.get('redirect')
   const { userMetadata, isArchiveUploaded } = useAuthAndArchive()
+  const isDevLoginEnabled =
+    process.env.NODE_ENV === 'development' ||
+    process.env.NEXT_PUBLIC_ENABLE_STAGING_DEV_LOGIN === 'true'
 
   const signIn = async () => {
     const supabase = createBrowserClient()
@@ -15,12 +18,11 @@ export default function SignIn() {
       userMetadata,
       useremote: process.env.NEXT_PUBLIC_USE_REMOTE_DEV_DB,
       isDev: process.env.NODE_ENV === 'development',
+      isDevLoginEnabled,
     })
 
-    // Always use dev login in development mode
-    if (process.env.NODE_ENV === 'development') {
+    if (isDevLoginEnabled) {
       try {
-        // Use the dev-login API endpoint for consistent behavior
         const response = await fetch('/api/auth/dev-login', {
           method: 'POST',
           headers: {
@@ -28,7 +30,7 @@ export default function SignIn() {
           },
           body: JSON.stringify({
             email: 'dev@example.com',
-            password: 'devpassword123'
+            password: 'devpassword123',
           }),
         })
 
@@ -42,7 +44,7 @@ export default function SignIn() {
         }
 
         devLog('Dev login successful:', result)
-        
+
         // Redirect to intended page after dev login
         if (redirectTo) {
           window.location.href = redirectTo
@@ -59,10 +61,10 @@ export default function SignIn() {
         userMetadata,
         origin: window.location.origin,
       })
-      const callbackUrl = redirectTo 
+      const callbackUrl = redirectTo
         ? `${window.location.origin}/api/auth/callback?next=${encodeURIComponent(redirectTo)}`
         : `${window.location.origin}/api/auth/callback`
-      
+
       const { data, error } = await supabase.auth.signInWithOAuth({
         provider: 'twitter',
         options: {
@@ -86,13 +88,11 @@ export default function SignIn() {
     }
   }
 
-  const isDev = process.env.NODE_ENV === 'development'
-  
   return userMetadata ? (
     <form action={handleSignOut} className="inline-block">
       <button
         type="submit"
-        className="px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-md transition-colors whitespace-nowrap"
+        className="whitespace-nowrap rounded-md bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
       >
         Sign Out
       </button>
@@ -102,13 +102,13 @@ export default function SignIn() {
       <form action={signIn} className="inline-block">
         <button
           type="submit"
-          className={`px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white focus:outline-none focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors duration-300 ${
-            isDev 
-              ? 'bg-yellow-600 hover:bg-yellow-700 dark:bg-yellow-500 dark:hover:bg-yellow-600 focus:ring-yellow-500' 
-              : 'bg-green-600 hover:bg-green-700 dark:bg-green-500 dark:hover:bg-green-600 focus:ring-green-500'
+          className={`rounded-md border border-transparent px-4 py-2 text-sm font-medium text-white transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-gray-800 ${
+            isDevLoginEnabled
+              ? 'bg-yellow-600 hover:bg-yellow-700 focus:ring-yellow-500 dark:bg-yellow-500 dark:hover:bg-yellow-600'
+              : 'bg-green-600 hover:bg-green-700 focus:ring-green-500 dark:bg-green-500 dark:hover:bg-green-600'
           }`}
         >
-          {isDev ? 'Sign in (Dev Mode)' : 'Sign in with Twitter'}
+          {isDevLoginEnabled ? 'Sign in (Staging)' : 'Sign in with Twitter'}
         </button>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- allow staging deployments to use an explicit email/password login bypass instead of Twitter OAuth
- keep the bypass server-gated with ENABLE_STAGING_DEV_LOGIN and refuse the known production Supabase host by default
- document staging Supabase setup, mock seed loading, and privacy-flow verification targets

## Verification
- pnpm type-check
- pnpm build

## Notes
- Staging still needs a separate Supabase project configured with these env vars and mock seed data loaded.
- This does not implement account opt-out/block tables yet; it creates the safer staging substrate for testing that work.