### PR TITLE
Hydrate deleted thread parents + quotes from Twitter syndication

### DIFF
--- a/src/components/ThreadView.tsx
+++ b/src/components/ThreadView.tsx
@@ -42,17 +42,22 @@ export const ThreadView: React.FC<ThreadViewProps> = ({
     return (
       <div key={tweetId} className={`thread-tweet-container ${depth > 0 ? 'ml-8 pl-4 border-l-2 border-gray-200 dark:border-gray-700' : ''}`}>
         {tweet.is_deleted_placeholder ? (
-          // Tombstone for a tweet that was deleted but is still referenced as the
-          // parent of one or more surviving replies. We don't have author / timestamp /
-          // text since the source row is gone.
+          // Tombstone — deleted from the archive AND syndication couldn't find it.
           <div className="border border-dashed border-gray-300 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/40 text-gray-500 dark:text-gray-400 italic p-4 rounded-lg mb-4 text-sm">
             [Tweet deleted]
           </div>
         ) : (
           <div className={`
-            ${isHighlighted ? 'bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800' : 'bg-background dark:bg-secondary'}
-            p-4 rounded-lg mb-4
+            ${isHighlighted ? 'bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800' : tweet.from_external ? 'bg-amber-50/60 dark:bg-amber-900/10 border border-dashed border-amber-300 dark:border-amber-700' : 'bg-background dark:bg-secondary'}
+            p-4 rounded-lg mb-4 relative
           `}>
+            {tweet.from_external && (
+              // Hydrated at render time from Twitter syndication — not stored in our
+              // archive, not returned in search.
+              <span className="absolute right-3 top-3 text-[10px] uppercase tracking-wide text-amber-700 dark:text-amber-300 bg-amber-100 dark:bg-amber-900/40 px-1.5 py-0.5 rounded">
+                from Twitter · not archived
+              </span>
+            )}
             <TweetComponent tweet={convertToTweetData(tweet)} />
           </div>
         )}

--- a/src/components/TweetComponent.tsx
+++ b/src/components/TweetComponent.tsx
@@ -47,8 +47,12 @@ export interface TweetData {
     username: string
     account_display_name: string
     media?: TweetMedia[]
-    // True when the quoted tweet was deleted; renderer shows a tombstone.
+    // True when the quoted tweet is missing from our archive AND wasn't recoverable
+    // via Twitter syndication; renderer shows a tombstone.
     is_deleted?: boolean
+    // True when the quoted tweet was hydrated at render time from Twitter's public
+    // syndication endpoint (not from our DB); renderer marks it as not archived.
+    from_external?: boolean
   }
   // Support both interface styles for compatibility
   account?: { 
@@ -226,9 +230,19 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({ tweet, className
       )
     }
     const quotedProfilePic = quotedTweet.avatar_media_url || '/placeholder.jpg'
+    // Border + marker for syndication-hydrated quotes so it's clear the data isn't
+    // from this archive.
+    const externalClasses = quotedTweet.from_external
+      ? 'border-dashed border-amber-300 dark:border-amber-700 bg-amber-50/60 dark:bg-amber-900/10'
+      : 'border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-card'
     
     return (
-      <div className="mt-3 border border-gray-200 dark:border-gray-700 rounded-lg p-3 bg-gray-50 dark:bg-card">
+      <div className={`mt-3 border rounded-lg p-3 relative ${externalClasses}`}>
+        {quotedTweet.from_external && (
+          <span className="absolute right-2 top-2 text-[10px] uppercase tracking-wide text-amber-700 dark:text-amber-300 bg-amber-100 dark:bg-amber-900/40 px-1.5 py-0.5 rounded">
+            from Twitter · not archived
+          </span>
+        )}
         <div className="flex items-start space-x-3">
           <Avatar className="h-8 w-8 flex-shrink-0">
             <AvatarImage

--- a/src/lib/getTweetPageData.ts
+++ b/src/lib/getTweetPageData.ts
@@ -2,6 +2,10 @@ import { createServerClient } from '@/utils/supabase'
 import { cookies } from 'next/headers'
 import { ConversationTree, ThreadTweet, buildConversationTree } from './threadUtils'
 import { TweetData } from '@/components/TweetComponent'
+import {
+  fetchSyndicatedTweets,
+  type SyndicatedTweet,
+} from './twitterSyndication'
 
 interface RpcTweet {
   tweet_id: string
@@ -91,18 +95,104 @@ export async function getTweetPageData(tweetId: string): Promise<TweetPageResult
     return { tweet: null, threadTree: null }
   }
 
-  // Build the main tweet in TweetData format
-  const mainTweet = buildTweetData(result.tweet, result.media, result.mentioned_users, result.quoted_tweets)
+  // Collect every tweet id referenced by the conversation that the RPC couldn't
+  // return — these are reply targets and quoted tweets that have been deleted from
+  // our archive. Try Twitter's syndication endpoint to hydrate them so the thread
+  // view shows real content instead of a tombstone when the original tweet still
+  // exists on Twitter. Results are NOT persisted and NOT used in search.
+  const presentIds = new Set<string>(
+    result.conversation_tweets.map((ct) => ct.tweet_id),
+  )
+  const presentQuotedSources = new Set<string>(
+    result.quoted_tweets.map((qt) => qt.source_tweet_id),
+  )
+  const missingIds = new Set<string>()
 
-  // Build conversation tree
+  // Missing reply parents in the conversation
+  for (const ct of result.conversation_tweets) {
+    if (ct.reply_to_tweet_id && !presentIds.has(ct.reply_to_tweet_id)) {
+      missingIds.add(ct.reply_to_tweet_id)
+    }
+  }
+  // Missing quoted tweets (the RPC INNER JOINs enriched_tweets so deleted targets
+  // are absent from `quoted_tweets`; enriched_tweets.quoted_tweet_id still has the id)
+  if (
+    result.tweet.quoted_tweet_id &&
+    !presentQuotedSources.has(result.tweet.tweet_id)
+  ) {
+    missingIds.add(result.tweet.quoted_tweet_id)
+  }
+  for (const ct of result.conversation_tweets) {
+    if (ct.quoted_tweet_id && !presentQuotedSources.has(ct.tweet_id)) {
+      missingIds.add(ct.quoted_tweet_id)
+    }
+  }
+
+  const syndicated =
+    missingIds.size > 0
+      ? await fetchSyndicatedTweets(Array.from(missingIds))
+      : new Map<string, SyndicatedTweet | null>()
+
+  // Build the main tweet
+  const mainTweet = buildTweetData(
+    result.tweet,
+    result.media,
+    result.mentioned_users,
+    result.quoted_tweets,
+    syndicated,
+  )
+
+  // Build conversation tree, injecting hydrated tweets as ThreadTweets so they end
+  // up in their natural position instead of becoming placeholders.
   const threadTree = buildThreadTree(
     result.tweet,
     result.conversation_tweets,
     result.conversation_media,
     result.quoted_tweets,
+    syndicated,
   )
 
   return { tweet: mainTweet, threadTree }
+}
+
+// Convert a SyndicatedTweet into the quoted-tweet shape both ThreadTweet and TweetData
+// expect. Includes `from_external` so the renderer can mark it visually.
+function syndicatedToQuotedTweet(s: SyndicatedTweet) {
+  return {
+    tweet_id: s.tweet_id,
+    account_id: s.account_id,
+    created_at: s.created_at,
+    full_text: s.full_text,
+    retweet_count: s.retweet_count,
+    favorite_count: s.favorite_count,
+    avatar_media_url: s.avatar_media_url,
+    username: s.username,
+    account_display_name: s.account_display_name,
+    media: s.media,
+    from_external: true as const,
+  }
+}
+
+// Convert a SyndicatedTweet into a ThreadTweet for insertion into the conversation.
+function syndicatedToThreadTweet(s: SyndicatedTweet): ThreadTweet {
+  return {
+    tweet_id: s.tweet_id,
+    account_id: s.account_id,
+    created_at: s.created_at,
+    full_text: s.full_text,
+    retweet_count: s.retweet_count,
+    favorite_count: s.favorite_count,
+    reply_to_tweet_id: s.reply_to_tweet_id,
+    reply_to_user_id: s.reply_to_user_id,
+    reply_to_username: s.reply_to_username,
+    username: s.username,
+    account_display_name: s.account_display_name,
+    avatar_media_url: s.avatar_media_url,
+    media: s.media,
+    quote_tweet_id: null,
+    quoted_tweet: null,
+    from_external: true,
+  }
 }
 
 function buildTweetData(
@@ -110,6 +200,7 @@ function buildTweetData(
   media: RpcMedia[],
   mentionedUsers: RpcMentionedUser[],
   quotedTweets: RpcQuotedTweet[],
+  syndicated: Map<string, SyndicatedTweet | null>,
 ): TweetData {
   const tweetMedia = media.map((m) => ({
     media_url: m.media_url,
@@ -184,21 +275,22 @@ function buildTweetData(
           })),
         }
       : tweet.quoted_tweet_id
-        ? {
-            // enriched_tweets exposes quoted_tweet_id even when the quoted tweet has
-            // been deleted (the RPC's quoted_tweets join can't find it). Surface a
-            // placeholder so the renderer shows a "[Quoted tweet deleted]" card.
-            tweet_id: tweet.quoted_tweet_id,
-            account_id: '',
-            created_at: '',
-            full_text: '',
-            retweet_count: 0,
-            favorite_count: 0,
-            avatar_media_url: undefined,
-            username: '',
-            account_display_name: '',
-            is_deleted: true,
-          }
+        ? // The RPC didn't include the quoted tweet (deleted from our archive). Prefer
+          // a syndication hydration if Twitter still has it; fall back to tombstone.
+          syndicated.get(tweet.quoted_tweet_id)
+          ? syndicatedToQuotedTweet(syndicated.get(tweet.quoted_tweet_id)!)
+          : {
+              tweet_id: tweet.quoted_tweet_id,
+              account_id: '',
+              created_at: '',
+              full_text: '',
+              retweet_count: 0,
+              favorite_count: 0,
+              avatar_media_url: undefined,
+              username: '',
+              account_display_name: '',
+              is_deleted: true,
+            }
         : undefined,
   }
 }
@@ -208,6 +300,7 @@ function buildThreadTree(
   conversationTweets: RpcTweet[],
   conversationMedia: RpcMedia[],
   quotedTweets: RpcQuotedTweet[],
+  syndicated: Map<string, SyndicatedTweet | null>,
 ): ConversationTree | null {
   if (conversationTweets.length <= 1) {
     return null
@@ -262,20 +355,38 @@ function buildThreadTree(
             })),
           }
         : ct.quoted_tweet_id
-          ? {
-              tweet_id: ct.quoted_tweet_id,
-              account_id: '',
-              created_at: '',
-              full_text: '',
-              retweet_count: 0,
-              favorite_count: 0,
-              username: '',
-              account_display_name: '',
-              is_deleted: true,
-            }
+          ? // Quote target deleted from our archive — try syndication first, then
+            // fall back to a tombstone placeholder.
+            syndicated.get(ct.quoted_tweet_id)
+            ? syndicatedToQuotedTweet(syndicated.get(ct.quoted_tweet_id)!)
+            : {
+                tweet_id: ct.quoted_tweet_id,
+                account_id: '',
+                created_at: '',
+                full_text: '',
+                retweet_count: 0,
+                favorite_count: 0,
+                username: '',
+                account_display_name: '',
+                is_deleted: true,
+              }
           : null,
     }
   })
+
+  // For any reply target the RPC couldn't supply, inject the hydrated syndication
+  // result as a real ThreadTweet so it slots into its natural position in the tree
+  // (rather than appearing as a tombstone via buildConversationTree's placeholder).
+  const presentIds = new Set(threadTweets.map((t) => t.tweet_id))
+  for (const ct of conversationTweets) {
+    const parentId = ct.reply_to_tweet_id
+    if (!parentId || presentIds.has(parentId)) continue
+    const hydrated = syndicated.get(parentId)
+    if (hydrated) {
+      threadTweets.push(syndicatedToThreadTweet(hydrated))
+      presentIds.add(parentId)
+    }
+  }
 
   return buildConversationTree(threadTweets)
 }

--- a/src/lib/threadUtils.ts
+++ b/src/lib/threadUtils.ts
@@ -27,12 +27,19 @@ export interface ThreadTweet {
     username: string
     account_display_name: string
     media?: any[]
-    // True when the quoted tweet was deleted; other fields are placeholder defaults.
+    // True when the quoted tweet isn't in our archive AND syndication didn't find it
+    // either — renderer shows a tombstone.
     is_deleted?: boolean
+    // True when the quoted tweet content was hydrated from Twitter's public
+    // syndication endpoint rather than our DB. Renderer marks it as "not in archive".
+    from_external?: boolean
   } | null
-  // True when this node is a synthesized placeholder for a tweet that has been deleted
-  // but is still referenced by a surviving reply.
+  // True when this node was synthesized for a tweet that's missing from our archive
+  // AND Twitter syndication also couldn't supply it. Renderer shows a tombstone.
   is_deleted_placeholder?: boolean
+  // True when this tweet was hydrated at render time from Twitter's syndication
+  // endpoint, not from our DB. Renderer marks it as "not in archive".
+  from_external?: boolean
 }
 
 export interface ConversationTree {

--- a/src/lib/twitterSyndication.ts
+++ b/src/lib/twitterSyndication.ts
@@ -1,0 +1,138 @@
+/**
+ * Twitter syndication API client for transient render-time hydration of tweets that
+ * have been deleted from our archive but may still be accessible via Twitter's public
+ * embed CDN. Used to fill in deleted reply parents and deleted quoted tweets so the
+ * thread view shows real content instead of a "[Tweet deleted]" tombstone whenever
+ * Twitter still has the original.
+ *
+ * Hard rules:
+ * - Never persist the response to our DB.
+ * - Never include hydrated tweets in search results, profile listings, or any other
+ *   query path. Only render-time hydration of explicitly-referenced parent/quoted ids.
+ * - Caller decides whether to render with a "(from Twitter)" marker.
+ *
+ * The endpoint requires a `token` query param derived from the tweet id. This is
+ * the same derivation used by Vercel's `react-tweet`:
+ *   token = ((Number(id) / 1e15) * Math.PI).toString(36).replace(/(0+|\.)/g, '')
+ */
+
+const SYNDICATION_BASE = 'https://cdn.syndication.twimg.com/tweet-result'
+
+const computeToken = (id: string): string =>
+  ((Number(id) / 1e15) * Math.PI)
+    .toString(6 ** 2)
+    .replace(/(0+|\.)/g, '')
+
+export interface SyndicatedMedia {
+  media_url: string
+  media_type: string
+  width?: number
+  height?: number
+}
+
+export interface SyndicatedTweet {
+  tweet_id: string
+  account_id: string
+  username: string
+  account_display_name: string
+  created_at: string
+  full_text: string
+  retweet_count: number | null
+  favorite_count: number
+  avatar_media_url?: string
+  media?: SyndicatedMedia[]
+  reply_to_tweet_id: string | null
+  reply_to_username: string | null
+  reply_to_user_id: string | null
+  // Identifies hydrated-from-Twitter tweets in renderers so they can be marked
+  // visibly as "not in the archive".
+  from_external: true
+}
+
+/**
+ * Fetch a single tweet via Twitter's public syndication endpoint and normalize it
+ * to our ThreadTweet-compatible shape. Returns null when:
+ * - the id isn't a valid Twitter-snowflake-shaped numeric string (e.g. staging mock
+ *   ids like "t_xiq_2") — saves a guaranteed-failing roundtrip
+ * - the endpoint responds with a non-2xx
+ * - the response is a TweetTombstone (Twitter also lost the tweet)
+ * - JSON shape isn't what we expect
+ *
+ * Relies on Next.js's `fetch` cache (1h revalidate) — multiple page requests for
+ * the same tweet within an hour don't re-hit Twitter.
+ */
+export async function fetchSyndicatedTweet(
+  tweetId: string,
+): Promise<SyndicatedTweet | null> {
+  if (!/^\d{5,}$/.test(tweetId)) return null
+
+  const url = new URL(SYNDICATION_BASE)
+  url.searchParams.set('id', tweetId)
+  url.searchParams.set('token', computeToken(tweetId))
+  url.searchParams.set('lang', 'en')
+
+  let response: Response
+  try {
+    response = await fetch(url.toString(), {
+      headers: { 'User-Agent': 'Mozilla/5.0 (community-archive hydration)' },
+      next: { revalidate: 3600 },
+    })
+  } catch {
+    return null
+  }
+
+  if (!response.ok) return null
+
+  let data: any
+  try {
+    data = await response.json()
+  } catch {
+    return null
+  }
+
+  if (!data || data.__typename === 'TweetTombstone' || !data.id_str) {
+    return null
+  }
+
+  const media: SyndicatedMedia[] = Array.isArray(data.mediaDetails)
+    ? data.mediaDetails.map((m: any) => ({
+        media_url: m.media_url_https ?? m.media_url ?? '',
+        media_type: m.type ?? 'photo',
+        width: m.original_info?.width,
+        height: m.original_info?.height,
+      }))
+    : []
+
+  return {
+    tweet_id: data.id_str,
+    account_id: data.user?.id_str ?? '',
+    username: data.user?.screen_name ?? '',
+    account_display_name: data.user?.name ?? '',
+    created_at: data.created_at ?? '',
+    full_text: data.text ?? '',
+    retweet_count:
+      typeof data.conversation_count === 'number' ? data.conversation_count : null,
+    favorite_count:
+      typeof data.favorite_count === 'number' ? data.favorite_count : 0,
+    avatar_media_url: data.user?.profile_image_url_https,
+    media: media.length > 0 ? media : undefined,
+    reply_to_tweet_id: data.in_reply_to_status_id_str ?? null,
+    reply_to_username: data.in_reply_to_screen_name ?? null,
+    reply_to_user_id: data.in_reply_to_user_id_str ?? null,
+    from_external: true,
+  }
+}
+
+/**
+ * Hydrate multiple tweet ids in parallel. Failed lookups become null in the
+ * returned map. Bounded by `limit` to keep page latency reasonable when a thread
+ * references many deleted tweets.
+ */
+export async function fetchSyndicatedTweets(
+  ids: string[],
+  { limit = 12 }: { limit?: number } = {},
+): Promise<Map<string, SyndicatedTweet | null>> {
+  const unique = Array.from(new Set(ids)).slice(0, limit)
+  const results = await Promise.all(unique.map((id) => fetchSyndicatedTweet(id)))
+  return new Map(unique.map((id, i) => [id, results[i]]))
+}


### PR DESCRIPTION
## Summary
When the thread/tweet view encounters a referenced tweet that has been deleted from our archive (a reply parent or a quoted tweet), try Twitter's public syndication endpoint to fetch the original and render it in its natural position with a "from Twitter · not archived" badge. Falls back to the existing `[Tweet deleted]` / `[Quoted tweet deleted]` tombstones when Twitter no longer has it either, when the id isn't a valid Twitter snowflake (staging mocks), or when the request fails.

Hard rules:
- **Never persisted to our DB.**
- **Never returned in search or other queries** — only render-time hydration of explicitly referenced reply/quote ids on the tweet page route.
- Relies on Next.js's `fetch` cache (1h revalidate) so the same hydration isn't requested repeatedly across page views.

## Implementation
- New `src/lib/twitterSyndication.ts` — `fetchSyndicatedTweet(id)` and a parallelized `fetchSyndicatedTweets(ids, {limit=12})`. Hits `cdn.syndication.twimg.com/tweet-result` with a deterministic token derived from the id (same derivation react-tweet uses, no auth needed).
- Wired into `getTweetPageData.ts`: collect missing reply parents and missing quoted-tweet ids, batch hydrate via syndication, inject results into the thread tweets list and the quoted-tweet fields so `buildConversationTree` slots them naturally.
- `ThreadTweet` / `TweetData.quoted_tweet` gain `from_external?: boolean`.
- `ThreadView` and `TweetComponent` both add a dashed amber border and a "from Twitter · not archived" badge for `from_external` content; tombstones unchanged.

## Trade-offs / things to know
- Each missed reference adds an external HTTP roundtrip on the tweet page. Capped at 12 hydrations per page, and we rely on Next.js's `fetch` cache (1h) — should be acceptable in practice.
- The tweet page route already has `revalidate = 3600`, so hydrated content effectively gets cached together with the rendered HTML.
- Staging mocks (`t_alice_4`, etc.) aren't Twitter snowflakes — they short-circuit at the regex check and fall through to the tombstone path, same as before. This feature is only verifiable against real tweet ids.

## Test plan
- [x] type-check + lint clean
- [ ] Open `/tweets/<real-twitter-id>` where the tweet quotes a deleted tweet → expect a hydrated quote card with the amber badge
- [ ] Open a real Twitter thread where the user replies to a now-deleted parent → expect the parent to render with the amber badge above the reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)