### PR TITLE
admin: fix hydration #423 + restrict staging admin to xiq_dev

### DIFF
--- a/src/app/admin/AdminTable.tsx
+++ b/src/app/admin/AdminTable.tsx
@@ -31,12 +31,24 @@ import {
 } from './actions'
 import type { AccountsCursor, MergedRow, OptInRecord } from './data'
 
+// Pinning to UTC + en-US so the same instant produces the same string on
+// both SSR (Vercel runs in UTC) and the client (any timezone). Without
+// this the SSR'd date row text differs from what the client formatter
+// produces during hydration, which surfaces as React error #423
+// ("hydration failed; React recovered by client-rendering the root").
 const formatDate = (value: string | null) => {
   if (!value) return 'never'
-  return new Intl.DateTimeFormat('en', {
-    dateStyle: 'medium',
-    timeStyle: 'short',
-  }).format(new Date(value))
+  return (
+    new Intl.DateTimeFormat('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+      timeZone: 'UTC',
+    }).format(new Date(value)) + ' UTC'
+  )
 }
 
 const compactNumber = (value: number | null | undefined) =>

--- a/src/app/admin/data.ts
+++ b/src/app/admin/data.ts
@@ -111,16 +111,53 @@ const isStagingAdminAccessEnabled = () =>
   process.env.ALLOW_STAGING_ADMIN_ON_PROD_SUPABASE !== 'true' &&
   !isKnownProductionSupabase()
 
+// Specific staging usernames that get admin powers when dev-logged in. NOT
+// every staging user — that was the old (overly permissive) behavior. Only
+// these usernames pass the gate, and only when isStagingAdminAccessEnabled()
+// is true (which can only happen off-prod).
+const STAGING_ADMIN_USERNAMES = new Set(['xiq_dev'])
+
+// Read the username Supabase Auth Admin set for this user. app_metadata is
+// not mutable via the regular auth API (only the admin SDK can write to it),
+// so reading it for an identity decision is safe — unlike user_metadata.
+// Returns null on prod where the staging code path doesn't apply.
+function getStagingAdminUsername(user: User): string | null {
+  if (!isStagingAdminAccessEnabled()) return null
+  const v = (user.app_metadata as { user_name?: unknown } | undefined)
+    ?.user_name
+  if (typeof v !== 'string') return null
+  return v.trim().toLowerCase().replace(/^@/, '') || null
+}
+
 // Pure predicate: is this user the configured real admin? No redirects.
-// Belt-and-suspenders: matches username AND, when ADMIN_TWITTER_PROVIDER_ID is
-// configured, the immutable Twitter numeric id too. Without the env var only
-// the username is checked — strong enough as long as @exgenesis stays
-// registered to the same Twitter account.
+// Two paths:
+//
+//   1. Real Twitter OAuth identity matches ADMIN_USERNAME. On prod, this
+//      is the only path that returns true — guarded by username plus,
+//      when ADMIN_TWITTER_PROVIDER_ID is set, the immutable Twitter
+//      numeric id (belt-and-suspenders against a future handle takeover).
+//
+//   2. (staging only) app_metadata.user_name is in the
+//      STAGING_ADMIN_USERNAMES allowlist. The dev-login route sets
+//      app_metadata.user_name to whatever username the dev-login form
+//      requested, and app_metadata is server-set and not mutable via the
+//      regular auth API — so this is a safe identity claim on staging.
 export function isAdminUser(user: User): boolean {
-  const usernameMatches = getTwitterUsername(user) === ADMIN_USERNAME
-  if (!usernameMatches) return false
-  if (ADMIN_TWITTER_PROVIDER_ID === null) return true
-  return getTwitterProviderId(user) === ADMIN_TWITTER_PROVIDER_ID
+  const twitterUsername = getTwitterUsername(user)
+  if (twitterUsername === ADMIN_USERNAME) {
+    if (ADMIN_TWITTER_PROVIDER_ID === null) return true
+    return getTwitterProviderId(user) === ADMIN_TWITTER_PROVIDER_ID
+  }
+  const stagingName = getStagingAdminUsername(user)
+  if (stagingName && STAGING_ADMIN_USERNAMES.has(stagingName)) return true
+  return false
+}
+
+// Username to display at the top of the admin page. Identity_data first
+// (real Twitter OAuth), staging dev-login app_metadata as fallback so the
+// header shows '@xiq_dev' instead of '@' when signed in via dev-login.
+export function getDisplayUsername(user: User): string | null {
+  return getTwitterUsername(user) ?? getStagingAdminUsername(user)
 }
 
 // Non-throwing variant for places that need to *know* whether the visitor is
@@ -133,7 +170,7 @@ export async function checkIsAdmin(): Promise<boolean> {
     error,
   } = await supabase.auth.getUser()
   if (error || !user) return false
-  return isAdminUser(user) || isStagingAdminAccessEnabled()
+  return isAdminUser(user)
 }
 
 export async function requireAdmin() {
@@ -148,7 +185,9 @@ export async function requireAdmin() {
     redirect('/login?redirect=/admin')
   }
 
-  if (!isAdminUser(user) && !isStagingAdminAccessEnabled()) {
+  // The staging allowance is now baked into isAdminUser (specific
+  // usernames only); no blanket bypass.
+  if (!isAdminUser(user)) {
     notFound()
   }
 

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -9,7 +9,7 @@ import {
 import { AdminTable } from './AdminTable'
 import {
   ADMIN_USERNAME,
-  getTwitterUsername,
+  getDisplayUsername,
   loadInitialAccounts,
   normalizeUsername,
   requireAdmin,
@@ -25,7 +25,7 @@ export default async function AdminPage({
   const { user } = await requireAdmin()
   const search = normalizeUsername(searchParams?.q)
   const data = await loadInitialAccounts(search)
-  const twitterUsername = getTwitterUsername(user)
+  const twitterUsername = getDisplayUsername(user)
 
   return (
     <main className="min-h-screen bg-white dark:bg-background">


### PR DESCRIPTION
## Two fixes shipped together

Both touch the admin gate area so they share a PR.

### 1. React error #423 (hydration mismatch on the dates column)

`formatDate` in `src/app/admin/AdminTable.tsx` used
`Intl.DateTimeFormat` without a `timeZone`, so the formatter picked
up the runtime's local zone. Vercel SSR runs in UTC and the user's
browser runs in their local zone, so the SSR'd HTML and the client's
first render disagreed by N hours, producing the React #423 console
error.

Pin `timeZone: 'UTC'` and append " UTC" to the rendered string.
Deterministic across SSR + any client. Small UX regression (admin
sees UTC times) in exchange for no hydration error.

### 2. Staging admin: only xiq_dev, alice_dev now denied

Before: `requireAdmin` was

```ts
if (!isAdminUser(user) && !isStagingAdminAccessEnabled()) notFound()
```

which let *every* logged-in user pass on staging. That made it
impossible to test the non-admin path while signed in. Tightened:

- The real-OAuth path (prod) remains: `identity_data.user_name === 'exgenesis'`, with the optional `ADMIN_TWITTER_PROVIDER_ID` belt-and-suspenders check.
- The staging dev-login path now checks `app_metadata.user_name`
  against a hard-coded allowlist of `STAGING_ADMIN_USERNAMES =
  {'xiq_dev'}`. `app_metadata` is server-set by
  `/api/auth/dev-login` and is not mutable via the regular auth API
  (only the admin SDK can write to it), so reading it for an
  identity decision is safe — unlike `user_metadata`.

The staging blanket bypass is removed from `requireAdmin` and
`checkIsAdmin`.

Behavior after this PR on staging:

| Signed in as | `/admin` | nav shield |
|--|--|--|
| `alice_dev` | 404 | hidden |
| `xiq_dev`   | works | shown |

The login UI's existing dropdown (`STAGING_USERS` in
`src/components/SignIn.tsx`) makes picking xiq_dev for testing one
click.

Also added `getDisplayUsername(user)` so the `@…` badge on the admin
page renders `@xiq_dev` instead of `@` when signed in via dev-login
(dev-login users have no Twitter identity entry, only `app_metadata`).

## Test plan
- [x] `pnpm type-check`
- [x] `pnpm lint`
- [ ] After merge: sign in as alice_dev → `/admin` 404, no shield in nav.
- [ ] Sign out, sign in as xiq_dev → `/admin` works, shield visible, header badge shows `@xiq_dev`.
- [ ] No more `Minified React error #423` in the browser console on the admin page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)