### PR TITLE
Fix staging-sync workflow: pass placeholder Twitter env vars

### DIFF
--- a/.github/workflows/sync-staging-db.yaml
+++ b/.github/workflows/sync-staging-db.yaml
@@ -39,4 +39,8 @@ jobs:
         env:
           SUPABASE_STAGING_PROJECT_REF: ${{ secrets.SUPABASE_STAGING_PROJECT_REF }}
           STAGING_DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+          # supabase config.toml references these for the local-dev Twitter OAuth provider.
+          # Hosted DB reset only needs them to satisfy config parsing — values aren't applied.
+          SUPABASE_AUTH_TWITTER_CLIENT_ID: unused-for-staging-reset
+          SUPABASE_AUTH_TWITTER_SECRET: unused-for-staging-reset
         run: ./scripts/sync-staging-db.sh


### PR DESCRIPTION
## Summary
The first real run of the sync-staging-db workflow failed because `supabase/config.toml` references `env(SUPABASE_AUTH_TWITTER_CLIENT_ID)` / `env(SUPABASE_AUTH_TWITTER_SECRET)` for the local-dev Twitter OAuth provider, and `supabase db reset` parses the config even when targeting a remote `--db-url`. The values aren't applied to the hosted Supabase project, so placeholder strings unblock the reset.

Failing run: https://github.com/TheExGenesis/community-archive/actions/runs/26125304572

## Test plan
- [ ] Re-trigger sync-staging-db workflow after merge and confirm migrations + seed apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)