### PR TITLE
Soft-reset staging in sync-staging-db script

### DIFF
--- a/docs/staging.md
+++ b/docs/staging.md
@@ -115,12 +115,13 @@ After updating Preview env vars, redeploy the PR preview so the new values are p
 
 ## Keeping Staging Schema Current
 
-The `Sync staging database` GitHub Action resets staging from the repo schema and mock seed data:
+The `Sync staging database` GitHub Action soft-resets staging from the repo schema and mock seed data:
 
 - It runs manually via `workflow_dispatch`.
 - It runs on pushes to `main` that touch `supabase/**` or `scripts/sync-staging-db.sh`.
 - It refuses to run if `STAGING_DATABASE_URL` does not include `SUPABASE_STAGING_PROJECT_REF`.
 - It refuses the production project ref.
+- "Soft reset" means: drop every schema not on the Supabase-managed allowlist (so `auth`, `storage`, `realtime`, etc. are left intact), recreate `public`, then run `supabase db push --include-all` and load `supabase/seed.sql`. This avoids the "must be owner of …" errors `supabase db reset` hits against the hosted pooler role. `auth.users` carries over between runs — clean it manually from the Supabase dashboard if you want to wipe mock accounts.
 
 Required GitHub repository secrets (configured on the `Preview` GitHub Environment):
 

--- a/scripts/sync-staging-db.sh
+++ b/scripts/sync-staging-db.sh
@@ -37,6 +37,44 @@ if [[ "$SUPABASE_STAGING_PROJECT_REF" == "fabxmporizzqflnftavs" ]]; then
   exit 1
 fi
 
-echo "Resetting staging database and loading repo migrations + supabase/seed.sql..."
-yes | pnpm supabase db reset --db-url "$STAGING_DATABASE_URL"
+echo "Soft-resetting staging: dropping project-owned schemas + migration history..."
+# `supabase db reset` against a hosted project fails because the pooler `postgres` role does
+# not own objects in auth/storage/realtime/etc. Instead, drop only the schemas this project
+# manages (everything outside the Supabase-managed allowlist below), recreate `public`, then
+# re-run migrations from history. `supabase_migrations` is dropped so all migrations re-apply.
+psql "$STAGING_DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL'
+do $$
+declare r record;
+begin
+  for r in
+    select n.nspname
+    from pg_namespace n
+    where n.nspname not in (
+      'pg_catalog','information_schema','pg_toast',
+      'auth','storage','realtime','vault','extensions',
+      'graphql','graphql_public','pgbouncer','pgsodium',
+      'pgsodium_masks','net','supabase_functions'
+    )
+    and n.nspname not like 'pg_%'
+  loop
+    execute format('drop schema if exists %I cascade', r.nspname);
+  end loop;
+end $$;
+
+create schema public;
+grant usage on schema public to anon, authenticated, service_role;
+grant all on schema public to postgres, service_role;
+comment on schema public is 'standard public schema';
+SQL
+
+echo "Applying repo migrations to staging..."
+yes | pnpm supabase db push --include-all --db-url "$STAGING_DATABASE_URL"
+
+if [[ -f supabase/seed.sql ]]; then
+  echo "Loading mock seed data..."
+  psql "$STAGING_DATABASE_URL" -v ON_ERROR_STOP=1 -f supabase/seed.sql
+else
+  echo "supabase/seed.sql not found; skipping seed load."
+fi
+
 echo "Staging database is in sync with the current repo schema and mock seed data."


### PR DESCRIPTION
## Summary
`supabase db reset --db-url <pooler>` fails on hosted Supabase because the pooler `postgres.<ref>` role can't drop objects in `auth` / `storage` / `realtime` (`ERROR: must be owner of sequence refresh_tokens_id_seq`). See the failing run: https://github.com/TheExGenesis/community-archive/actions/runs/26125404126

This switches to a soft reset: drop every schema outside the Supabase-managed allowlist, recreate `public` with standard grants, then `supabase db push --include-all` + load `supabase/seed.sql`. Schemas dropped are determined dynamically (every schema not in the allowlist), so future repo schemas don't need a script update.

Trade-off: `auth.users` carries over between runs. Mock signups from the staging dev-login bypass accumulate and have to be cleaned from the Supabase dashboard if you want a clean auth state.

## Test plan
- [x] `bash -n` clean
- [x] Safety guards still reject prod ref / mismatched URL
- [ ] After merge: `gh workflow run sync-staging-db.yaml` and confirm the run succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)