### PR TITLE
feat(home): update hero + upload section copy

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -149,8 +149,10 @@ export default async function Homepage() {
             <h1 className="text-5xl md:text-6xl font-bold tracking-tight text-gray-900 dark:text-white">
               Community Archive
             </h1>
-            <p className="text-xl md:text-2xl text-gray-600 dark:text-gray-300">
-              An open Twitter database.
+            <p className="text-xl text-gray-600 dark:text-gray-300">
+              An open Twitter database. Join the archive to{' '}
+              <br className="hidden sm:block" />
+              contribute to open source public infrastructure.
             </p>
           </div>
 

--- a/src/components/UploadArchiveSection.tsx
+++ b/src/components/UploadArchiveSection.tsx
@@ -136,9 +136,11 @@ export default function UploadArchiveSection() {
   return (
     <div className="w-full">
       <div className="text-center mb-8">
-        <h2 className="text-3xl font-semibold text-gray-900 dark:text-white">Upload Your Archive</h2>
+        <h2 className="text-3xl font-semibold text-gray-900 dark:text-white">Upload your archive</h2>
         <p className="mt-3 text-lg text-gray-600 dark:text-gray-300">
-          Add your full Twitter history to the archive
+          Contribute to collective intelligence research{' '}
+          <br className="hidden sm:block" />
+          to build on top of our data and access our tools.
         </p>
       </div>
 


### PR DESCRIPTION
Follow-up to #395 (which merged before these final copy edits landed).

- **Hero subcopy:** "An open Twitter database. Join the archive to contribute to open source public infrastructure." — set to 20px (`text-xl`) and balanced onto two lines via a responsive `<br>`.
- **Upload section:** sentence-case "Upload your archive" header; new two-line subcopy "Contribute to collective intelligence research to build on top of our data and access our tools."

Copy-only; no logic or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)