### PR TITLE
Show unified participant count and compact directory statuses

### DIFF
--- a/src/app/mission-control/page.tsx
+++ b/src/app/mission-control/page.tsx
@@ -13,8 +13,7 @@ export default async function MissionControlPage() {
   const stats = await getStats(supabase).catch((error) => {
     console.error('Failed to fetch stats for mission control:', error)
     return {
-      accountCount: null,
-      optInCount: null,
+      userCount: null,
       tweetCount: null,
       userMentionsCount: null, // Ensure all potential fields from getStats are handled
     }
@@ -27,8 +26,7 @@ export default async function MissionControlPage() {
       <h1 className="mb-6 text-3xl font-bold">Mission Control</h1>
 
       <CommunityStats 
-        accountCount={stats.accountCount}
-        optInCount={stats.optInCount}
+        userCount={stats.userCount}
         tweetCount={stats.tweetCount}
       />
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -130,8 +130,7 @@ export default async function Homepage() {
   const stats = await getStats(supabase).catch((error) => {
     console.error('Failed to fetch stats for homepage:', error)
     return {
-      accountCount: null,
-      optInCount: null,
+      userCount: null,
       tweetCount: null,
       userMentionsCount: null,
     }
@@ -171,8 +170,7 @@ export default async function Homepage() {
           className="max-w-5xl mx-auto rounded-none sm:rounded-xl p-6 md:p-8 space-y-4 text-center bg-slate-100 dark:bg-gray-900"
         >
           <CommunityStats
-            accountCount={stats.accountCount}
-            optInCount={stats.optInCount}
+            userCount={stats.userCount}
             tweetCount={stats.tweetCount}
             showGoal={false}
           />

--- a/src/app/user-dir/page.tsx
+++ b/src/app/user-dir/page.tsx
@@ -13,7 +13,6 @@ import {
 } from 'lucide-react'
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
-import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -24,6 +23,12 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { formatNumber } from '@/lib/formatNumber'
 import {
   fetchUsers,
@@ -184,7 +189,7 @@ export default function UserDirectoryPage() {
             <TableHeader className="bg-gray-50/80 dark:bg-gray-900/60">
               <TableRow className="hover:bg-transparent">
                 <TableHead
-                  className="w-[42%] py-2"
+                  className="w-[48%] py-2"
                   aria-sort={
                     sortKey === 'account_display_name'
                       ? sortOrder === 'asc'
@@ -202,11 +207,8 @@ export default function UserDirectoryPage() {
                     Member {renderSortIcon('account_display_name')}
                   </Button>
                 </TableHead>
-                <TableHead className="w-[25%] text-xs font-semibold uppercase tracking-wider">
-                  Participation
-                </TableHead>
                 <TableHead
-                  className="w-[15%] py-2 text-right"
+                  className="w-[20%] py-2 text-right"
                   aria-sort={
                     sortKey === 'num_followers'
                       ? sortOrder === 'asc'
@@ -225,7 +227,7 @@ export default function UserDirectoryPage() {
                   </Button>
                 </TableHead>
                 <TableHead
-                  className="w-[18%] py-2 text-right"
+                  className="w-[22%] py-2 text-right"
                   aria-sort={
                     sortKey === 'joined_at'
                       ? sortOrder === 'asc'
@@ -242,6 +244,9 @@ export default function UserDirectoryPage() {
                   >
                     Joined {renderSortIcon('joined_at')}
                   </Button>
+                </TableHead>
+                <TableHead className="w-[10%]">
+                  <span className="sr-only">Participation</span>
                 </TableHead>
               </TableRow>
             </TableHeader>
@@ -310,36 +315,6 @@ export default function UserDirectoryPage() {
                           {identity}
                         </Link>
                       </TableCell>
-                      <TableCell>
-                        <div className="flex flex-wrap gap-2">
-                          {user.has_archive && (
-                            <Badge
-                              variant="outline"
-                              title="Contributed a Twitter archive"
-                              className="gap-1.5 border-blue-200 bg-blue-50 px-2.5 py-1 font-medium text-blue-700 dark:border-blue-900 dark:bg-blue-950/50 dark:text-blue-300"
-                            >
-                              <Archive
-                                aria-hidden="true"
-                                className="h-3.5 w-3.5"
-                              />
-                              Archive
-                            </Badge>
-                          )}
-                          {user.is_opted_in && (
-                            <Badge
-                              variant="outline"
-                              title="Opted in to tweet streaming"
-                              className="gap-1.5 border-emerald-200 bg-emerald-50 px-2.5 py-1 font-medium text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950/50 dark:text-emerald-300"
-                            >
-                              <Radio
-                                aria-hidden="true"
-                                className="h-3.5 w-3.5"
-                              />
-                              Opted in
-                            </Badge>
-                          )}
-                        </div>
-                      </TableCell>
                       <TableCell className="whitespace-nowrap text-right text-sm font-medium tabular-nums text-gray-700 dark:text-gray-300">
                         {user.num_followers == null
                           ? '—'
@@ -349,6 +324,52 @@ export default function UserDirectoryPage() {
                         <time dateTime={user.joined_at || undefined}>
                           {formatJoinedDate(user.joined_at)}
                         </time>
+                      </TableCell>
+                      <TableCell className="pr-4">
+                        <TooltipProvider delayDuration={150}>
+                          <div className="flex justify-end gap-1">
+                            {user.has_archive && (
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <span
+                                    role="img"
+                                    tabIndex={0}
+                                    aria-label="Archive"
+                                    className="inline-flex h-8 w-8 items-center justify-center rounded-md text-blue-500 outline-none transition-colors hover:bg-blue-50 hover:text-blue-700 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:text-blue-400 dark:hover:bg-blue-950/60 dark:hover:text-blue-300 dark:focus-visible:ring-offset-gray-950"
+                                  >
+                                    <Archive
+                                      aria-hidden="true"
+                                      className="h-4 w-4"
+                                    />
+                                  </span>
+                                </TooltipTrigger>
+                                <TooltipContent side="top">
+                                  Archive
+                                </TooltipContent>
+                              </Tooltip>
+                            )}
+                            {user.is_opted_in && (
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <span
+                                    role="img"
+                                    tabIndex={0}
+                                    aria-label="Opted in"
+                                    className="inline-flex h-8 w-8 items-center justify-center rounded-md text-emerald-500 outline-none transition-colors hover:bg-emerald-50 hover:text-emerald-700 focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 dark:text-emerald-400 dark:hover:bg-emerald-950/60 dark:hover:text-emerald-300 dark:focus-visible:ring-offset-gray-950"
+                                  >
+                                    <Radio
+                                      aria-hidden="true"
+                                      className="h-4 w-4"
+                                    />
+                                  </span>
+                                </TooltipTrigger>
+                                <TooltipContent side="top">
+                                  Opted in
+                                </TooltipContent>
+                              </Tooltip>
+                            )}
+                          </div>
+                        </TooltipProvider>
                       </TableCell>
                     </TableRow>
                   )

--- a/src/components/CommunityStats.tsx
+++ b/src/components/CommunityStats.tsx
@@ -1,39 +1,39 @@
 import React from 'react'
 import { formatNumber } from '@/lib/formatNumber'
 
-const calculateGoal = (accountCount: number): number => {
+const calculateGoal = (userCount: number): number => {
   const goals = [25, 50, 100, 250, 500, 750, 1000]
-  if (accountCount < 25) return 25
-  return goals.find((goal) => goal > accountCount) || goals[goals.length - 1]
+  if (userCount < 25) return 25
+  return goals.find((goal) => goal > userCount) || goals[goals.length - 1]
 }
 
 interface CommunityStatsProps {
-  accountCount: number | null
-  optInCount: number | null
+  userCount: number | null
   tweetCount: number | null
   showGoal?: boolean
 }
 
-const CommunityStats = ({ 
-  accountCount,
-  optInCount,
+const CommunityStats = ({
+  userCount,
   tweetCount,
-  showGoal = false
+  showGoal = false,
 }: CommunityStatsProps) => {
-
-  if (accountCount === null || optInCount === null || tweetCount === null) {
-    return <p className="text-lg sm:text-xl text-center text-gray-700 dark:text-gray-300">Community statistics are currently unavailable.</p>
+  if (userCount === null || tweetCount === null) {
+    return (
+      <p className="text-center text-lg text-gray-700 dark:text-gray-300 sm:text-xl">
+        Community statistics are currently unavailable.
+      </p>
+    )
   }
 
-  const goal = calculateGoal(accountCount || 0)
+  const goal = calculateGoal(userCount || 0)
 
   return (
     <p className="text-xl text-gray-800 dark:text-gray-200">
-      We have <strong>{formatNumber(tweetCount)}</strong> tweets,{' '}
-      <strong>{formatNumber(accountCount)}</strong> uploaded, and{' '}
-      <strong>{formatNumber(optInCount)}</strong> opted in.
+      We have <strong>{formatNumber(tweetCount)}</strong> tweets from{' '}
+      <strong>{formatNumber(userCount)}</strong> users.
       {showGoal && goal && (
-        <span className="italic ml-1">
+        <span className="ml-1 italic">
           Next milestone: <strong>{formatNumber(goal)}</strong> accounts.
         </span>
       )}

--- a/src/components/CommunityStats.tsx
+++ b/src/components/CommunityStats.tsx
@@ -29,9 +29,9 @@ const CommunityStats = ({
 
   return (
     <p className="text-xl text-gray-800 dark:text-gray-200">
-      We have <strong>{formatNumber(tweetCount)}</strong> tweets from{' '}
-      <strong>{formatNumber(accountCount)}</strong> users who uploaded archives,
-      and <strong>{formatNumber(optInCount)}</strong> users opted in.
+      We have <strong>{formatNumber(tweetCount)}</strong> tweets,{' '}
+      <strong>{formatNumber(accountCount)}</strong> uploaded, and{' '}
+      <strong>{formatNumber(optInCount)}</strong> opted in.
       {showGoal && goal && (
         <span className="italic ml-1">
           Next milestone: <strong>{formatNumber(goal)}</strong> accounts.

--- a/src/lib/communityStats.test.tsx
+++ b/src/lib/communityStats.test.tsx
@@ -13,8 +13,9 @@ describe('<CommunityStats />', () => {
     )
 
     expect(markup).toContain('<strong>13.6M</strong> tweets')
-    expect(markup).toContain('<strong>337</strong> users who uploaded archives')
-    expect(markup).toContain('<strong>48</strong> users opted in')
+    expect(markup).toContain('<strong>337</strong> uploaded')
+    expect(markup).toContain('<strong>48</strong> opted in')
+    expect(markup).not.toMatch(/users|archives/i)
     expect(markup).not.toMatch(/liked tweets/i)
   })
 })

--- a/src/lib/communityStats.test.tsx
+++ b/src/lib/communityStats.test.tsx
@@ -3,19 +3,14 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import CommunityStats from '@/components/CommunityStats'
 
 describe('<CommunityStats />', () => {
-  it('shows tweet, uploaded-user, and opted-in-user totals without liked tweets', () => {
+  it('shows tweet and deduplicated participating-user totals', () => {
     const markup = renderToStaticMarkup(
-      <CommunityStats
-        accountCount={337}
-        optInCount={48}
-        tweetCount={13_600_000}
-      />,
+      <CommunityStats userCount={500} tweetCount={13_600_000} />,
     )
 
     expect(markup).toContain('<strong>13.6M</strong> tweets')
-    expect(markup).toContain('<strong>337</strong> uploaded')
-    expect(markup).toContain('<strong>48</strong> opted in')
-    expect(markup).not.toMatch(/users|archives/i)
+    expect(markup).toContain('from <strong>500</strong> users')
+    expect(markup).not.toMatch(/uploaded|opted in/i)
     expect(markup).not.toMatch(/liked tweets/i)
   })
 })

--- a/src/lib/stats.test.ts
+++ b/src/lib/stats.test.ts
@@ -1,40 +1,38 @@
 import { getStats } from './stats'
 
 describe('getStats', () => {
-  it('fetches the archive summary and the opted-in user count', async () => {
+  it('fetches the tweet summary and deduplicated participating-user count', async () => {
     const summarySingle = jest.fn().mockResolvedValue({
       data: {
-        total_accounts: 337,
         total_tweets: 13_600_000,
         total_user_mentions: 4_200_000,
       },
       error: null,
     })
     const summarySelect = jest.fn().mockReturnValue({ single: summarySingle })
-    const optInEq = jest.fn().mockResolvedValue({ count: 48, error: null })
-    const optInSelect = jest.fn().mockReturnValue({ eq: optInEq })
+    const memberSelect = jest
+      .fn()
+      .mockResolvedValue({ count: 500, error: null })
     const from = jest.fn((table: string) =>
       table === 'global_activity_summary'
         ? { select: summarySelect }
-        : { select: optInSelect },
+        : { select: memberSelect },
     )
     const supabase = {
       schema: jest.fn().mockReturnValue({ from }),
     }
 
     await expect(getStats(supabase as any)).resolves.toEqual({
-      accountCount: 337,
-      optInCount: 48,
+      userCount: 500,
       tweetCount: 13_600_000,
       userMentionsCount: 4_200_000,
     })
     expect(summarySelect).toHaveBeenCalledWith(
-      'total_accounts, total_tweets, total_user_mentions',
+      'total_tweets, total_user_mentions',
     )
-    expect(optInSelect).toHaveBeenCalledWith('*', {
+    expect(memberSelect).toHaveBeenCalledWith('directory_id', {
       count: 'exact',
       head: true,
     })
-    expect(optInEq).toHaveBeenCalledWith('opted_in', true)
   })
 })

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -4,30 +4,34 @@ import { SupabaseClient } from '@supabase/supabase-js'
 
 export const getStats = async (supabase: SupabaseClient) => {
   const publicSchema = supabase.schema('public')
-  const [summaryResult, optInResult] = await Promise.all([
+  const [summaryResult, memberResult] = await Promise.all([
     publicSchema
       .from('global_activity_summary')
-      .select('total_accounts, total_tweets, total_user_mentions')
+      .select('total_tweets, total_user_mentions')
       .single(),
     publicSchema
-      .from('optin')
-      .select('*', { count: 'exact', head: true })
-      .eq('opted_in', true),
+      .from('user_directory')
+      .select('directory_id', { count: 'exact', head: true }),
   ])
 
   if (summaryResult.error) {
-    console.error('Error fetching global activity summary:', summaryResult.error)
+    console.error(
+      'Error fetching global activity summary:',
+      summaryResult.error,
+    )
     throw summaryResult.error
   }
 
-  if (optInResult.error) {
-    console.error('Error fetching opted-in user count:', optInResult.error)
-    throw optInResult.error
+  if (memberResult.error) {
+    console.error(
+      'Error fetching participating user count:',
+      memberResult.error,
+    )
+    throw memberResult.error
   }
 
   return {
-    accountCount: summaryResult.data.total_accounts,
-    optInCount: optInResult.count,
+    userCount: memberResult.count,
     tweetCount: summaryResult.data.total_tweets,
     userMentionsCount: summaryResult.data.total_user_mentions,
   }


### PR DESCRIPTION
## Summary
- count the deduplicated union of archive uploaders and opted-in users via `user_directory`
- render the homepage copy as “We have {tweets} tweets from {users} users” without liked-tweet stats
- replace directory participation pills with right-edge icons and hover/focus labels

## Validation
- `pnpm exec jest --selectProjects server --runInBand src/lib/communityStats.test.tsx src/lib/stats.test.ts`
- `pnpm type-check`
- `pnpm lint`
- production build
- Playwright runtime check for both Archive and Opted in tooltips
- local production homepage rendered “We have 13.6M tweets from 484 users.”