### PR TITLE
fix(home): drop tweet count from featured avatar list

### DIFF
--- a/src/components/AvatarList.tsx
+++ b/src/components/AvatarList.tsx
@@ -49,12 +49,6 @@ const AvatarList = ({ initialAvatars, title = 'Avatars' }: AvatarListProps) => {
                 {avatar.num_followers &&
                   `${formatNumber(avatar.num_followers)} followers`}
               </span>
-              <span
-                className="mt-0.5 text-[10px] text-zinc-500 dark:text-zinc-400"
-              >
-                {avatar.num_tweets &&
-                  `${formatNumber(avatar.num_tweets)} tweets`}
-              </span>
             </a>
           ))}
         </div>


### PR DESCRIPTION
Show only the followers line under each featured account in the homepage social-proof row (removes the `… tweets` line).

Single-file copy/display change to `src/components/AvatarList.tsx`; no logic or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)