### PR TITLE
Security: harden admin gate + hide nav from non-admins

### DIFF
--- a/src/app/admin/data.ts
+++ b/src/app/admin/data.ts
@@ -64,33 +64,43 @@ const OPT_IN_SELECT =
 const ACCOUNT_SELECT =
   'account_id, username, account_display_name, num_tweets, created_via, updated_at'
 
-const getMetadataString = (
-  metadata: Record<string, unknown>,
-  keys: string[],
-) => {
-  for (const key of keys) {
-    const value = metadata[key]
-    if (typeof value === 'string' && value.trim()) {
-      return value.trim()
+// SECURITY: only trust identity_data from the Twitter OAuth identity entry.
+// user_metadata is user-mutable via supabase.auth.updateUser({ data: ... }) —
+// reading user_name from there would let any logged-in user promote themselves
+// to admin by setting user_metadata.user_name = 'exgenesis'. identity_data is
+// set by Supabase during the OAuth callback from the provider's response and
+// is not user-editable.
+function getTwitterIdentity(user: User) {
+  return (
+    user.identities?.find((identity) =>
+      ['twitter', 'x'].includes(identity.provider ?? ''),
+    ) ?? null
+  )
+}
+
+export const getTwitterUsername = (user: User): string | null => {
+  const identity = getTwitterIdentity(user)
+  if (!identity) return null
+  const data = (identity.identity_data ?? {}) as Record<string, unknown>
+  for (const key of ['user_name', 'preferred_username', 'screen_name', 'username']) {
+    const v = data[key]
+    if (typeof v === 'string' && v.trim()) {
+      return v.trim().toLowerCase().replace(/^@/, '')
     }
   }
   return null
 }
 
-export const getTwitterUsername = (user: User) => {
-  const userMetadata = user.user_metadata ?? {}
-  const appMetadata = user.app_metadata ?? {}
-  const twitterIdentity =
-    user.identities?.find((identity) =>
-      ['twitter', 'x'].includes(identity.provider ?? ''),
-    ) ?? user.identities?.[0]
-  const identityData = twitterIdentity?.identity_data ?? {}
-
-  return getMetadataString(
-    { ...identityData, ...appMetadata, ...userMetadata },
-    ['user_name', 'preferred_username', 'username', 'screen_name'],
-  )?.toLowerCase()
+export const getTwitterProviderId = (user: User): string | null => {
+  const identity = getTwitterIdentity(user)
+  if (!identity) return null
+  const data = (identity.identity_data ?? {}) as Record<string, unknown>
+  const v = data.provider_id ?? data.sub ?? identity.id
+  return typeof v === 'string' && v.trim() ? v.trim() : null
 }
+
+const ADMIN_TWITTER_PROVIDER_ID =
+  process.env.ADMIN_TWITTER_PROVIDER_ID?.trim() || null
 
 const isKnownProductionSupabase = () =>
   process.env.NEXT_PUBLIC_SUPABASE_URL?.includes(PRODUCTION_SUPABASE_HOST) ??
@@ -100,6 +110,31 @@ const isStagingAdminAccessEnabled = () =>
   process.env.ENABLE_STAGING_DEV_LOGIN === 'true' &&
   process.env.ALLOW_STAGING_ADMIN_ON_PROD_SUPABASE !== 'true' &&
   !isKnownProductionSupabase()
+
+// Pure predicate: is this user the configured real admin? No redirects.
+// Belt-and-suspenders: matches username AND, when ADMIN_TWITTER_PROVIDER_ID is
+// configured, the immutable Twitter numeric id too. Without the env var only
+// the username is checked — strong enough as long as @exgenesis stays
+// registered to the same Twitter account.
+export function isAdminUser(user: User): boolean {
+  const usernameMatches = getTwitterUsername(user) === ADMIN_USERNAME
+  if (!usernameMatches) return false
+  if (ADMIN_TWITTER_PROVIDER_ID === null) return true
+  return getTwitterProviderId(user) === ADMIN_TWITTER_PROVIDER_ID
+}
+
+// Non-throwing variant for places that need to *know* whether the visitor is
+// admin (e.g. to hide nav links) but must not redirect.
+export async function checkIsAdmin(): Promise<boolean> {
+  const cookieStore = await cookies()
+  const supabase = createServerClient(cookieStore)
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser()
+  if (error || !user) return false
+  return isAdminUser(user) || isStagingAdminAccessEnabled()
+}
 
 export async function requireAdmin() {
   const cookieStore = await cookies()
@@ -113,10 +148,7 @@ export async function requireAdmin() {
     redirect('/login?redirect=/admin')
   }
 
-  if (
-    getTwitterUsername(user) !== ADMIN_USERNAME &&
-    !isStagingAdminAccessEnabled()
-  ) {
+  if (!isAdminUser(user) && !isStagingAdminAccessEnabled()) {
     notFound()
   }
 

--- a/src/app/api/opt-in/route.ts
+++ b/src/app/api/opt-in/route.ts
@@ -6,26 +6,23 @@ import type { User } from '@supabase/supabase-js'
 import { cookies } from 'next/headers'
 import { NextRequest, NextResponse } from 'next/server'
 
-// Derive the session's Twitter username from auth metadata. Used as the
-// source of truth for identity instead of trusting the request body —
-// otherwise a logged-in user could claim an unclaimed opt-in row for any
-// username (with the new service-role client, RLS no longer blocks this).
+// Derive the session's Twitter username from the OAuth identity entry.
+// SECURITY: only identity_data is trusted — user_metadata is user-mutable via
+// supabase.auth.updateUser({ data: ... }), so reading user_name from there
+// would let a logged-in user spoof their identity and claim an unclaimed
+// opt-in row for any username (combined with the service-role client that
+// bypasses RLS, this would be a real impersonation vector).
 function getSessionTwitterUsername(user: User): string | null {
-  const sources: Record<string, unknown>[] = [
-    user.user_metadata ?? {},
-    user.app_metadata ?? {},
-    ...((user.identities ?? []).map((i) => i.identity_data ?? {}) as Record<
-      string,
-      unknown
-    >[]),
-  ]
-  const keys = ['user_name', 'preferred_username', 'username', 'screen_name']
-  for (const src of sources) {
-    for (const k of keys) {
-      const v = src[k]
-      if (typeof v === 'string' && v.trim()) {
-        return v.trim().toLowerCase().replace(/^@/, '')
-      }
+  const identity =
+    user.identities?.find((i) =>
+      ['twitter', 'x'].includes(i.provider ?? ''),
+    ) ?? null
+  if (!identity) return null
+  const data = (identity.identity_data ?? {}) as Record<string, unknown>
+  for (const k of ['user_name', 'preferred_username', 'screen_name', 'username']) {
+    const v = data[k]
+    if (typeof v === 'string' && v.trim()) {
+      return v.trim().toLowerCase().replace(/^@/, '')
     }
   }
   return null

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ import dynamic from 'next/dynamic'
 import HeaderNavigation from '@/components/HeaderNavigation'
 import HeaderSearch from '@/components/HeaderSearch'
 import MobileMenu from '@/components/MobileMenu'
+import { checkIsAdmin } from '@/app/admin/data'
 
 const DynamicSignIn = dynamic(() => import('@/components/SignIn'), {
   ssr: false,
@@ -26,11 +27,12 @@ export const metadata = {
   description: "A public archive of everyone's tweets ",
 }
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
+  const isAdmin = await checkIsAdmin()
   return (
     <html
       lang="en"
@@ -52,7 +54,7 @@ export default function RootLayout({
                 <Link href="/" className="flex items-center space-x-2 flex-shrink-0">
                   <span className="font-bold text-lg text-gray-800 dark:text-gray-200 whitespace-nowrap">Community Archive</span>
                 </Link>
-                <HeaderNavigation />
+                <HeaderNavigation isAdmin={isAdmin} />
                 <div className="flex items-center space-x-3">
                   <HeaderSearch />
                 </div>
@@ -61,7 +63,7 @@ export default function RootLayout({
                   <div className="text-sm">
                     <DynamicSignIn />
                   </div>
-                  <MobileMenu />
+                  <MobileMenu isAdmin={isAdmin} />
                 </div>
               </div>
             </header>

--- a/src/components/HeaderNavigation.tsx
+++ b/src/components/HeaderNavigation.tsx
@@ -12,7 +12,11 @@ import {
 } from '@/components/ui/navigation-menu'
 import { cn } from '@/utils/tailwind'
 
-export default function HeaderNavigation() {
+export default function HeaderNavigation({
+  isAdmin = false,
+}: {
+  isAdmin?: boolean
+}) {
   const pathname = usePathname()
 
   const baseNavItems = [
@@ -48,23 +52,25 @@ export default function HeaderNavigation() {
             </Link>
           </NavigationMenuItem>
         ))}
-        <NavigationMenuItem>
-          <Link href="/admin" legacyBehavior passHref>
-            <NavigationMenuLink
-              aria-label="Admin dashboard"
-              title="Admin"
-              className={cn(
-                navigationMenuTriggerStyle(),
-                'w-10 px-0 hover:bg-gray-100 dark:hover:bg-gray-800',
-                pathname === '/admin'
-                  ? 'bg-gray-100 font-semibold dark:bg-gray-800'
-                  : '',
-              )}
-            >
-              <Shield className="h-4 w-4" />
-            </NavigationMenuLink>
-          </Link>
-        </NavigationMenuItem>
+        {isAdmin ? (
+          <NavigationMenuItem>
+            <Link href="/admin" legacyBehavior passHref>
+              <NavigationMenuLink
+                aria-label="Admin dashboard"
+                title="Admin"
+                className={cn(
+                  navigationMenuTriggerStyle(),
+                  'w-10 px-0 hover:bg-gray-100 dark:hover:bg-gray-800',
+                  pathname === '/admin'
+                    ? 'bg-gray-100 font-semibold dark:bg-gray-800'
+                    : '',
+                )}
+              >
+                <Shield className="h-4 w-4" />
+              </NavigationMenuLink>
+            </Link>
+          </NavigationMenuItem>
+        ) : null}
       </NavigationMenuList>
     </NavigationMenu>
   )

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -21,17 +21,23 @@ const baseNavItems = [
 
 const streamingNavItems = [{ href: '/stream-monitor', label: 'Stream Monitor' }]
 
-const userNavItems = [
-  { href: '/profile', label: 'Profile' },
-  { href: '/admin', label: 'Admin' },
-]
+const userNavItems = [{ href: '/profile', label: 'Profile' }]
+const adminNavItems = [{ href: '/admin', label: 'Admin' }]
 
-export default function MobileMenu() {
+export default function MobileMenu({
+  isAdmin = false,
+}: {
+  isAdmin?: boolean
+}) {
   const pathname = usePathname()
   const [isOpen, setIsOpen] = useState(false)
 
-  // Include all navigation items
-  const navItems = [...baseNavItems, ...streamingNavItems, ...userNavItems]
+  const navItems = [
+    ...baseNavItems,
+    ...streamingNavItems,
+    ...userNavItems,
+    ...(isAdmin ? adminNavItems : []),
+  ]
 
   return (
     <Sheet open={isOpen} onOpenChange={setIsOpen}>


### PR DESCRIPTION
## Summary
Closes a real privilege-escalation vulnerability in the admin gate (and the
same bug class in `/api/opt-in`), and hides the admin nav for non-admins.

## The vulnerability
`getTwitterUsername` in `src/app/admin/data.ts` was merging metadata with
object spread:

```ts
{ ...identityData, ...appMetadata, ...userMetadata }
```

JS spread = last wins, so `user_metadata.user_name` beat the trustworthy
`identity_data.user_name`. **`user_metadata` is user-mutable** via
`supabase.auth.updateUser({ data: { user_name: 'exgenesis' } })` from the
browser console, so any logged-in user could promote themselves to admin.

The same merge pattern existed in `/api/opt-in`'s `getSessionTwitterUsername`,
where it would have let an attacker claim an unowned opt-in row for any
username (combined with the service-role client added in #331, RLS no
longer backstops this).

## Fix
Both helpers now read **only** `identity_data` from the Twitter OAuth
identity entry. `identity_data` is set by Supabase during the OAuth callback
from the provider's response and is not editable via the auth API.

Belt-and-suspenders: optional `ADMIN_TWITTER_PROVIDER_ID` env var. When set,
`isAdminUser` also requires `identity_data.provider_id` to match — the
immutable Twitter numeric user id — so a future @exgenesis handle swap
can't defeat the gate.

## Nav hiding
Layout becomes async, calls a new non-throwing `checkIsAdmin()` helper, and
passes `isAdmin` down to `HeaderNavigation` + `MobileMenu`. Both conditionally
render the shield and mobile Admin entry. Hiding the link doesn't gate
anything on its own — `requireAdmin()` still does that — but anon users no
longer see the link.

## Verification
- pnpm type-check ✓
- pnpm lint ✓
- pnpm build ✓
- Manual: logged out → no shield, no mobile Admin entry, `/admin` redirects
  to `/login?redirect=/admin`.
- Manual: logged in as @alice_dev (staging dev login) → shield visible
  because `isStagingAdminAccessEnabled()` permits non-admin Twitter accounts
  on staging. In prod this would resolve to false.

## Test plan
- [ ] Set `ADMIN_TWITTER_PROVIDER_ID` in Vercel prod env to your Twitter
      numeric user id for full belt-and-suspenders. Until then the gate is
      username-only (still secure given the precedence fix).
- [ ] Verify logged-out users don't see the admin shield in prod.
- [ ] Verify a non-admin logged-in user doesn't see the shield in prod.
- [ ] Verify @exgenesis still does.

## Out of scope (follow-up)
`getTwitterUsername` in `src/app/profile/page.tsx:6` has the same
user_metadata-first bug. Lower severity (display-only lookup; doesn't grant
elevated access since this PR's /api/opt-in fix enforces session-derived
username on writes), but worth tightening separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)