### PR TITLE
feat: add profiles for opted-in members

### DIFF
--- a/src/app/user-dir/page.tsx
+++ b/src/app/user-dir/page.tsx
@@ -25,7 +25,11 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { formatNumber } from '@/lib/formatNumber'
-import { fetchUsers, fetchUsersCount } from '@/lib/queries/fetchUsers'
+import {
+  fetchUsers,
+  fetchUsersCount,
+  getDirectoryProfileHref,
+} from '@/lib/queries/fetchUsers'
 import { DirectoryUser, SortKey } from '@/lib/types'
 import { createBrowserClient } from '@/utils/supabase'
 
@@ -299,16 +303,12 @@ export default function UserDirectoryPage() {
                       className="group border-gray-200 hover:bg-gray-50/80 dark:border-gray-800 dark:hover:bg-gray-900/60"
                     >
                       <TableCell className="py-4">
-                        {user.has_archive && user.account_id ? (
-                          <Link
-                            href={`/user/${user.account_id}`}
-                            className="block rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 group-hover:[&_div.font-semibold]:underline"
-                          >
-                            {identity}
-                          </Link>
-                        ) : (
-                          identity
-                        )}
+                        <Link
+                          href={getDirectoryProfileHref(user)}
+                          className="block rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 group-hover:[&_div.font-semibold]:underline"
+                        >
+                          {identity}
+                        </Link>
                       </TableCell>
                       <TableCell>
                         <div className="flex flex-wrap gap-2">

--- a/src/app/user/[account_id]/page.tsx
+++ b/src/app/user/[account_id]/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
+import { Badge } from '@/components/ui/badge'
 import TopMentionedUsers, {
   MentionedUser,
 } from '@/components/TopMentionedMissingUsers'
@@ -14,20 +15,21 @@ import { DownloadArchiveButton } from './DownloadArchiveButton'
 import Image from 'next/image'
 import TweetList from '@/components/TweetList'
 import { FilterCriteria } from '@/lib/queries/tweetQueries'
-import { createBrowserClient } from '@/utils/supabase'
+import { Archive, Radio } from 'lucide-react'
 
 // Style constants (glows removed)
-const unifiedDeepBlueBase = "bg-white dark:bg-background"
-const sectionPaddingClasses = "py-12 md:py-16 lg:py-20"
-const contentWrapperClasses = "w-full max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10"
+const unifiedDeepBlueBase = 'bg-white dark:bg-background'
+const sectionPaddingClasses = 'py-12 md:py-16 lg:py-20'
+const contentWrapperClasses =
+  'w-full max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10'
 
 const UserProfile = ({ userData }: { userData: FormattedUser }) => {
   const account = userData
   return (
     // Profile info card - Removed shadow
-    <div className="bg-slate-100 dark:bg-card p-6 sm:p-8 rounded-lg mb-8">
-      <div className="flex flex-col sm:flex-row items-center sm:items-start space-y-4 sm:space-y-0 sm:space-x-6">
-        <Avatar className="h-24 w-24 sm:h-28 sm:w-28 ring-2 ring-offset-2 ring-blue-500 dark:ring-offset-slate-800">
+    <div className="mb-8 rounded-lg bg-slate-100 p-6 dark:bg-card sm:p-8">
+      <div className="flex flex-col items-center space-y-4 sm:flex-row sm:items-start sm:space-x-6 sm:space-y-0">
+        <Avatar className="h-24 w-24 ring-2 ring-blue-500 ring-offset-2 dark:ring-offset-slate-800 sm:h-28 sm:w-28">
           <AvatarImage
             src={account.avatar_media_url || '/placeholder.jpg'}
             alt={`${account.account_display_name}'s avatar`}
@@ -36,75 +38,144 @@ const UserProfile = ({ userData }: { userData: FormattedUser }) => {
             {account.account_display_name.charAt(0).toUpperCase()}
           </AvatarFallback>
         </Avatar>
-        <div className="text-center sm:text-left flex-grow">
-          <h1 className="text-3xl sm:text-4xl font-bold text-gray-900 dark:text-white">{account.account_display_name}</h1>
-          <p className="text-lg text-gray-600 dark:text-gray-400">@{account.username}</p>
-          {account.bio && <p className="mt-3 text-gray-700 dark:text-gray-300 text-sm sm:text-base">{account.bio}</p>}
-          <div className="mt-3 space-y-1 text-sm text-gray-500 dark:text-gray-400">
-            {account.location && (
-              <p>📍 {account.location}</p>
+        <div className="flex-grow text-center sm:text-left">
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white sm:text-4xl">
+            {account.account_display_name}
+          </h1>
+          <p className="text-lg text-gray-600 dark:text-gray-400">
+            @{account.username}
+          </p>
+          <div className="mt-3 flex flex-wrap justify-center gap-2 sm:justify-start">
+            {account.has_archive && (
+              <Badge variant="outline" className="gap-1.5">
+                <Archive aria-hidden="true" className="h-3.5 w-3.5" />
+                Archive contributor
+              </Badge>
             )}
-            <p>📅 Joined: {new Date(account.created_at).toLocaleDateString()}</p>
+            {account.is_opted_in && (
+              <Badge variant="outline" className="gap-1.5">
+                <Radio aria-hidden="true" className="h-3.5 w-3.5" />
+                Opted in
+              </Badge>
+            )}
+          </div>
+          {account.bio && (
+            <p className="mt-3 text-sm text-gray-700 dark:text-gray-300 sm:text-base">
+              {account.bio}
+            </p>
+          )}
+          <div className="mt-3 space-y-1 text-sm text-gray-500 dark:text-gray-400">
+            {account.location && <p>📍 {account.location}</p>}
+            {account.created_at && (
+              <p>
+                📅 Joined Twitter:{' '}
+                {new Date(account.created_at).toLocaleDateString()}
+              </p>
+            )}
+            {account.joined_at && (
+              <p>
+                🤝 Community member since:{' '}
+                {new Date(account.joined_at).toLocaleDateString()}
+              </p>
+            )}
             {account.archive_at && (
-              <p>🗄️ Archived: {new Date(account.archive_at).toLocaleDateString()}</p>
+              <p>
+                🗄️ Archived: {new Date(account.archive_at).toLocaleDateString()}
+              </p>
             )}
           </div>
         </div>
       </div>
-      <div className="mt-6 pt-6 border-t border-gray-200 dark:border-gray-700 flex flex-wrap justify-center sm:justify-start gap-x-6 gap-y-3 text-sm text-gray-700 dark:text-gray-300">
-        <p><strong className="font-semibold text-gray-800 dark:text-white">{formatNumber(account.num_tweets)}</strong> Tweets</p>
-        <p><strong className="font-semibold text-gray-800 dark:text-white">{formatNumber(account.num_followers)}</strong> Followers</p>
-        <p><strong className="font-semibold text-gray-800 dark:text-white">{formatNumber(account.num_following)}</strong> Following</p>
-        <p><strong className="font-semibold text-gray-800 dark:text-white">{formatNumber(account.num_likes)}</strong> Likes</p>
+      <div className="mt-6 flex flex-wrap justify-center gap-x-6 gap-y-3 border-t border-gray-200 pt-6 text-sm text-gray-700 dark:border-gray-700 dark:text-gray-300 sm:justify-start">
+        <p>
+          <strong className="font-semibold text-gray-800 dark:text-white">
+            {formatNumber(account.num_tweets)}
+          </strong>{' '}
+          Tweets
+        </p>
+        <p>
+          <strong className="font-semibold text-gray-800 dark:text-white">
+            {formatNumber(account.num_followers)}
+          </strong>{' '}
+          Followers
+        </p>
+        <p>
+          <strong className="font-semibold text-gray-800 dark:text-white">
+            {formatNumber(account.num_following)}
+          </strong>{' '}
+          Following
+        </p>
+        <p>
+          <strong className="font-semibold text-gray-800 dark:text-white">
+            {formatNumber(account.num_likes)}
+          </strong>{' '}
+          Likes
+        </p>
       </div>
-      <div className="mt-6 text-center sm:text-left">
-        <DownloadArchiveButton username={account.username} />
-      </div>
+      {account.has_archive && (
+        <div className="mt-6 text-center sm:text-left">
+          <DownloadArchiveButton username={account.username} />
+        </div>
+      )}
     </div>
   )
 }
 
-export default async function User({ params }: any) {
-  const { account_id } = params;
-  const cookieStore = cookies();
-  const supabase = createServerClient(cookieStore);
+export default async function User({
+  params,
+}: {
+  params: { account_id: string }
+}) {
+  const { account_id } = params
+  const cookieStore = cookies()
+  const supabase = createServerClient(cookieStore)
 
-  const userData = await getUserData(supabase, account_id);
+  const userData = await getUserData(supabase, account_id)
 
   if (!userData) {
     // Styled error message for consistency - Removed glow and shadow
     return (
-      <section 
-        className={`${unifiedDeepBlueBase} ${sectionPaddingClasses} flex-grow flex items-center justify-center overflow-hidden`}
+      <section
+        className={`${unifiedDeepBlueBase} ${sectionPaddingClasses} flex flex-grow items-center justify-center overflow-hidden`}
       >
         <div className={`${contentWrapperClasses} text-center`}>
-            {/* Error card - Removed shadow */}
-            <div className="bg-slate-100 dark:bg-card p-8 rounded-lg">
-                <h1 className="text-2xl font-bold text-red-600 dark:text-red-400">Error Fetching User Data</h1>
-                <p className="mt-2 text-gray-600 dark:text-gray-300">Could not retrieve information for this user. Please try again later.</p>
-            </div>
+          {/* Error card - Removed shadow */}
+          <div className="rounded-lg bg-slate-100 p-8 dark:bg-card">
+            <h1 className="text-2xl font-bold text-red-600 dark:text-red-400">
+              Error Fetching User Data
+            </h1>
+            <p className="mt-2 text-gray-600 dark:text-gray-300">
+              Could not retrieve information for this user. Please try again
+              later.
+            </p>
+          </div>
         </div>
       </section>
-    );
+    )
   }
 
-  const { data: summaryData, error: summaryError } = await supabase
+  let summaryQuery = supabase
     .from('account_activity_summary')
     .select('mentioned_accounts')
-    .or(`account_id.eq.${account_id},username.ilike.${account_id}`)
-    .single();
 
-  const showingSummaryData = !summaryError && summaryData?.mentioned_accounts;
+  summaryQuery = userData.account_id
+    ? summaryQuery.eq('account_id', userData.account_id)
+    : summaryQuery.eq('username', userData.username)
+
+  const { data: summaryData, error: summaryError } =
+    await summaryQuery.maybeSingle()
+
+  const showingSummaryData = !summaryError && summaryData?.mentioned_accounts
 
   return (
-    <section 
+    <section
       className={`${unifiedDeepBlueBase} ${sectionPaddingClasses} flex-grow overflow-hidden`}
     >
       <div className={`${contentWrapperClasses} space-y-8`}>
         {/* Banner Image - Removed shadow */}
         {userData?.header_media_url && (
-          <div className="relative w-full h-48 md:h-64 rounded-xl overflow-hidden mb-8">
-            <Image 
+          <div className="relative mb-8 h-48 w-full overflow-hidden rounded-xl md:h-64">
+            <Image
               src={userData.header_media_url}
               alt={`${userData.account_display_name}'s cover photo`}
               layout="fill"
@@ -115,16 +186,26 @@ export default async function User({ params }: any) {
         )}
 
         {/* UserProfile Suspense - Removed shadow from Skeleton */}
-        <Suspense fallback={<Skeleton className="bg-slate-100 dark:bg-card p-8 rounded-lg h-60 w-full" />}>
+        <Suspense
+          fallback={
+            <Skeleton className="h-60 w-full rounded-lg bg-slate-100 p-8 dark:bg-card" />
+          }
+        >
           <UserProfile userData={userData} />
         </Suspense>
 
         {showingSummaryData ? (
           <>
             {/* Most Mentioned Accounts card - Removed shadow */}
-            <div className="bg-slate-100 dark:bg-card p-6 sm:p-8 rounded-lg">
-              <h2 className="text-2xl font-semibold mb-4 text-gray-900 dark:text-white">Most Mentioned Accounts</h2>
-              <Suspense fallback={<Skeleton className="h-[20vh] w-full bg-slate-200 dark:bg-slate-700 rounded" />}>
+            <div className="rounded-lg bg-slate-100 p-6 dark:bg-card sm:p-8">
+              <h2 className="mb-4 text-2xl font-semibold text-gray-900 dark:text-white">
+                Most Mentioned Accounts
+              </h2>
+              <Suspense
+                fallback={
+                  <Skeleton className="h-[20vh] w-full rounded bg-slate-200 dark:bg-slate-700" />
+                }
+              >
                 <TopMentionedUsers
                   users={summaryData.mentioned_accounts as MentionedUser[]}
                   height="h-[20vh]"
@@ -133,36 +214,48 @@ export default async function User({ params }: any) {
             </div>
 
             {/* Top Tweets card - Removed shadow */}
-            <div className="bg-slate-100 dark:bg-card p-6 sm:p-8 rounded-lg">
-              <h2 className="text-2xl font-semibold mb-4 text-gray-900 dark:text-white">Top Tweets</h2>
-              <Suspense fallback={<Skeleton className="h-96 w-full bg-slate-200 dark:bg-slate-700 rounded" />}>
+            <div className="rounded-lg bg-slate-100 p-6 dark:bg-card sm:p-8">
+              <h2 className="mb-4 text-2xl font-semibold text-gray-900 dark:text-white">
+                Top Tweets
+              </h2>
+              <Suspense
+                fallback={
+                  <Skeleton className="h-96 w-full rounded bg-slate-200 dark:bg-slate-700" />
+                }
+              >
                 <AccountTopTweets userData={userData} />
               </Suspense>
             </div>
           </>
         ) : (
-          <div className="bg-slate-100 dark:bg-card p-8 rounded-lg text-center">
+          <div className="rounded-lg bg-slate-100 p-8 text-center dark:bg-card">
             {/* Activity summary placeholder card - Removed shadow */}
             <h3 className="text-xl font-semibold text-gray-800 dark:text-gray-200">
-              Activity summary not yet available.
+              {userData.account_id
+                ? 'Activity summary not yet available.'
+                : 'Activity is not linked yet.'}
             </h3>
             <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
-              Detailed activity data like top tweets and mentions is currently
-              being processed or is not available for this user. Basic profile
-              information is still shown above.
+              {userData.account_id
+                ? 'Detailed activity data like top tweets and mentions is currently being processed or is not available for this user. Basic profile information is still shown above.'
+                : 'This member has opted in, but their Twitter account ID has not been connected to archived or streamed activity yet.'}
             </p>
           </div>
         )}
 
-        {/* New Section for User's Recent Tweets - MOVED BELOW ACTIVITY SUMMARY */}
-        <div className="bg-slate-100 dark:bg-card p-6 sm:p-8 rounded-lg">
-          <h2 className="text-2xl font-semibold mb-6 text-gray-900 dark:text-white">Recent Tweets</h2>
-          <TweetList 
-            filterCriteria={{ userId: account_id } satisfies FilterCriteria}
-            itemsPerPage={20} // Example: can be adjusted or made a prop
-          />
-        </div>
-
+        {userData.account_id && (
+          <div className="rounded-lg bg-slate-100 p-6 dark:bg-card sm:p-8">
+            <h2 className="mb-6 text-2xl font-semibold text-gray-900 dark:text-white">
+              Recent Tweets
+            </h2>
+            <TweetList
+              filterCriteria={
+                { userId: userData.account_id } satisfies FilterCriteria
+              }
+              itemsPerPage={20}
+            />
+          </div>
+        )}
       </div>
     </section>
   )

--- a/src/database-types.ts
+++ b/src/database-types.ts
@@ -7,11 +7,6 @@ export type Json =
   | Json[]
 
 export type Database = {
-  // Allows to automatically instantiate createClient with right options
-  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
-  __InternalSupabase: {
-    PostgrestVersion: "12.2.2 (db9da0b)"
-  }
   dev: {
     Tables: {
       [_ in never]: never
@@ -21,77 +16,142 @@ export type Database = {
     }
     Functions: {
       apply_dev_entities_rls_policies: {
-        Args: { schema_name: string; table_name: string }
+        Args: {
+          schema_name: string
+          table_name: string
+        }
         Returns: undefined
       }
       apply_dev_liked_tweets_rls_policies: {
-        Args: { schema_name: string; table_name: string }
+        Args: {
+          schema_name: string
+          table_name: string
+        }
         Returns: undefined
       }
       apply_dev_rls_policies: {
-        Args: { schema_name: string; table_name: string }
+        Args: {
+          schema_name: string
+          table_name: string
+        }
         Returns: undefined
       }
-      commit_temp_data: { Args: { p_suffix: string }; Returns: undefined }
-      create_temp_tables: { Args: { p_suffix: string }; Returns: undefined }
+      commit_temp_data: {
+        Args: {
+          p_suffix: string
+        }
+        Returns: undefined
+      }
+      create_temp_tables: {
+        Args: {
+          p_suffix: string
+        }
+        Returns: undefined
+      }
       delete_all_archives: {
-        Args: { p_account_id: string }
+        Args: {
+          p_account_id: string
+        }
         Returns: undefined
       }
       drop_function_if_exists: {
-        Args: { function_args: string[]; function_name: string }
+        Args: {
+          function_name: string
+          function_args: string[]
+        }
         Returns: undefined
       }
-      drop_temp_tables: { Args: { p_suffix: string }; Returns: undefined }
+      drop_temp_tables: {
+        Args: {
+          p_suffix: string
+        }
+        Returns: undefined
+      }
       get_top_accounts_with_followers: {
-        Args: { limit_count: number }
+        Args: {
+          limit_count: number
+        }
         Returns: {
-          account_display_name: string
           account_id: string
+          created_via: string
+          username: string
+          created_at: string
+          account_display_name: string
           avatar_media_url: string
           bio: string
-          created_at: string
-          created_via: string
-          follower_count: number
-          header_media_url: string
-          location: string
-          username: string
           website: string
+          location: string
+          header_media_url: string
+          follower_count: number
         }[]
       }
       insert_temp_account: {
-        Args: { p_account: Json; p_suffix: string }
+        Args: {
+          p_account: Json
+          p_suffix: string
+        }
         Returns: undefined
       }
       insert_temp_archive_upload: {
-        Args: { p_account_id: string; p_archive_at: string; p_suffix: string }
+        Args: {
+          p_account_id: string
+          p_archive_at: string
+          p_suffix: string
+        }
         Returns: number
       }
       insert_temp_followers: {
-        Args: { p_account_id: string; p_followers: Json; p_suffix: string }
+        Args: {
+          p_followers: Json
+          p_account_id: string
+          p_suffix: string
+        }
         Returns: undefined
       }
       insert_temp_following: {
-        Args: { p_account_id: string; p_following: Json; p_suffix: string }
+        Args: {
+          p_following: Json
+          p_account_id: string
+          p_suffix: string
+        }
         Returns: undefined
       }
       insert_temp_likes: {
-        Args: { p_account_id: string; p_likes: Json; p_suffix: string }
+        Args: {
+          p_likes: Json
+          p_account_id: string
+          p_suffix: string
+        }
         Returns: undefined
       }
       insert_temp_profiles: {
-        Args: { p_account_id: string; p_profile: Json; p_suffix: string }
+        Args: {
+          p_profile: Json
+          p_account_id: string
+          p_suffix: string
+        }
         Returns: undefined
       }
       insert_temp_tweets: {
-        Args: { p_suffix: string; p_tweets: Json }
+        Args: {
+          p_tweets: Json
+          p_suffix: string
+        }
         Returns: undefined
       }
       process_and_insert_tweet_entities: {
-        Args: { p_suffix: string; p_tweets: Json }
+        Args: {
+          p_tweets: Json
+          p_suffix: string
+        }
         Returns: undefined
       }
-      process_archive: { Args: { archive_data: Json }; Returns: undefined }
+      process_archive: {
+        Args: {
+          archive_data: Json
+        }
+        Returns: undefined
+      }
     }
     Enums: {
       [_ in never]: never
@@ -409,17 +469,17 @@ export type Database = {
       }
       liked_tweets: {
         Row: {
-          fts: unknown
+          fts: unknown | null
           full_text: string
           tweet_id: string
         }
         Insert: {
-          fts?: unknown
+          fts?: unknown | null
           full_text: string
           tweet_id: string
         }
         Update: {
-          fts?: unknown
+          fts?: unknown | null
           full_text?: string
           tweet_id?: string
         }
@@ -775,7 +835,7 @@ export type Database = {
           archive_upload_id: number | null
           created_at: string
           favorite_count: number
-          fts: unknown
+          fts: unknown | null
           full_text: string
           reply_to_tweet_id: string | null
           reply_to_user_id: string | null
@@ -789,7 +849,7 @@ export type Database = {
           archive_upload_id?: number | null
           created_at: string
           favorite_count: number
-          fts?: unknown
+          fts?: unknown | null
           full_text: string
           reply_to_tweet_id?: string | null
           reply_to_user_id?: string | null
@@ -803,7 +863,7 @@ export type Database = {
           archive_upload_id?: number | null
           created_at?: string
           favorite_count?: number
-          fts?: unknown
+          fts?: unknown | null
           full_text?: string
           reply_to_tweet_id?: string | null
           reply_to_user_id?: string | null
@@ -1123,7 +1183,7 @@ export type Database = {
           conversation_id: string | null
           created_at: string | null
           favorite_count: number | null
-          fts: unknown
+          fts: unknown | null
           full_text: string | null
           reply_to_tweet_id: string | null
           reply_to_user_id: string | null
@@ -1191,204 +1251,278 @@ export type Database = {
       admin_enqueue_delete_with_export: {
         Args: {
           p_account_id: string
+          p_username: string
           p_reason?: string
           p_requested_by_user_id?: string
-          p_username: string
         }
         Returns: string
       }
       admin_list_blocked_scraping_users: {
-        Args: { p_account_ids: string[] }
+        Args: {
+          p_account_ids: string[]
+        }
         Returns: string[]
       }
       admin_set_scrape_block: {
-        Args: { p_account_id: string; p_blocked: boolean }
+        Args: {
+          p_account_id: string
+          p_blocked: boolean
+        }
         Returns: undefined
       }
       apply_public_entities_rls_policies: {
-        Args: { schema_name: string; table_name: string }
+        Args: {
+          schema_name: string
+          table_name: string
+        }
         Returns: undefined
       }
       apply_public_liked_tweets_rls_policies: {
-        Args: { schema_name: string; table_name: string }
+        Args: {
+          schema_name: string
+          table_name: string
+        }
         Returns: undefined
       }
       apply_public_rls_policies: {
-        Args: { schema_name: string; table_name: string }
+        Args: {
+          schema_name: string
+          table_name: string
+        }
         Returns: undefined
       }
       apply_public_rls_policies_not_private: {
-        Args: { schema_name: string; table_name: string }
+        Args: {
+          schema_name: string
+          table_name: string
+        }
         Returns: undefined
       }
       apply_readonly_rls_policies: {
-        Args: { schema_name: string; table_name: string }
+        Args: {
+          schema_name: string
+          table_name: string
+        }
         Returns: undefined
       }
-      commit_temp_data: { Args: { p_suffix: string }; Returns: undefined }
+      commit_temp_data: {
+        Args: {
+          p_suffix: string
+        }
+        Returns: undefined
+      }
       compute_hourly_scraping_stats: {
-        Args: { p_end_date: string; p_start_date: string }
+        Args: {
+          p_start_date: string
+          p_end_date: string
+        }
         Returns: {
-          period_end: string
           period_start: string
+          period_end: string
           tweet_count: number
           unique_scrapers: number
         }[]
       }
-      create_temp_tables: { Args: { p_suffix: string }; Returns: undefined }
+      create_temp_tables: {
+        Args: {
+          p_suffix: string
+        }
+        Returns: undefined
+      }
       delete_non_allowlist_streamed_tweet_batch: {
-        Args: { p_limit?: number }
+        Args: {
+          p_limit?: number
+        }
         Returns: {
-          deleted_conversations: number
-          deleted_private_tweet_user: number
-          deleted_tweet_media: number
-          deleted_tweet_urls: number
-          deleted_tweets: number
-          deleted_user_mentions: number
           requested_tweets: number
+          deleted_tweets: number
+          deleted_conversations: number
+          deleted_tweet_media: number
+          deleted_user_mentions: number
+          deleted_tweet_urls: number
+          deleted_private_tweet_user: number
         }[]
       }
       delete_single_archive: {
-        Args: { p_account_id: string; p_archive_upload_id: number }
+        Args: {
+          p_account_id: string
+          p_archive_upload_id: number
+        }
         Returns: undefined
       }
       delete_tweets: {
-        Args: { p_tweet_ids: string[] }
+        Args: {
+          p_tweet_ids: string[]
+        }
         Returns: {
-          deleted_conversations: number
-          deleted_private_tweet_user: number
-          deleted_tweet_media: number
-          deleted_tweet_urls: number
           deleted_tweets: number
+          deleted_conversations: number
+          deleted_tweet_media: number
           deleted_user_mentions: number
+          deleted_tweet_urls: number
+          deleted_private_tweet_user: number
         }[]
       }
       delete_user_archive: {
-        Args: { p_account_id: string }
+        Args: {
+          p_account_id: string
+        }
         Returns: undefined
       }
       drop_all_policies: {
-        Args: { schema_name: string; table_name: string }
+        Args: {
+          schema_name: string
+          table_name: string
+        }
         Returns: undefined
       }
-      drop_temp_tables: { Args: { p_suffix: string }; Returns: undefined }
+      drop_temp_tables: {
+        Args: {
+          p_suffix: string
+        }
+        Returns: undefined
+      }
       get_account_most_liked_tweets_archive_users: {
-        Args: { limit_?: number; username_: string }
+        Args: {
+          username_: string
+          limit_?: number
+        }
         Returns: {
+          tweet_id: string
           account_id: string
-          archive_upload_id: number
           created_at: string
-          favorite_count: number
           full_text: string
-          num_likes: number
+          retweet_count: number
+          favorite_count: number
           reply_to_tweet_id: string
           reply_to_user_id: string
           reply_to_username: string
-          retweet_count: number
-          tweet_id: string
+          archive_upload_id: number
+          num_likes: number
         }[]
       }
       get_account_most_mentioned_accounts: {
-        Args: { limit_: number; username_: string }
+        Args: {
+          username_: string
+          limit_: number
+        }
         Returns: {
-          mention_count: number
+          user_id: string
           name: string
           screen_name: string
-          user_id: string
+          mention_count: number
         }[]
       }
       get_account_most_replied_tweets_by_archive_users: {
-        Args: { limit_: number; username_: string }
+        Args: {
+          username_: string
+          limit_: number
+        }
         Returns: {
+          tweet_id: string
           account_id: string
-          archive_upload_id: number
           created_at: string
-          favorite_count: number
           full_text: string
-          num_replies: number
+          retweet_count: number
+          favorite_count: number
           reply_to_tweet_id: string
           reply_to_user_id: string
           reply_to_username: string
-          retweet_count: number
-          tweet_id: string
+          archive_upload_id: number
+          num_replies: number
         }[]
       }
       get_account_top_favorite_count_tweets: {
-        Args: { limit_: number; username_: string }
+        Args: {
+          username_: string
+          limit_: number
+        }
         Returns: {
+          tweet_id: string
           account_id: string
-          archive_upload_id: number
           created_at: string
-          favorite_count: number
           full_text: string
+          retweet_count: number
+          favorite_count: number
           reply_to_tweet_id: string
           reply_to_user_id: string
           reply_to_username: string
-          retweet_count: number
-          tweet_id: string
+          archive_upload_id: number
         }[]
       }
       get_account_top_retweet_count_tweets: {
-        Args: { limit_: number; username_: string }
+        Args: {
+          username_: string
+          limit_: number
+        }
         Returns: {
+          tweet_id: string
           account_id: string
-          archive_upload_id: number
           created_at: string
-          favorite_count: number
           full_text: string
+          retweet_count: number
+          favorite_count: number
           reply_to_tweet_id: string
           reply_to_user_id: string
           reply_to_username: string
-          retweet_count: number
-          tweet_id: string
+          archive_upload_id: number
         }[]
       }
       get_hourly_scraping_stats: {
-        Args: { p_hours_back?: number }
+        Args: {
+          p_hours_back?: number
+        }
         Returns: {
-          period_end: string
           period_start: string
+          period_end: string
           tweet_count: number
           unique_scrapers: number
         }[]
       }
       get_hourly_stats_simple: {
-        Args: { p_hours_back?: number }
+        Args: {
+          p_hours_back?: number
+        }
         Returns: {
           period_start: string
           tweet_count: number
         }[]
       }
       get_latest_tweets: {
-        Args: { count: number; p_account_id?: string }
+        Args: {
+          count: number
+          p_account_id?: string
+        }
         Returns: {
-          account_display_name: string
-          account_id: string
-          avatar_media_url: string
-          created_at: string
-          favorite_count: number
-          full_text: string
-          reply_to_tweet_id: string
-          retweet_count: number
           tweet_id: string
+          account_id: string
+          created_at: string
+          full_text: string
+          retweet_count: number
+          favorite_count: number
+          reply_to_tweet_id: string
+          avatar_media_url: string
           username: string
+          account_display_name: string
         }[]
       }
       get_main_thread: {
-        Args: { p_conversation_id: string }
+        Args: {
+          p_conversation_id: string
+        }
         Returns: {
-          account_id: string
-          conversation_id: string
-          depth: number
-          favorite_count: number
-          max_depth: number
-          reply_to_tweet_id: string
-          retweet_count: number
           tweet_id: string
+          conversation_id: string
+          reply_to_tweet_id: string
+          account_id: string
+          depth: number
+          max_depth: number
+          favorite_count: number
+          retweet_count: number
         }[]
       }
       get_monthly_tweet_counts: {
-        Args: never
+        Args: Record<PropertyKey, never>
         Returns: {
           month: string
           tweet_count: number
@@ -1397,343 +1531,481 @@ export type Database = {
       get_monthly_tweet_counts_fast: {
         Args: {
           p_account_id?: string
-          p_end_date?: string
           p_start_date?: string
+          p_end_date?: string
         }
         Returns: {
+          month: string
           account_id: string
+          tweet_count: number
+          days_active: number
           avg_favorites: number
           avg_retweets: number
-          days_active: number
-          month: string
-          tweet_count: number
         }[]
       }
       get_most_liked_tweets_by_username: {
-        Args: { username_: string }
+        Args: {
+          username_: string
+        }
         Returns: {
+          tweet_id: string
           full_text: string
           num_likes: number
-          tweet_id: string
         }[]
       }
       get_most_mentioned_accounts_by_username: {
-        Args: { username_: string }
+        Args: {
+          username_: string
+        }
         Returns: {
-          mention_count: number
           mentioned_user_id: string
           mentioned_username: string
+          mention_count: number
         }[]
       }
       get_non_allowlist_streamed_tweet_candidates: {
-        Args: { p_limit?: number }
+        Args: {
+          p_limit?: number
+        }
         Returns: {
+          tweet_id: string
           account_id: string
           created_at: string
-          is_quote: boolean
           reply_to_tweet_id: string
-          tweet_id: string
+          is_quote: boolean
         }[]
       }
       get_scraper_counts_by_granularity: {
-        Args: { end_date: string; granularity: string; start_date: string }
+        Args: {
+          start_date: string
+          end_date: string
+          granularity: string
+        }
         Returns: {
           scraper_date: string
           unique_scrapers: number
         }[]
       }
       get_simple_streamed_tweet_counts: {
-        Args: { end_date: string; granularity: string; start_date: string }
+        Args: {
+          start_date: string
+          end_date: string
+          granularity: string
+        }
         Returns: {
-          tweet_count: number
           tweet_date: string
+          tweet_count: number
         }[]
       }
       get_streaming_stats: {
         Args: {
+          p_start_date: string
           p_end_date: string
           p_granularity?: string
-          p_start_date: string
           p_streamed_only?: boolean
         }
         Returns: {
-          period_end: string
           period_start: string
+          period_end: string
           tweet_count: number
           unique_scrapers: number
         }[]
       }
       get_streaming_stats_daily: {
-        Args: { p_end_date: string; p_start_date: string }
+        Args: {
+          p_start_date: string
+          p_end_date: string
+        }
         Returns: {
-          period_end: string
           period_start: string
+          period_end: string
           tweet_count: number
           unique_scrapers: number
         }[]
       }
       get_streaming_stats_daily_streamed_only: {
-        Args: { p_end_date: string; p_start_date: string }
+        Args: {
+          p_start_date: string
+          p_end_date: string
+        }
         Returns: {
-          period_end: string
           period_start: string
+          period_end: string
           tweet_count: number
           unique_scrapers: number
         }[]
       }
       get_streaming_stats_hourly: {
-        Args: { p_end_date: string; p_start_date: string }
+        Args: {
+          p_start_date: string
+          p_end_date: string
+        }
         Returns: {
-          period_end: string
           period_start: string
+          period_end: string
           tweet_count: number
           unique_scrapers: number
         }[]
       }
       get_streaming_stats_hourly_streamed_only: {
-        Args: { p_end_date: string; p_start_date: string }
+        Args: {
+          p_start_date: string
+          p_end_date: string
+        }
         Returns: {
-          period_end: string
           period_start: string
+          period_end: string
           tweet_count: number
           unique_scrapers: number
         }[]
       }
       get_streaming_stats_weekly: {
-        Args: { p_end_date: string; p_start_date: string }
+        Args: {
+          p_start_date: string
+          p_end_date: string
+        }
         Returns: {
-          period_end: string
           period_start: string
+          period_end: string
           tweet_count: number
           unique_scrapers: number
         }[]
       }
       get_streaming_stats_weekly_streamed_only: {
-        Args: { p_end_date: string; p_start_date: string }
+        Args: {
+          p_start_date: string
+          p_end_date: string
+        }
         Returns: {
-          period_end: string
           period_start: string
+          period_end: string
           tweet_count: number
           unique_scrapers: number
         }[]
       }
       get_top_accounts_with_followers: {
-        Args: { limit_count: number }
+        Args: {
+          limit_count: number
+        }
         Returns: {
-          account_display_name: string
           account_id: string
+          created_via: string
+          username: string
+          created_at: string
+          account_display_name: string
           avatar_media_url: string
           bio: string
-          created_at: string
-          created_via: string
-          header_media_url: string
+          website: string
           location: string
+          header_media_url: string
           num_followers: number
           num_tweets: number
-          username: string
-          website: string
         }[]
       }
       get_top_liked_users: {
-        Args: never
+        Args: Record<PropertyKey, never>
         Returns: {
+          tweet_id: string
           full_text: string
           like_count: number
           reply_to_tweet_id: string
           reply_to_user_id: string
           reply_to_username: string
-          tweet_id: string
         }[]
       }
       get_top_mentioned_users: {
-        Args: { limit_: number }
+        Args: {
+          limit_: number
+        }
         Returns: {
-          mention_count: number
+          user_id: string
           name: string
           screen_name: string
-          user_id: string
+          mention_count: number
         }[]
       }
       get_top_retweeted_tweets_by_username: {
-        Args: { limit_: number; username_: string }
+        Args: {
+          username_: string
+          limit_: number
+        }
         Returns: {
+          tweet_id: string
           account_id: string
-          archive_upload_id: number
           created_at: string
-          favorite_count: number
           full_text: string
+          retweet_count: number
+          favorite_count: number
           reply_to_tweet_id: string
           reply_to_user_id: string
           reply_to_username: string
-          retweet_count: number
-          tweet_id: string
+          archive_upload_id: number
         }[]
       }
       get_trending_tweets: {
-        Args: { hours_back?: number; limit_count?: number }
+        Args: {
+          hours_back?: number
+          limit_count?: number
+        }
         Returns: {
-          account_id: string
-          created_at: string
-          engagement_score: number
-          favorite_count: number
-          full_text: string
-          retweet_count: number
           tweet_id: string
+          account_id: string
+          full_text: string
+          created_at: string
+          favorite_count: number
+          retweet_count: number
+          engagement_score: number
         }[]
       }
       get_tweet_count_by_date:
         | {
-            Args: { end_date: string; start_date: string }
+            Args: {
+              start_date: string
+              end_date: string
+            }
             Returns: {
-              tweet_count: number
               tweet_date: string
+              tweet_count: number
             }[]
           }
         | {
-            Args: { end_date: string; granularity: string; start_date: string }
+            Args: {
+              start_date: string
+              end_date: string
+              granularity: string
+            }
             Returns: {
-              tweet_count: number
               tweet_date: string
+              tweet_count: number
             }[]
           }
       get_tweet_counts_by_granularity: {
-        Args: { end_date: string; granularity: string; start_date: string }
+        Args: {
+          start_date: string
+          end_date: string
+          granularity: string
+        }
         Returns: {
-          tweet_count: number
           tweet_date: string
+          tweet_count: number
         }[]
       }
-      get_tweet_page_data: { Args: { p_tweet_id: string }; Returns: Json }
+      get_tweet_page_data: {
+        Args: {
+          p_tweet_id: string
+        }
+        Returns: Json
+      }
       get_unique_scraper_count: {
-        Args: { end_date: string; start_date: string }
+        Args: {
+          start_date: string
+          end_date: string
+        }
         Returns: number
       }
+      gtrgm_compress: {
+        Args: {
+          "": unknown
+        }
+        Returns: unknown
+      }
+      gtrgm_decompress: {
+        Args: {
+          "": unknown
+        }
+        Returns: unknown
+      }
+      gtrgm_in: {
+        Args: {
+          "": unknown
+        }
+        Returns: unknown
+      }
+      gtrgm_options: {
+        Args: {
+          "": unknown
+        }
+        Returns: undefined
+      }
+      gtrgm_out: {
+        Args: {
+          "": unknown
+        }
+        Returns: unknown
+      }
       insert_temp_account: {
-        Args: { p_account: Json; p_suffix: string }
+        Args: {
+          p_account: Json
+          p_suffix: string
+        }
         Returns: undefined
       }
       insert_temp_archive_upload: {
         Args: {
           p_account_id: string
           p_archive_at: string
-          p_end_date: string
           p_keep_private: boolean
-          p_start_date: string
-          p_suffix: string
           p_upload_likes: boolean
+          p_start_date: string
+          p_end_date: string
+          p_suffix: string
         }
         Returns: number
       }
       insert_temp_followers: {
-        Args: { p_account_id: string; p_followers: Json; p_suffix: string }
+        Args: {
+          p_followers: Json
+          p_account_id: string
+          p_suffix: string
+        }
         Returns: undefined
       }
       insert_temp_following: {
-        Args: { p_account_id: string; p_following: Json; p_suffix: string }
+        Args: {
+          p_following: Json
+          p_account_id: string
+          p_suffix: string
+        }
         Returns: undefined
       }
       insert_temp_likes: {
-        Args: { p_account_id: string; p_likes: Json; p_suffix: string }
+        Args: {
+          p_likes: Json
+          p_account_id: string
+          p_suffix: string
+        }
         Returns: undefined
       }
       insert_temp_profiles: {
-        Args: { p_account_id: string; p_profile: Json; p_suffix: string }
+        Args: {
+          p_profile: Json
+          p_account_id: string
+          p_suffix: string
+        }
         Returns: undefined
       }
       insert_temp_tweets: {
-        Args: { p_suffix: string; p_tweets: Json }
+        Args: {
+          p_tweets: Json
+          p_suffix: string
+        }
         Returns: undefined
       }
       process_and_insert_tweet_entities: {
-        Args: { p_suffix: string; p_tweets: Json }
+        Args: {
+          p_tweets: Json
+          p_suffix: string
+        }
         Returns: undefined
       }
-      process_archive: { Args: { archive_data: Json }; Returns: undefined }
-      refresh_global_activity_summary: { Args: never; Returns: undefined }
+      process_archive: {
+        Args: {
+          archive_data: Json
+        }
+        Returns: undefined
+      }
+      refresh_global_activity_summary: {
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
       search_tweets:
         | {
             Args: {
+              search_query: string
               from_user?: string
+              to_user?: string
+              since_date?: string
+              until_date?: string
               limit_?: number
               offset_?: number
-              search_query: string
-              since_date?: string
-              to_user?: string
-              until_date?: string
             }
             Returns: {
-              account_display_name: string
-              account_id: string
-              archive_upload_id: number
-              avatar_media_url: string
-              created_at: string
-              favorite_count: number
-              full_text: string
-              media: Json
-              reply_to_tweet_id: string
-              retweet_count: number
               tweet_id: string
+              account_id: string
+              created_at: string
+              full_text: string
+              retweet_count: number
+              favorite_count: number
+              reply_to_tweet_id: string
+              avatar_media_url: string
+              archive_upload_id: number
               username: string
+              account_display_name: string
+              media: Json
             }[]
           }
         | {
             Args: {
+              search_query: string
+              limit_count?: number
               account_filter?: string
               date_from?: string
               date_to?: string
-              limit_count?: number
-              search_query: string
             }
             Returns: {
+              tweet_id: string
               account_id: string
+              full_text: string
               created_at: string
               favorite_count: number
-              full_text: string
-              relevance: number
               retweet_count: number
-              tweet_id: string
+              relevance: number
             }[]
           }
       search_tweets_exact_phrase: {
         Args: {
           exact_phrase: string
           from_user?: string
+          to_user?: string
+          since_date?: string
+          until_date?: string
           limit_?: number
           offset_?: number
-          since_date?: string
-          to_user?: string
-          until_date?: string
         }
         Returns: {
-          account_display_name: string
-          account_id: string
-          archive_upload_id: number
-          avatar_media_url: string
-          created_at: string
-          favorite_count: number
-          full_text: string
-          media: Json
-          reply_to_tweet_id: string
-          retweet_count: number
           tweet_id: string
+          account_id: string
+          created_at: string
+          full_text: string
+          retweet_count: number
+          favorite_count: number
+          reply_to_tweet_id: string
+          avatar_media_url: string
+          archive_upload_id: number
           username: string
+          account_display_name: string
+          media: Json
         }[]
       }
-      show_limit: { Args: never; Returns: number }
-      show_trgm: { Args: { "": string }; Returns: string[] }
+      set_limit: {
+        Args: {
+          "": number
+        }
+        Returns: number
+      }
+      show_limit: {
+        Args: Record<PropertyKey, never>
+        Returns: number
+      }
+      show_trgm: {
+        Args: {
+          "": string
+        }
+        Returns: string[]
+      }
       update_foreign_keys: {
         Args: {
-          new_table_name: string
           old_table_name: string
+          new_table_name: string
           schema_name: string
         }
         Returns: undefined
       }
       word_occurrences: {
         Args: {
-          end_date?: string
           search_word: string
           start_date?: string
+          end_date?: string
           user_ids?: string[]
         }
         Returns: {
@@ -1756,33 +2028,27 @@ export type Database = {
   }
 }
 
-type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
-
-type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+type PublicSchema = Database[Extract<keyof Database, "public">]
 
 export type Tables<
-  DefaultSchemaTableNameOrOptions extends
-    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
-    | { schema: keyof DatabaseWithoutInternals },
-  TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
-  }
-    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+  PublicTableNameOrOptions extends
+    | keyof (PublicSchema["Tables"] & PublicSchema["Views"])
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+        Database[PublicTableNameOrOptions["schema"]]["Views"])
     : never = never,
-> = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
-}
-  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+      Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
       Row: infer R
     }
     ? R
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])
-    ? (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
+        PublicSchema["Views"])
+    ? (PublicSchema["Tables"] &
+        PublicSchema["Views"])[PublicTableNameOrOptions] extends {
         Row: infer R
       }
       ? R
@@ -1790,24 +2056,20 @@ export type Tables<
     : never
 
 export type TablesInsert<
-  DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
-    | { schema: keyof DatabaseWithoutInternals },
-  TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
-  }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+  PublicTableNameOrOptions extends
+    | keyof PublicSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
     : never = never,
-> = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
-}
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Insert: infer I
     }
     ? I
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
         Insert: infer I
       }
       ? I
@@ -1815,24 +2077,20 @@ export type TablesInsert<
     : never
 
 export type TablesUpdate<
-  DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
-    | { schema: keyof DatabaseWithoutInternals },
-  TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
-  }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+  PublicTableNameOrOptions extends
+    | keyof PublicSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
     : never = never,
-> = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
-}
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Update: infer U
     }
     ? U
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
         Update: infer U
       }
       ? U
@@ -1840,52 +2098,30 @@ export type TablesUpdate<
     : never
 
 export type Enums<
-  DefaultSchemaEnumNameOrOptions extends
-    | keyof DefaultSchema["Enums"]
-    | { schema: keyof DatabaseWithoutInternals },
-  EnumName extends DefaultSchemaEnumNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
-  }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+  PublicEnumNameOrOptions extends
+    | keyof PublicSchema["Enums"]
+    | { schema: keyof Database },
+  EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
     : never = never,
-> = DefaultSchemaEnumNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
-}
-  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
-  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
-    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+> = PublicEnumNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
+    ? PublicSchema["Enums"][PublicEnumNameOrOptions]
     : never
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
-    | keyof DefaultSchema["CompositeTypes"]
-    | { schema: keyof DatabaseWithoutInternals },
+    | keyof PublicSchema["CompositeTypes"]
+    | { schema: keyof Database },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof Database
   }
-    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
     : never = never,
-> = PublicCompositeTypeNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
-}
-  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
-    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+> = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
+    ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never
 
-export const Constants = {
-  dev: {
-    Enums: {},
-  },
-  public: {
-    Enums: {
-      upload_phase_enum: [
-        "uploading",
-        "ready_for_commit",
-        "committing",
-        "completed",
-        "failed",
-      ],
-    },
-  },
-} as const

--- a/src/database-types.ts
+++ b/src/database-types.ts
@@ -7,6 +7,11 @@ export type Json =
   | Json[]
 
 export type Database = {
+  // Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
+  __InternalSupabase: {
+    PostgrestVersion: "12.2.2 (db9da0b)"
+  }
   dev: {
     Tables: {
       [_ in never]: never
@@ -16,142 +21,77 @@ export type Database = {
     }
     Functions: {
       apply_dev_entities_rls_policies: {
-        Args: {
-          schema_name: string
-          table_name: string
-        }
+        Args: { schema_name: string; table_name: string }
         Returns: undefined
       }
       apply_dev_liked_tweets_rls_policies: {
-        Args: {
-          schema_name: string
-          table_name: string
-        }
+        Args: { schema_name: string; table_name: string }
         Returns: undefined
       }
       apply_dev_rls_policies: {
-        Args: {
-          schema_name: string
-          table_name: string
-        }
+        Args: { schema_name: string; table_name: string }
         Returns: undefined
       }
-      commit_temp_data: {
-        Args: {
-          p_suffix: string
-        }
-        Returns: undefined
-      }
-      create_temp_tables: {
-        Args: {
-          p_suffix: string
-        }
-        Returns: undefined
-      }
+      commit_temp_data: { Args: { p_suffix: string }; Returns: undefined }
+      create_temp_tables: { Args: { p_suffix: string }; Returns: undefined }
       delete_all_archives: {
-        Args: {
-          p_account_id: string
-        }
+        Args: { p_account_id: string }
         Returns: undefined
       }
       drop_function_if_exists: {
-        Args: {
-          function_name: string
-          function_args: string[]
-        }
+        Args: { function_args: string[]; function_name: string }
         Returns: undefined
       }
-      drop_temp_tables: {
-        Args: {
-          p_suffix: string
-        }
-        Returns: undefined
-      }
+      drop_temp_tables: { Args: { p_suffix: string }; Returns: undefined }
       get_top_accounts_with_followers: {
-        Args: {
-          limit_count: number
-        }
+        Args: { limit_count: number }
         Returns: {
-          account_id: string
-          created_via: string
-          username: string
-          created_at: string
           account_display_name: string
+          account_id: string
           avatar_media_url: string
           bio: string
-          website: string
-          location: string
-          header_media_url: string
+          created_at: string
+          created_via: string
           follower_count: number
+          header_media_url: string
+          location: string
+          username: string
+          website: string
         }[]
       }
       insert_temp_account: {
-        Args: {
-          p_account: Json
-          p_suffix: string
-        }
+        Args: { p_account: Json; p_suffix: string }
         Returns: undefined
       }
       insert_temp_archive_upload: {
-        Args: {
-          p_account_id: string
-          p_archive_at: string
-          p_suffix: string
-        }
+        Args: { p_account_id: string; p_archive_at: string; p_suffix: string }
         Returns: number
       }
       insert_temp_followers: {
-        Args: {
-          p_followers: Json
-          p_account_id: string
-          p_suffix: string
-        }
+        Args: { p_account_id: string; p_followers: Json; p_suffix: string }
         Returns: undefined
       }
       insert_temp_following: {
-        Args: {
-          p_following: Json
-          p_account_id: string
-          p_suffix: string
-        }
+        Args: { p_account_id: string; p_following: Json; p_suffix: string }
         Returns: undefined
       }
       insert_temp_likes: {
-        Args: {
-          p_likes: Json
-          p_account_id: string
-          p_suffix: string
-        }
+        Args: { p_account_id: string; p_likes: Json; p_suffix: string }
         Returns: undefined
       }
       insert_temp_profiles: {
-        Args: {
-          p_profile: Json
-          p_account_id: string
-          p_suffix: string
-        }
+        Args: { p_account_id: string; p_profile: Json; p_suffix: string }
         Returns: undefined
       }
       insert_temp_tweets: {
-        Args: {
-          p_tweets: Json
-          p_suffix: string
-        }
+        Args: { p_suffix: string; p_tweets: Json }
         Returns: undefined
       }
       process_and_insert_tweet_entities: {
-        Args: {
-          p_tweets: Json
-          p_suffix: string
-        }
+        Args: { p_suffix: string; p_tweets: Json }
         Returns: undefined
       }
-      process_archive: {
-        Args: {
-          archive_data: Json
-        }
-        Returns: undefined
-      }
+      process_archive: { Args: { archive_data: Json }; Returns: undefined }
     }
     Enums: {
       [_ in never]: never
@@ -469,17 +409,17 @@ export type Database = {
       }
       liked_tweets: {
         Row: {
-          fts: unknown | null
+          fts: unknown
           full_text: string
           tweet_id: string
         }
         Insert: {
-          fts?: unknown | null
+          fts?: unknown
           full_text: string
           tweet_id: string
         }
         Update: {
-          fts?: unknown | null
+          fts?: unknown
           full_text?: string
           tweet_id?: string
         }
@@ -835,7 +775,7 @@ export type Database = {
           archive_upload_id: number | null
           created_at: string
           favorite_count: number
-          fts: unknown | null
+          fts: unknown
           full_text: string
           reply_to_tweet_id: string | null
           reply_to_user_id: string | null
@@ -849,7 +789,7 @@ export type Database = {
           archive_upload_id?: number | null
           created_at: string
           favorite_count: number
-          fts?: unknown | null
+          fts?: unknown
           full_text: string
           reply_to_tweet_id?: string | null
           reply_to_user_id?: string | null
@@ -863,7 +803,7 @@ export type Database = {
           archive_upload_id?: number | null
           created_at?: string
           favorite_count?: number
-          fts?: unknown | null
+          fts?: unknown
           full_text?: string
           reply_to_tweet_id?: string | null
           reply_to_user_id?: string | null
@@ -1183,7 +1123,7 @@ export type Database = {
           conversation_id: string | null
           created_at: string | null
           favorite_count: number | null
-          fts: unknown | null
+          fts: unknown
           full_text: string | null
           reply_to_tweet_id: string | null
           reply_to_user_id: string | null
@@ -1251,278 +1191,204 @@ export type Database = {
       admin_enqueue_delete_with_export: {
         Args: {
           p_account_id: string
-          p_username: string
           p_reason?: string
           p_requested_by_user_id?: string
+          p_username: string
         }
         Returns: string
       }
       admin_list_blocked_scraping_users: {
-        Args: {
-          p_account_ids: string[]
-        }
+        Args: { p_account_ids: string[] }
         Returns: string[]
       }
       admin_set_scrape_block: {
-        Args: {
-          p_account_id: string
-          p_blocked: boolean
-        }
+        Args: { p_account_id: string; p_blocked: boolean }
         Returns: undefined
       }
       apply_public_entities_rls_policies: {
-        Args: {
-          schema_name: string
-          table_name: string
-        }
+        Args: { schema_name: string; table_name: string }
         Returns: undefined
       }
       apply_public_liked_tweets_rls_policies: {
-        Args: {
-          schema_name: string
-          table_name: string
-        }
+        Args: { schema_name: string; table_name: string }
         Returns: undefined
       }
       apply_public_rls_policies: {
-        Args: {
-          schema_name: string
-          table_name: string
-        }
+        Args: { schema_name: string; table_name: string }
         Returns: undefined
       }
       apply_public_rls_policies_not_private: {
-        Args: {
-          schema_name: string
-          table_name: string
-        }
+        Args: { schema_name: string; table_name: string }
         Returns: undefined
       }
       apply_readonly_rls_policies: {
-        Args: {
-          schema_name: string
-          table_name: string
-        }
+        Args: { schema_name: string; table_name: string }
         Returns: undefined
       }
-      commit_temp_data: {
-        Args: {
-          p_suffix: string
-        }
-        Returns: undefined
-      }
+      commit_temp_data: { Args: { p_suffix: string }; Returns: undefined }
       compute_hourly_scraping_stats: {
-        Args: {
-          p_start_date: string
-          p_end_date: string
-        }
+        Args: { p_end_date: string; p_start_date: string }
         Returns: {
-          period_start: string
           period_end: string
+          period_start: string
           tweet_count: number
           unique_scrapers: number
         }[]
       }
-      create_temp_tables: {
-        Args: {
-          p_suffix: string
-        }
-        Returns: undefined
-      }
+      create_temp_tables: { Args: { p_suffix: string }; Returns: undefined }
       delete_non_allowlist_streamed_tweet_batch: {
-        Args: {
-          p_limit?: number
-        }
+        Args: { p_limit?: number }
         Returns: {
-          requested_tweets: number
-          deleted_tweets: number
           deleted_conversations: number
-          deleted_tweet_media: number
-          deleted_user_mentions: number
-          deleted_tweet_urls: number
           deleted_private_tweet_user: number
+          deleted_tweet_media: number
+          deleted_tweet_urls: number
+          deleted_tweets: number
+          deleted_user_mentions: number
+          requested_tweets: number
         }[]
       }
       delete_single_archive: {
-        Args: {
-          p_account_id: string
-          p_archive_upload_id: number
-        }
+        Args: { p_account_id: string; p_archive_upload_id: number }
         Returns: undefined
       }
       delete_tweets: {
-        Args: {
-          p_tweet_ids: string[]
-        }
+        Args: { p_tweet_ids: string[] }
         Returns: {
-          deleted_tweets: number
           deleted_conversations: number
-          deleted_tweet_media: number
-          deleted_user_mentions: number
-          deleted_tweet_urls: number
           deleted_private_tweet_user: number
+          deleted_tweet_media: number
+          deleted_tweet_urls: number
+          deleted_tweets: number
+          deleted_user_mentions: number
         }[]
       }
       delete_user_archive: {
-        Args: {
-          p_account_id: string
-        }
+        Args: { p_account_id: string }
         Returns: undefined
       }
       drop_all_policies: {
-        Args: {
-          schema_name: string
-          table_name: string
-        }
+        Args: { schema_name: string; table_name: string }
         Returns: undefined
       }
-      drop_temp_tables: {
-        Args: {
-          p_suffix: string
-        }
-        Returns: undefined
-      }
+      drop_temp_tables: { Args: { p_suffix: string }; Returns: undefined }
       get_account_most_liked_tweets_archive_users: {
-        Args: {
-          username_: string
-          limit_?: number
-        }
+        Args: { limit_?: number; username_: string }
         Returns: {
-          tweet_id: string
           account_id: string
+          archive_upload_id: number
           created_at: string
-          full_text: string
-          retweet_count: number
           favorite_count: number
+          full_text: string
+          num_likes: number
           reply_to_tweet_id: string
           reply_to_user_id: string
           reply_to_username: string
-          archive_upload_id: number
-          num_likes: number
+          retweet_count: number
+          tweet_id: string
         }[]
       }
       get_account_most_mentioned_accounts: {
-        Args: {
-          username_: string
-          limit_: number
-        }
+        Args: { limit_: number; username_: string }
         Returns: {
-          user_id: string
+          mention_count: number
           name: string
           screen_name: string
-          mention_count: number
+          user_id: string
         }[]
       }
       get_account_most_replied_tweets_by_archive_users: {
-        Args: {
-          username_: string
-          limit_: number
-        }
+        Args: { limit_: number; username_: string }
         Returns: {
-          tweet_id: string
           account_id: string
+          archive_upload_id: number
           created_at: string
-          full_text: string
-          retweet_count: number
           favorite_count: number
+          full_text: string
+          num_replies: number
           reply_to_tweet_id: string
           reply_to_user_id: string
           reply_to_username: string
-          archive_upload_id: number
-          num_replies: number
+          retweet_count: number
+          tweet_id: string
         }[]
       }
       get_account_top_favorite_count_tweets: {
-        Args: {
-          username_: string
-          limit_: number
-        }
+        Args: { limit_: number; username_: string }
         Returns: {
-          tweet_id: string
           account_id: string
+          archive_upload_id: number
           created_at: string
-          full_text: string
-          retweet_count: number
           favorite_count: number
+          full_text: string
           reply_to_tweet_id: string
           reply_to_user_id: string
           reply_to_username: string
-          archive_upload_id: number
+          retweet_count: number
+          tweet_id: string
         }[]
       }
       get_account_top_retweet_count_tweets: {
-        Args: {
-          username_: string
-          limit_: number
-        }
+        Args: { limit_: number; username_: string }
         Returns: {
-          tweet_id: string
           account_id: string
+          archive_upload_id: number
           created_at: string
-          full_text: string
-          retweet_count: number
           favorite_count: number
+          full_text: string
           reply_to_tweet_id: string
           reply_to_user_id: string
           reply_to_username: string
-          archive_upload_id: number
+          retweet_count: number
+          tweet_id: string
         }[]
       }
       get_hourly_scraping_stats: {
-        Args: {
-          p_hours_back?: number
-        }
+        Args: { p_hours_back?: number }
         Returns: {
-          period_start: string
           period_end: string
+          period_start: string
           tweet_count: number
           unique_scrapers: number
         }[]
       }
       get_hourly_stats_simple: {
-        Args: {
-          p_hours_back?: number
-        }
+        Args: { p_hours_back?: number }
         Returns: {
           period_start: string
           tweet_count: number
         }[]
       }
       get_latest_tweets: {
-        Args: {
-          count: number
-          p_account_id?: string
-        }
+        Args: { count: number; p_account_id?: string }
         Returns: {
-          tweet_id: string
-          account_id: string
-          created_at: string
-          full_text: string
-          retweet_count: number
-          favorite_count: number
-          reply_to_tweet_id: string
-          avatar_media_url: string
-          username: string
           account_display_name: string
+          account_id: string
+          avatar_media_url: string
+          created_at: string
+          favorite_count: number
+          full_text: string
+          reply_to_tweet_id: string
+          retweet_count: number
+          tweet_id: string
+          username: string
         }[]
       }
       get_main_thread: {
-        Args: {
-          p_conversation_id: string
-        }
+        Args: { p_conversation_id: string }
         Returns: {
-          tweet_id: string
-          conversation_id: string
-          reply_to_tweet_id: string
           account_id: string
+          conversation_id: string
           depth: number
-          max_depth: number
           favorite_count: number
+          max_depth: number
+          reply_to_tweet_id: string
           retweet_count: number
+          tweet_id: string
         }[]
       }
       get_monthly_tweet_counts: {
-        Args: Record<PropertyKey, never>
+        Args: never
         Returns: {
           month: string
           tweet_count: number
@@ -1531,481 +1397,343 @@ export type Database = {
       get_monthly_tweet_counts_fast: {
         Args: {
           p_account_id?: string
-          p_start_date?: string
           p_end_date?: string
+          p_start_date?: string
         }
         Returns: {
-          month: string
           account_id: string
-          tweet_count: number
-          days_active: number
           avg_favorites: number
           avg_retweets: number
+          days_active: number
+          month: string
+          tweet_count: number
         }[]
       }
       get_most_liked_tweets_by_username: {
-        Args: {
-          username_: string
-        }
+        Args: { username_: string }
         Returns: {
-          tweet_id: string
           full_text: string
           num_likes: number
+          tweet_id: string
         }[]
       }
       get_most_mentioned_accounts_by_username: {
-        Args: {
-          username_: string
-        }
+        Args: { username_: string }
         Returns: {
+          mention_count: number
           mentioned_user_id: string
           mentioned_username: string
-          mention_count: number
         }[]
       }
       get_non_allowlist_streamed_tweet_candidates: {
-        Args: {
-          p_limit?: number
-        }
+        Args: { p_limit?: number }
         Returns: {
-          tweet_id: string
           account_id: string
           created_at: string
-          reply_to_tweet_id: string
           is_quote: boolean
+          reply_to_tweet_id: string
+          tweet_id: string
         }[]
       }
       get_scraper_counts_by_granularity: {
-        Args: {
-          start_date: string
-          end_date: string
-          granularity: string
-        }
+        Args: { end_date: string; granularity: string; start_date: string }
         Returns: {
           scraper_date: string
           unique_scrapers: number
         }[]
       }
       get_simple_streamed_tweet_counts: {
-        Args: {
-          start_date: string
-          end_date: string
-          granularity: string
-        }
+        Args: { end_date: string; granularity: string; start_date: string }
         Returns: {
-          tweet_date: string
           tweet_count: number
+          tweet_date: string
         }[]
       }
       get_streaming_stats: {
         Args: {
-          p_start_date: string
           p_end_date: string
           p_granularity?: string
+          p_start_date: string
           p_streamed_only?: boolean
         }
         Returns: {
-          period_start: string
           period_end: string
+          period_start: string
           tweet_count: number
           unique_scrapers: number
         }[]
       }
       get_streaming_stats_daily: {
-        Args: {
-          p_start_date: string
-          p_end_date: string
-        }
+        Args: { p_end_date: string; p_start_date: string }
         Returns: {
-          period_start: string
           period_end: string
+          period_start: string
           tweet_count: number
           unique_scrapers: number
         }[]
       }
       get_streaming_stats_daily_streamed_only: {
-        Args: {
-          p_start_date: string
-          p_end_date: string
-        }
+        Args: { p_end_date: string; p_start_date: string }
         Returns: {
-          period_start: string
           period_end: string
+          period_start: string
           tweet_count: number
           unique_scrapers: number
         }[]
       }
       get_streaming_stats_hourly: {
-        Args: {
-          p_start_date: string
-          p_end_date: string
-        }
+        Args: { p_end_date: string; p_start_date: string }
         Returns: {
-          period_start: string
           period_end: string
+          period_start: string
           tweet_count: number
           unique_scrapers: number
         }[]
       }
       get_streaming_stats_hourly_streamed_only: {
-        Args: {
-          p_start_date: string
-          p_end_date: string
-        }
+        Args: { p_end_date: string; p_start_date: string }
         Returns: {
-          period_start: string
           period_end: string
+          period_start: string
           tweet_count: number
           unique_scrapers: number
         }[]
       }
       get_streaming_stats_weekly: {
-        Args: {
-          p_start_date: string
-          p_end_date: string
-        }
+        Args: { p_end_date: string; p_start_date: string }
         Returns: {
-          period_start: string
           period_end: string
+          period_start: string
           tweet_count: number
           unique_scrapers: number
         }[]
       }
       get_streaming_stats_weekly_streamed_only: {
-        Args: {
-          p_start_date: string
-          p_end_date: string
-        }
+        Args: { p_end_date: string; p_start_date: string }
         Returns: {
-          period_start: string
           period_end: string
+          period_start: string
           tweet_count: number
           unique_scrapers: number
         }[]
       }
       get_top_accounts_with_followers: {
-        Args: {
-          limit_count: number
-        }
+        Args: { limit_count: number }
         Returns: {
-          account_id: string
-          created_via: string
-          username: string
-          created_at: string
           account_display_name: string
+          account_id: string
           avatar_media_url: string
           bio: string
-          website: string
-          location: string
+          created_at: string
+          created_via: string
           header_media_url: string
+          location: string
           num_followers: number
           num_tweets: number
+          username: string
+          website: string
         }[]
       }
       get_top_liked_users: {
-        Args: Record<PropertyKey, never>
+        Args: never
         Returns: {
-          tweet_id: string
           full_text: string
           like_count: number
           reply_to_tweet_id: string
           reply_to_user_id: string
           reply_to_username: string
+          tweet_id: string
         }[]
       }
       get_top_mentioned_users: {
-        Args: {
-          limit_: number
-        }
+        Args: { limit_: number }
         Returns: {
-          user_id: string
+          mention_count: number
           name: string
           screen_name: string
-          mention_count: number
+          user_id: string
         }[]
       }
       get_top_retweeted_tweets_by_username: {
-        Args: {
-          username_: string
-          limit_: number
-        }
+        Args: { limit_: number; username_: string }
         Returns: {
-          tweet_id: string
           account_id: string
+          archive_upload_id: number
           created_at: string
-          full_text: string
-          retweet_count: number
           favorite_count: number
+          full_text: string
           reply_to_tweet_id: string
           reply_to_user_id: string
           reply_to_username: string
-          archive_upload_id: number
+          retweet_count: number
+          tweet_id: string
         }[]
       }
       get_trending_tweets: {
-        Args: {
-          hours_back?: number
-          limit_count?: number
-        }
+        Args: { hours_back?: number; limit_count?: number }
         Returns: {
-          tweet_id: string
           account_id: string
-          full_text: string
           created_at: string
-          favorite_count: number
-          retweet_count: number
           engagement_score: number
+          favorite_count: number
+          full_text: string
+          retweet_count: number
+          tweet_id: string
         }[]
       }
       get_tweet_count_by_date:
         | {
-            Args: {
-              start_date: string
-              end_date: string
-            }
+            Args: { end_date: string; start_date: string }
             Returns: {
-              tweet_date: string
               tweet_count: number
+              tweet_date: string
             }[]
           }
         | {
-            Args: {
-              start_date: string
-              end_date: string
-              granularity: string
-            }
+            Args: { end_date: string; granularity: string; start_date: string }
             Returns: {
-              tweet_date: string
               tweet_count: number
+              tweet_date: string
             }[]
           }
       get_tweet_counts_by_granularity: {
-        Args: {
-          start_date: string
-          end_date: string
-          granularity: string
-        }
+        Args: { end_date: string; granularity: string; start_date: string }
         Returns: {
-          tweet_date: string
           tweet_count: number
+          tweet_date: string
         }[]
       }
-      get_tweet_page_data: {
-        Args: {
-          p_tweet_id: string
-        }
-        Returns: Json
-      }
+      get_tweet_page_data: { Args: { p_tweet_id: string }; Returns: Json }
       get_unique_scraper_count: {
-        Args: {
-          start_date: string
-          end_date: string
-        }
+        Args: { end_date: string; start_date: string }
         Returns: number
       }
-      gtrgm_compress: {
-        Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
-      gtrgm_decompress: {
-        Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
-      gtrgm_in: {
-        Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
-      gtrgm_options: {
-        Args: {
-          "": unknown
-        }
-        Returns: undefined
-      }
-      gtrgm_out: {
-        Args: {
-          "": unknown
-        }
-        Returns: unknown
-      }
       insert_temp_account: {
-        Args: {
-          p_account: Json
-          p_suffix: string
-        }
+        Args: { p_account: Json; p_suffix: string }
         Returns: undefined
       }
       insert_temp_archive_upload: {
         Args: {
           p_account_id: string
           p_archive_at: string
-          p_keep_private: boolean
-          p_upload_likes: boolean
-          p_start_date: string
           p_end_date: string
+          p_keep_private: boolean
+          p_start_date: string
           p_suffix: string
+          p_upload_likes: boolean
         }
         Returns: number
       }
       insert_temp_followers: {
-        Args: {
-          p_followers: Json
-          p_account_id: string
-          p_suffix: string
-        }
+        Args: { p_account_id: string; p_followers: Json; p_suffix: string }
         Returns: undefined
       }
       insert_temp_following: {
-        Args: {
-          p_following: Json
-          p_account_id: string
-          p_suffix: string
-        }
+        Args: { p_account_id: string; p_following: Json; p_suffix: string }
         Returns: undefined
       }
       insert_temp_likes: {
-        Args: {
-          p_likes: Json
-          p_account_id: string
-          p_suffix: string
-        }
+        Args: { p_account_id: string; p_likes: Json; p_suffix: string }
         Returns: undefined
       }
       insert_temp_profiles: {
-        Args: {
-          p_profile: Json
-          p_account_id: string
-          p_suffix: string
-        }
+        Args: { p_account_id: string; p_profile: Json; p_suffix: string }
         Returns: undefined
       }
       insert_temp_tweets: {
-        Args: {
-          p_tweets: Json
-          p_suffix: string
-        }
+        Args: { p_suffix: string; p_tweets: Json }
         Returns: undefined
       }
       process_and_insert_tweet_entities: {
-        Args: {
-          p_tweets: Json
-          p_suffix: string
-        }
+        Args: { p_suffix: string; p_tweets: Json }
         Returns: undefined
       }
-      process_archive: {
-        Args: {
-          archive_data: Json
-        }
-        Returns: undefined
-      }
-      refresh_global_activity_summary: {
-        Args: Record<PropertyKey, never>
-        Returns: undefined
-      }
+      process_archive: { Args: { archive_data: Json }; Returns: undefined }
+      refresh_global_activity_summary: { Args: never; Returns: undefined }
       search_tweets:
         | {
             Args: {
-              search_query: string
               from_user?: string
-              to_user?: string
-              since_date?: string
-              until_date?: string
               limit_?: number
               offset_?: number
+              search_query: string
+              since_date?: string
+              to_user?: string
+              until_date?: string
             }
             Returns: {
-              tweet_id: string
-              account_id: string
-              created_at: string
-              full_text: string
-              retweet_count: number
-              favorite_count: number
-              reply_to_tweet_id: string
-              avatar_media_url: string
-              archive_upload_id: number
-              username: string
               account_display_name: string
+              account_id: string
+              archive_upload_id: number
+              avatar_media_url: string
+              created_at: string
+              favorite_count: number
+              full_text: string
               media: Json
+              reply_to_tweet_id: string
+              retweet_count: number
+              tweet_id: string
+              username: string
             }[]
           }
         | {
             Args: {
-              search_query: string
-              limit_count?: number
               account_filter?: string
               date_from?: string
               date_to?: string
+              limit_count?: number
+              search_query: string
             }
             Returns: {
-              tweet_id: string
               account_id: string
-              full_text: string
               created_at: string
               favorite_count: number
-              retweet_count: number
+              full_text: string
               relevance: number
+              retweet_count: number
+              tweet_id: string
             }[]
           }
       search_tweets_exact_phrase: {
         Args: {
           exact_phrase: string
           from_user?: string
-          to_user?: string
-          since_date?: string
-          until_date?: string
           limit_?: number
           offset_?: number
+          since_date?: string
+          to_user?: string
+          until_date?: string
         }
         Returns: {
-          tweet_id: string
-          account_id: string
-          created_at: string
-          full_text: string
-          retweet_count: number
-          favorite_count: number
-          reply_to_tweet_id: string
-          avatar_media_url: string
-          archive_upload_id: number
-          username: string
           account_display_name: string
+          account_id: string
+          archive_upload_id: number
+          avatar_media_url: string
+          created_at: string
+          favorite_count: number
+          full_text: string
           media: Json
+          reply_to_tweet_id: string
+          retweet_count: number
+          tweet_id: string
+          username: string
         }[]
       }
-      set_limit: {
-        Args: {
-          "": number
-        }
-        Returns: number
-      }
-      show_limit: {
-        Args: Record<PropertyKey, never>
-        Returns: number
-      }
-      show_trgm: {
-        Args: {
-          "": string
-        }
-        Returns: string[]
-      }
+      show_limit: { Args: never; Returns: number }
+      show_trgm: { Args: { "": string }; Returns: string[] }
       update_foreign_keys: {
         Args: {
-          old_table_name: string
           new_table_name: string
+          old_table_name: string
           schema_name: string
         }
         Returns: undefined
       }
       word_occurrences: {
         Args: {
+          end_date?: string
           search_word: string
           start_date?: string
-          end_date?: string
           user_ids?: string[]
         }
         Returns: {
@@ -2028,27 +1756,33 @@ export type Database = {
   }
 }
 
-type PublicSchema = Database[Extract<keyof Database, "public">]
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
 
 export type Tables<
-  PublicTableNameOrOptions extends
-    | keyof (PublicSchema["Tables"] & PublicSchema["Views"])
-    | { schema: keyof Database },
-  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
-        Database[PublicTableNameOrOptions["schema"]]["Views"])
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
     : never = never,
-> = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
-      Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
       Row: infer R
     }
     ? R
     : never
-  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
-        PublicSchema["Views"])
-    ? (PublicSchema["Tables"] &
-        PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
         Row: infer R
       }
       ? R
@@ -2056,20 +1790,24 @@ export type Tables<
     : never
 
 export type TablesInsert<
-  PublicTableNameOrOptions extends
-    | keyof PublicSchema["Tables"]
-    | { schema: keyof Database },
-  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
-> = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Insert: infer I
     }
     ? I
     : never
-  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
         Insert: infer I
       }
       ? I
@@ -2077,20 +1815,24 @@ export type TablesInsert<
     : never
 
 export type TablesUpdate<
-  PublicTableNameOrOptions extends
-    | keyof PublicSchema["Tables"]
-    | { schema: keyof Database },
-  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
-> = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Update: infer U
     }
     ? U
     : never
-  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
         Update: infer U
       }
       ? U
@@ -2098,30 +1840,52 @@ export type TablesUpdate<
     : never
 
 export type Enums<
-  PublicEnumNameOrOptions extends
-    | keyof PublicSchema["Enums"]
-    | { schema: keyof Database },
-  EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
     : never = never,
-> = PublicEnumNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
-  : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
-    ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
     : never
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
-    | keyof PublicSchema["CompositeTypes"]
-    | { schema: keyof Database },
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof Database
+    schema: keyof DatabaseWithoutInternals
   }
-    ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
     : never = never,
-> = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
-    ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never
 
+export const Constants = {
+  dev: {
+    Enums: {},
+  },
+  public: {
+    Enums: {
+      upload_phase_enum: [
+        "uploading",
+        "ready_for_commit",
+        "committing",
+        "completed",
+        "failed",
+      ],
+    },
+  },
+} as const

--- a/src/lib/queries/fetchUsers.test.ts
+++ b/src/lib/queries/fetchUsers.test.ts
@@ -1,4 +1,24 @@
-import { buildDirectorySearchFilter } from './fetchUsers'
+import { DirectoryUser } from '@/lib/types'
+import {
+  buildDirectorySearchFilter,
+  getDirectoryProfileHref,
+  getUserData,
+} from './fetchUsers'
+
+const directoryUser = (overrides: Partial<DirectoryUser>): DirectoryUser => ({
+  directory_id: 'optin:1',
+  account_id: null,
+  username: 'archive_member',
+  account_display_name: 'Archive Member',
+  avatar_media_url: null,
+  num_followers: null,
+  has_archive: false,
+  is_opted_in: true,
+  opted_in_at: '2026-07-11T00:00:00Z',
+  archive_uploaded_at: null,
+  joined_at: '2026-07-11T00:00:00Z',
+  ...overrides,
+})
 
 describe('buildDirectorySearchFilter', () => {
   it('quotes commas and other PostgREST logic characters', () => {
@@ -11,5 +31,136 @@ describe('buildDirectorySearchFilter', () => {
     expect(buildDirectorySearchFilter('a"b\\c')).toBe(
       'username.ilike."%a\\"b\\\\c%",account_display_name.ilike."%a\\"b\\\\c%"',
     )
+  })
+})
+
+describe('getDirectoryProfileHref', () => {
+  it('links account-backed members by account ID', () => {
+    expect(
+      getDirectoryProfileHref(
+        directoryUser({
+          directory_id: 'archive:123456789',
+          account_id: '123456789',
+        }),
+      ),
+    ).toBe('/user/archive%3A123456789')
+  })
+
+  it('links opt-in-only members by their stable directory ID', () => {
+    expect(
+      getDirectoryProfileHref(
+        directoryUser({ directory_id: 'optin:42', account_id: null }),
+      ),
+    ).toBe('/user/optin%3A42')
+  })
+})
+
+const mockSupabase = (
+  directoryRows: Array<Record<string, unknown>>,
+  profileRows: Array<Record<string, unknown>> = [],
+) => ({
+  schema: () => ({
+    from: (table: string) => {
+      const filters: Array<[string, string]> = []
+      const query = {
+        select: () => query,
+        eq: (column: string, value: string) => {
+          filters.push([column, value])
+          return query
+        },
+        ilike: (column: string, value: string) => {
+          filters.push([column, value.toLowerCase()])
+          return query
+        },
+        order: () => query,
+        limit: () => query,
+        maybeSingle: async () => {
+          const rows = table === 'user_directory' ? directoryRows : profileRows
+          const data = rows.find((row) =>
+            filters.every(([column, value]) => {
+              const candidate = String(row[column] ?? '')
+              return column === 'username'
+                ? candidate.toLowerCase() === value
+                : candidate === value
+            }),
+          )
+
+          return { data: data ?? null, error: null }
+        },
+      }
+
+      return query
+    },
+  }),
+})
+
+describe('getUserData', () => {
+  it('loads an opt-in-only profile by directory ID', async () => {
+    const row = {
+      directory_id: 'optin:42',
+      account_id: null,
+      username: 'opted_in_member',
+      account_display_name: 'Opted In Member',
+      created_at: null,
+      bio: null,
+      website: null,
+      location: null,
+      avatar_media_url: null,
+      archive_at: null,
+      archive_uploaded_at: null,
+      num_tweets: null,
+      num_followers: null,
+      num_following: null,
+      num_likes: null,
+      joined_at: '2026-07-11T00:00:00Z',
+      has_archive: false,
+      is_opted_in: true,
+    }
+
+    const result = await getUserData(mockSupabase([row]) as any, 'optin%3A42')
+
+    expect(result).toMatchObject({
+      username: 'opted_in_member',
+      account_id: null,
+      has_archive: false,
+      is_opted_in: true,
+      header_media_url: null,
+    })
+  })
+
+  it('keeps old account-ID URLs working and loads the profile header', async () => {
+    const row = {
+      directory_id: 'archive:123',
+      account_id: '123',
+      username: 'archive_member',
+      account_display_name: 'Archive Member',
+      created_at: '2009-01-01T00:00:00Z',
+      bio: 'Preserving the web',
+      website: null,
+      location: null,
+      avatar_media_url: null,
+      archive_at: '2026-01-01T00:00:00Z',
+      archive_uploaded_at: '2026-01-02T00:00:00Z',
+      num_tweets: 10,
+      num_followers: 20,
+      num_following: 30,
+      num_likes: 40,
+      joined_at: '2026-01-02T00:00:00Z',
+      has_archive: true,
+      is_opted_in: false,
+    }
+
+    const result = await getUserData(
+      mockSupabase([row], [
+        { account_id: '123', header_media_url: 'https://example.com/header' },
+      ]) as any,
+      '123',
+    )
+
+    expect(result).toMatchObject({
+      account_id: '123',
+      has_archive: true,
+      header_media_url: 'https://example.com/header',
+    })
   })
 })

--- a/src/lib/queries/fetchUsers.ts
+++ b/src/lib/queries/fetchUsers.ts
@@ -1,5 +1,4 @@
-import { DirectoryUser, SortKey } from '@/lib/types'
-import { formatUserData } from '@/lib/user-utils'
+import { DirectoryUser, FormattedUser, SortKey } from '@/lib/types'
 import { SupabaseClient } from '@supabase/supabase-js'
 import { devLog } from '@/lib/devLog'
 
@@ -17,6 +16,9 @@ export const buildDirectorySearchFilter = (search: string) => {
 
   return `username.ilike.${pattern},account_display_name.ilike.${pattern}`
 }
+
+export const getDirectoryProfileHref = (user: DirectoryUser) =>
+  `/user/${encodeURIComponent(user.directory_id)}`
 
 export const fetchUsers = async (
   supabase: SupabaseClient,
@@ -91,33 +93,87 @@ export const fetchUsersCount = async (
 
 export const getUserData = async (
   supabase: SupabaseClient,
-  account_id: string,
+  identifier: string,
 ) => {
-  const { data } = await supabase
+  let decodedIdentifier: string
+  try {
+    decodedIdentifier = decodeURIComponent(identifier)
+  } catch {
+    return null
+  }
+  const select = `
+    account_id,
+    username,
+    account_display_name,
+    created_at,
+    bio,
+    website,
+    location,
+    avatar_media_url,
+    archive_at,
+    archive_uploaded_at,
+    num_tweets,
+    num_followers,
+    num_following,
+    num_likes,
+    joined_at,
+    has_archive,
+    is_opted_in
+  `
+
+  const isDirectoryIdentifier = /^(archive|optin):/.test(decodedIdentifier)
+  const initialQuery = supabase
     .schema('public')
-    .from('account')
-    .select(
-      `
-      account_id,
-      username,
-      account_display_name,
-      created_at,
-      num_tweets,
-      num_followers,
-      num_following,
-      num_likes,
-      profile:profile(bio, website, location, avatar_media_url, header_media_url),
-      archive_upload:archive_upload(id, archive_at, created_at)
-    `,
-    )
-    .or(`account_id.eq.${account_id},username.ilike.${account_id}`)
-    .single()
+    .from('user_directory')
+    .select(select)
+
+  const { data: accountMatch, error: accountError } = isDirectoryIdentifier
+    ? await initialQuery.eq('directory_id', decodedIdentifier).maybeSingle()
+    : await initialQuery.eq('account_id', decodedIdentifier).maybeSingle()
+
+  if (accountError) throw accountError
+
+  let data = accountMatch
+  if (!data) {
+    const { data: usernameMatch, error: usernameError } = await supabase
+      .schema('public')
+      .from('user_directory')
+      .select(select)
+      .ilike('username', decodedIdentifier)
+      .limit(1)
+      .maybeSingle()
+
+    if (usernameError) throw usernameError
+    data = usernameMatch
+  }
 
   if (!data) {
     return null
   }
 
-  const formattedUser = formatUserData(data)
+  let headerMediaUrl: string | null = null
+  if (data.account_id) {
+    const { data: profile } = await supabase
+      .schema('public')
+      .from('all_profile')
+      .select('header_media_url')
+      .eq('account_id', data.account_id)
+      .order('archive_upload_id', { ascending: false, nullsFirst: false })
+      .limit(1)
+      .maybeSingle()
+
+    headerMediaUrl = profile?.header_media_url ?? null
+  }
+
+  const formattedUser: FormattedUser = {
+    ...data,
+    username: data.username || decodedIdentifier,
+    account_display_name:
+      data.account_display_name || data.username || decodedIdentifier,
+    header_media_url: headerMediaUrl,
+    has_archive: data.has_archive === true,
+    is_opted_in: data.is_opted_in === true,
+  }
   devLog('getUserData', { data, formattedUser })
 
   return formattedUser

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -179,21 +179,24 @@ export type SortKey =
   | 'joined_at'
 
 export type FormattedUser = {
-  account_id: string
+  account_id: string | null
   username: string
   account_display_name: string
-  created_at: string
+  created_at: string | null
   bio: string | null
   website: string | null
   location: string | null
   avatar_media_url: string | null
   header_media_url?: string | null
   archive_at: string | null
-  num_tweets: number
-  num_followers: number
-  num_following: number
-  num_likes: number
+  num_tweets: number | null
+  num_followers: number | null
+  num_following: number | null
+  num_likes: number | null
   archive_uploaded_at: string | null
+  joined_at: string | null
+  has_archive: boolean
+  is_opted_in: boolean
 }
 
 // Interfaces for fetching and displaying tweets via Supabase queries

--- a/src/lib/user-utils.ts
+++ b/src/lib/user-utils.ts
@@ -48,5 +48,8 @@ export function formatUserData(data: any): FormattedUser {
     num_following: data.num_following,
     num_likes: data.num_likes,
     archive_uploaded_at: getLatestValue(data.archive_upload, 'created_at'),
+    joined_at: data.joined_at ?? data.created_at,
+    has_archive: data.has_archive ?? true,
+    is_opted_in: data.is_opted_in ?? false,
   }
 }


### PR DESCRIPTION
## What changed

- Link every user-directory member to a profile using the row's stable `directory_id`.
- Load public profile data from `user_directory`, including opt-in-only members without a completed archive.
- Preserve legacy account-ID and username profile URLs.
- Show archive and opt-in participation badges on profiles.
- Show public follower and activity stats when available.
- Hide archive downloads and archive dates when a member has not contributed an archive.
- Only render tweet activity when the opt-in is connected to a Twitter account ID.
- Avoid PostgREST filter interpolation in profile and activity-summary lookups.

## Why

#405 added opted-in members to the directory, but intentionally left opt-in-only rows unlinked because the existing profile loader only queried archive-backed accounts. Opted-in members should have profile pages too.

## Production safety

This PR changes application code and tests only. It contains no Supabase migration, schema mutation, or production database write.

## Validation

- 6 focused server Jest tests
- TypeScript type-check
- ESLint
- Production Next.js build
- Diff whitespace check
