### PR TITLE
Security: lock delete_tweets to service_role only (codify prod hotfix)

### DIFF
--- a/supabase/migrations/20260521000000_lock_delete_tweets_grants.sql
+++ b/supabase/migrations/20260521000000_lock_delete_tweets_grants.sql
@@ -1,0 +1,27 @@
+-- Lock down public.delete_tweets to service_role only.
+--
+-- Background: the function is SECURITY DEFINER (runs as postgres, bypasses
+-- RLS) and has no per-tweet ownership/JWT check inside the body. The
+-- original schema (20250910105058_remote_schema.sql:9965-9967) granted
+-- EXECUTE to anon and authenticated. Combined with the SECURITY DEFINER
+-- escalation, this meant anyone holding the public anon key (shipped in
+-- every browser bundle as NEXT_PUBLIC_SUPABASE_ANON_KEY) could call the
+-- function via PostgREST RPC and delete arbitrary tweets from the
+-- archive — no login required.
+--
+-- This migration codifies a REVOKE that was applied manually to prod
+-- via the Supabase SQL editor on 2026-05-21. Without this in
+-- supabase/migrations/, the next staging db reset would silently
+-- re-grant the function to anon/authenticated and reintroduce the hole
+-- on staging.
+--
+-- If the function is ever needed again in the future, the replacement
+-- should add an ownership check inside the body (verify each tweet's
+-- account_id matches auth.jwt()->'app_metadata'->>'provider_id') and
+-- only grant EXECUTE to authenticated — same pattern as
+-- delete_user_archive / delete_single_archive.
+
+REVOKE ALL ON FUNCTION public.delete_tweets(text[]) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.delete_tweets(text[]) FROM anon;
+REVOKE ALL ON FUNCTION public.delete_tweets(text[]) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.delete_tweets(text[]) TO service_role;

--- a/supabase/schemas/prod.sql
+++ b/supabase/schemas/prod.sql
@@ -3359,9 +3359,15 @@ GRANT ALL ON FUNCTION "public"."create_temp_tables"("p_suffix" "text") TO "servi
 
 
 
-GRANT ALL ON FUNCTION "public"."delete_tweets"("p_tweet_ids" "text"[]) TO "anon";
-GRANT ALL ON FUNCTION "public"."delete_tweets"("p_tweet_ids" "text"[]) TO "authenticated";
-GRANT ALL ON FUNCTION "public"."delete_tweets"("p_tweet_ids" "text"[]) TO "service_role";
+-- public.delete_tweets is SECURITY DEFINER (runs as postgres, bypasses RLS)
+-- and has no per-tweet ownership check inside the body. Granting EXECUTE to
+-- anon/authenticated meant any holder of the public anon key could delete
+-- arbitrary tweets via PostgREST. Service-role only.
+-- See migration 20260521000000_lock_delete_tweets_grants.sql.
+REVOKE ALL ON FUNCTION "public"."delete_tweets"("p_tweet_ids" "text"[]) FROM PUBLIC;
+REVOKE ALL ON FUNCTION "public"."delete_tweets"("p_tweet_ids" "text"[]) FROM "anon";
+REVOKE ALL ON FUNCTION "public"."delete_tweets"("p_tweet_ids" "text"[]) FROM "authenticated";
+GRANT EXECUTE ON FUNCTION "public"."delete_tweets"("p_tweet_ids" "text"[]) TO "service_role";
 
 
 


### PR DESCRIPTION
## Summary

Codifies the manual REVOKE you ran in the prod Supabase SQL editor on
2026-05-21 so it survives staging resets.

## Background

`public.delete_tweets` is `SECURITY DEFINER` (runs as postgres,
bypasses RLS) and has no per-tweet ownership check in the body. The
original schema (\`supabase/migrations/20250910105058_remote_schema.sql:9965-9967\`)
granted `EXECUTE` to `anon` AND `authenticated`. Combined with the
SECURITY DEFINER escalation, this meant **anyone holding the public
anon key (shipped in every browser bundle as
`NEXT_PUBLIC_SUPABASE_ANON_KEY`) could delete arbitrary tweets from
the archive via PostgREST RPC — no login required.**

This was the C-1 finding from the 2026-05-21 security audit.

## Fix

```sql
REVOKE ALL ON FUNCTION public.delete_tweets(text[]) FROM PUBLIC;
REVOKE ALL ON FUNCTION public.delete_tweets(text[]) FROM anon;
REVOKE ALL ON FUNCTION public.delete_tweets(text[]) FROM authenticated;
GRANT EXECUTE ON FUNCTION public.delete_tweets(text[]) TO service_role;
```

Plus the same REVOKE block mirrored into `supabase/schemas/prod.sql`
(the declarative source of truth) with an inline comment explaining
why.

## Why this PR matters even though prod is already patched

The `sync-staging-db.yaml` workflow does `supabase db reset` on every
PR push, which re-applies every migration in order. Without the REVOKE
codified as a migration, the next staging reset silently re-grants
`delete_tweets` to `anon`/`authenticated` and reopens the hole on
staging. Any future prod schema sync from staging would then
re-introduce it on prod.

## Test plan
- [ ] Sync workflow reruns on staging → confirm `delete_tweets` is
      EXECUTE-restricted to `service_role`/`postgres` on staging
- [ ] No application code calls `delete_tweets` (`grep -rn delete_tweets src` returns nothing)
- [ ] Migration is idempotent (REVOKE/GRANT are safe to re-apply)

## Followup

`delete_tweets` has zero callers — consider dropping the function
entirely in a follow-up. If it ever needs to come back, the
replacement must add a JWT-based ownership check inside the body
(same pattern as `delete_user_archive` / `delete_single_archive`) and
grant EXECUTE only to `authenticated`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)