### PR TITLE
Show homepage upload and opt-in counts

### DIFF
--- a/src/app/mission-control/page.tsx
+++ b/src/app/mission-control/page.tsx
@@ -14,8 +14,8 @@ export default async function MissionControlPage() {
     console.error('Failed to fetch stats for mission control:', error)
     return {
       accountCount: null,
+      optInCount: null,
       tweetCount: null,
-      likedTweetCount: null,
       userMentionsCount: null, // Ensure all potential fields from getStats are handled
     }
   });
@@ -28,8 +28,8 @@ export default async function MissionControlPage() {
 
       <CommunityStats 
         accountCount={stats.accountCount}
+        optInCount={stats.optInCount}
         tweetCount={stats.tweetCount}
-        likedTweetCount={stats.likedTweetCount}
       />
 
       <div className="rounded-lg bg-gray-100 p-4 shadow dark:bg-gray-800">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -131,8 +131,8 @@ export default async function Homepage() {
     console.error('Failed to fetch stats for homepage:', error)
     return {
       accountCount: null,
+      optInCount: null,
       tweetCount: null,
-      likedTweetCount: null,
       userMentionsCount: null,
     }
   })
@@ -172,8 +172,8 @@ export default async function Homepage() {
         >
           <CommunityStats
             accountCount={stats.accountCount}
+            optInCount={stats.optInCount}
             tweetCount={stats.tweetCount}
-            likedTweetCount={stats.likedTweetCount}
             showGoal={false}
           />
           {mostFollowed.length > 0 ? (

--- a/src/components/CommunityStats.tsx
+++ b/src/components/CommunityStats.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { formatNumber } from '@/lib/formatNumber'
 
 const calculateGoal = (accountCount: number): number => {
@@ -8,19 +9,19 @@ const calculateGoal = (accountCount: number): number => {
 
 interface CommunityStatsProps {
   accountCount: number | null
+  optInCount: number | null
   tweetCount: number | null
-  likedTweetCount: number | null
   showGoal?: boolean
 }
 
 const CommunityStats = ({ 
   accountCount,
+  optInCount,
   tweetCount,
-  likedTweetCount,
   showGoal = false
 }: CommunityStatsProps) => {
 
-  if (accountCount === null || tweetCount === null || likedTweetCount === null) {
+  if (accountCount === null || optInCount === null || tweetCount === null) {
     return <p className="text-lg sm:text-xl text-center text-gray-700 dark:text-gray-300">Community statistics are currently unavailable.</p>
   }
 
@@ -28,9 +29,9 @@ const CommunityStats = ({
 
   return (
     <p className="text-xl text-gray-800 dark:text-gray-200">
-      We have <strong>{formatNumber(tweetCount)}</strong> tweets and{' '}
-      <strong>{formatNumber(likedTweetCount)}</strong> liked tweets from{' '}
-      <strong>{formatNumber(accountCount)}</strong> accounts.
+      We have <strong>{formatNumber(tweetCount)}</strong> tweets from{' '}
+      <strong>{formatNumber(accountCount)}</strong> users who uploaded archives,
+      and <strong>{formatNumber(optInCount)}</strong> users opted in.
       {showGoal && goal && (
         <span className="italic ml-1">
           Next milestone: <strong>{formatNumber(goal)}</strong> accounts.

--- a/src/lib/communityStats.test.tsx
+++ b/src/lib/communityStats.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import CommunityStats from '@/components/CommunityStats'
+
+describe('<CommunityStats />', () => {
+  it('shows tweet, uploaded-user, and opted-in-user totals without liked tweets', () => {
+    const markup = renderToStaticMarkup(
+      <CommunityStats
+        accountCount={337}
+        optInCount={48}
+        tweetCount={13_600_000}
+      />,
+    )
+
+    expect(markup).toContain('<strong>13.6M</strong> tweets')
+    expect(markup).toContain('<strong>337</strong> users who uploaded archives')
+    expect(markup).toContain('<strong>48</strong> users opted in')
+    expect(markup).not.toMatch(/liked tweets/i)
+  })
+})

--- a/src/lib/stats.test.ts
+++ b/src/lib/stats.test.ts
@@ -1,0 +1,40 @@
+import { getStats } from './stats'
+
+describe('getStats', () => {
+  it('fetches the archive summary and the opted-in user count', async () => {
+    const summarySingle = jest.fn().mockResolvedValue({
+      data: {
+        total_accounts: 337,
+        total_tweets: 13_600_000,
+        total_user_mentions: 4_200_000,
+      },
+      error: null,
+    })
+    const summarySelect = jest.fn().mockReturnValue({ single: summarySingle })
+    const optInEq = jest.fn().mockResolvedValue({ count: 48, error: null })
+    const optInSelect = jest.fn().mockReturnValue({ eq: optInEq })
+    const from = jest.fn((table: string) =>
+      table === 'global_activity_summary'
+        ? { select: summarySelect }
+        : { select: optInSelect },
+    )
+    const supabase = {
+      schema: jest.fn().mockReturnValue({ from }),
+    }
+
+    await expect(getStats(supabase as any)).resolves.toEqual({
+      accountCount: 337,
+      optInCount: 48,
+      tweetCount: 13_600_000,
+      userMentionsCount: 4_200_000,
+    })
+    expect(summarySelect).toHaveBeenCalledWith(
+      'total_accounts, total_tweets, total_user_mentions',
+    )
+    expect(optInSelect).toHaveBeenCalledWith('*', {
+      count: 'exact',
+      head: true,
+    })
+    expect(optInEq).toHaveBeenCalledWith('opted_in', true)
+  })
+})

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -3,21 +3,32 @@ import { cookies } from 'next/headers'
 import { SupabaseClient } from '@supabase/supabase-js'
 
 export const getStats = async (supabase: SupabaseClient) => {
-  const { data, error } = await supabase
-    .schema('public')
-    .from('global_activity_summary')
-    .select('total_accounts, total_tweets, total_likes, total_user_mentions')
-    .single()
+  const publicSchema = supabase.schema('public')
+  const [summaryResult, optInResult] = await Promise.all([
+    publicSchema
+      .from('global_activity_summary')
+      .select('total_accounts, total_tweets, total_user_mentions')
+      .single(),
+    publicSchema
+      .from('optin')
+      .select('*', { count: 'exact', head: true })
+      .eq('opted_in', true),
+  ])
 
-  if (error) {
-    console.error('Error fetching global activity summary:', error)
-    throw error
+  if (summaryResult.error) {
+    console.error('Error fetching global activity summary:', summaryResult.error)
+    throw summaryResult.error
+  }
+
+  if (optInResult.error) {
+    console.error('Error fetching opted-in user count:', optInResult.error)
+    throw optInResult.error
   }
 
   return {
-    accountCount: data.total_accounts,
-    tweetCount: data.total_tweets,
-    likedTweetCount: data.total_likes,
-    userMentionsCount: data.total_user_mentions,
+    accountCount: summaryResult.data.total_accounts,
+    optInCount: optInResult.count,
+    tweetCount: summaryResult.data.total_tweets,
+    userMentionsCount: summaryResult.data.total_user_mentions,
   }
 }


### PR DESCRIPTION
## What changed

- show the number of users with completed archive uploads on the homepage stats line
- show the exact number of publicly opted-in users
- remove the liked-tweet total so the line focuses on tweets and contributors
- keep Mission Control's shared stats component consistent

## Why

The homepage previously combined tweet and liked-tweet volume with a generic account count. The updated copy makes the two participation paths—uploading an archive and opting in—visible at a glance.

## Validation

- `pnpm exec jest --selectProjects server --runInBand src/lib/communityStats.test.tsx src/lib/stats.test.ts`
- `pnpm type-check`
- `pnpm lint`
- `pnpm build`
- local production runtime fetch against configured production data (`13.6M` tweets, `337` uploaders, `255` opted-in users)
