### PR TITLE
admin: show actual archived tweet count alongside Twitter profile count

### DIFF
--- a/src/app/admin/AdminTable.tsx
+++ b/src/app/admin/AdminTable.tsx
@@ -257,6 +257,10 @@ export function AdminTable({
             username: updated.username,
             account: result.account ?? null,
             archiveUploadCount: result.archiveUploadCount ?? 0,
+            // Best-effort: server-side manualOptIn doesn't fetch the
+            // archived tweet count for the prepended row (would cost a
+            // COUNT per call). Page-level refresh fills it in.
+            archivedTweetCount: 0,
             blockedFromScraping: result.blockedFromScraping,
             optInRecord: updated,
             fromOptIn: true,
@@ -276,6 +280,9 @@ export function AdminTable({
         archiveUploadCount: result.archiveDeleted
           ? 0
           : (result.archiveUploadCount ?? row.archiveUploadCount),
+        // archiveDeleted clears archived count to 0; otherwise preserve
+        // the prior server-computed value.
+        archivedTweetCount: result.archiveDeleted ? 0 : row.archivedTweetCount,
       }
       return next
     })
@@ -431,12 +438,24 @@ export function AdminTable({
                   <OptInStatusBadge record={row.optInRecord} />
                 </TableCell>
                 <TableCell>
-                  {row.account ? (
+                  {row.account || row.archivedTweetCount > 0 ? (
                     <div>
-                      <div>{compactNumber(row.account.num_tweets)} tweets</div>
+                      <div>
+                        {compactNumber(row.archivedTweetCount)} archived
+                        {row.account &&
+                        row.account.num_tweets != null &&
+                        row.account.num_tweets !== row.archivedTweetCount ? (
+                          <span className="text-muted-foreground">
+                            {' '}
+                            (
+                            {compactNumber(row.account.num_tweets)} on
+                            Twitter)
+                          </span>
+                        ) : null}
+                      </div>
                       <div className="text-xs text-muted-foreground">
-                        {row.archiveUploadCount} direct uploads · via{' '}
-                        {row.account.created_via}
+                        {row.archiveUploadCount} direct uploads
+                        {row.account ? ` · via ${row.account.created_via}` : ''}
                       </div>
                     </div>
                   ) : (

--- a/src/app/admin/data.ts
+++ b/src/app/admin/data.ts
@@ -38,6 +38,15 @@ export type MergedRow = {
   username: string
   account: AccountRecord | null
   archiveUploadCount: number
+  /**
+   * Actual `COUNT(*) FROM public.tweets WHERE account_id = ?`. Distinct from
+   * `account.num_tweets`, which is the Twitter public-profile counter the
+   * scraper writes — that number reflects what the account has on Twitter,
+   * not what we have stored. For `twitter_import` accounts the two can
+   * differ by 10–1000x; for `web` (uploaded archive) accounts they roughly
+   * match (off by retweets/replies the archive sometimes excludes).
+   */
+  archivedTweetCount: number
   blockedFromScraping: boolean
   optInRecord: OptInRecord | null
   /** True when this row was sourced from public.optin (vs all_account only). */
@@ -249,6 +258,40 @@ async function fetchUploadCounts(
   }, new Map())
 }
 
+// Actual `COUNT(*)` of rows in public.tweets per account. We need this
+// alongside all_account.num_tweets because the latter is the Twitter
+// public-profile counter (what the scraper saw at ingest), not what we
+// have stored — they can differ by 10–1000x for scrape-sourced accounts.
+// Done as N parallel `head:true` counts (one per account) rather than a
+// SELECT-then-aggregate, because:
+//   - SELECT account_id would be capped at 1000 rows by PostgREST and we
+//     could be summing across millions of tweet rows
+//   - GROUP BY isn't expressible from supabase-js without an RPC
+//   - 50 accounts × 10 concurrency = 5 batches, ~250ms end-to-end —
+//     fine for a per-page admin view, no RPC migration needed
+async function fetchArchivedTweetCounts(
+  admin: AdminClient,
+  accountIds: string[],
+): Promise<Map<string, number>> {
+  if (!accountIds.length) return new Map()
+  const CONCURRENCY = 10
+  const result = new Map<string, number>()
+  for (let i = 0; i < accountIds.length; i += CONCURRENCY) {
+    const batch = accountIds.slice(i, i + CONCURRENCY)
+    const counts = await Promise.all(
+      batch.map(async (id) => {
+        const { count, error } = await admin
+          .from('tweets')
+          .select('tweet_id', { count: 'exact', head: true })
+          .eq('account_id', id)
+        return { id, count: error ? 0 : (count ?? 0) }
+      }),
+    )
+    for (const c of counts) result.set(c.id, c.count)
+  }
+  return result
+}
+
 async function fetchOptInRows(
   admin: AdminClient,
   search: string,
@@ -334,6 +377,7 @@ function buildOptInMergedRows(
   accountsByUsername: Map<string, AccountRecord>,
   accountsById: Map<string, AccountRecord>,
   uploadCounts: Map<string, number>,
+  archivedTweetCounts: Map<string, number>,
   blocked: Set<string>,
 ): MergedRow[] {
   return records.map((record) => {
@@ -352,6 +396,9 @@ function buildOptInMergedRows(
       archiveUploadCount: account
         ? (uploadCounts.get(account.account_id) ?? 0)
         : 0,
+      archivedTweetCount: effectiveAccountId
+        ? (archivedTweetCounts.get(effectiveAccountId) ?? 0)
+        : 0,
       blockedFromScraping: effectiveAccountId
         ? blocked.has(effectiveAccountId)
         : false,
@@ -364,6 +411,7 @@ function buildOptInMergedRows(
 function buildAccountMergedRows(
   accounts: AccountRecord[],
   uploadCounts: Map<string, number>,
+  archivedTweetCounts: Map<string, number>,
   blocked: Set<string>,
 ): MergedRow[] {
   return accounts.map((account) => ({
@@ -371,6 +419,7 @@ function buildAccountMergedRows(
     username: account.username,
     account,
     archiveUploadCount: uploadCounts.get(account.account_id) ?? 0,
+    archivedTweetCount: archivedTweetCounts.get(account.account_id) ?? 0,
     blockedFromScraping: blocked.has(account.account_id),
     optInRecord: null,
     fromOptIn: false,
@@ -436,29 +485,39 @@ export async function loadInitialAccounts(
     ...firstAccounts.map((a) => a.account_id),
   ].filter(Boolean)
 
-  const [uploadCounts, scrapeBlocklist] = await Promise.all([
-    fetchUploadCounts(
-      admin,
-      Array.from(
-        new Set([
-          ...optInAccountList.map((a) => a.account_id),
-          ...firstAccounts.map((a) => a.account_id),
-        ]),
-      ),
-    ),
-    fetchScrapeBlocklist(admin, candidateAccountIds),
-  ])
+  const accountIdsForCounts = Array.from(
+    new Set([
+      ...optInAccountList.map((a) => a.account_id),
+      ...firstAccounts.map((a) => a.account_id),
+      // Include opt-in rows' twitter_user_id even when no matching
+      // all_account exists, so the archived count can still resolve from
+      // tweets table (rare but possible for accounts the firehose touched
+      // before user_directory got refreshed).
+      ...optInRecords
+        .map((r) => r.twitter_user_id)
+        .filter((id): id is string => Boolean(id)),
+    ]),
+  )
+
+  const [uploadCounts, archivedTweetCounts, scrapeBlocklist] =
+    await Promise.all([
+      fetchUploadCounts(admin, accountIdsForCounts),
+      fetchArchivedTweetCounts(admin, accountIdsForCounts),
+      fetchScrapeBlocklist(admin, candidateAccountIds),
+    ])
 
   const optInRows = buildOptInMergedRows(
     optInRecords,
     accountsByUsernameMap,
     accountsByIdMap,
     uploadCounts,
+    archivedTweetCounts,
     scrapeBlocklist.blocked,
   )
   const accountRows = buildAccountMergedRows(
     firstAccounts,
     uploadCounts,
+    archivedTweetCounts,
     scrapeBlocklist.blocked,
   )
 
@@ -488,15 +547,18 @@ export async function loadMoreAccountsData(
   )
 
   const accountIds = accounts.map((a) => a.account_id)
-  const [uploadCounts, scrapeBlocklist] = await Promise.all([
-    fetchUploadCounts(admin, accountIds),
-    fetchScrapeBlocklist(admin, accountIds),
-  ])
+  const [uploadCounts, archivedTweetCounts, scrapeBlocklist] =
+    await Promise.all([
+      fetchUploadCounts(admin, accountIds),
+      fetchArchivedTweetCounts(admin, accountIds),
+      fetchScrapeBlocklist(admin, accountIds),
+    ])
 
   return {
     rows: buildAccountMergedRows(
       accounts,
       uploadCounts,
+      archivedTweetCounts,
       scrapeBlocklist.blocked,
     ),
     nextCursor,


### PR DESCRIPTION
## Summary

The admin table's "tweets" column was rendering `account.num_tweets`,
which is the Twitter public-profile counter the scraper writes at
ingest — **what the account has on Twitter, not what we've actually
archived**. For `twitter_import` accounts the two diverge by 10–1000x.

Numbers from a prod sample today:

| Account | `num_tweets` (was displayed) | actual `COUNT(*)` in `tweets` |
| --- | ---: | ---: |
| @Meaningness | 63,977 | 1,909 |
| @owenology | 2,946 | 2 |
| @andreasgysin | 11,815 | 81 |
| @tr_babb (archive upload) | 14,600 | 11,231 |

## Fix

`MergedRow` gains `archivedTweetCount`, populated server-side via
`fetchArchivedTweetCounts` — `N` parallel `head:true` counts
(concurrency 10) keyed by `account_id`. About 250ms for a 50-row
page; no RPC migration needed.

The cell now renders:

  - `"1,909 archived (63,977 on Twitter)"` — when the counts disagree
  - `"5,000 archived"` — when they match (staging mocks, archive uploads)
  - `"No archive data"` — when neither exists

The `(N on Twitter)` parenthetical only shows when the field disagrees
with the archived count, so the display stays compact for the common
case.

## Followup

The `>10k` warning in the "Opt out and delete data" dialog (currently
on the open #350 PR) gates on `num_tweets`, which means it fires on
accounts like `@Meaningness` (63k Twitter, 2k archived) even though
the actual export workload is tiny. Once both this PR and #350 land,
that warning should be re-pointed at `archivedTweetCount`. I'll roll
that into #350 when it next gets touched.

## Test plan

- [x] `pnpm type-check` ✓
- [x] `pnpm lint` ✓
- [x] Verified locally against staging: rows render as
      `"3 archived"`, `"5,000 archived"`, `"100,000 archived"` — no
      parenthetical because staging seed has `num_tweets ===
      archivedTweetCount` by construction.
- [ ] After deploy: verify on prod that twitter_import accounts
      render `"N archived (M on Twitter)"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)