### PR TITLE
style(home): Petrona/Manrope fonts, header tuning, 8px control radius

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -56,4 +56,10 @@
   body {
     @apply bg-background text-foreground;
   }
+  /* Petrona is reserved for the hero (h1) and section headers (h2).
+     Smaller headings (card titles, etc.) stay on the Manrope body font. */
+  h1,
+  h2 {
+    font-family: var(--font-petrona), Georgia, 'Times New Roman', serif;
+  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import { GeistSans } from 'geist/font/sans'
+import { Petrona, Manrope } from 'next/font/google'
 import ThemeProvider from '@/providers/ThemeProvider'
 import NextTopLoader from 'nextjs-toploader'
 import { Analytics } from '@vercel/analytics/react'
@@ -15,6 +15,18 @@ import { checkIsAdmin } from '@/app/admin/data'
 
 const DynamicSignIn = dynamic(() => import('@/components/SignIn'), {
   ssr: false,
+})
+
+// Headings use Petrona (serif); body uses Manrope (sans).
+const petrona = Petrona({
+  subsets: ['latin'],
+  variable: '--font-petrona',
+  display: 'swap',
+})
+const manrope = Manrope({
+  subsets: ['latin'],
+  variable: '--font-manrope',
+  display: 'swap',
 })
 
 const defaultUrl = process.env.VERCEL_URL
@@ -36,7 +48,7 @@ export default async function RootLayout({
   return (
     <html
       lang="en"
-      className={`${GeistSans.className} antialiased`}
+      className={`${manrope.className} ${petrona.variable} antialiased`}
       style={{ colorScheme: 'dark' }}
       suppressHydrationWarning={true}
     >
@@ -52,7 +64,12 @@ export default async function RootLayout({
             <header className="sticky top-0 z-50 w-full border-b border-gray-200 dark:border-gray-800 bg-white/80 dark:bg-gray-950/80 backdrop-blur-md">
               <div className="container mx-auto flex h-16 max-w-screen-xl items-center justify-between px-4 sm:px-6 lg:px-8">
                 <Link href="/" className="flex items-center space-x-2 flex-shrink-0">
-                  <span className="font-bold text-lg text-gray-800 dark:text-gray-200 whitespace-nowrap">Community Archive</span>
+                  <span
+                    className="font-bold text-lg text-gray-800 dark:text-gray-200 whitespace-nowrap"
+                    style={{ fontFamily: 'var(--font-petrona), Georgia, "Times New Roman", serif' }}
+                  >
+                    Community Archive
+                  </span>
                 </Link>
                 <HeaderNavigation isAdmin={isAdmin} />
                 <div className="flex items-center space-x-3">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -156,14 +156,19 @@ export default async function Homepage() {
             </p>
           </div>
 
-          <DynamicHeroCTAButtons />
+          <div className="space-y-4">
+            <DynamicHeroCTAButtons />
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              Backed by Survival and Flourishing Fund and Vitalik Buterin
+            </p>
+          </div>
         </div>
       </section>
 
       {/* Section 2: Social Proof */}
       <section className="bg-white dark:bg-slate-900 overflow-hidden">
         <div
-          className="max-w-5xl mx-auto rounded-xl p-6 md:p-8 space-y-4 text-center bg-slate-100 dark:bg-slate-700/60"
+          className="max-w-5xl mx-auto rounded-none sm:rounded-xl p-6 md:p-8 space-y-4 text-center bg-slate-100 dark:bg-slate-700/60"
         >
           <CommunityStats
             accountCount={stats.accountCount}
@@ -200,8 +205,8 @@ export default async function Homepage() {
       <section className={`bg-white dark:bg-slate-900 ${sectionPaddingClasses} overflow-hidden`}>
         <div className={`${contentWrapperClasses} space-y-8`}>
           <div className="text-center">
-            <h2 className="text-3xl font-semibold text-gray-900 dark:text-white">Data & Source Code</h2>
-            <p className="mt-3 text-lg text-gray-600 dark:text-gray-300 max-w-xl mx-auto px-4 md:px-0">
+            <h2 className="text-3xl font-bold text-gray-900 dark:text-white">Data & Source Code</h2>
+            <p className="mt-3 text-base text-gray-600 dark:text-gray-300 max-w-xl mx-auto px-4 md:px-0">
               Access the data, explore the code, and see how everything works.
             </p>
           </div>
@@ -218,8 +223,8 @@ export default async function Homepage() {
       <section className={`bg-sky-100 dark:bg-slate-800 ${sectionPaddingClasses} overflow-hidden`}>
         <div className={`${contentWrapperClasses} space-y-8`}>
           <div className="text-center">
-            <h2 className="text-3xl font-semibold text-gray-900 dark:text-white">Our Supporters</h2>
-            <p className="mt-3 text-lg text-gray-600 dark:text-gray-300">
+            <h2 className="text-3xl font-bold text-gray-900 dark:text-white">Our Supporters</h2>
+            <p className="mt-3 text-base text-gray-600 dark:text-gray-300">
               Thanks to everyone who makes this possible
             </p>
           </div>
@@ -228,7 +233,7 @@ export default async function Homepage() {
           <div className="bg-white dark:bg-slate-800 rounded-2xl p-6 md:p-8 border border-gray-200 dark:border-slate-700 max-w-4xl mx-auto">
             {/* Major Backers */}
             <div className="text-center mb-6">
-              <p className="text-sm font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-4">Major Backers</p>
+              <p className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-4">Major Backers</p>
               <div className="flex flex-wrap justify-center items-center gap-x-6 gap-y-3">
                 <Link href="https://survivalandflourishing.fund/" target="_blank" rel="noopener noreferrer" className="text-base font-medium text-gray-700 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
                   Survival and Flourishing Fund
@@ -255,7 +260,7 @@ export default async function Homepage() {
 
             {/* Community Supporters */}
             <div className="text-center mb-4">
-              <p className="text-sm font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-4">Community Backers</p>
+              <p className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-4">Community Backers</p>
             </div>
             <TieredSupportersDisplay
               highestDonorWithImage={highestDonorWithImage}

--- a/src/components/FeaturedAppsSection.tsx
+++ b/src/components/FeaturedAppsSection.tsx
@@ -79,10 +79,10 @@ export default function FeaturedAppsSection() {
   return (
     <section className="space-y-8">
       <div className="text-center">
-        <h2 className="text-3xl font-semibold text-gray-900 dark:text-white">
+        <h2 className="text-3xl font-bold text-gray-900 dark:text-white">
           Explore the archive
         </h2>
-        <p className="mt-3 text-lg text-gray-600 dark:text-gray-300 max-w-xl mx-auto">
+        <p className="mt-3 text-base text-gray-600 dark:text-gray-300 max-w-xl mx-auto">
           Browse the evolution of Twitter narratives, ideas, memes, and stories that shape our culture today.
         </p>
       </div>

--- a/src/components/HeaderNavigation.tsx
+++ b/src/components/HeaderNavigation.tsx
@@ -41,11 +41,13 @@ export default function HeaderNavigation({
           <NavigationMenuItem key={item.href}>
             <Link href={item.href} legacyBehavior passHref>
               <NavigationMenuLink
-                className={`${navigationMenuTriggerStyle()} ${
+                className={cn(
+                  navigationMenuTriggerStyle(),
+                  'transition-colors duration-150 hover:bg-gray-100 dark:hover:bg-gray-800',
                   pathname === item.href
                     ? 'bg-gray-100 font-semibold dark:bg-gray-800' // Enhanced active style
-                    : ''
-                } transition-colors duration-150 hover:bg-gray-100 dark:hover:bg-gray-800`}
+                    : '',
+                )}
               >
                 {item.label}
               </NavigationMenuLink>

--- a/src/components/HeroCTAButtons.tsx
+++ b/src/components/HeroCTAButtons.tsx
@@ -158,9 +158,9 @@ export default function HeroCTAButtons() {
 
   const getOptInButtonText = () => {
     if (isOptInLoading) return 'Processing...'
-    if (isOptedIn) return 'Opted In'
-    if (!user) return 'Opt In'
-    return 'Opt In'
+    if (isOptedIn) return 'Opted in'
+    if (!user) return 'Opt in'
+    return 'Opt in'
   }
 
   const getOptInButtonStyle = () => {
@@ -180,7 +180,7 @@ export default function HeroCTAButtons() {
               <Button
                 onClick={handleOptIn}
                 disabled={isOptInLoading || isOptedIn === true}
-                className={`h-14 px-8 text-lg font-semibold rounded-xl w-full ${getOptInButtonStyle()}`}
+                className={`h-14 px-8 text-lg font-semibold w-full ${getOptInButtonStyle()}`}
                 size="lg"
               >
                 <Users className="w-5 h-5 mr-2" />
@@ -198,12 +198,12 @@ export default function HeroCTAButtons() {
               <Button
                 asChild
                 variant="outline"
-                className="h-14 px-8 text-lg font-semibold rounded-xl border-2 w-full"
+                className="h-14 px-8 text-lg font-semibold border-2 w-full"
                 size="lg"
               >
                 <a href={CHROME_EXTENSION_URL} target="_blank" rel="noopener noreferrer">
                   <Puzzle className="w-5 h-5 mr-2" />
-                  Extension
+                  Get extension
                 </a>
               </Button>
             </TooltipTrigger>
@@ -216,12 +216,12 @@ export default function HeroCTAButtons() {
               <Button
                 asChild
                 variant="outline"
-                className="h-14 px-8 text-lg font-semibold rounded-xl border-2 w-full"
+                className="h-14 px-8 text-lg font-semibold border-2 w-full"
                 size="lg"
               >
                 <a href="#upload-archive">
                   <Upload className="w-5 h-5 mr-2" />
-                  Upload
+                  Upload archive
                 </a>
               </Button>
             </TooltipTrigger>

--- a/src/components/SignIn.tsx
+++ b/src/components/SignIn.tsx
@@ -146,7 +146,7 @@ export default function SignIn() {
       <form action={signIn} className="inline-block">
         <button
           type="submit"
-          className={`rounded-md border border-transparent px-4 py-2 text-sm font-medium text-white transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-gray-800 ${
+          className={`rounded-[8px] border border-transparent px-4 py-2 text-sm font-medium text-white transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-gray-800 ${
             isDevLoginEnabled
               ? 'bg-yellow-600 hover:bg-yellow-700 focus:ring-yellow-500 dark:bg-yellow-500 dark:hover:bg-yellow-600'
               : 'bg-green-600 hover:bg-green-700 focus:ring-green-500 dark:bg-green-500 dark:hover:bg-green-600'

--- a/src/components/UploadArchiveSection.tsx
+++ b/src/components/UploadArchiveSection.tsx
@@ -136,8 +136,8 @@ export default function UploadArchiveSection() {
   return (
     <div className="w-full">
       <div className="text-center mb-8">
-        <h2 className="text-3xl font-semibold text-gray-900 dark:text-white">Upload your archive</h2>
-        <p className="mt-3 text-lg text-gray-600 dark:text-gray-300">
+        <h2 className="text-3xl font-bold text-gray-900 dark:text-white">Upload your archive</h2>
+        <p className="mt-3 text-base text-gray-600 dark:text-gray-300">
           Contribute to collective intelligence research{' '}
           <br className="hidden sm:block" />
           to build on top of our data and access our tools.

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/utils/tailwind"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-[8px] text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
@@ -21,8 +21,8 @@ const buttonVariants = cva(
       },
       size: {
         default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
+        sm: "h-9 rounded-[8px] px-3",
+        lg: "h-11 rounded-[8px] px-8",
         icon: "h-10 w-10",
       },
     },

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -11,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-[8px] border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -41,7 +41,7 @@ NavigationMenuList.displayName = NavigationMenuPrimitive.List.displayName
 const NavigationMenuItem = NavigationMenuPrimitive.Item
 
 const navigationMenuTriggerStyle = cva(
-  "group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-accent/50 data-[state=open]:bg-accent/50"
+  "group inline-flex h-10 w-max items-center justify-center rounded-[8px] bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-accent/50 data-[state=open]:bg-accent/50"
 )
 
 const NavigationMenuTrigger = React.forwardRef<


### PR DESCRIPTION
A homepage styling pass.

### Typography
- Swap Geist for **Petrona** (headings) + **Manrope** (body) via `next/font/google` (self-hosted).
- Petrona scoped to `h1`/`h2` (hero + section headers); `h3` card titles and the rest of the UI use Manrope.
- Section headers (`h2`): `font-bold` (700); their subcopies: `text-base` (16px).
- "Community Archive" wordmark uses Petrona; **MAJOR/COMMUNITY BACKERS** labels set to semibold.

### Hero
- CTA copy: **Opt in** / **Get extension** / **Upload archive** (Upload still scrolls to `#upload-archive`).
- Added blurb under the CTAs: _"Backed by Survival and Flourishing Fund and Vitalik Buterin"_.
- Social-proof card: square corners on mobile (`rounded-none sm:rounded-xl`).

### Controls
- Buttons, inputs, and nav links now share an **8px** radius, set at the **component level** (`button.tsx`, `input.tsx`, `navigation-menu.tsx`) plus the raw sign-in button. Uses `rounded-[8px]` because this project's `rounded-lg` is tied to `--radius` (0.3rem = 4.8px); other `rounded-lg`/`md` elements (cards, popovers) are untouched.

Styling/copy only — no logic or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)