### PR TITLE
admin: search icon + inline loading spinner

### DIFF
--- a/src/app/admin/AdminTable.tsx
+++ b/src/app/admin/AdminTable.tsx
@@ -2,6 +2,7 @@
 
 import { Badge } from '@/components/ui/badge'
 import { Input } from '@/components/ui/input'
+import { Loader2, Search } from 'lucide-react'
 import {
   Table,
   TableBody,
@@ -289,14 +290,19 @@ export function AdminTable({
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <Input
-          value={searchInput}
-          onChange={(event) => setSearchInput(event.target.value)}
-          placeholder="Search by @username or account id (server-side)"
-          className="sm:max-w-md"
-        />
+        <div className="relative sm:max-w-md sm:flex-1">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          {searching ? (
+            <Loader2 className="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-muted-foreground" />
+          ) : null}
+          <Input
+            value={searchInput}
+            onChange={(event) => setSearchInput(event.target.value)}
+            placeholder="Search by @username or account id"
+            className="pl-9"
+          />
+        </div>
         <p className="text-xs text-muted-foreground">
-          {searching ? 'Searching… ' : ''}
           {optInCount > 0
             ? `${optInCount} opt-in row${optInCount === 1 ? '' : 's'} pinned at top · `
             : ''}


### PR DESCRIPTION
## Summary

Visual polish on the Accounts search input in `/admin`:
- Leading Search icon (matching `/user-dir`)
- Trailing inline spinner while a search request is in flight
- Dropped the "(server-side)" placeholder parenthetical — the load is
  debounced and replaces rows in place, indistinguishable from a client
  filter for the user

## Context

User reported the search "reloads the page." Reproduced locally and the
search actually works correctly — debounced server action, no URL
change, no RSC reload. The reload symptom was a stale dev-server bundle
(404'd `.next/static/chunks/*` after multiple `pnpm build` runs
clobbered the `.next/` cache). `rm -rf .next` + restart fixed it.

While verifying, I also brought the visual treatment closer to
`/user-dir`'s search so the in-place behavior is obvious without
needing to explain it in the placeholder.

## Test plan
- [x] Type a query → table filters in place, URL stays at `/admin`
- [x] Clear the query → all rows return
- [x] Search icon visible at left edge of input
- [x] Spinner shows during in-flight request
- [x] `pnpm type-check` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)