### PR TITLE
Bump pnpm to v9 in sync-staging-db workflow

### DIFF
--- a/.github/workflows/sync-staging-db.yaml
+++ b/.github/workflows/sync-staging-db.yaml
@@ -27,9 +27,9 @@ jobs:
           node-version: 18
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9
           run_install: false
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- `pnpm-lock.yaml` is `lockfileVersion: 9.0` but the sync-staging-db workflow used pnpm 8, causing `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` on `pnpm install --frozen-lockfile`.
- Bumps `pnpm/action-setup` to v4 with `version: 9` to match the lockfile.

## Test plan
- [x] Failing run: https://github.com/TheExGenesis/community-archive/actions/runs/26125185791
- [ ] After merge, re-trigger via `gh workflow run sync-staging-db.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)