### PR TITLE
feat(home): reorder Explore above Upload; rename to "Upload your tweets"

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -186,18 +186,18 @@ export default async function Homepage() {
         </div>
       </section>
 
-      {/* Section 3: Upload Your Archive */}
-      <section id="upload-archive" className={`bg-white dark:bg-gray-950 ${sectionPaddingClasses} scroll-mt-16 overflow-hidden`}>
-        <div className={contentWrapperClasses}>
-          <DynamicUploadArchiveSection />
-        </div>
-      </section>
-
-      {/* Section 4: Get Started - Featured Apps */}
-      <section className={`bg-sky-100 dark:bg-gray-900 ${sectionPaddingClasses} overflow-hidden`}>
+      {/* Section 3: Explore the archive - Featured Apps */}
+      <section className={`bg-white dark:bg-gray-950 ${sectionPaddingClasses} overflow-hidden`}>
         <div className={contentWrapperClasses}>
           <FeaturedAppsSection />
           <AppGallery />
+        </div>
+      </section>
+
+      {/* Section 4: Upload Your Archive */}
+      <section id="upload-archive" className={`bg-sky-100 dark:bg-gray-900 ${sectionPaddingClasses} scroll-mt-16 overflow-hidden`}>
+        <div className={contentWrapperClasses}>
+          <DynamicUploadArchiveSection />
         </div>
       </section>
 

--- a/src/components/UploadArchiveSection.tsx
+++ b/src/components/UploadArchiveSection.tsx
@@ -136,7 +136,7 @@ export default function UploadArchiveSection() {
   return (
     <div className="w-full">
       <div className="text-center mb-8">
-        <h2 className="text-3xl font-bold text-gray-900 dark:text-white">Upload your archive</h2>
+        <h2 className="text-3xl font-bold text-gray-900 dark:text-white">Upload your tweets</h2>
         <p className="mt-3 text-base text-gray-600 dark:text-gray-300">
           Contribute to collective intelligence research{' '}
           <br className="hidden sm:block" />


### PR DESCRIPTION
- Move the **"Explore the archive"** section above **"Upload your tweets"**, swapping their background classes so the bg colors stay by position (Explore = `white`/`gray-950`, Upload = `sky-100`/`gray-900`). The `#upload-archive` anchor moves with the Upload section, so the hero's "Upload archive" CTA still scrolls correctly.
- Rename the upload section header **"Upload your archive" → "Upload your tweets"**.

Copy/layout only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)