### PR TITLE
perf: index all_account username ILIKE lookups

### DIFF
--- a/supabase/migrations/20260714023214_optimize_all_account_ilike.sql
+++ b/supabase/migrations/20260714023214_optimize_all_account_ilike.sql
@@ -1,0 +1,9 @@
+-- Make the public PostgREST username ILIKE lookup use an index instead of
+-- scanning every row in all_account. The existing btree indexes only serve
+-- equality and explicit lower(username) predicates.
+--
+-- PRODUCTION NOTE: build this index with CREATE INDEX CONCURRENTLY outside the
+-- migration transaction before running db push. The IF NOT EXISTS guard then
+-- records this migration without rebuilding or locking the live table.
+CREATE INDEX IF NOT EXISTS "idx_all_account_username_trgm"
+  ON "public"."all_account" USING "gin" ("username" "public"."gin_trgm_ops");

--- a/supabase/schemas/030_indexes.sql
+++ b/supabase/schemas/030_indexes.sql
@@ -86,6 +86,11 @@ CREATE INDEX IF NOT EXISTS "idx_all_account_username"
   ON "public"."all_account" USING "btree" ("username");
 CREATE INDEX IF NOT EXISTS "idx_all_account_lower_username"
   ON "public"."all_account" USING "btree" ("lower"("username"));
+-- PostgREST's .ilike('username', value) uses the ILIKE operator directly, so
+-- the btree indexes above cannot prevent a full-table scan. Trigrams support
+-- both exact and wildcard ILIKE lookups.
+CREATE INDEX IF NOT EXISTS "idx_all_account_username_trgm"
+  ON "public"."all_account" USING "gin" ("username" "public"."gin_trgm_ops");
 
 -- private.tweet_user: every get_streaming_stats_* function filters on created_at.
 CREATE INDEX IF NOT EXISTS "idx_tweet_user_created_at"


### PR DESCRIPTION
## What
- add a GIN trigram index on `public.all_account.username`
- keep the declarative schema and migration history in sync

## Why
The public PostgREST lookup `username=ilike.<handle>&limit=1` is currently doing a sequential scan across roughly 500k accounts. That query shape has been called millions of times and is the dominant database cost during the current abusive traffic.

## Impact
The API contract is unchanged. PostgreSQL can satisfy exact and wildcard `ILIKE` username lookups from the trigram index instead of scanning the whole table. The tradeoff is modest index storage and write-maintenance overhead on `all_account`.

## Production rollout
Build `idx_all_account_username_trgm` with `CREATE INDEX CONCURRENTLY` before recording the migration, following the existing large-index procedure. The migration is idempotent, so the subsequent production push becomes a no-op for the index itself.

## Checks
- `pnpm lint`
- `pnpm type-check`
- `git diff --check`
- production migration audit: only this migration is pending
- hosted staging schema reset required before merge (local Docker storage is unavailable on this machine)
