### PR TITLE
admin: surface real Postgres errors instead of generic "Failed to ..."

### DIFF
--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -13,6 +13,46 @@ import {
   normalizeUsername,
 } from './data'
 
+// Supabase's PostgrestError is a plain TypeScript type alias, not an
+// Error subclass — so `error instanceof Error` is false and a bare
+// `e.message ?? 'Failed'` was the only thing preventing the real error
+// from being swallowed. Pull a message out of anything error-shaped, log
+// the full object server-side so it shows up in deploy logs, and
+// surface a useful string to the client.
+function describeError(e: unknown, context: string): string {
+  console.error(`[admin action] ${context}:`, e)
+  if (e instanceof Error) return e.message
+  if (e && typeof e === 'object') {
+    const obj = e as {
+      message?: unknown
+      details?: unknown
+      hint?: unknown
+      code?: unknown
+    }
+    const parts: string[] = []
+    if (typeof obj.message === 'string' && obj.message.trim()) {
+      parts.push(obj.message.trim())
+    }
+    if (typeof obj.details === 'string' && obj.details.trim()) {
+      parts.push(obj.details.trim())
+    }
+    if (typeof obj.hint === 'string' && obj.hint.trim()) {
+      parts.push(`hint: ${obj.hint.trim()}`)
+    }
+    if (typeof obj.code === 'string' && obj.code.trim()) {
+      parts.push(`(${obj.code})`)
+    }
+    if (parts.length) return parts.join(' — ')
+    try {
+      return JSON.stringify(e)
+    } catch {
+      // fall through
+    }
+  }
+  if (typeof e === 'string' && e.trim()) return e
+  return `${context} failed`
+}
+
 // Returned to the client so it can patch the affected row in place — no
 // refetch round-trip and no risk of resolving to undefined on the wire (which
 // is what threw "Cannot read properties of undefined (reading 'rows')" when
@@ -214,7 +254,7 @@ export async function manualOptIn(
   } catch (e) {
     return {
       ok: false,
-      error: e instanceof Error ? e.message : 'Failed to opt in',
+      error: describeError(e, 'manual opt-in'),
     }
   }
 }
@@ -295,7 +335,7 @@ export async function adminSetOptInState(
   } catch (e) {
     return {
       ok: false,
-      error: e instanceof Error ? e.message : 'Failed to update opt-in state',
+      error: describeError(e, 'set opt-in state'),
     }
   }
 }
@@ -372,7 +412,7 @@ export async function adminOptOutAccount(
   } catch (e) {
     return {
       ok: false,
-      error: e instanceof Error ? e.message : 'Failed to opt out',
+      error: describeError(e, 'opt out'),
     }
   }
 }


### PR DESCRIPTION
## Summary

Admin actions were swallowing the actual Postgres error and showing a
generic "Failed to opt out" / "Failed to opt in" / "Failed to update
opt-in state" string. User hit this on prod and we had no idea what
was actually wrong.

## Root cause

\`PostgrestError\` in \`@supabase/supabase-js\` v2 is a plain
TypeScript type alias (\`{ message, details, hint, code }\`), not an
Error subclass. The three catch blocks all did:

\`\`\`ts
error: e instanceof Error ? e.message : 'Failed to opt out',
\`\`\`

When \`upsertScrapeBlock\` does \`throw error\`, that thrown value
fails \`instanceof Error\` and falls through to the fallback —
silently discarding the Postgres code, message, and hint.

## Fix

\`describeError(e, context)\`:
- Returns \`e.message\` if \`e instanceof Error\`
- Extracts \`message + details + hint + code\` from any error-shaped
  object (handles \`PostgrestError\`, \`AuthError\`, raw thrown objects)
- Falls back to JSON.stringify, then \`"<context> failed"\` as last resort
- Always \`console.error\`s the raw value so Vercel logs show the full
  payload even when the client message is truncated

All three catch blocks (\`manualOptIn\`, \`adminSetOptInState\`,
\`adminOptOutAccount\`) now route through it.

## What this'll likely surface on prod

User's prod hit was probably the \`admin_set_scrape_block\` RPC
missing — that migration (\`20260520050000_admin_scrape_block_rpcs.sql\`)
hasn't been applied to prod yet. After this PR ships, the next
opt-out attempt will return something like:

> function public.admin_set_scrape_block(text, boolean) does not exist — (42883)

…which makes the actual fix obvious: \`supabase db push\` against
prod (and also #348 for the \`delete_tweets\` REVOKE).

## Test plan
- [x] \`pnpm type-check\` ✓
- [x] \`pnpm lint\` ✓
- [x] Opt-out a "No opt-in row" account on staging → flips to
      Explicit opt-out, no error
- [ ] After deploy, retry opt-out on prod → expect a specific
      Postgres error message visible in the dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)