### PR TITLE
Show opted-in members in the user directory

### DIFF
--- a/database.types.ts
+++ b/database.types.ts
@@ -1211,16 +1211,11 @@ export type Database = {
           avatar_media_url: string | null
           bio: string | null
           created_at: string | null
-          directory_id: string | null
-          has_archive: boolean | null
-          is_opted_in: boolean | null
-          joined_at: string | null
           location: string | null
           num_followers: number | null
           num_following: number | null
           num_likes: number | null
           num_tweets: number | null
-          opted_in_at: string | null
           username: string | null
           website: string | null
         }

--- a/database.types.ts
+++ b/database.types.ts
@@ -1211,11 +1211,16 @@ export type Database = {
           avatar_media_url: string | null
           bio: string | null
           created_at: string | null
+          directory_id: string | null
+          has_archive: boolean | null
+          is_opted_in: boolean | null
+          joined_at: string | null
           location: string | null
           num_followers: number | null
           num_following: number | null
           num_likes: number | null
           num_tweets: number | null
+          opted_in_at: string | null
           username: string | null
           website: string | null
         }

--- a/src/app/api/opt-in/route.ts
+++ b/src/app/api/opt-in/route.ts
@@ -14,18 +14,29 @@ import { NextRequest, NextResponse } from 'next/server'
 // bypasses RLS, this would be a real impersonation vector).
 function getSessionTwitterUsername(user: User): string | null {
   const identity =
-    user.identities?.find((i) =>
-      ['twitter', 'x'].includes(i.provider ?? ''),
-    ) ?? null
+    user.identities?.find((i) => ['twitter', 'x'].includes(i.provider ?? '')) ??
+    null
   if (!identity) return null
   const data = (identity.identity_data ?? {}) as Record<string, unknown>
-  for (const k of ['user_name', 'preferred_username', 'screen_name', 'username']) {
+  for (const k of [
+    'user_name',
+    'preferred_username',
+    'screen_name',
+    'username',
+  ]) {
     const v = data[k]
     if (typeof v === 'string' && v.trim()) {
       return v.trim().toLowerCase().replace(/^@/, '')
     }
   }
   return null
+}
+
+function getSessionTwitterUserId(user: User): string | null {
+  const providerId = user.app_metadata?.provider_id
+  return typeof providerId === 'string' && providerId.trim()
+    ? providerId.trim()
+    : null
 }
 
 export async function POST(request: NextRequest) {
@@ -52,7 +63,6 @@ export async function POST(request: NextRequest) {
     const body = await request.json()
     const {
       username: bodyUsername,
-      twitterUserId,
       optedIn,
       termsVersion,
       explicitOptOut = false,
@@ -83,6 +93,7 @@ export async function POST(request: NextRequest) {
       )
     }
     const normalizedUsername = sessionUsername
+    const sessionTwitterUserId = getSessionTwitterUserId(user)
 
     const [byUserIdResponse, byUsernameResponse] = await Promise.all([
       admin.from('optin').select('*').eq('user_id', user.id).maybeSingle(),
@@ -129,7 +140,10 @@ export async function POST(request: NextRequest) {
     const payload = {
       user_id: user.id,
       username: normalizedUsername,
-      twitter_user_id: twitterUserId || null,
+      // Never associate a directory/archive account from a client-supplied ID.
+      // app_metadata is set by the auth provider and cannot be changed by users.
+      twitter_user_id:
+        sessionTwitterUserId ?? existingRecord?.twitter_user_id ?? null,
       opted_in: Boolean(optedIn) && !nextExplicitOptOut,
       terms_version: optedIn
         ? termsVersion

--- a/src/app/user-dir/page.tsx
+++ b/src/app/user-dir/page.tsx
@@ -24,6 +24,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { formatNumber } from '@/lib/formatNumber'
 import { fetchUsers, fetchUsersCount } from '@/lib/queries/fetchUsers'
 import { DirectoryUser, SortKey } from '@/lib/types'
 import { createBrowserClient } from '@/utils/supabase'
@@ -122,7 +123,7 @@ export default function UserDirectoryPage() {
       setSortOrder((current) => (current === 'asc' ? 'desc' : 'asc'))
     } else {
       setSortKey(key)
-      setSortOrder('asc')
+      setSortOrder(key === 'num_followers' ? 'desc' : 'asc')
     }
   }
 
@@ -142,7 +143,7 @@ export default function UserDirectoryPage() {
 
   return (
     <main className="min-h-screen bg-white py-12 dark:bg-background md:py-16">
-      <div className="relative mx-auto w-full max-w-5xl px-4 sm:px-6 lg:px-8">
+      <div className="relative mx-auto w-full max-w-6xl px-4 sm:px-6 lg:px-8">
         <div className="mx-auto mb-10 max-w-2xl text-center">
           <h1 className="text-4xl font-bold tracking-tight text-gray-950 dark:text-white sm:text-5xl">
             User Directory
@@ -179,7 +180,7 @@ export default function UserDirectoryPage() {
             <TableHeader className="bg-gray-50/80 dark:bg-gray-900/60">
               <TableRow className="hover:bg-transparent">
                 <TableHead
-                  className="w-[52%] py-2"
+                  className="w-[42%] py-2"
                   aria-sort={
                     sortKey === 'account_display_name'
                       ? sortOrder === 'asc'
@@ -197,8 +198,27 @@ export default function UserDirectoryPage() {
                     Member {renderSortIcon('account_display_name')}
                   </Button>
                 </TableHead>
-                <TableHead className="w-[30%] text-xs font-semibold uppercase tracking-wider">
+                <TableHead className="w-[25%] text-xs font-semibold uppercase tracking-wider">
                   Participation
+                </TableHead>
+                <TableHead
+                  className="w-[15%] py-2 text-right"
+                  aria-sort={
+                    sortKey === 'num_followers'
+                      ? sortOrder === 'asc'
+                        ? 'ascending'
+                        : 'descending'
+                      : 'none'
+                  }
+                >
+                  <Button
+                    variant="ghost"
+                    onClick={() => handleSort('num_followers')}
+                    aria-label="Sort by follower count"
+                    className="-mr-3 h-8 px-3 text-xs font-semibold uppercase tracking-wider hover:bg-gray-200/70 dark:hover:bg-gray-800"
+                  >
+                    Followers {renderSortIcon('num_followers')}
+                  </Button>
                 </TableHead>
                 <TableHead
                   className="w-[18%] py-2 text-right"
@@ -224,7 +244,7 @@ export default function UserDirectoryPage() {
             <TableBody>
               {loading ? (
                 <TableRow>
-                  <TableCell colSpan={3} className="h-40 text-center">
+                  <TableCell colSpan={4} className="h-40 text-center">
                     <span className="inline-flex items-center text-sm text-gray-500 dark:text-gray-400">
                       <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                       Loading members…
@@ -234,7 +254,7 @@ export default function UserDirectoryPage() {
               ) : error && users.length === 0 ? (
                 <TableRow>
                   <TableCell
-                    colSpan={3}
+                    colSpan={4}
                     className="h-40 text-center text-sm text-red-600 dark:text-red-400"
                   >
                     {error}
@@ -243,7 +263,7 @@ export default function UserDirectoryPage() {
               ) : users.length === 0 ? (
                 <TableRow>
                   <TableCell
-                    colSpan={3}
+                    colSpan={4}
                     className="h-40 text-center text-sm text-gray-500 dark:text-gray-400"
                   >
                     No members match “{debouncedSearch}”.
@@ -319,6 +339,11 @@ export default function UserDirectoryPage() {
                             </Badge>
                           )}
                         </div>
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap text-right text-sm font-medium tabular-nums text-gray-700 dark:text-gray-300">
+                        {user.num_followers == null
+                          ? '—'
+                          : formatNumber(user.num_followers)}
                       </TableCell>
                       <TableCell className="whitespace-nowrap text-right text-sm font-medium text-gray-700 dark:text-gray-300">
                         <time dateTime={user.joined_at || undefined}>

--- a/src/app/user-dir/page.tsx
+++ b/src/app/user-dir/page.tsx
@@ -1,327 +1,365 @@
 'use client'
-import { useEffect, useState, useCallback } from 'react'
-import { User, SortKey } from '@/lib/types'
-import { fetchUsers, fetchUsersCount } from '@/lib/queries/fetchUsers'
-import Link from 'next/link'
 
+import { useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
 import {
-  Table,
-  TableHeader,
-  TableBody,
-  TableHead,
-  TableRow,
-  TableCell,
-} from '@/components/ui/table'
-import { ArrowUpDown, Loader2, Search } from 'lucide-react'
+  Archive,
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
+  Loader2,
+  Radio,
+  Search,
+} from 'lucide-react'
+
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
-import { formatNumber } from '@/lib/formatNumber'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { fetchUsers, fetchUsersCount } from '@/lib/queries/fetchUsers'
+import { DirectoryUser, SortKey } from '@/lib/types'
 import { createBrowserClient } from '@/utils/supabase'
 
 const USERS_PER_PAGE = 50
 
+const joinedDateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+})
+
+function formatJoinedDate(date: string | null) {
+  if (!date) return '—'
+  return joinedDateFormatter.format(new Date(date))
+}
+
 export default function UserDirectoryPage() {
-  const [users, setUsers] = useState<User[]>([])
+  const supabase = useMemo(() => createBrowserClient(), [])
+  const [users, setUsers] = useState<DirectoryUser[]>([])
   const [loading, setLoading] = useState(true)
   const [loadingMore, setLoadingMore] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [sortKey, setSortKey] = useState<SortKey>('archive_uploaded_at')
+  const [sortKey, setSortKey] = useState<SortKey>('joined_at')
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
-  const [totalCount, setTotalCount] = useState<number>(0)
-  const [hasMore, setHasMore] = useState(true)
+  const [totalCount, setTotalCount] = useState(0)
   const [searchQuery, setSearchQuery] = useState('')
   const [debouncedSearch, setDebouncedSearch] = useState('')
 
-  // Style definitions copied from homepage
-  const unifiedDeepBlueBase = "bg-white dark:bg-background";
-  const sectionPaddingClasses = "py-12 md:py-16 lg:py-20"
-  // Using max-w-6xl for user directory to accommodate table width
-  const contentWrapperClasses = "w-full max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10"
-
-  const supabase = createBrowserClient()
-
-  // Debounce search input
   useEffect(() => {
-    const timer = setTimeout(() => {
-      setDebouncedSearch(searchQuery)
-    }, 300)
+    const timer = setTimeout(() => setDebouncedSearch(searchQuery), 300)
     return () => clearTimeout(timer)
   }, [searchQuery])
 
-  const loadUsers = useCallback(async (reset: boolean = false) => {
-    try {
-      if (reset) {
-        setLoading(true)
-        setUsers([])
-      } else {
-        setLoadingMore(true)
-      }
+  useEffect(() => {
+    let isCurrentRequest = true
 
-      const offset = reset ? 0 : users.length
+    const reload = async () => {
+      setLoading(true)
+      setError(null)
+
+      try {
+        const search = debouncedSearch || undefined
+        const [count, fetchedUsers] = await Promise.all([
+          fetchUsersCount(supabase, search),
+          fetchUsers(supabase, {
+            limit: USERS_PER_PAGE,
+            offset: 0,
+            sortBy: sortKey,
+            sortOrder,
+            search,
+          }),
+        ])
+
+        if (!isCurrentRequest) return
+        setTotalCount(count)
+        setUsers(fetchedUsers)
+      } catch (err) {
+        if (!isCurrentRequest) return
+        setError('We could not load the directory. Please try again.')
+        console.error('Error fetching users:', err)
+      } finally {
+        if (isCurrentRequest) setLoading(false)
+      }
+    }
+
+    reload()
+    return () => {
+      isCurrentRequest = false
+    }
+  }, [debouncedSearch, sortKey, sortOrder, supabase])
+
+  const loadMore = async () => {
+    setLoadingMore(true)
+    setError(null)
+
+    try {
       const fetchedUsers = await fetchUsers(supabase, {
         limit: USERS_PER_PAGE,
-        offset,
+        offset: users.length,
         sortBy: sortKey,
         sortOrder,
-        search: debouncedSearch || undefined
+        search: debouncedSearch || undefined,
       })
-
-      if (reset) {
-        setUsers(fetchedUsers)
-      } else {
-        setUsers(prev => [...prev, ...fetchedUsers])
-      }
-
-      setHasMore(fetchedUsers.length === USERS_PER_PAGE)
+      setUsers((currentUsers) => [...currentUsers, ...fetchedUsers])
     } catch (err) {
-      setError('Failed to fetch users')
-      console.error('Error fetching users:', err)
+      setError('We could not load more members. Please try again.')
+      console.error('Error fetching more users:', err)
     } finally {
-      setLoading(false)
       setLoadingMore(false)
     }
-  }, [supabase, users.length, sortKey, sortOrder, debouncedSearch])
-
-  // Load initial users and count
-  useEffect(() => {
-    const init = async () => {
-      try {
-        const count = await fetchUsersCount(supabase)
-        setTotalCount(count)
-      } catch (err) {
-        console.error('Error fetching count:', err)
-      }
-      loadUsers(true)
-    }
-    init()
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
-
-  // Reload when sort or search changes
-  useEffect(() => {
-    const reload = async () => {
-      try {
-        const count = await fetchUsersCount(supabase, debouncedSearch || undefined)
-        setTotalCount(count)
-      } catch (err) {
-        console.error('Error fetching count:', err)
-      }
-      loadUsers(true)
-    }
-    reload()
-  }, [sortKey, sortOrder, debouncedSearch]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  if (loading && !searchQuery) return (
-    <div className="flex justify-center items-center min-h-screen">
-      <Loader2 className="h-8 w-8 animate-spin text-blue-600" />
-      <p className="text-xl ml-3">Loading users...</p>
-    </div>
-  )
-  if (error) return <div className="flex justify-center items-center min-h-screen"><p className="text-xl text-red-500">Error: {error}</p></div>
+  }
 
   const handleSort = (key: SortKey) => {
     if (key === sortKey) {
-      setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc')
+      setSortOrder((current) => (current === 'asc' ? 'desc' : 'asc'))
     } else {
       setSortKey(key)
-      setSortOrder('desc')
+      setSortOrder('asc')
     }
   }
 
   const renderSortIcon = (key: SortKey) => {
-    if (sortKey === key) {
-      return (
-        <ArrowUpDown
-          className={`ml-2 h-4 w-4 ${
-            sortOrder === 'desc' ? 'rotate-180 transform' : ''
-          }`}
-        />
-      )
-    }
-    return <ArrowUpDown className="ml-2 h-4 w-4 opacity-20" />
+    const SortIcon =
+      sortKey !== key ? ArrowUpDown : sortOrder === 'asc' ? ArrowUp : ArrowDown
+
+    return (
+      <SortIcon
+        aria-hidden="true"
+        className={`ml-2 h-3.5 w-3.5 transition-opacity ${
+          sortKey === key ? 'opacity-70' : 'opacity-25'
+        }`}
+      />
+    )
   }
 
   return (
-    <main>
-      <section
-        className={`${unifiedDeepBlueBase} ${sectionPaddingClasses} overflow-hidden min-h-screen`}
-      >
-        <div className={`${contentWrapperClasses}`}>
-          <div className="mb-8 text-center">
-            <h2 className="text-4xl font-bold text-gray-900 dark:text-white">User Directory</h2>
-            {totalCount > 0 && (
-              <p className="text-gray-600 dark:text-gray-400 mt-2">
-                Showing {users.length} of {formatNumber(totalCount)} users
-              </p>
-            )}
-          </div>
-          <div className="relative mb-4 max-w-sm mx-auto">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
-            <Input
-              placeholder="Search by name or username..."
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="pl-9"
-            />
-          </div>
-          {/* Shadcn <Table> already wraps in a `relative w-full overflow-auto` div, so it
-              handles horizontal overflow itself — no need for an additional scroll wrapper
-              (which gave us a second always-on scrollbar). */}
-          <div className="w-full bg-slate-100 dark:bg-card p-6 rounded-lg">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Avatar</TableHead>
-                  <TableHead>
-                    <Button
-                      variant="ghost"
-                      onClick={() => handleSort('account_display_name')}
-                          className="hover:bg-slate-200 dark:hover:bg-slate-700"
-                    >
-                      Display Name {renderSortIcon('account_display_name')}
-                    </Button>
-                  </TableHead>
-                  <TableHead>
-                        <Button
-                          variant="ghost"
-                          onClick={() => handleSort('username')}
-                          className="hover:bg-slate-200 dark:hover:bg-slate-700"
-                        >
-                      Username {renderSortIcon('username')}
-                    </Button>
-                  </TableHead>
-                  <TableHead>
-                        <Button
-                          variant="ghost"
-                          onClick={() => handleSort('num_tweets')}
-                          className="hover:bg-slate-200 dark:hover:bg-slate-700"
-                        >
-                      Tweets {renderSortIcon('num_tweets')}
-                    </Button>
-                  </TableHead>
-                  <TableHead>
-                        <Button
-                          variant="ghost"
-                          onClick={() => handleSort('num_likes')}
-                          className="hover:bg-slate-200 dark:hover:bg-slate-700"
-                        >
-                      Likes {renderSortIcon('num_likes')}
-                    </Button>
-                  </TableHead>
-                  <TableHead>
-                    <Button
-                      variant="ghost"
-                      onClick={() => handleSort('num_followers')}
-                          className="hover:bg-slate-200 dark:hover:bg-slate-700"
-                    >
-                      Followers {renderSortIcon('num_followers')}
-                    </Button>
-                  </TableHead>
-                  <TableHead>
-                        <Button
-                          variant="ghost"
-                          onClick={() => handleSort('archive_at')}
-                          className="hover:bg-slate-200 dark:hover:bg-slate-700"
-                        >
-                      Archive Date {renderSortIcon('archive_at')}
-                    </Button>
-                  </TableHead>
-                  <TableHead>
-                        <Button
-                          variant="ghost"
-                          onClick={() => handleSort('created_at')}
-                          className="hover:bg-slate-200 dark:hover:bg-slate-700"
-                        >
-                      Account Created At {renderSortIcon('created_at')}
-                    </Button>
-                  </TableHead>
-                  <TableHead>
-                    <Button
-                      variant="ghost"
-                      onClick={() => handleSort('archive_uploaded_at')}
-                          className="hover:bg-slate-200 dark:hover:bg-slate-700"
-                    >
-                      Archive Uploaded At {renderSortIcon('archive_uploaded_at')}
-                    </Button>
-                  </TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {users.map((user) => (
-                      <TableRow key={user.account_id} className="dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700/50">
-                    <TableCell>
-                      <Link href={`/user/${user.account_id}`}>
-                        <Avatar>
-                          <AvatarImage
-                            src={user.avatar_media_url || '/placeholder.jpg'}
-                            alt={`${user.account_display_name}'s avatar`}
-                          />
-                          <AvatarFallback>
-                            {user.account_display_name.charAt(0).toUpperCase()}
-                          </AvatarFallback>
-                        </Avatar>
-                      </Link>
-                    </TableCell>
-                        <TableCell className="font-medium">
-                      <Link
-                        href={`/user/${user.account_id}`}
-                        className="hover:underline"
-                      >
-                        {user.account_display_name}
-                      </Link>
-                    </TableCell>
-                    <TableCell>
-                      <Link
-                        href={`/user/${user.account_id}`}
-                        className="hover:underline"
-                      >
-                            @{user.username}
-                      </Link>
-                    </TableCell>
-                        <TableCell className="text-right">{formatNumber(user.num_tweets)}</TableCell>
-                        <TableCell className="text-right">{formatNumber(user.num_likes)}</TableCell>
-                        <TableCell className="text-right">{formatNumber(user.num_followers)}</TableCell>
-                    <TableCell>
-                      {user.archive_at
-                        ? new Date(user.archive_at).toLocaleDateString()
-                        : '-'}
-                    </TableCell>
-                    <TableCell>
-                      {new Date(user.created_at).toLocaleDateString()}
-                    </TableCell>
-                    <TableCell>
-                      {user.archive_uploaded_at
-                        ? new Date(user.archive_uploaded_at).toLocaleDateString()
-                        : '-'}
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </div>
-
-          {/* Load More Button */}
-          {hasMore && (
-            <div className="flex justify-center mt-6">
-              <Button
-                onClick={() => loadUsers(false)}
-                disabled={loadingMore}
-                variant="outline"
-                size="lg"
-              >
-                {loadingMore ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Loading...
-                  </>
-                ) : (
-                  `Load More (${Math.min(USERS_PER_PAGE, totalCount - users.length)} more)`
-                )}
-              </Button>
-            </div>
-          )}
+    <main className="min-h-screen bg-white py-12 dark:bg-background md:py-16">
+      <div className="relative mx-auto w-full max-w-5xl px-4 sm:px-6 lg:px-8">
+        <div className="mx-auto mb-10 max-w-2xl text-center">
+          <h1 className="text-4xl font-bold tracking-tight text-gray-950 dark:text-white sm:text-5xl">
+            User Directory
+          </h1>
+          <p className="mt-3 text-base text-gray-600 dark:text-gray-400">
+            People preserving and participating in the Community Archive.
+          </p>
+          <p className="mt-2 text-sm font-medium text-gray-500 dark:text-gray-500">
+            {loading && users.length === 0
+              ? 'Loading members…'
+              : `${users.length} of ${totalCount.toLocaleString()} members`}
+          </p>
         </div>
-      </section>
+
+        <div className="relative mx-auto mb-6 max-w-xl">
+          <Search
+            aria-hidden="true"
+            className="absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+          />
+          <Input
+            aria-label="Search the user directory"
+            placeholder="Search by name or username…"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            className="h-12 rounded-xl border-gray-300 bg-white pl-11 shadow-sm dark:border-gray-700 dark:bg-gray-950"
+          />
+        </div>
+
+        <div
+          className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-card"
+          aria-busy={loading}
+        >
+          <Table>
+            <TableHeader className="bg-gray-50/80 dark:bg-gray-900/60">
+              <TableRow className="hover:bg-transparent">
+                <TableHead
+                  className="w-[52%] py-2"
+                  aria-sort={
+                    sortKey === 'account_display_name'
+                      ? sortOrder === 'asc'
+                        ? 'ascending'
+                        : 'descending'
+                      : 'none'
+                  }
+                >
+                  <Button
+                    variant="ghost"
+                    onClick={() => handleSort('account_display_name')}
+                    aria-label="Sort by member name"
+                    className="-ml-3 h-8 px-3 text-xs font-semibold uppercase tracking-wider hover:bg-gray-200/70 dark:hover:bg-gray-800"
+                  >
+                    Member {renderSortIcon('account_display_name')}
+                  </Button>
+                </TableHead>
+                <TableHead className="w-[30%] text-xs font-semibold uppercase tracking-wider">
+                  Participation
+                </TableHead>
+                <TableHead
+                  className="w-[18%] py-2 text-right"
+                  aria-sort={
+                    sortKey === 'joined_at'
+                      ? sortOrder === 'asc'
+                        ? 'ascending'
+                        : 'descending'
+                      : 'none'
+                  }
+                >
+                  <Button
+                    variant="ghost"
+                    onClick={() => handleSort('joined_at')}
+                    aria-label="Sort by join date"
+                    className="-mr-3 h-8 px-3 text-xs font-semibold uppercase tracking-wider hover:bg-gray-200/70 dark:hover:bg-gray-800"
+                  >
+                    Joined {renderSortIcon('joined_at')}
+                  </Button>
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {loading ? (
+                <TableRow>
+                  <TableCell colSpan={3} className="h-40 text-center">
+                    <span className="inline-flex items-center text-sm text-gray-500 dark:text-gray-400">
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Loading members…
+                    </span>
+                  </TableCell>
+                </TableRow>
+              ) : error && users.length === 0 ? (
+                <TableRow>
+                  <TableCell
+                    colSpan={3}
+                    className="h-40 text-center text-sm text-red-600 dark:text-red-400"
+                  >
+                    {error}
+                  </TableCell>
+                </TableRow>
+              ) : users.length === 0 ? (
+                <TableRow>
+                  <TableCell
+                    colSpan={3}
+                    className="h-40 text-center text-sm text-gray-500 dark:text-gray-400"
+                  >
+                    No members match “{debouncedSearch}”.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                users.map((user) => {
+                  const identity = (
+                    <div className="flex min-w-0 items-center gap-3">
+                      <Avatar className="h-11 w-11 border border-gray-200 dark:border-gray-700">
+                        <AvatarImage
+                          src={user.avatar_media_url || '/placeholder.jpg'}
+                          alt={`${user.account_display_name}'s avatar`}
+                        />
+                        <AvatarFallback>
+                          {user.account_display_name.charAt(0).toUpperCase()}
+                        </AvatarFallback>
+                      </Avatar>
+                      <div className="min-w-0">
+                        <div className="truncate font-semibold text-gray-950 dark:text-gray-100">
+                          {user.account_display_name}
+                        </div>
+                        <div className="truncate text-sm text-gray-500 dark:text-gray-400">
+                          @{user.username}
+                        </div>
+                      </div>
+                    </div>
+                  )
+
+                  return (
+                    <TableRow
+                      key={user.directory_id}
+                      className="group border-gray-200 hover:bg-gray-50/80 dark:border-gray-800 dark:hover:bg-gray-900/60"
+                    >
+                      <TableCell className="py-4">
+                        {user.has_archive && user.account_id ? (
+                          <Link
+                            href={`/user/${user.account_id}`}
+                            className="block rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 group-hover:[&_div.font-semibold]:underline"
+                          >
+                            {identity}
+                          </Link>
+                        ) : (
+                          identity
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex flex-wrap gap-2">
+                          {user.has_archive && (
+                            <Badge
+                              variant="outline"
+                              title="Contributed a Twitter archive"
+                              className="gap-1.5 border-blue-200 bg-blue-50 px-2.5 py-1 font-medium text-blue-700 dark:border-blue-900 dark:bg-blue-950/50 dark:text-blue-300"
+                            >
+                              <Archive
+                                aria-hidden="true"
+                                className="h-3.5 w-3.5"
+                              />
+                              Archive
+                            </Badge>
+                          )}
+                          {user.is_opted_in && (
+                            <Badge
+                              variant="outline"
+                              title="Opted in to tweet streaming"
+                              className="gap-1.5 border-emerald-200 bg-emerald-50 px-2.5 py-1 font-medium text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950/50 dark:text-emerald-300"
+                            >
+                              <Radio
+                                aria-hidden="true"
+                                className="h-3.5 w-3.5"
+                              />
+                              Opted in
+                            </Badge>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap text-right text-sm font-medium text-gray-700 dark:text-gray-300">
+                        <time dateTime={user.joined_at || undefined}>
+                          {formatJoinedDate(user.joined_at)}
+                        </time>
+                      </TableCell>
+                    </TableRow>
+                  )
+                })
+              )}
+            </TableBody>
+          </Table>
+        </div>
+
+        {error && users.length > 0 && (
+          <p className="mt-4 text-center text-sm text-red-600 dark:text-red-400">
+            {error}
+          </p>
+        )}
+
+        {!loading && users.length < totalCount && (
+          <div className="mt-6 flex justify-center">
+            <Button
+              onClick={loadMore}
+              disabled={loadingMore}
+              variant="outline"
+              size="lg"
+              className="rounded-full px-6"
+            >
+              {loadingMore ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Loading…
+                </>
+              ) : (
+                `Load ${Math.min(USERS_PER_PAGE, totalCount - users.length)} more`
+              )}
+            </Button>
+          </div>
+        )}
+      </div>
     </main>
   )
 }

--- a/src/database-types.ts
+++ b/src/database-types.ts
@@ -7,11 +7,6 @@ export type Json =
   | Json[]
 
 export type Database = {
-  // Allows to automatically instantiate createClient with right options
-  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
-  __InternalSupabase: {
-    PostgrestVersion: "12.2.2 (db9da0b)"
-  }
   dev: {
     Tables: {
       [_ in never]: never
@@ -21,77 +16,142 @@ export type Database = {
     }
     Functions: {
       apply_dev_entities_rls_policies: {
-        Args: { schema_name: string; table_name: string }
+        Args: {
+          schema_name: string
+          table_name: string
+        }
         Returns: undefined
       }
       apply_dev_liked_tweets_rls_policies: {
-        Args: { schema_name: string; table_name: string }
+        Args: {
+          schema_name: string
+          table_name: string
+        }
         Returns: undefined
       }
       apply_dev_rls_policies: {
-        Args: { schema_name: string; table_name: string }
+        Args: {
+          schema_name: string
+          table_name: string
+        }
         Returns: undefined
       }
-      commit_temp_data: { Args: { p_suffix: string }; Returns: undefined }
-      create_temp_tables: { Args: { p_suffix: string }; Returns: undefined }
+      commit_temp_data: {
+        Args: {
+          p_suffix: string
+        }
+        Returns: undefined
+      }
+      create_temp_tables: {
+        Args: {
+          p_suffix: string
+        }
+        Returns: undefined
+      }
       delete_all_archives: {
-        Args: { p_account_id: string }
+        Args: {
+          p_account_id: string
+        }
         Returns: undefined
       }
       drop_function_if_exists: {
-        Args: { function_args: string[]; function_name: string }
+        Args: {
+          function_name: string
+          function_args: string[]
+        }
         Returns: undefined
       }
-      drop_temp_tables: { Args: { p_suffix: string }; Returns: undefined }
+      drop_temp_tables: {
+        Args: {
+          p_suffix: string
+        }
+        Returns: undefined
+      }
       get_top_accounts_with_followers: {
-        Args: { limit_count: number }
+        Args: {
+          limit_count: number
+        }
         Returns: {
-          account_display_name: string
           account_id: string
+          created_via: string
+          username: string
+          created_at: string
+          account_display_name: string
           avatar_media_url: string
           bio: string
-          created_at: string
-          created_via: string
-          follower_count: number
-          header_media_url: string
-          location: string
-          username: string
           website: string
+          location: string
+          header_media_url: string
+          follower_count: number
         }[]
       }
       insert_temp_account: {
-        Args: { p_account: Json; p_suffix: string }
+        Args: {
+          p_account: Json
+          p_suffix: string
+        }
         Returns: undefined
       }
       insert_temp_archive_upload: {
-        Args: { p_account_id: string; p_archive_at: string; p_suffix: string }
+        Args: {
+          p_account_id: string
+          p_archive_at: string
+          p_suffix: string
+        }
         Returns: number
       }
       insert_temp_followers: {
-        Args: { p_account_id: string; p_followers: Json; p_suffix: string }
+        Args: {
+          p_followers: Json
+          p_account_id: string
+          p_suffix: string
+        }
         Returns: undefined
       }
       insert_temp_following: {
-        Args: { p_account_id: string; p_following: Json; p_suffix: string }
+        Args: {
+          p_following: Json
+          p_account_id: string
+          p_suffix: string
+        }
         Returns: undefined
       }
       insert_temp_likes: {
-        Args: { p_account_id: string; p_likes: Json; p_suffix: string }
+        Args: {
+          p_likes: Json
+          p_account_id: string
+          p_suffix: string
+        }
         Returns: undefined
       }
       insert_temp_profiles: {
-        Args: { p_account_id: string; p_profile: Json; p_suffix: string }
+        Args: {
+          p_profile: Json
+          p_account_id: string
+          p_suffix: string
+        }
         Returns: undefined
       }
       insert_temp_tweets: {
-        Args: { p_suffix: string; p_tweets: Json }
+        Args: {
+          p_tweets: Json
+          p_suffix: string
+        }
         Returns: undefined
       }
       process_and_insert_tweet_entities: {
-        Args: { p_suffix: string; p_tweets: Json }
+        Args: {
+          p_tweets: Json
+          p_suffix: string
+        }
         Returns: undefined
       }
-      process_archive: { Args: { archive_data: Json }; Returns: undefined }
+      process_archive: {
+        Args: {
+          archive_data: Json
+        }
+        Returns: undefined
+      }
     }
     Enums: {
       [_ in never]: never
@@ -195,13 +255,6 @@ export type Database = {
             referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: "all_profile_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: true
-            referencedRelation: "user_directory"
-            referencedColumns: ["account_id"]
-          },
-          {
             foreignKeyName: "all_profile_archive_upload_id_fkey"
             columns: ["archive_upload_id"]
             isOneToOne: false
@@ -267,13 +320,6 @@ export type Database = {
             columns: ["account_id"]
             isOneToOne: false
             referencedRelation: "all_account"
-            referencedColumns: ["account_id"]
-          },
-          {
-            foreignKeyName: "archive_upload_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "user_directory"
             referencedColumns: ["account_id"]
           },
         ]
@@ -360,13 +406,6 @@ export type Database = {
             referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: "followers_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "user_directory"
-            referencedColumns: ["account_id"]
-          },
-          {
             foreignKeyName: "followers_archive_upload_id_fkey"
             columns: ["archive_upload_id"]
             isOneToOne: false
@@ -420,13 +459,6 @@ export type Database = {
             referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: "following_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "user_directory"
-            referencedColumns: ["account_id"]
-          },
-          {
             foreignKeyName: "following_archive_upload_id_fkey"
             columns: ["archive_upload_id"]
             isOneToOne: false
@@ -437,17 +469,17 @@ export type Database = {
       }
       liked_tweets: {
         Row: {
-          fts: unknown
+          fts: unknown | null
           full_text: string
           tweet_id: string
         }
         Insert: {
-          fts?: unknown
+          fts?: unknown | null
           full_text: string
           tweet_id: string
         }
         Update: {
-          fts?: unknown
+          fts?: unknown | null
           full_text?: string
           tweet_id?: string
         }
@@ -495,13 +527,6 @@ export type Database = {
             columns: ["account_id"]
             isOneToOne: false
             referencedRelation: "all_account"
-            referencedColumns: ["account_id"]
-          },
-          {
-            foreignKeyName: "likes_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "user_directory"
             referencedColumns: ["account_id"]
           },
           {
@@ -810,7 +835,7 @@ export type Database = {
           archive_upload_id: number | null
           created_at: string
           favorite_count: number
-          fts: unknown
+          fts: unknown | null
           full_text: string
           reply_to_tweet_id: string | null
           reply_to_user_id: string | null
@@ -824,7 +849,7 @@ export type Database = {
           archive_upload_id?: number | null
           created_at: string
           favorite_count: number
-          fts?: unknown
+          fts?: unknown | null
           full_text: string
           reply_to_tweet_id?: string | null
           reply_to_user_id?: string | null
@@ -838,7 +863,7 @@ export type Database = {
           archive_upload_id?: number | null
           created_at?: string
           favorite_count?: number
-          fts?: unknown
+          fts?: unknown | null
           full_text?: string
           reply_to_tweet_id?: string | null
           reply_to_user_id?: string | null
@@ -867,13 +892,6 @@ export type Database = {
             columns: ["account_id"]
             isOneToOne: false
             referencedRelation: "all_account"
-            referencedColumns: ["account_id"]
-          },
-          {
-            foreignKeyName: "tweets_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "user_directory"
             referencedColumns: ["account_id"]
           },
           {
@@ -1038,13 +1056,6 @@ export type Database = {
             referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: "tweets_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "user_directory"
-            referencedColumns: ["account_id"]
-          },
-          {
             foreignKeyName: "tweets_archive_upload_id_fkey"
             columns: ["archive_upload_id"]
             isOneToOne: false
@@ -1107,13 +1118,6 @@ export type Database = {
             referencedRelation: "all_account"
             referencedColumns: ["account_id"]
           },
-          {
-            foreignKeyName: "tweets_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "user_directory"
-            referencedColumns: ["account_id"]
-          },
         ]
       }
       profile: {
@@ -1149,13 +1153,6 @@ export type Database = {
             referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: "all_profile_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: true
-            referencedRelation: "user_directory"
-            referencedColumns: ["account_id"]
-          },
-          {
             foreignKeyName: "all_profile_archive_upload_id_fkey"
             columns: ["archive_upload_id"]
             isOneToOne: false
@@ -1186,7 +1183,7 @@ export type Database = {
           conversation_id: string | null
           created_at: string | null
           favorite_count: number | null
-          fts: unknown
+          fts: unknown | null
           full_text: string | null
           reply_to_tweet_id: string | null
           reply_to_user_id: string | null
@@ -1217,13 +1214,6 @@ export type Database = {
             referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: "tweets_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "user_directory"
-            referencedColumns: ["account_id"]
-          },
-          {
             foreignKeyName: "tweets_archive_upload_id_fkey"
             columns: ["archive_upload_id"]
             isOneToOne: false
@@ -1241,11 +1231,16 @@ export type Database = {
           avatar_media_url: string | null
           bio: string | null
           created_at: string | null
+          directory_id: string | null
+          has_archive: boolean | null
+          is_opted_in: boolean | null
+          joined_at: string | null
           location: string | null
           num_followers: number | null
           num_following: number | null
           num_likes: number | null
           num_tweets: number | null
+          opted_in_at: string | null
           username: string | null
           website: string | null
         }
@@ -1256,204 +1251,278 @@ export type Database = {
       admin_enqueue_delete_with_export: {
         Args: {
           p_account_id: string
+          p_username: string
           p_reason?: string
           p_requested_by_user_id?: string
-          p_username: string
         }
         Returns: string
       }
       admin_list_blocked_scraping_users: {
-        Args: { p_account_ids: string[] }
+        Args: {
+          p_account_ids: string[]
+        }
         Returns: string[]
       }
       admin_set_scrape_block: {
-        Args: { p_account_id: string; p_blocked: boolean }
+        Args: {
+          p_account_id: string
+          p_blocked: boolean
+        }
         Returns: undefined
       }
       apply_public_entities_rls_policies: {
-        Args: { schema_name: string; table_name: string }
+        Args: {
+          schema_name: string
+          table_name: string
+        }
         Returns: undefined
       }
       apply_public_liked_tweets_rls_policies: {
-        Args: { schema_name: string; table_name: string }
+        Args: {
+          schema_name: string
+          table_name: string
+        }
         Returns: undefined
       }
       apply_public_rls_policies: {
-        Args: { schema_name: string; table_name: string }
+        Args: {
+          schema_name: string
+          table_name: string
+        }
         Returns: undefined
       }
       apply_public_rls_policies_not_private: {
-        Args: { schema_name: string; table_name: string }
+        Args: {
+          schema_name: string
+          table_name: string
+        }
         Returns: undefined
       }
       apply_readonly_rls_policies: {
-        Args: { schema_name: string; table_name: string }
+        Args: {
+          schema_name: string
+          table_name: string
+        }
         Returns: undefined
       }
-      commit_temp_data: { Args: { p_suffix: string }; Returns: undefined }
+      commit_temp_data: {
+        Args: {
+          p_suffix: string
+        }
+        Returns: undefined
+      }
       compute_hourly_scraping_stats: {
-        Args: { p_end_date: string; p_start_date: string }
+        Args: {
+          p_start_date: string
+          p_end_date: string
+        }
         Returns: {
-          period_end: string
           period_start: string
+          period_end: string
           tweet_count: number
           unique_scrapers: number
         }[]
       }
-      create_temp_tables: { Args: { p_suffix: string }; Returns: undefined }
+      create_temp_tables: {
+        Args: {
+          p_suffix: string
+        }
+        Returns: undefined
+      }
       delete_non_allowlist_streamed_tweet_batch: {
-        Args: { p_limit?: number }
+        Args: {
+          p_limit?: number
+        }
         Returns: {
-          deleted_conversations: number
-          deleted_private_tweet_user: number
-          deleted_tweet_media: number
-          deleted_tweet_urls: number
-          deleted_tweets: number
-          deleted_user_mentions: number
           requested_tweets: number
+          deleted_tweets: number
+          deleted_conversations: number
+          deleted_tweet_media: number
+          deleted_user_mentions: number
+          deleted_tweet_urls: number
+          deleted_private_tweet_user: number
         }[]
       }
       delete_single_archive: {
-        Args: { p_account_id: string; p_archive_upload_id: number }
+        Args: {
+          p_account_id: string
+          p_archive_upload_id: number
+        }
         Returns: undefined
       }
       delete_tweets: {
-        Args: { p_tweet_ids: string[] }
+        Args: {
+          p_tweet_ids: string[]
+        }
         Returns: {
-          deleted_conversations: number
-          deleted_private_tweet_user: number
-          deleted_tweet_media: number
-          deleted_tweet_urls: number
           deleted_tweets: number
+          deleted_conversations: number
+          deleted_tweet_media: number
           deleted_user_mentions: number
+          deleted_tweet_urls: number
+          deleted_private_tweet_user: number
         }[]
       }
       delete_user_archive: {
-        Args: { p_account_id: string }
+        Args: {
+          p_account_id: string
+        }
         Returns: undefined
       }
       drop_all_policies: {
-        Args: { schema_name: string; table_name: string }
+        Args: {
+          schema_name: string
+          table_name: string
+        }
         Returns: undefined
       }
-      drop_temp_tables: { Args: { p_suffix: string }; Returns: undefined }
+      drop_temp_tables: {
+        Args: {
+          p_suffix: string
+        }
+        Returns: undefined
+      }
       get_account_most_liked_tweets_archive_users: {
-        Args: { limit_?: number; username_: string }
+        Args: {
+          username_: string
+          limit_?: number
+        }
         Returns: {
+          tweet_id: string
           account_id: string
-          archive_upload_id: number
           created_at: string
-          favorite_count: number
           full_text: string
-          num_likes: number
+          retweet_count: number
+          favorite_count: number
           reply_to_tweet_id: string
           reply_to_user_id: string
           reply_to_username: string
-          retweet_count: number
-          tweet_id: string
+          archive_upload_id: number
+          num_likes: number
         }[]
       }
       get_account_most_mentioned_accounts: {
-        Args: { limit_: number; username_: string }
+        Args: {
+          username_: string
+          limit_: number
+        }
         Returns: {
-          mention_count: number
+          user_id: string
           name: string
           screen_name: string
-          user_id: string
+          mention_count: number
         }[]
       }
       get_account_most_replied_tweets_by_archive_users: {
-        Args: { limit_: number; username_: string }
+        Args: {
+          username_: string
+          limit_: number
+        }
         Returns: {
+          tweet_id: string
           account_id: string
-          archive_upload_id: number
           created_at: string
-          favorite_count: number
           full_text: string
-          num_replies: number
+          retweet_count: number
+          favorite_count: number
           reply_to_tweet_id: string
           reply_to_user_id: string
           reply_to_username: string
-          retweet_count: number
-          tweet_id: string
+          archive_upload_id: number
+          num_replies: number
         }[]
       }
       get_account_top_favorite_count_tweets: {
-        Args: { limit_: number; username_: string }
+        Args: {
+          username_: string
+          limit_: number
+        }
         Returns: {
+          tweet_id: string
           account_id: string
-          archive_upload_id: number
           created_at: string
-          favorite_count: number
           full_text: string
+          retweet_count: number
+          favorite_count: number
           reply_to_tweet_id: string
           reply_to_user_id: string
           reply_to_username: string
-          retweet_count: number
-          tweet_id: string
+          archive_upload_id: number
         }[]
       }
       get_account_top_retweet_count_tweets: {
-        Args: { limit_: number; username_: string }
+        Args: {
+          username_: string
+          limit_: number
+        }
         Returns: {
+          tweet_id: string
           account_id: string
-          archive_upload_id: number
           created_at: string
-          favorite_count: number
           full_text: string
+          retweet_count: number
+          favorite_count: number
           reply_to_tweet_id: string
           reply_to_user_id: string
           reply_to_username: string
-          retweet_count: number
-          tweet_id: string
+          archive_upload_id: number
         }[]
       }
       get_hourly_scraping_stats: {
-        Args: { p_hours_back?: number }
+        Args: {
+          p_hours_back?: number
+        }
         Returns: {
-          period_end: string
           period_start: string
+          period_end: string
           tweet_count: number
           unique_scrapers: number
         }[]
       }
       get_hourly_stats_simple: {
-        Args: { p_hours_back?: number }
+        Args: {
+          p_hours_back?: number
+        }
         Returns: {
           period_start: string
           tweet_count: number
         }[]
       }
       get_latest_tweets: {
-        Args: { count: number; p_account_id?: string }
+        Args: {
+          count: number
+          p_account_id?: string
+        }
         Returns: {
-          account_display_name: string
-          account_id: string
-          avatar_media_url: string
-          created_at: string
-          favorite_count: number
-          full_text: string
-          reply_to_tweet_id: string
-          retweet_count: number
           tweet_id: string
+          account_id: string
+          created_at: string
+          full_text: string
+          retweet_count: number
+          favorite_count: number
+          reply_to_tweet_id: string
+          avatar_media_url: string
           username: string
+          account_display_name: string
         }[]
       }
       get_main_thread: {
-        Args: { p_conversation_id: string }
+        Args: {
+          p_conversation_id: string
+        }
         Returns: {
-          account_id: string
-          conversation_id: string
-          depth: number
-          favorite_count: number
-          max_depth: number
-          reply_to_tweet_id: string
-          retweet_count: number
           tweet_id: string
+          conversation_id: string
+          reply_to_tweet_id: string
+          account_id: string
+          depth: number
+          max_depth: number
+          favorite_count: number
+          retweet_count: number
         }[]
       }
       get_monthly_tweet_counts: {
-        Args: never
+        Args: Record<PropertyKey, never>
         Returns: {
           month: string
           tweet_count: number
@@ -1462,343 +1531,481 @@ export type Database = {
       get_monthly_tweet_counts_fast: {
         Args: {
           p_account_id?: string
-          p_end_date?: string
           p_start_date?: string
+          p_end_date?: string
         }
         Returns: {
+          month: string
           account_id: string
+          tweet_count: number
+          days_active: number
           avg_favorites: number
           avg_retweets: number
-          days_active: number
-          month: string
-          tweet_count: number
         }[]
       }
       get_most_liked_tweets_by_username: {
-        Args: { username_: string }
+        Args: {
+          username_: string
+        }
         Returns: {
+          tweet_id: string
           full_text: string
           num_likes: number
-          tweet_id: string
         }[]
       }
       get_most_mentioned_accounts_by_username: {
-        Args: { username_: string }
+        Args: {
+          username_: string
+        }
         Returns: {
-          mention_count: number
           mentioned_user_id: string
           mentioned_username: string
+          mention_count: number
         }[]
       }
       get_non_allowlist_streamed_tweet_candidates: {
-        Args: { p_limit?: number }
+        Args: {
+          p_limit?: number
+        }
         Returns: {
+          tweet_id: string
           account_id: string
           created_at: string
-          is_quote: boolean
           reply_to_tweet_id: string
-          tweet_id: string
+          is_quote: boolean
         }[]
       }
       get_scraper_counts_by_granularity: {
-        Args: { end_date: string; granularity: string; start_date: string }
+        Args: {
+          start_date: string
+          end_date: string
+          granularity: string
+        }
         Returns: {
           scraper_date: string
           unique_scrapers: number
         }[]
       }
       get_simple_streamed_tweet_counts: {
-        Args: { end_date: string; granularity: string; start_date: string }
+        Args: {
+          start_date: string
+          end_date: string
+          granularity: string
+        }
         Returns: {
-          tweet_count: number
           tweet_date: string
+          tweet_count: number
         }[]
       }
       get_streaming_stats: {
         Args: {
+          p_start_date: string
           p_end_date: string
           p_granularity?: string
-          p_start_date: string
           p_streamed_only?: boolean
         }
         Returns: {
-          period_end: string
           period_start: string
+          period_end: string
           tweet_count: number
           unique_scrapers: number
         }[]
       }
       get_streaming_stats_daily: {
-        Args: { p_end_date: string; p_start_date: string }
+        Args: {
+          p_start_date: string
+          p_end_date: string
+        }
         Returns: {
-          period_end: string
           period_start: string
+          period_end: string
           tweet_count: number
           unique_scrapers: number
         }[]
       }
       get_streaming_stats_daily_streamed_only: {
-        Args: { p_end_date: string; p_start_date: string }
+        Args: {
+          p_start_date: string
+          p_end_date: string
+        }
         Returns: {
-          period_end: string
           period_start: string
+          period_end: string
           tweet_count: number
           unique_scrapers: number
         }[]
       }
       get_streaming_stats_hourly: {
-        Args: { p_end_date: string; p_start_date: string }
+        Args: {
+          p_start_date: string
+          p_end_date: string
+        }
         Returns: {
-          period_end: string
           period_start: string
+          period_end: string
           tweet_count: number
           unique_scrapers: number
         }[]
       }
       get_streaming_stats_hourly_streamed_only: {
-        Args: { p_end_date: string; p_start_date: string }
+        Args: {
+          p_start_date: string
+          p_end_date: string
+        }
         Returns: {
-          period_end: string
           period_start: string
+          period_end: string
           tweet_count: number
           unique_scrapers: number
         }[]
       }
       get_streaming_stats_weekly: {
-        Args: { p_end_date: string; p_start_date: string }
+        Args: {
+          p_start_date: string
+          p_end_date: string
+        }
         Returns: {
-          period_end: string
           period_start: string
+          period_end: string
           tweet_count: number
           unique_scrapers: number
         }[]
       }
       get_streaming_stats_weekly_streamed_only: {
-        Args: { p_end_date: string; p_start_date: string }
+        Args: {
+          p_start_date: string
+          p_end_date: string
+        }
         Returns: {
-          period_end: string
           period_start: string
+          period_end: string
           tweet_count: number
           unique_scrapers: number
         }[]
       }
       get_top_accounts_with_followers: {
-        Args: { limit_count: number }
+        Args: {
+          limit_count: number
+        }
         Returns: {
-          account_display_name: string
           account_id: string
+          created_via: string
+          username: string
+          created_at: string
+          account_display_name: string
           avatar_media_url: string
           bio: string
-          created_at: string
-          created_via: string
-          header_media_url: string
+          website: string
           location: string
+          header_media_url: string
           num_followers: number
           num_tweets: number
-          username: string
-          website: string
         }[]
       }
       get_top_liked_users: {
-        Args: never
+        Args: Record<PropertyKey, never>
         Returns: {
+          tweet_id: string
           full_text: string
           like_count: number
           reply_to_tweet_id: string
           reply_to_user_id: string
           reply_to_username: string
-          tweet_id: string
         }[]
       }
       get_top_mentioned_users: {
-        Args: { limit_: number }
+        Args: {
+          limit_: number
+        }
         Returns: {
-          mention_count: number
+          user_id: string
           name: string
           screen_name: string
-          user_id: string
+          mention_count: number
         }[]
       }
       get_top_retweeted_tweets_by_username: {
-        Args: { limit_: number; username_: string }
+        Args: {
+          username_: string
+          limit_: number
+        }
         Returns: {
+          tweet_id: string
           account_id: string
-          archive_upload_id: number
           created_at: string
-          favorite_count: number
           full_text: string
+          retweet_count: number
+          favorite_count: number
           reply_to_tweet_id: string
           reply_to_user_id: string
           reply_to_username: string
-          retweet_count: number
-          tweet_id: string
+          archive_upload_id: number
         }[]
       }
       get_trending_tweets: {
-        Args: { hours_back?: number; limit_count?: number }
+        Args: {
+          hours_back?: number
+          limit_count?: number
+        }
         Returns: {
-          account_id: string
-          created_at: string
-          engagement_score: number
-          favorite_count: number
-          full_text: string
-          retweet_count: number
           tweet_id: string
+          account_id: string
+          full_text: string
+          created_at: string
+          favorite_count: number
+          retweet_count: number
+          engagement_score: number
         }[]
       }
       get_tweet_count_by_date:
         | {
-            Args: { end_date: string; start_date: string }
+            Args: {
+              start_date: string
+              end_date: string
+            }
             Returns: {
-              tweet_count: number
               tweet_date: string
+              tweet_count: number
             }[]
           }
         | {
-            Args: { end_date: string; granularity: string; start_date: string }
+            Args: {
+              start_date: string
+              end_date: string
+              granularity: string
+            }
             Returns: {
-              tweet_count: number
               tweet_date: string
+              tweet_count: number
             }[]
           }
       get_tweet_counts_by_granularity: {
-        Args: { end_date: string; granularity: string; start_date: string }
+        Args: {
+          start_date: string
+          end_date: string
+          granularity: string
+        }
         Returns: {
-          tweet_count: number
           tweet_date: string
+          tweet_count: number
         }[]
       }
-      get_tweet_page_data: { Args: { p_tweet_id: string }; Returns: Json }
+      get_tweet_page_data: {
+        Args: {
+          p_tweet_id: string
+        }
+        Returns: Json
+      }
       get_unique_scraper_count: {
-        Args: { end_date: string; start_date: string }
+        Args: {
+          start_date: string
+          end_date: string
+        }
         Returns: number
       }
+      gtrgm_compress: {
+        Args: {
+          "": unknown
+        }
+        Returns: unknown
+      }
+      gtrgm_decompress: {
+        Args: {
+          "": unknown
+        }
+        Returns: unknown
+      }
+      gtrgm_in: {
+        Args: {
+          "": unknown
+        }
+        Returns: unknown
+      }
+      gtrgm_options: {
+        Args: {
+          "": unknown
+        }
+        Returns: undefined
+      }
+      gtrgm_out: {
+        Args: {
+          "": unknown
+        }
+        Returns: unknown
+      }
       insert_temp_account: {
-        Args: { p_account: Json; p_suffix: string }
+        Args: {
+          p_account: Json
+          p_suffix: string
+        }
         Returns: undefined
       }
       insert_temp_archive_upload: {
         Args: {
           p_account_id: string
           p_archive_at: string
-          p_end_date: string
           p_keep_private: boolean
-          p_start_date: string
-          p_suffix: string
           p_upload_likes: boolean
+          p_start_date: string
+          p_end_date: string
+          p_suffix: string
         }
         Returns: number
       }
       insert_temp_followers: {
-        Args: { p_account_id: string; p_followers: Json; p_suffix: string }
+        Args: {
+          p_followers: Json
+          p_account_id: string
+          p_suffix: string
+        }
         Returns: undefined
       }
       insert_temp_following: {
-        Args: { p_account_id: string; p_following: Json; p_suffix: string }
+        Args: {
+          p_following: Json
+          p_account_id: string
+          p_suffix: string
+        }
         Returns: undefined
       }
       insert_temp_likes: {
-        Args: { p_account_id: string; p_likes: Json; p_suffix: string }
+        Args: {
+          p_likes: Json
+          p_account_id: string
+          p_suffix: string
+        }
         Returns: undefined
       }
       insert_temp_profiles: {
-        Args: { p_account_id: string; p_profile: Json; p_suffix: string }
+        Args: {
+          p_profile: Json
+          p_account_id: string
+          p_suffix: string
+        }
         Returns: undefined
       }
       insert_temp_tweets: {
-        Args: { p_suffix: string; p_tweets: Json }
+        Args: {
+          p_tweets: Json
+          p_suffix: string
+        }
         Returns: undefined
       }
       process_and_insert_tweet_entities: {
-        Args: { p_suffix: string; p_tweets: Json }
+        Args: {
+          p_tweets: Json
+          p_suffix: string
+        }
         Returns: undefined
       }
-      process_archive: { Args: { archive_data: Json }; Returns: undefined }
-      refresh_global_activity_summary: { Args: never; Returns: undefined }
+      process_archive: {
+        Args: {
+          archive_data: Json
+        }
+        Returns: undefined
+      }
+      refresh_global_activity_summary: {
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
       search_tweets:
         | {
             Args: {
+              search_query: string
               from_user?: string
+              to_user?: string
+              since_date?: string
+              until_date?: string
               limit_?: number
               offset_?: number
-              search_query: string
-              since_date?: string
-              to_user?: string
-              until_date?: string
             }
             Returns: {
-              account_display_name: string
-              account_id: string
-              archive_upload_id: number
-              avatar_media_url: string
-              created_at: string
-              favorite_count: number
-              full_text: string
-              media: Json
-              reply_to_tweet_id: string
-              retweet_count: number
               tweet_id: string
+              account_id: string
+              created_at: string
+              full_text: string
+              retweet_count: number
+              favorite_count: number
+              reply_to_tweet_id: string
+              avatar_media_url: string
+              archive_upload_id: number
               username: string
+              account_display_name: string
+              media: Json
             }[]
           }
         | {
             Args: {
+              search_query: string
+              limit_count?: number
               account_filter?: string
               date_from?: string
               date_to?: string
-              limit_count?: number
-              search_query: string
             }
             Returns: {
+              tweet_id: string
               account_id: string
+              full_text: string
               created_at: string
               favorite_count: number
-              full_text: string
-              relevance: number
               retweet_count: number
-              tweet_id: string
+              relevance: number
             }[]
           }
       search_tweets_exact_phrase: {
         Args: {
           exact_phrase: string
           from_user?: string
+          to_user?: string
+          since_date?: string
+          until_date?: string
           limit_?: number
           offset_?: number
-          since_date?: string
-          to_user?: string
-          until_date?: string
         }
         Returns: {
-          account_display_name: string
-          account_id: string
-          archive_upload_id: number
-          avatar_media_url: string
-          created_at: string
-          favorite_count: number
-          full_text: string
-          media: Json
-          reply_to_tweet_id: string
-          retweet_count: number
           tweet_id: string
+          account_id: string
+          created_at: string
+          full_text: string
+          retweet_count: number
+          favorite_count: number
+          reply_to_tweet_id: string
+          avatar_media_url: string
+          archive_upload_id: number
           username: string
+          account_display_name: string
+          media: Json
         }[]
       }
-      show_limit: { Args: never; Returns: number }
-      show_trgm: { Args: { "": string }; Returns: string[] }
+      set_limit: {
+        Args: {
+          "": number
+        }
+        Returns: number
+      }
+      show_limit: {
+        Args: Record<PropertyKey, never>
+        Returns: number
+      }
+      show_trgm: {
+        Args: {
+          "": string
+        }
+        Returns: string[]
+      }
       update_foreign_keys: {
         Args: {
-          new_table_name: string
           old_table_name: string
+          new_table_name: string
           schema_name: string
         }
         Returns: undefined
       }
       word_occurrences: {
         Args: {
-          end_date?: string
           search_word: string
           start_date?: string
+          end_date?: string
           user_ids?: string[]
         }
         Returns: {
@@ -1821,33 +2028,27 @@ export type Database = {
   }
 }
 
-type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
-
-type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+type PublicSchema = Database[Extract<keyof Database, "public">]
 
 export type Tables<
-  DefaultSchemaTableNameOrOptions extends
-    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
-    | { schema: keyof DatabaseWithoutInternals },
-  TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
-  }
-    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+  PublicTableNameOrOptions extends
+    | keyof (PublicSchema["Tables"] & PublicSchema["Views"])
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+        Database[PublicTableNameOrOptions["schema"]]["Views"])
     : never = never,
-> = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
-}
-  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+      Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
       Row: infer R
     }
     ? R
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])
-    ? (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
+        PublicSchema["Views"])
+    ? (PublicSchema["Tables"] &
+        PublicSchema["Views"])[PublicTableNameOrOptions] extends {
         Row: infer R
       }
       ? R
@@ -1855,24 +2056,20 @@ export type Tables<
     : never
 
 export type TablesInsert<
-  DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
-    | { schema: keyof DatabaseWithoutInternals },
-  TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
-  }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+  PublicTableNameOrOptions extends
+    | keyof PublicSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
     : never = never,
-> = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
-}
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Insert: infer I
     }
     ? I
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
         Insert: infer I
       }
       ? I
@@ -1880,24 +2077,20 @@ export type TablesInsert<
     : never
 
 export type TablesUpdate<
-  DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
-    | { schema: keyof DatabaseWithoutInternals },
-  TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
-  }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+  PublicTableNameOrOptions extends
+    | keyof PublicSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
     : never = never,
-> = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
-}
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Update: infer U
     }
     ? U
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
         Update: infer U
       }
       ? U
@@ -1905,52 +2098,30 @@ export type TablesUpdate<
     : never
 
 export type Enums<
-  DefaultSchemaEnumNameOrOptions extends
-    | keyof DefaultSchema["Enums"]
-    | { schema: keyof DatabaseWithoutInternals },
-  EnumName extends DefaultSchemaEnumNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
-  }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+  PublicEnumNameOrOptions extends
+    | keyof PublicSchema["Enums"]
+    | { schema: keyof Database },
+  EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
     : never = never,
-> = DefaultSchemaEnumNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
-}
-  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
-  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
-    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+> = PublicEnumNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
+    ? PublicSchema["Enums"][PublicEnumNameOrOptions]
     : never
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
-    | keyof DefaultSchema["CompositeTypes"]
-    | { schema: keyof DatabaseWithoutInternals },
+    | keyof PublicSchema["CompositeTypes"]
+    | { schema: keyof Database },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof Database
   }
-    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
     : never = never,
-> = PublicCompositeTypeNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
-}
-  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
-    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+> = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
+    ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never
 
-export const Constants = {
-  dev: {
-    Enums: {},
-  },
-  public: {
-    Enums: {
-      upload_phase_enum: [
-        "uploading",
-        "ready_for_commit",
-        "committing",
-        "completed",
-        "failed",
-      ],
-    },
-  },
-} as const

--- a/src/lib/queries/fetchUsers.test.ts
+++ b/src/lib/queries/fetchUsers.test.ts
@@ -1,0 +1,15 @@
+import { buildDirectorySearchFilter } from './fetchUsers'
+
+describe('buildDirectorySearchFilter', () => {
+  it('quotes commas and other PostgREST logic characters', () => {
+    expect(buildDirectorySearchFilter('archive, team')).toBe(
+      'username.ilike."%archive, team%",account_display_name.ilike."%archive, team%"',
+    )
+  })
+
+  it('escapes quotes and backslashes inside quoted filter values', () => {
+    expect(buildDirectorySearchFilter('a"b\\c')).toBe(
+      'username.ilike."%a\\"b\\\\c%",account_display_name.ilike."%a\\"b\\\\c%"',
+    )
+  })
+})

--- a/src/lib/queries/fetchUsers.ts
+++ b/src/lib/queries/fetchUsers.ts
@@ -1,4 +1,4 @@
-import { User } from '@/lib/types'
+import { DirectoryUser, SortKey } from '@/lib/types'
 import { formatUserData } from '@/lib/user-utils'
 import { SupabaseClient } from '@supabase/supabase-js'
 import { devLog } from '@/lib/devLog'
@@ -6,16 +6,22 @@ import { devLog } from '@/lib/devLog'
 export interface FetchUsersOptions {
   limit?: number
   offset?: number
-  sortBy?: string
+  sortBy?: SortKey
   sortOrder?: 'asc' | 'desc'
   search?: string
 }
 
 export const fetchUsers = async (
   supabase: SupabaseClient,
-  options?: FetchUsersOptions
-): Promise<User[]> => {
-  const { limit, offset = 0, sortBy = 'archive_uploaded_at', sortOrder = 'desc', search } = options || {}
+  options?: FetchUsersOptions,
+): Promise<DirectoryUser[]> => {
+  const {
+    limit,
+    offset = 0,
+    sortBy = 'joined_at',
+    sortOrder = 'desc',
+    search,
+  } = options || {}
 
   let query = supabase
     .schema('public')
@@ -25,25 +31,26 @@ export const fetchUsers = async (
       account_id,
       username,
       account_display_name,
-      created_at,
-      num_tweets,
-      num_followers,
-      num_following,
-      num_likes,
-      bio,
-      website,
-      location,
       avatar_media_url,
-      archive_at,
-      archive_uploaded_at
+      archive_uploaded_at,
+      directory_id,
+      has_archive,
+      is_opted_in,
+      opted_in_at,
+      joined_at
     `,
     )
 
   if (search) {
-    query = query.or(`username.ilike.%${search}%,account_display_name.ilike.%${search}%`)
+    query = query.or(
+      `username.ilike.%${search}%,account_display_name.ilike.%${search}%`,
+    )
   }
 
-  query = query.order(sortBy, { ascending: sortOrder === 'asc', nullsFirst: false })
+  query = query.order(sortBy, {
+    ascending: sortOrder === 'asc',
+    nullsFirst: false,
+  })
 
   if (limit) {
     query = query.range(offset, offset + limit - 1)
@@ -53,17 +60,22 @@ export const fetchUsers = async (
 
   if (error) throw error
 
-  return (data as User[]) || []
+  return (data as DirectoryUser[]) || []
 }
 
-export const fetchUsersCount = async (supabase: SupabaseClient, search?: string): Promise<number> => {
+export const fetchUsersCount = async (
+  supabase: SupabaseClient,
+  search?: string,
+): Promise<number> => {
   let query = supabase
     .schema('public')
     .from('user_directory')
     .select('account_id', { count: 'exact', head: true })
 
   if (search) {
-    query = query.or(`username.ilike.%${search}%,account_display_name.ilike.%${search}%`)
+    query = query.or(
+      `username.ilike.%${search}%,account_display_name.ilike.%${search}%`,
+    )
   }
 
   const { count, error } = await query

--- a/src/lib/queries/fetchUsers.ts
+++ b/src/lib/queries/fetchUsers.ts
@@ -11,6 +11,13 @@ export interface FetchUsersOptions {
   search?: string
 }
 
+export const buildDirectorySearchFilter = (search: string) => {
+  const escapedSearch = search.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+  const pattern = `"%${escapedSearch}%"`
+
+  return `username.ilike.${pattern},account_display_name.ilike.${pattern}`
+}
+
 export const fetchUsers = async (
   supabase: SupabaseClient,
   options?: FetchUsersOptions,
@@ -42,15 +49,14 @@ export const fetchUsers = async (
     )
 
   if (search) {
-    query = query.or(
-      `username.ilike.%${search}%,account_display_name.ilike.%${search}%`,
-    )
+    query = query.or(buildDirectorySearchFilter(search))
   }
 
   query = query.order(sortBy, {
     ascending: sortOrder === 'asc',
     nullsFirst: false,
   })
+  query = query.order('directory_id', { ascending: true })
 
   if (limit) {
     query = query.range(offset, offset + limit - 1)
@@ -73,9 +79,7 @@ export const fetchUsersCount = async (
     .select('account_id', { count: 'exact', head: true })
 
   if (search) {
-    query = query.or(
-      `username.ilike.%${search}%,account_display_name.ilike.%${search}%`,
-    )
+    query = query.or(buildDirectorySearchFilter(search))
   }
 
   const { count, error } = await query

--- a/src/lib/queries/fetchUsers.ts
+++ b/src/lib/queries/fetchUsers.ts
@@ -39,6 +39,7 @@ export const fetchUsers = async (
       username,
       account_display_name,
       avatar_media_url,
+      num_followers,
       archive_uploaded_at,
       directory_id,
       has_archive,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -158,33 +158,20 @@ export type PopularTweet = {
   num_replies?: number
 }
 
-// Add this new type to the existing types
-export type User = {
-  account_id: string
+export type DirectoryUser = {
+  directory_id: string
+  account_id: string | null
   username: string
   account_display_name: string
-  created_at: string
-  bio: string | null
-  website: string | null
-  location: string | null
   avatar_media_url: string | null
-  archive_at: string | null
-  num_tweets: number
-  num_followers: number
-  num_following: number
-  num_likes: number
+  has_archive: boolean
+  is_opted_in: boolean
+  opted_in_at: string | null
   archive_uploaded_at: string | null
+  joined_at: string | null
 }
 
-export type SortKey =
-  | 'username'
-  | 'created_at'
-  | 'account_display_name'
-  | 'archive_at'
-  | 'num_tweets'
-  | 'num_likes'
-  | 'num_followers'
-  | 'archive_uploaded_at'
+export type SortKey = 'username' | 'account_display_name' | 'joined_at'
 
 export type FormattedUser = {
   account_id: string

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -164,6 +164,7 @@ export type DirectoryUser = {
   username: string
   account_display_name: string
   avatar_media_url: string | null
+  num_followers: number | null
   has_archive: boolean
   is_opted_in: boolean
   opted_in_at: string | null
@@ -171,7 +172,11 @@ export type DirectoryUser = {
   joined_at: string | null
 }
 
-export type SortKey = 'username' | 'account_display_name' | 'joined_at'
+export type SortKey =
+  | 'username'
+  | 'account_display_name'
+  | 'num_followers'
+  | 'joined_at'
 
 export type FormattedUser = {
   account_id: string

--- a/supabase/migrations/20260710170000_include_opted_in_members_in_user_directory.sql
+++ b/supabase/migrations/20260710170000_include_opted_in_members_in_user_directory.sql
@@ -17,36 +17,42 @@ WITH archived_members AS (
     au.created_at AS archive_uploaded_at,
     'archive:' || a.account_id AS directory_id,
     true AS has_archive,
-    oi.id IS NOT NULL AS is_opted_in,
+    oi.is_opted_in IS TRUE AS is_opted_in,
     oi.opted_in_at,
     LEAST(
-      au.created_at,
-      COALESCE(oi.opted_in_at, oi.created_at, au.created_at)
+      au.first_archive_uploaded_at,
+      COALESCE(
+        oi.opted_in_at,
+        oi.created_at,
+        au.first_archive_uploaded_at
+      )
     ) AS joined_at
   FROM public.account a
   LEFT JOIN public.profile p ON a.account_id = p.account_id
-  JOIN public.archive_upload au ON a.account_id = au.account_id
-    AND au.id = (
-      SELECT max(au2.id) FROM public.archive_upload au2
-      WHERE au2.account_id = a.account_id
-      AND au2.upload_phase = 'completed'
-    )
+  JOIN LATERAL (
+    SELECT
+      candidate.*,
+      min(candidate.created_at) OVER () AS first_archive_uploaded_at
+    FROM public.archive_upload candidate
+    WHERE candidate.account_id = a.account_id
+      AND candidate.upload_phase = 'completed'
+    ORDER BY candidate.id DESC
+    LIMIT 1
+  ) au ON true
   LEFT JOIN LATERAL (
-    SELECT o.id, o.created_at, o.opted_in_at
+    SELECT
+      bool_or(true) AS is_opted_in,
+      min(COALESCE(o.opted_in_at, o.created_at, o.updated_at)) AS opted_in_at,
+      min(o.created_at) AS created_at
     FROM public.optin o
     WHERE o.opted_in = true
       AND (
         o.twitter_user_id = a.account_id
         OR lower(o.username) = lower(a.username)
       )
-    ORDER BY
-      (o.twitter_user_id = a.account_id) DESC NULLS LAST,
-      o.opted_in_at DESC NULLS LAST,
-      o.created_at DESC NULLS LAST
-    LIMIT 1
   ) oi ON true
 ),
-opted_in_members AS (
+opted_in_candidates AS (
   SELECT
     COALESCE(a.account_id, o.twitter_user_id) AS account_id,
     o.username,
@@ -99,6 +105,17 @@ opted_in_members AS (
       )
         OR lower(archived.username) = lower(o.username)
     )
+),
+opted_in_members AS (
+  SELECT DISTINCT ON (
+    COALESCE(account_id, 'username:' || lower(username))
+  )
+    *
+  FROM opted_in_candidates
+  ORDER BY
+    COALESCE(account_id, 'username:' || lower(username)),
+    joined_at ASC NULLS LAST,
+    directory_id
 )
 SELECT * FROM archived_members
 UNION ALL

--- a/supabase/migrations/20260710170000_include_opted_in_members_in_user_directory.sql
+++ b/supabase/migrations/20260710170000_include_opted_in_members_in_user_directory.sql
@@ -1,75 +1,3 @@
--- Views split from prod.sql (no functional changes)
-
--- public.account moved to 032_views_prereq.sql
-
--- public.enriched_tweets
-CREATE OR REPLACE VIEW "public"."enriched_tweets" AS
- SELECT "t"."tweet_id",
-    "t"."account_id",
-    "a"."username",
-    "a"."account_display_name",
-    "t"."created_at",
-    "t"."full_text",
-    "t"."retweet_count",
-    "t"."favorite_count",
-    "t"."reply_to_tweet_id",
-    "t"."reply_to_user_id",
-    "t"."reply_to_username",
-    "qt"."quoted_tweet_id",
-    "c"."conversation_id",
-    "p"."avatar_media_url",
-    "t"."archive_upload_id"
-   FROM (((("public"."tweets" "t"
-     JOIN "public"."all_account" "a" ON (("t"."account_id" = "a"."account_id")))
-     LEFT JOIN "public"."conversations" "c" ON (("t"."tweet_id" = "c"."tweet_id")))
-     LEFT JOIN "public"."quote_tweets" "qt" ON (("t"."tweet_id" = "qt"."tweet_id")))
-     LEFT JOIN LATERAL ( SELECT "all_profile"."avatar_media_url"
-           FROM "public"."all_profile"
-          WHERE ("all_profile"."account_id" = "t"."account_id")
-          ORDER BY "all_profile"."archive_upload_id" DESC
-         LIMIT 1) "p" ON (true));
-ALTER TABLE "public"."enriched_tweets" OWNER TO "postgres";
-
--- public.global_monthly_tweet_counts
-CREATE OR REPLACE VIEW "public"."global_monthly_tweet_counts" AS
- SELECT "monthly_tweet_counts_mv"."month",
-    "sum"("monthly_tweet_counts_mv"."tweet_count") AS "total_tweets",
-    "count"(DISTINCT "monthly_tweet_counts_mv"."account_id") AS "active_accounts",
-    ("avg"("monthly_tweet_counts_mv"."tweet_count"))::numeric(10,2) AS "avg_tweets_per_account"
-   FROM "public"."monthly_tweet_counts_mv"
-  GROUP BY "monthly_tweet_counts_mv"."month"
-  ORDER BY "monthly_tweet_counts_mv"."month" DESC;
-ALTER TABLE "public"."global_monthly_tweet_counts" OWNER TO "postgres";
-
--- public.profile moved to 032_views_prereq.sql
-
--- public.tweet_replies_view
-CREATE OR REPLACE VIEW "public"."tweet_replies_view" AS
- SELECT "tweets"."reply_to_tweet_id",
-    "tweets"."reply_to_user_id"
-   FROM "public"."tweets"
-  WHERE ("tweets"."reply_to_tweet_id" IS NOT NULL);
-ALTER TABLE "public"."tweet_replies_view" OWNER TO "postgres";
-
--- public.tweets_w_conversation_id
-CREATE OR REPLACE VIEW "public"."tweets_w_conversation_id" AS
- SELECT "tweets"."tweet_id",
-    "tweets"."account_id",
-    "tweets"."created_at",
-    "tweets"."full_text",
-    "tweets"."retweet_count",
-    "tweets"."favorite_count",
-    "tweets"."reply_to_tweet_id",
-    "tweets"."reply_to_user_id",
-    "tweets"."reply_to_username",
-    "tweets"."archive_upload_id",
-    "tweets"."fts",
-    "c"."conversation_id"
-   FROM ("public"."tweets"
-     LEFT JOIN "public"."conversations" "c" ON (("tweets"."tweet_id" = "c"."tweet_id")));
-ALTER TABLE "public"."tweets_w_conversation_id" OWNER TO "postgres";
-
--- public.user_directory
 CREATE OR REPLACE VIEW "public"."user_directory" AS
 WITH archived_members AS (
   SELECT
@@ -175,4 +103,5 @@ opted_in_members AS (
 SELECT * FROM archived_members
 UNION ALL
 SELECT * FROM opted_in_members;
-ALTER TABLE "public"."user_directory" OWNER TO "postgres";
+
+GRANT SELECT ON TABLE "public"."user_directory" TO "readclient";

--- a/supabase/migrations/20260711150000_optimize_user_directory_account_lookup.sql
+++ b/supabase/migrations/20260711150000_optimize_user_directory_account_lookup.sql
@@ -1,3 +1,6 @@
+-- Avoid a case-insensitive scan of the full all_account table for every
+-- opted-in member. New opt-ins receive a trusted Twitter user ID from auth;
+-- legacy rows without one remain visible but are not enriched from all_account.
 CREATE OR REPLACE VIEW "public"."user_directory" AS
 WITH archived_members AS (
   SELECT

--- a/supabase/schemas/040_views.sql
+++ b/supabase/schemas/040_views.sql
@@ -146,20 +146,9 @@ opted_in_candidates AS (
     o.opted_in_at,
     COALESCE(o.opted_in_at, o.created_at, o.updated_at) AS joined_at
   FROM public.optin o
-  LEFT JOIN LATERAL (
-    SELECT candidate.*
-    FROM public.all_account candidate
-    WHERE (
-      o.twitter_user_id IS NOT NULL
-      AND candidate.account_id = o.twitter_user_id
-    )
-      OR lower(candidate.username) = lower(o.username)
-    ORDER BY (
-      o.twitter_user_id IS NOT NULL
-      AND candidate.account_id = o.twitter_user_id
-    ) DESC
-    LIMIT 1
-  ) a ON true
+  LEFT JOIN public.all_account a
+    ON o.twitter_user_id IS NOT NULL
+    AND a.account_id = o.twitter_user_id
   LEFT JOIN LATERAL (
     SELECT candidate.*
     FROM public.all_profile candidate

--- a/supabase/schemas/040_views.sql
+++ b/supabase/schemas/040_views.sql
@@ -89,36 +89,42 @@ WITH archived_members AS (
     au.created_at AS archive_uploaded_at,
     'archive:' || a.account_id AS directory_id,
     true AS has_archive,
-    oi.id IS NOT NULL AS is_opted_in,
+    oi.is_opted_in IS TRUE AS is_opted_in,
     oi.opted_in_at,
     LEAST(
-      au.created_at,
-      COALESCE(oi.opted_in_at, oi.created_at, au.created_at)
+      au.first_archive_uploaded_at,
+      COALESCE(
+        oi.opted_in_at,
+        oi.created_at,
+        au.first_archive_uploaded_at
+      )
     ) AS joined_at
   FROM public.account a
   LEFT JOIN public.profile p ON a.account_id = p.account_id
-  JOIN public.archive_upload au ON a.account_id = au.account_id
-    AND au.id = (
-      SELECT max(au2.id) FROM public.archive_upload au2
-      WHERE au2.account_id = a.account_id
-      AND au2.upload_phase = 'completed'
-    )
+  JOIN LATERAL (
+    SELECT
+      candidate.*,
+      min(candidate.created_at) OVER () AS first_archive_uploaded_at
+    FROM public.archive_upload candidate
+    WHERE candidate.account_id = a.account_id
+      AND candidate.upload_phase = 'completed'
+    ORDER BY candidate.id DESC
+    LIMIT 1
+  ) au ON true
   LEFT JOIN LATERAL (
-    SELECT o.id, o.created_at, o.opted_in_at
+    SELECT
+      bool_or(true) AS is_opted_in,
+      min(COALESCE(o.opted_in_at, o.created_at, o.updated_at)) AS opted_in_at,
+      min(o.created_at) AS created_at
     FROM public.optin o
     WHERE o.opted_in = true
       AND (
         o.twitter_user_id = a.account_id
         OR lower(o.username) = lower(a.username)
       )
-    ORDER BY
-      (o.twitter_user_id = a.account_id) DESC NULLS LAST,
-      o.opted_in_at DESC NULLS LAST,
-      o.created_at DESC NULLS LAST
-    LIMIT 1
   ) oi ON true
 ),
-opted_in_members AS (
+opted_in_candidates AS (
   SELECT
     COALESCE(a.account_id, o.twitter_user_id) AS account_id,
     o.username,
@@ -171,6 +177,17 @@ opted_in_members AS (
       )
         OR lower(archived.username) = lower(o.username)
     )
+),
+opted_in_members AS (
+  SELECT DISTINCT ON (
+    COALESCE(account_id, 'username:' || lower(username))
+  )
+    *
+  FROM opted_in_candidates
+  ORDER BY
+    COALESCE(account_id, 'username:' || lower(username)),
+    joined_at ASC NULLS LAST,
+    directory_id
 )
 SELECT * FROM archived_members
 UNION ALL


### PR DESCRIPTION
## What changed

- include currently opted-in people in the public user directory, even when they have not uploaded an archive
- de-duplicate members by Twitter account ID or case-insensitive username and preserve both participation states
- record the earliest completed archive-upload or current opt-in timestamp as the directory join date
- simplify the directory to Member, Participation, Followers, and Joined columns
- add distinct Archive and Opted in icon badges while preserving search, sorting, pagination, dark mode, and archive-profile links

## Why

The directory view previously required a completed archive upload, so people who explicitly opted in to tweet streaming were missing. The previous nine-column table also obscured the participation information users need most.

## Review cleanup

- use the earliest completed upload for Joined while retaining the latest completed upload as archive metadata
- collapse duplicate opt-ins after resolving account IDs and case-insensitive usernames
- quote and escape public search values so punctuation cannot break the PostgREST filter
- add a stable directory ID tie-breaker for offset paginationn- avoid repeated full-table account scans when enriching opted-in members
- derive Twitter account association from trusted auth app metadata instead of the request body
- remove the unrelated edit to the legacy root database.types.ts file

## Impact

After the included migration reaches production, the directory will show archive contributors and active opt-ins in one list. Archive-backed rows remain linkable; opt-in-only rows do not create dead profile links.

## Deployment note

#406 is merged and supplies the reproducible readclient/bootstrap prerequisite. This PR still requires its forward-only optimization migration to be applied through the normal audited production migration process before merge./ No production database command was run during this review.

## Validation

- pnpm type-check
- pnpm build
- focused Jest coverage for quoted/escaped directory search filters
- PostgreSQL 16 migration test over the existing viewn- read-only production plan: exact count ~205 ms and follower sort ~140 ms with the optimized lookup
- verified archive-only, opt-in-only, dual-status, opted-out, case-insensitive and account-ID de-duplication, multiple-upload joined dates, and latest archive metadata behavior