### PR TITLE
Staging: multi-user dev login + richer mock data

### DIFF
--- a/docs/staging.md
+++ b/docs/staging.md
@@ -30,14 +30,14 @@ STAGING_DEV_LOGIN_DISPLAY_NAME=Alice Staging
 ALLOW_STAGING_DEV_LOGIN_ON_PROD_SUPABASE=false
 ```
 
-The default staging login identity is:
+The default staging login identity is configured via env:
 
 - Email: value of `STAGING_DEV_LOGIN_EMAIL`
-- Password: value of `STAGING_DEV_LOGIN_PASSWORD`
+- Password: value of `STAGING_DEV_LOGIN_PASSWORD` (shared by every staging mock user)
 - Mock Twitter username: value of `STAGING_DEV_LOGIN_USERNAME`
 - Mock Twitter account id: value of `STAGING_DEV_LOGIN_PROVIDER_ID`
 
-The staging UI does not ask for these credentials. When `NEXT_PUBLIC_ENABLE_STAGING_DEV_LOGIN=true`, the sign-in button calls the server-side staging login route with no client-side password. The server uses `STAGING_DEV_LOGIN_PASSWORD` from the staging environment.
+The staging UI shows a dropdown of seeded mock users (currently `alice_dev` and `xiq_dev`, see `supabase/seed.sql`) plus a sign-in button. Picking a user posts `{ username, providerId, displayName }` to the dev-login route; the server uses `STAGING_DEV_LOGIN_PASSWORD` from the environment as the shared password and derives the email as `<username>@staging.local`. No password is sent from the client. You can also deep-link to a specific user with `?as=<username>` on the sign-in page.
 
 Do not commit the real password. The bootstrap script below writes it to an ignored `.env.staging.generated` file so it can be copied into Vercel's Preview environment.
 
@@ -132,12 +132,13 @@ Use the Supabase Dashboard connection string for `STAGING_DATABASE_URL`. Prefer 
 
 ## What To Verify Before Privacy PRs
 
-- Staging login creates/signs in the configured mock user.
+- Staging login creates/signs in the picked mock user (alice_dev, xiq_dev, etc.).
 - `/profile` resolves the mock account and shows archive state.
 - Upload and opt-in flows mutate only the staging database.
-- Explicit opt-out/deletion removes or hides the mock user's public data.
-- Thread pages still render acceptably when one account in the thread has been deleted or blocked.
+- Explicit opt-out/deletion removes or hides the mock user's public data, **including** orphan rows inserted with NULL `archive_upload_id` (the seed includes a few of these in `followers`, `following`, and `likes` so the fix can be exercised).
+- Thread pages still render acceptably when one account in the thread (e.g. `alice_dev` participating in the postgres-RPC conversation with `bob_writes` and `xiq_dev`) has been deleted or blocked.
 - Public pages do not show opted-out account data after deletion/hiding.
+- Quote-tweet relationships across two staging users (`alice_dev` quotes `xiq_dev`'s `t_xiq_1`; `eve_data` quotes `quoteduser`'s `t_quoted_1`) survive or are removed as expected.
 
 ## Thread Rendering TODO
 

--- a/src/app/api/auth/dev-login/route.ts
+++ b/src/app/api/auth/dev-login/route.ts
@@ -21,6 +21,11 @@ const getStagingLoginConfig = () => ({
   displayName: process.env.STAGING_DEV_LOGIN_DISPLAY_NAME ?? 'Staging User',
 })
 
+// Staging signs in as one of the seeded mock accounts. The username chosen by the client
+// picks the provider_id (which delete/admin checks rely on); the password is shared across
+// mock users because they all live on a staging-only auth backend.
+const STAGING_EMAIL_DOMAIN = 'staging.local'
+
 export async function POST(request: NextRequest) {
   const allowDevLogin = isDevelopment() || isStagingDevLoginEnabled()
 
@@ -60,13 +65,29 @@ export async function POST(request: NextRequest) {
       )
     }
 
+    // In staging, the client may pick which seeded mock user to sign in as by passing
+    // `username` / `providerId` / `displayName`. When unspecified, fall back to the
+    // env-configured defaults (currently alice_dev). In dev, body.email/password still wins.
+    const username = (
+      body.username ??
+      (isDevelopment() ? undefined : stagingConfig.username) ??
+      stagingConfig.username
+    )
+      .toString()
+      .toLowerCase()
+    const providerId =
+      (body.providerId as string | undefined) ?? stagingConfig.providerId
+    const displayName =
+      (body.displayName as string | undefined) ?? stagingConfig.displayName
+
     const email = isDevelopment()
       ? (body.email ?? stagingConfig.email)
-      : stagingConfig.email
+      : body.username
+        ? `${username}@${STAGING_EMAIL_DOMAIN}`
+        : stagingConfig.email
     const password = isDevelopment()
       ? (body.password ?? stagingConfig.password ?? 'devpassword123')
       : stagingConfig.password
-    const username = stagingConfig.username.toLowerCase()
 
     // Try to sign in first
     const { data: signInData, error: signInError } =
@@ -84,13 +105,13 @@ export async function POST(request: NextRequest) {
             password,
             email_confirm: true,
             user_metadata: {
-              full_name: stagingConfig.displayName,
+              full_name: displayName,
               user_name: username,
-              provider_id: stagingConfig.providerId,
+              provider_id: providerId,
               provider: isDevelopment() ? 'email' : 'staging',
             },
             app_metadata: {
-              provider_id: stagingConfig.providerId,
+              provider_id: providerId,
               user_name: username,
               provider: isDevelopment() ? 'email' : 'staging',
             },

--- a/src/components/SignIn.tsx
+++ b/src/components/SignIn.tsx
@@ -3,6 +3,14 @@ import { useAuthAndArchive } from '@/hooks/useAuthAndArchive'
 import { devLog } from '@/lib/devLog'
 import { createBrowserClient } from '@/utils/supabase'
 import { useSearchParams } from 'next/navigation'
+import { useState } from 'react'
+
+// Seeded mock users available for staging dev-login bypass.
+// Keep in sync with supabase/seed.sql.
+const STAGING_USERS = [
+  { username: 'alice_dev', providerId: 'mock_alice', displayName: 'Alice Developer' },
+  { username: 'xiq_dev',   providerId: 'mock_xiq',   displayName: 'XIQ Dev' },
+] as const
 
 export default function SignIn() {
   const searchParams = useSearchParams()
@@ -14,6 +22,14 @@ export default function SignIn() {
   const isStagingLogin =
     process.env.NODE_ENV !== 'development' &&
     process.env.NEXT_PUBLIC_ENABLE_STAGING_DEV_LOGIN === 'true'
+
+  // ?as=<username> lets you deep-link to a specific staging user, otherwise default to first.
+  const asParam = searchParams.get('as')
+  const initialUser =
+    STAGING_USERS.find((u) => u.username === asParam) ?? STAGING_USERS[0]
+  const [selectedUser, setSelectedUser] = useState<(typeof STAGING_USERS)[number]>(
+    initialUser,
+  )
 
   const signIn = async () => {
     const supabase = createBrowserClient()
@@ -33,7 +49,11 @@ export default function SignIn() {
           },
           body: JSON.stringify(
             isStagingLogin
-              ? {}
+              ? {
+                  username: selectedUser.username,
+                  providerId: selectedUser.providerId,
+                  displayName: selectedUser.displayName,
+                }
               : {
                   email: 'dev@example.com',
                   password: 'devpassword123',
@@ -105,7 +125,24 @@ export default function SignIn() {
       </button>
     </form>
   ) : (
-    <div className="inline-block">
+    <div className="inline-flex items-center gap-2">
+      {isStagingLogin && (
+        <select
+          value={selectedUser.username}
+          onChange={(e) => {
+            const next = STAGING_USERS.find((u) => u.username === e.target.value)
+            if (next) setSelectedUser(next)
+          }}
+          className="rounded-md border border-yellow-700 bg-white px-2 py-1.5 text-sm font-medium text-yellow-900 focus:outline-none focus:ring-2 focus:ring-yellow-500 dark:border-yellow-500 dark:bg-gray-800 dark:text-yellow-200"
+          aria-label="Pick staging mock user"
+        >
+          {STAGING_USERS.map((u) => (
+            <option key={u.username} value={u.username}>
+              {u.displayName} (@{u.username})
+            </option>
+          ))}
+        </select>
+      )}
       <form action={signIn} className="inline-block">
         <button
           type="submit"
@@ -116,7 +153,7 @@ export default function SignIn() {
           }`}
         >
           {isStagingLogin
-            ? 'Sign in as Alice Staging'
+            ? `Sign in as ${selectedUser.displayName}`
             : isDevLoginEnabled
               ? 'Sign in (Dev Mode)'
               : 'Sign in with Twitter'}

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -19,13 +19,14 @@ SET row_security = off;
 -- Accounts
 INSERT INTO "public"."all_account" ("account_id", "created_via", "username", "created_at", "account_display_name", "num_tweets", "num_following", "num_followers", "num_likes")
 VALUES
-  ('mock_alice',  'web', 'alice_dev',   '2019-03-15T10:00:00Z', 'Alice Developer', 3, 2, 4, 0),
+  ('mock_alice',  'web', 'alice_dev',   '2019-03-15T10:00:00Z', 'Alice Developer', 5, 3, 5, 1),
   ('mock_bob',    'web', 'bob_writes',  '2020-06-01T12:00:00Z', 'Bob Writes',      2, 1, 2, 0),
   ('mock_carol',  'web', 'carol_ml',    '2018-11-20T08:00:00Z', 'Carol ML',        2, 3, 2, 0),
   ('mock_dave',   'web', 'dave_design', '2021-01-10T14:00:00Z', 'Dave Design',     1, 2, 1, 0),
   ('mock_eve',    'web', 'eve_data',    '2020-09-05T16:00:00Z', 'Eve Data',        2, 1, 1, 0),
   ('mock_frank',  'web', 'frank_ops',   '2022-02-14T09:00:00Z', 'Frank Ops',       1, 2, 0, 0),
-  ('mock_quoted', 'web', 'quoteduser',  '2017-05-01T00:00:00Z', 'Quoted User',     1, 0, 0, 0);
+  ('mock_quoted', 'web', 'quoteduser',  '2017-05-01T00:00:00Z', 'Quoted User',     1, 0, 0, 0),
+  ('mock_xiq',    'web', 'xiq_dev',     '2018-08-20T09:00:00Z', 'XIQ Dev',         3, 2, 3, 1);
 
 -- Archive uploads (must be 'completed' for account/profile views to work)
 INSERT INTO "public"."archive_upload" ("id", "account_id", "archive_at", "created_at", "upload_phase") OVERRIDING SYSTEM VALUE
@@ -36,7 +37,8 @@ VALUES
   (104, 'mock_dave',   '2024-12-01T00:00:00Z', '2024-12-01T00:00:00Z', 'completed'),
   (105, 'mock_eve',    '2024-12-01T00:00:00Z', '2024-12-01T00:00:00Z', 'completed'),
   (106, 'mock_frank',  '2024-12-01T00:00:00Z', '2024-12-01T00:00:00Z', 'completed'),
-  (107, 'mock_quoted', '2024-12-01T00:00:00Z', '2024-12-01T00:00:00Z', 'completed');
+  (107, 'mock_quoted', '2024-12-01T00:00:00Z', '2024-12-01T00:00:00Z', 'completed'),
+  (108, 'mock_xiq',    '2024-12-01T00:00:00Z', '2024-12-01T00:00:00Z', 'completed');
 
 SELECT setval(pg_get_serial_sequence('public.archive_upload', 'id'), 200);
 
@@ -49,7 +51,8 @@ VALUES
   ('mock_dave',   'Design systems enthusiast',           NULL,                    'Berlin',        'https://api.dicebear.com/7.x/avataaars/svg?seed=dave_design', NULL, 104),
   ('mock_eve',    'Data engineering all day',            'https://evedata.io',    'Tokyo',         'https://api.dicebear.com/7.x/avataaars/svg?seed=eve_data',    NULL, 105),
   ('mock_frank',  'DevOps and infrastructure',           NULL,                    'Austin',        'https://api.dicebear.com/7.x/avataaars/svg?seed=frank_ops',   NULL, 106),
-  ('mock_quoted', 'Quotes and RTs',                      NULL,                    NULL,            'https://api.dicebear.com/7.x/avataaars/svg?seed=quoteduser',  NULL, 107);
+  ('mock_quoted', 'Quotes and RTs',                      NULL,                    NULL,            'https://api.dicebear.com/7.x/avataaars/svg?seed=quoteduser',  NULL, 107),
+  ('mock_xiq',    'Distributed systems & formal methods',NULL,                    'Lisbon',        'https://api.dicebear.com/7.x/avataaars/svg?seed=xiq_dev',     NULL, 108);
 
 -- Tweets (with conversation threads)
 INSERT INTO "public"."tweets" ("tweet_id", "account_id", "created_at", "full_text", "retweet_count", "favorite_count", "reply_to_tweet_id", "reply_to_user_id", "reply_to_username", "archive_upload_id")
@@ -78,16 +81,30 @@ VALUES
   ('t_frank_1', 'mock_frank', '2024-11-05T10:00:00Z', 'Deployed our new monitoring stack today. Grafana + Prometheus + custom alerting. Finally sleeping through the night.', 4, 18, NULL, NULL, NULL, 106),
 
   -- Quoted user
-  ('t_quoted_1', 'mock_quoted', '2024-10-15T12:00:00Z', 'The best code is the code you never write. Reduce complexity before adding features.', 30, 120, NULL, NULL, NULL, 107);
+  ('t_quoted_1', 'mock_quoted', '2024-10-15T12:00:00Z', 'The best code is the code you never write. Reduce complexity before adding features.', 30, 120, NULL, NULL, NULL, 107),
+
+  -- XIQ: standalone tweet (will be quoted by Alice)
+  ('t_xiq_1',   'mock_xiq',   '2024-10-28T09:00:00Z', 'Most distributed systems bugs are actually unhandled partial failures pretending to be edge cases.', 18, 72, NULL, NULL, NULL, 108),
+  -- XIQ joins Alice''s thread (reply to t_alice_3)
+  ('t_xiq_2',   'mock_xiq',   '2024-11-01T12:30:00Z', 'Add to this: if your RPC returns JSONB, version the response shape from day one. Cheap insurance.', 4, 22, 't_alice_3', 'mock_alice', 'alice_dev', 108),
+  -- Alice replies to XIQ in the same thread (and references xiq''s standalone tweet)
+  ('t_alice_4', 'mock_alice', '2024-11-01T12:45:00Z', '@xiq_dev good call — we wrap responses in {data, version} and the client picks a parser by version.', 1, 9, 't_xiq_2', 'mock_xiq', 'xiq_dev', 101),
+  -- Alice quotes XIQ''s standalone tweet (separate tweet, not in the thread)
+  ('t_alice_5', 'mock_alice', '2024-10-28T19:30:00Z', 'This — write your retry logic before you write your happy path.', 6, 28, NULL, NULL, NULL, 101),
+  -- XIQ replies to Bob''s reply in Alice''s thread (continues the conversation_id)
+  ('t_xiq_3',   'mock_xiq',   '2024-11-02T08:00:00Z', '90%! Sharing the migration notes would be a gift to the rest of us @bob_writes.', 0, 6, 't_bob_1', 'mock_bob', 'bob_writes', 108);
 
 -- Conversations (link tweets to conversation threads)
 INSERT INTO "public"."conversations" ("conversation_id", "tweet_id")
 VALUES
-  -- Alice's thread is one conversation
+  -- Alice's thread is one conversation; xiq + alice continue it after bob's reply
   ('t_alice_1', 't_alice_1'),
   ('t_alice_1', 't_alice_2'),
   ('t_alice_1', 't_alice_3'),
-  ('t_alice_1', 't_bob_1');
+  ('t_alice_1', 't_bob_1'),
+  ('t_alice_1', 't_xiq_2'),
+  ('t_alice_1', 't_alice_4'),
+  ('t_alice_1', 't_xiq_3');
 
 -- Tweet media
 INSERT INTO "public"."tweet_media" ("media_id", "tweet_id", "media_url", "media_type", "width", "height", "archive_upload_id")
@@ -101,22 +118,27 @@ INSERT INTO "public"."mentioned_users" ("user_id", "name", "screen_name", "updat
 VALUES
   ('mu_alice', 'Alice Developer', 'alice_dev',  '2024-12-01T00:00:00Z'),
   ('mu_carol', 'Carol ML',        'carol_ml',   '2024-12-01T00:00:00Z'),
-  ('mu_bob',   'Bob Writes',      'bob_writes', '2024-12-01T00:00:00Z')
+  ('mu_bob',   'Bob Writes',      'bob_writes', '2024-12-01T00:00:00Z'),
+  ('mu_xiq',   'XIQ Dev',         'xiq_dev',    '2024-12-01T00:00:00Z')
 ON CONFLICT ("user_id") DO NOTHING;
 
 -- User mentions (who was mentioned in which tweet)
 INSERT INTO "public"."user_mentions" ("id", "mentioned_user_id", "tweet_id") OVERRIDING SYSTEM VALUE
 VALUES
-  (2001, 'mu_alice', 't_bob_1');
+  (2001, 'mu_alice', 't_bob_1'),
+  (2002, 'mu_xiq',   't_alice_4'),
+  (2003, 'mu_bob',   't_xiq_3');
 
 SELECT setval(pg_get_serial_sequence('public.user_mentions', 'id'), 3000);
 
--- Quote tweets
+-- Quote tweets — Alice quotes XIQ; existing quote chain still here
 INSERT INTO "public"."quote_tweets" ("tweet_id", "quoted_tweet_id")
 VALUES
-  ('t_eve_2', 't_quoted_1');
+  ('t_eve_2',   't_quoted_1'),
+  ('t_alice_5', 't_xiq_1');
 
--- Followers
+-- Followers — also includes a few orphan rows with NULL archive_upload_id (simulating
+-- scraper/browser-extension inserts) so the delete_user_archive orphan fix can be exercised.
 INSERT INTO "public"."followers" ("id", "account_id", "follower_account_id", "archive_upload_id") OVERRIDING SYSTEM VALUE
 VALUES
   (3001, 'mock_alice', 'mock_bob',    101),
@@ -128,11 +150,18 @@ VALUES
   (3007, 'mock_carol', 'mock_alice',  103),
   (3008, 'mock_carol', 'mock_dave',   103),
   (3009, 'mock_dave',  'mock_alice',  104),
-  (3010, 'mock_eve',   'mock_frank',  105);
+  (3010, 'mock_eve',   'mock_frank',  105),
+  -- XIQ <-> Alice mutual + xiq followed by carol
+  (3011, 'mock_xiq',   'mock_alice',  108),
+  (3012, 'mock_alice', 'mock_xiq',    101),
+  (3013, 'mock_xiq',   'mock_carol',  108),
+  -- Orphan follower rows (scraper-inserted, NULL archive_upload_id)
+  (3014, 'mock_xiq',   'mock_eve',    NULL),
+  (3015, 'mock_alice', 'mock_frank',  NULL);
 
 SELECT setval(pg_get_serial_sequence('public.followers', 'id'), 4000);
 
--- Following
+-- Following — also includes orphan NULL archive_upload_id rows (scraper-inserted)
 INSERT INTO "public"."following" ("id", "account_id", "following_account_id", "archive_upload_id") OVERRIDING SYSTEM VALUE
 VALUES
   (5001, 'mock_alice',  'mock_bob',   101),
@@ -145,7 +174,12 @@ VALUES
   (5008, 'mock_dave',   'mock_eve',   104),
   (5009, 'mock_eve',    'mock_carol', 105),
   (5010, 'mock_frank',  'mock_alice', 106),
-  (5011, 'mock_frank',  'mock_eve',   106);
+  (5011, 'mock_frank',  'mock_eve',   106),
+  (5012, 'mock_xiq',    'mock_alice', 108),
+  (5013, 'mock_alice',  'mock_xiq',   101),
+  -- Orphan following rows
+  (5014, 'mock_xiq',    'mock_bob',   NULL),
+  (5015, 'mock_alice',  'mock_carol', NULL);
 
 SELECT setval(pg_get_serial_sequence('public.following', 'id'), 6000);
 
@@ -153,14 +187,19 @@ SELECT setval(pg_get_serial_sequence('public.following', 'id'), 6000);
 INSERT INTO "public"."liked_tweets" ("tweet_id", "full_text")
 VALUES
   ('liked_t_1', 'This is a great insight about distributed systems'),
-  ('liked_t_2', 'Love this approach to API design')
+  ('liked_t_2', 'Love this approach to API design'),
+  ('liked_t_3', 'CRDTs are underrated for collaborative apps')
 ON CONFLICT ("tweet_id") DO NOTHING;
 
--- Likes
+-- Likes — also includes orphan NULL archive_upload_id rows (scraper-inserted)
 INSERT INTO "public"."likes" ("id", "account_id", "liked_tweet_id", "archive_upload_id") OVERRIDING SYSTEM VALUE
 VALUES
   (7001, 'mock_alice', 'liked_t_1', 101),
-  (7002, 'mock_bob',   'liked_t_2', 102);
+  (7002, 'mock_bob',   'liked_t_2', 102),
+  (7003, 'mock_xiq',   'liked_t_3', 108),
+  -- Orphan likes
+  (7004, 'mock_xiq',   'liked_t_1', NULL),
+  (7005, 'mock_alice', 'liked_t_3', NULL);
 
 SELECT setval(pg_get_serial_sequence('public.likes', 'id'), 8000);
 


### PR DESCRIPTION
## Summary
Lets you pick which seeded mock user to sign in as on the staging dev-login bypass, and adds enough mock data to actually exercise PR #329's delete-all-user-data fix.

## Seed additions
- New user `xiq_dev` / `mock_xiq` with bio + avatar.
- Multi-account conversation thread: alice's postgres-RPC thread now continues into xiq and back to alice, with xiq also replying to bob's reply. Conversation_id `t_alice_1` covers 7 tweets across alice/bob/xiq.
- Quote tweet: alice's new `t_alice_5` quotes xiq's `t_xiq_1`.
- Mutual follow alice<->xiq, plus xiq<-carol.
- **Orphan rows** (NULL `archive_upload_id`) in `followers`, `following`, and `likes` — these are what PR #329's `delete_user_archive` fix is supposed to catch.

## Dev-login route changes
- Body now accepts optional `username`, `providerId`, `displayName`. When `username` is sent (staging), email is derived as `<username>@staging.local`. Password stays env-driven (`STAGING_DEV_LOGIN_PASSWORD`) and is shared across mock users since they all live on a staging-only auth backend.
- Backward compatible: with no body, the route falls back to the env-configured defaults (currently alice).
- Production-host guard untouched.

## SignIn UI
- Staging mode shows a small dropdown (Alice Developer / XIQ Dev) next to the sign-in button.
- `?as=<username>` deep-links to a specific user.
- Dev mode unchanged.

## Test plan
- [x] Type check + lint clean
- [ ] After merge, sync workflow auto-fires (paths trigger). Confirm staging seed reflects new data.
- [ ] On the staging Vercel preview: pick "Alice Developer" → sign in → /profile shows alice's tweets including the new thread reply and quoted-by-alice list.
- [ ] Switch to "XIQ Dev" → sign in → /profile shows xiq's 3 tweets and 1 like.
- [ ] Exercise "Delete All Your Data" on alice and on xiq separately; confirm orphan rows (NULL archive_upload_id) get wiped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)