### PR TITLE
sync-staging-db: tolerate yes(1) SIGPIPE

### DIFF
--- a/scripts/sync-staging-db.sh
+++ b/scripts/sync-staging-db.sh
@@ -69,7 +69,16 @@ if [[ -f supabase/roles.sql ]]; then
 fi
 
 echo "Applying repo migrations to staging..."
+# `yes` keeps writing after pnpm exits and dies with SIGPIPE (141); pipefail would surface
+# that as a script failure even though the push succeeded. Toggle pipefail around the call.
+set +o pipefail
 yes | pnpm supabase db push --include-all --db-url "$STAGING_DATABASE_URL"
+push_status=${PIPESTATUS[1]}
+set -o pipefail
+if [[ $push_status -ne 0 ]]; then
+  echo "supabase db push failed with status $push_status" >&2
+  exit $push_status
+fi
 
 if [[ -f supabase/seed.sql ]]; then
   echo "Loading mock seed data..."


### PR DESCRIPTION
All migrations apply successfully in the workflow run, but the script exits 1 on `yes: standard output: Broken pipe` because pipefail surfaces yes's 141. Disabling pipefail around the push and checking pnpm's exit code via PIPESTATUS instead.

Failing run: https://github.com/TheExGenesis/community-archive/actions/runs/26126109497