### PR TITLE
Trigger staging sync on PR pushes touching supabase/**

### DIFF
--- a/.github/workflows/sync-staging-db.yaml
+++ b/.github/workflows/sync-staging-db.yaml
@@ -8,8 +8,14 @@ on:
     paths:
       - 'supabase/**'
       - 'scripts/sync-staging-db.sh'
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'supabase/**'
+      - 'scripts/sync-staging-db.sh'
 
 concurrency:
+  # Single global mutex — only one run touches the staging DB at a time. Pushes queue.
   group: sync-staging-db
   cancel-in-progress: false
 
@@ -17,6 +23,9 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     environment: Preview
+    # Fork PRs can't access the Preview environment secrets — skip the job rather than
+    # let it fail. Trusted maintainers can still trigger via workflow_dispatch.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
Adds a \`pull_request\` trigger to the staging-sync workflow so any PR push that touches \`supabase/**\` or the sync script automatically refreshes the staging DB to match the PR's tree. Lets maintainers exercise DB changes on the shared staging environment before merging.

## Behavior
- Fires on \`opened\` / \`synchronize\` / \`reopened\` with the same path filter as the existing \`push\` trigger
- **Fork-safe**: job-level \`if\` skips fork PRs (they don't have access to Preview environment secrets); trusted maintainers can still trigger via \`workflow_dispatch\`
- **Concurrency**: kept as a single global \`sync-staging-db\` mutex with \`cancel-in-progress: false\` so the staging DB never has two concurrent runs racing

## Trade-off
Staging is one shared DB — last PR synced wins. If multiple DB-changing PRs are open at once and you want to test a specific one, dispatch manually:
\`\`\`
gh workflow run sync-staging-db.yaml --ref <pr-branch>
\`\`\`

## Test plan
- [x] YAML parses clean
- [ ] After merge, push a no-op commit to a PR touching \`supabase/**\` and confirm the workflow fires + completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)