### PR TITLE
[codex] Improve navigation and avatar fallbacks

### DIFF
--- a/src/app/api/syndication/avatar/[tweet_id]/route.ts
+++ b/src/app/api/syndication/avatar/[tweet_id]/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server'
+import { fetchSyndicatedTweet } from '@/lib/twitterSyndication'
+
+export async function GET(
+  _request: Request,
+  { params }: { params: { tweet_id: string } },
+) {
+  const tweet = await fetchSyndicatedTweet(params.tweet_id)
+  const avatarMediaUrl = tweet?.avatar_media_url
+
+  if (!avatarMediaUrl) {
+    return NextResponse.json(
+      { avatar_media_url: null },
+      {
+        status: 404,
+        headers: { 'Cache-Control': 'public, s-maxage=300' },
+      },
+    )
+  }
+
+  return NextResponse.json(
+    { avatar_media_url: avatarMediaUrl },
+    {
+      headers: {
+        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+      },
+    },
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,7 @@ import dynamic from 'next/dynamic'
 import HeaderNavigation from '@/components/HeaderNavigation'
 import HeaderSearch from '@/components/HeaderSearch'
 import MobileMenu from '@/components/MobileMenu'
+import Footer from '@/components/Footer'
 import { checkIsAdmin } from '@/app/admin/data'
 
 const DynamicSignIn = dynamic(() => import('@/components/SignIn'), {
@@ -93,10 +94,11 @@ export default async function RootLayout({
                 </div>
               </div>
             </header>
-            <main className="flex min-h-[calc(100vh-4rem)] flex-col">
+            <div className="flex min-h-[calc(100vh-4rem)] flex-col">
               {children}
               <Analytics />
-            </main>
+              <Footer />
+            </div>
             <ReactQueryDevtools initialIsOpen={false} />
           </ReactQueryProvider>
         </ThemeProvider>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,6 @@ import { cookies } from 'next/headers'
 import AvatarList from '@/components/AvatarList'
 import { SupabaseClient } from '@supabase/supabase-js'
 import { FaGithub, FaDiscord, FaBook, FaHeart, FaDatabase } from 'react-icons/fa'
-import Footer from '@/components/Footer'
 import Link from 'next/link'
 import { getStats } from '@/lib/stats'
 import TieredSupportersDisplay, { Contributor } from '@/components/TieredSupportersDisplay'
@@ -280,8 +279,6 @@ export default async function Homepage() {
           </div>
         </div>
       </section>
-
-      <Footer />
     </main>
   )
 }

--- a/src/app/user/[account_id]/page.tsx
+++ b/src/app/user/[account_id]/page.tsx
@@ -194,7 +194,7 @@ export default async function User({
           <UserProfile userData={userData} />
         </Suspense>
 
-        {showingSummaryData ? (
+        {showingSummaryData && (
           <>
             {/* Most Mentioned Accounts card - Removed shadow */}
             <div className="rounded-lg bg-slate-100 p-6 dark:bg-card sm:p-8">
@@ -227,20 +227,6 @@ export default async function User({
               </Suspense>
             </div>
           </>
-        ) : (
-          <div className="rounded-lg bg-slate-100 p-8 text-center dark:bg-card">
-            {/* Activity summary placeholder card - Removed shadow */}
-            <h3 className="text-xl font-semibold text-gray-800 dark:text-gray-200">
-              {userData.account_id
-                ? 'Activity summary not yet available.'
-                : 'Activity is not linked yet.'}
-            </h3>
-            <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
-              {userData.account_id
-                ? 'Detailed activity data like top tweets and mentions is currently being processed or is not available for this user. Basic profile information is still shown above.'
-                : 'This member has opted in, but their Twitter account ID has not been connected to archived or streamed activity yet.'}
-            </p>
-          </div>
         )}
 
         {userData.account_id && (

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -10,6 +10,10 @@ const Footer = () => {
       <Link href="/data-policy" className="hover:underline">
         Data Policy
       </Link>
+      <span className="mx-2">•</span>
+      <Link href="/stream-monitor" className="hover:underline">
+        Stream Monitor
+      </Link>
     </footer>
   )
 }

--- a/src/components/HeaderNavigation.tsx
+++ b/src/components/HeaderNavigation.tsx
@@ -22,17 +22,11 @@ export default function HeaderNavigation({
   const baseNavItems = [
     { href: '/', label: 'Home' },
     { href: '/user-dir', label: 'Directory' },
-    { href: '/search', label: 'Search' },
-  ]
-
-  const streamingNavItems = [
-    { href: '/stream-monitor', label: 'Stream Monitor' },
   ]
 
   const userNavItems = [{ href: '/profile', label: 'Profile' }]
 
-  // Include all navigation items
-  const navItems = [...baseNavItems, ...streamingNavItems, ...userNavItems]
+  const navItems = [...baseNavItems, ...userNavItems]
 
   return (
     <NavigationMenu className="hidden md:flex">

--- a/src/components/HeaderSearch.tsx
+++ b/src/components/HeaderSearch.tsx
@@ -2,8 +2,10 @@
 
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { Search } from 'lucide-react'
+import Link from 'next/link'
+import { ListFilter, Search } from 'lucide-react'
 import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
 
 export default function HeaderSearch() {
   const router = useRouter()
@@ -18,17 +20,37 @@ export default function HeaderSearch() {
     }
   }
 
+  const advancedSearchHref = query.trim()
+    ? `/search?q=${encodeURIComponent(query.trim())}`
+    : '/search'
+
   return (
     <form onSubmit={handleSubmit} className="hidden sm:flex items-center">
-      <div className="relative">
-        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
-        <Input
-          type="search"
-          placeholder="Search tweets..."
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          className="pl-8 pr-3 py-1.5 h-9 w-40 lg:w-56 text-sm bg-gray-100 dark:bg-gray-800 border-gray-200 dark:border-gray-700 focus:ring-blue-500"
-        />
+      <div className="flex items-center">
+        <div className="relative">
+          <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+          <Input
+            type="search"
+            placeholder="Search tweets..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="h-9 w-40 rounded-r-none border-gray-200 bg-gray-100 py-1.5 pl-8 pr-3 text-sm focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 lg:w-56"
+          />
+        </div>
+        <Button
+          asChild
+          variant="outline"
+          size="icon"
+          className="h-9 w-9 rounded-l-none border-l-0"
+        >
+          <Link
+            href={advancedSearchHref}
+            aria-label="Open advanced search"
+            title="Advanced search"
+          >
+            <ListFilter className="h-4 w-4" />
+          </Link>
+        </Button>
       </div>
     </form>
   )

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button'
 import {
   Sheet,
   SheetContent,
+  SheetDescription,
   SheetHeader,
   SheetTitle,
   SheetTrigger,
@@ -18,8 +19,6 @@ const baseNavItems = [
   { href: '/user-dir', label: 'User Directory' },
   { href: '/search', label: 'Advanced Search' },
 ]
-
-const streamingNavItems = [{ href: '/stream-monitor', label: 'Stream Monitor' }]
 
 const userNavItems = [{ href: '/profile', label: 'Profile' }]
 const adminNavItems = [{ href: '/admin', label: 'Admin' }]
@@ -34,7 +33,6 @@ export default function MobileMenu({
 
   const navItems = [
     ...baseNavItems,
-    ...streamingNavItems,
     ...userNavItems,
     ...(isAdmin ? adminNavItems : []),
   ]
@@ -52,6 +50,9 @@ export default function MobileMenu({
           <SheetTitle className="text-left text-lg font-semibold">
             Navigation
           </SheetTitle>
+          <SheetDescription className="sr-only">
+            Browse Community Archive pages.
+          </SheetDescription>
         </SheetHeader>
         <nav className="flex flex-col space-y-2">
           {navItems.map((item) => (

--- a/src/components/TopMentionedMissingUsers.tsx
+++ b/src/components/TopMentionedMissingUsers.tsx
@@ -17,6 +17,7 @@ import { createBrowserClient } from '@/utils/supabase'
 import { devLog } from '@/lib/devLog'
 import { Label } from '@/components/ui/label'
 import { formatNumber } from '@/lib/formatNumber'
+import { getLatestAvatarMediaUrl } from '@/lib/avatar'
 
 export type MentionedUser = {
   mentioned_user_id: string
@@ -52,6 +53,7 @@ export default function TopMentionedUsers({
         .from('account')
         .select(
           `
+          account_id,
           username,
           account_display_name,
           profile:profile (
@@ -76,11 +78,11 @@ export default function TopMentionedUsers({
         if (!accountData) {
           return { ...user, uploaded: false }
         }
-        const media_url = accountData.profile?.avatar_media_url
-          ? accountData.profile.avatar_media_url
-          : undefined
+        const media_url = getLatestAvatarMediaUrl(accountData.profile)
         return {
           ...user,
+          mentioned_user_id:
+            accountData.account_id || user.mentioned_user_id,
           account_display_name: accountData.account_display_name!,
           avatar_media_url: media_url,
           uploaded: true,

--- a/src/components/TweetAvatarImage.tsx
+++ b/src/components/TweetAvatarImage.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { AvatarImage } from '@/components/ui/avatar'
+
+const avatarRequests = new Map<string, Promise<string | null>>()
+
+async function fetchSyndicatedAvatar(
+  username: string,
+  tweetId: string,
+): Promise<string | null> {
+  if (!/^\d{5,}$/.test(tweetId)) return null
+
+  const cacheKey = username.toLowerCase() || tweetId
+  const pendingRequest = avatarRequests.get(cacheKey)
+  if (pendingRequest) return pendingRequest
+
+  const request = fetch(
+    `/api/syndication/avatar/${encodeURIComponent(tweetId)}`,
+  )
+    .then(async (response) => {
+      if (!response.ok) return null
+      const data = (await response.json()) as {
+        avatar_media_url?: string | null
+      }
+      return data.avatar_media_url || null
+    })
+    .catch(() => null)
+
+  avatarRequests.set(cacheKey, request)
+  const avatarUrl = await request
+
+  if (!avatarUrl) {
+    avatarRequests.delete(cacheKey)
+  }
+
+  return avatarUrl
+}
+
+export default function TweetAvatarImage({
+  src,
+  alt,
+  username,
+  tweetId,
+}: {
+  src?: string | null
+  alt: string
+  username: string
+  tweetId: string
+}) {
+  const [resolvedSrc, setResolvedSrc] = useState(src || '')
+  const attemptKey = `${username.toLowerCase()}:${tweetId}`
+  const attemptedKeyRef = useRef<string | null>(null)
+
+  const recoverAvatar = useCallback(async () => {
+    if (attemptedKeyRef.current === attemptKey) return
+    attemptedKeyRef.current = attemptKey
+
+    const avatarUrl = await fetchSyndicatedAvatar(username, tweetId)
+    if (avatarUrl && attemptedKeyRef.current === attemptKey) {
+      setResolvedSrc(avatarUrl)
+    }
+  }, [attemptKey, tweetId, username])
+
+  useEffect(() => {
+    setResolvedSrc(src || '')
+    attemptedKeyRef.current = null
+
+    if (!src) {
+      void recoverAvatar()
+    }
+  }, [recoverAvatar, src])
+
+  return (
+    <AvatarImage
+      src={resolvedSrc || undefined}
+      alt={alt}
+      onError={() => {
+        setResolvedSrc('')
+        void recoverAvatar()
+      }}
+    />
+  )
+}

--- a/src/components/TweetComponent.tsx
+++ b/src/components/TweetComponent.tsx
@@ -3,9 +3,10 @@
 import React from 'react'
 import { formatDistanceToNow } from 'date-fns'
 import { FaHeart, FaRetweet, FaExternalLinkAlt, FaReply } from 'react-icons/fa'
-import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
+import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { formatNumber } from '@/lib/formatNumber'
 import NextImage from 'next/image'
+import TweetAvatarImage from '@/components/TweetAvatarImage'
 
 export interface TweetMedia {
   media_url: string
@@ -107,7 +108,7 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({ tweet, className
   // Support both interface formats for backwards compatibility
   const originalUsername = tweet.username || tweet.account?.username || 'Unknown'
   const originalDisplayName = tweet.account_display_name || tweet.account?.account_display_name || 'Unknown'
-  const originalProfilePicUrl = tweet.avatar_media_url || tweet.account?.profile?.avatar_media_url || '/placeholder.jpg'
+  const originalProfilePicUrl = tweet.avatar_media_url || tweet.account?.profile?.avatar_media_url
   const replyToUsername = tweet.reply_to_username
 
   const isRetweet = !!tweet.retweeted_tweet_id
@@ -139,13 +140,13 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({ tweet, className
         profilePicUrl = mentionedUser.account.profile.avatar_media_url
       } else {
         // For RT tweets, if we don't have the retweeted user's avatar, use placeholder
-        profilePicUrl = '/placeholder.jpg'
+        profilePicUrl = undefined
       }
     } else {
       // If we can't find the mentioned user data, still use extracted username but placeholder avatar
       displayUsername = rtUsername
       displayName = rtUsername // fallback to username as display name
-      profilePicUrl = '/placeholder.jpg'
+      profilePicUrl = undefined
     }
   }
 
@@ -229,7 +230,7 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({ tweet, className
         </div>
       )
     }
-    const quotedProfilePic = quotedTweet.avatar_media_url || '/placeholder.jpg'
+    const quotedProfilePic = quotedTweet.avatar_media_url
     // Border + marker for syndication-hydrated quotes so it's clear the data isn't
     // from this archive.
     const externalClasses = quotedTweet.from_external
@@ -245,9 +246,11 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({ tweet, className
         )}
         <div className="flex items-start space-x-3">
           <Avatar className="h-8 w-8 flex-shrink-0">
-            <AvatarImage
+            <TweetAvatarImage
               src={quotedProfilePic}
               alt={`${quotedTweet.account_display_name}'s profile picture`}
+              username={quotedTweet.username}
+              tweetId={quotedTweet.tweet_id}
             />
             <AvatarFallback>{quotedTweet.account_display_name?.charAt(0) || quotedTweet.username?.charAt(0) || 'U'}</AvatarFallback>
           </Avatar>
@@ -328,9 +331,11 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({ tweet, className
 
       <div className="mb-2 flex items-start">
         <Avatar className="mr-3 h-12 w-12">
-          <AvatarImage
+          <TweetAvatarImage
             src={profilePicUrl}
             alt={`${displayName}'s profile picture`}
+            username={displayUsername}
+            tweetId={tweet.retweeted_tweet_id || tweet.tweet_id}
           />
           <AvatarFallback>{displayName?.charAt(0) || displayUsername?.charAt(0) || 'U'}</AvatarFallback>
         </Avatar>

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -2,7 +2,6 @@
 
 import * as React from 'react'
 import * as AvatarPrimitive from '@radix-ui/react-avatar'
-import Image from 'next/image'
 
 import { cn } from '@/utils/tailwind'
 
@@ -29,10 +28,6 @@ const AvatarImage = React.forwardRef<
     ref={ref}
     className={cn('aspect-square h-full w-full', className)}
     {...props}
-    onError={(e) => {
-      const target = e.target as HTMLImageElement
-      target.src = '/placeholder.jpg'
-    }}
   />
 ))
 AvatarImage.displayName = AvatarPrimitive.Image.displayName
@@ -48,14 +43,7 @@ const AvatarFallback = React.forwardRef<
       className,
     )}
     {...props}
-  >
-    <Image
-      src="/placeholder.jpg"
-      alt="Placeholder"
-      layout="fill"
-      objectFit="cover"
-    />
-  </AvatarPrimitive.Fallback>
+  />
 ))
 AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName
 

--- a/src/lib/avatar.test.ts
+++ b/src/lib/avatar.test.ts
@@ -1,0 +1,46 @@
+import { getLatestAvatarMediaUrl } from './avatar'
+
+describe('getLatestAvatarMediaUrl', () => {
+  it('reads an embedded one-to-one profile object', () => {
+    expect(
+      getLatestAvatarMediaUrl({
+        avatar_media_url: 'https://example.com/avatar.jpg',
+      }),
+    ).toBe('https://example.com/avatar.jpg')
+  })
+
+  it('selects the newest profile when PostgREST embeds an array', () => {
+    expect(
+      getLatestAvatarMediaUrl([
+        {
+          avatar_media_url: 'https://example.com/old.jpg',
+          archive_upload_id: 10,
+        },
+        {
+          avatar_media_url: 'https://example.com/new.jpg',
+          archive_upload_id: 20,
+        },
+      ]),
+    ).toBe('https://example.com/new.jpg')
+  })
+
+  it('uses the newest available image when the latest profile has none', () => {
+    expect(
+      getLatestAvatarMediaUrl([
+        {
+          avatar_media_url: 'https://example.com/available.jpg',
+          archive_upload_id: 10,
+        },
+        {
+          avatar_media_url: null,
+          archive_upload_id: 20,
+        },
+      ]),
+    ).toBe('https://example.com/available.jpg')
+  })
+
+  it('returns undefined when no profile image exists', () => {
+    expect(getLatestAvatarMediaUrl(null)).toBeUndefined()
+    expect(getLatestAvatarMediaUrl([])).toBeUndefined()
+  })
+})

--- a/src/lib/avatar.ts
+++ b/src/lib/avatar.ts
@@ -1,0 +1,26 @@
+export type AvatarProfile = {
+  avatar_media_url?: string | null
+  archive_upload_id?: number | null
+}
+
+export function getLatestAvatarMediaUrl(
+  profile: AvatarProfile | AvatarProfile[] | null | undefined,
+): string | undefined {
+  if (!profile) return undefined
+
+  if (!Array.isArray(profile)) {
+    return profile.avatar_media_url || undefined
+  }
+
+  const latestProfileWithAvatar = profile
+    .filter((candidate) => candidate.avatar_media_url)
+    .reduce<AvatarProfile | undefined>((latest, candidate) => {
+      if (!latest) return candidate
+
+      const latestId = Number(latest.archive_upload_id ?? 0)
+      const candidateId = Number(candidate.archive_upload_id ?? 0)
+      return candidateId >= latestId ? candidate : latest
+    }, undefined)
+
+  return latestProfileWithAvatar?.avatar_media_url || undefined
+}

--- a/src/lib/avatarSyndicationRoute.test.ts
+++ b/src/lib/avatarSyndicationRoute.test.ts
@@ -1,0 +1,43 @@
+const mockFetchSyndicatedTweet = jest.fn()
+
+jest.mock('./twitterSyndication', () => ({
+  fetchSyndicatedTweet: (...args: unknown[]) =>
+    mockFetchSyndicatedTweet(...args),
+}))
+
+import { GET } from '@/app/api/syndication/avatar/[tweet_id]/route'
+
+describe('syndication avatar route', () => {
+  beforeEach(() => {
+    mockFetchSyndicatedTweet.mockReset()
+  })
+
+  it('returns the syndicated avatar URL', async () => {
+    mockFetchSyndicatedTweet.mockResolvedValueOnce({
+      avatar_media_url: 'https://pbs.twimg.com/profile_images/avatar.jpg',
+    })
+
+    const response = await GET(new Request('http://localhost'), {
+      params: { tweet_id: '1234567890' },
+    })
+
+    expect(mockFetchSyndicatedTweet).toHaveBeenCalledWith('1234567890')
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      avatar_media_url: 'https://pbs.twimg.com/profile_images/avatar.jpg',
+    })
+  })
+
+  it('returns 404 when syndication has no usable avatar', async () => {
+    mockFetchSyndicatedTweet.mockResolvedValueOnce(null)
+
+    const response = await GET(new Request('http://localhost'), {
+      params: { tweet_id: '1234567890' },
+    })
+
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toEqual({
+      avatar_media_url: null,
+    })
+  })
+})

--- a/src/lib/queries/tweetQueries.test.ts
+++ b/src/lib/queries/tweetQueries.test.ts
@@ -199,3 +199,46 @@ describe('fetchTweets — exact phrase search via FTS simple', () => {
     expect(result.error.message).toContain('timed out')
   })
 })
+
+describe('fetchTweets — direct profile embeds', () => {
+  it('preserves an avatar when PostgREST returns profile as an array', async () => {
+    const supabase = buildMockSupabase()
+    supabase._builder.range.mockResolvedValueOnce({
+      data: [
+        {
+          tweet_id: '1',
+          created_at: '2025-01-01T00:00:00Z',
+          full_text: 'Hello',
+          favorite_count: 1,
+          retweet_count: 0,
+          reply_to_tweet_id: null,
+          account: {
+            username: 'mahlnr',
+            account_display_name: 'mahlen',
+            profile: [
+              {
+                avatar_media_url: 'https://example.com/avatar.jpg',
+                archive_upload_id: 42,
+              },
+            ],
+          },
+          media: [],
+        },
+      ],
+      error: null,
+      count: 1,
+    })
+
+    const result = await fetchTweets(
+      supabase,
+      { userId: 'account-1' },
+      1,
+      20,
+    )
+
+    expect(result.error).toBeNull()
+    expect(result.tweets[0].account.profile?.avatar_media_url).toBe(
+      'https://example.com/avatar.jpg',
+    )
+  })
+})

--- a/src/lib/queries/tweetQueries.ts
+++ b/src/lib/queries/tweetQueries.ts
@@ -2,6 +2,7 @@ import { SupabaseClient } from '@supabase/supabase-js';
 import { TimelineTweet, RawSupabaseTweet, RawSupabaseAccount, RawSupabaseProfile } from '@/lib/types';
 import { searchTweets as rpcSearchTweets, searchTweetsExactPhrase as rpcSearchExactPhrase } from '../pgSearch';
 import { type SearchParams } from '../types';
+import { getLatestAvatarMediaUrl } from '@/lib/avatar';
 
 export interface FilterCriteria {
   userId?: string; // For fetching tweets by a specific user
@@ -44,12 +45,13 @@ function transformRawTweetsToTimelineTweets(rawData: any[], isRpcResult: boolean
       // Direct query result has nested account data
       const accountData = rawTweet.account as RawSupabaseAccount | undefined;
       if (accountData && accountData.username) {
-        const profileData = accountData.profile as RawSupabaseProfile | null | undefined;
+        const profileData = accountData.profile as RawSupabaseProfile | RawSupabaseProfile[] | null | undefined;
+        const avatarMediaUrl = getLatestAvatarMediaUrl(profileData);
         timelineAccount = {
           username: accountData.username,
           account_display_name: accountData.account_display_name,
-          profile: profileData?.avatar_media_url
-            ? { avatar_media_url: profileData.avatar_media_url === null ? undefined : profileData.avatar_media_url }
+          profile: avatarMediaUrl
+            ? { avatar_media_url: avatarMediaUrl }
             : undefined,
         };
       } else {
@@ -178,7 +180,8 @@ export async function fetchTweets(
           username,
           account_display_name,
           profile:profile!left (
-            avatar_media_url
+            avatar_media_url,
+            archive_upload_id
           )
         ),
         media:tweet_media (
@@ -244,4 +247,4 @@ export async function fetchTweets(
     const transformedTweets = transformRawTweetsToTimelineTweets(rawData, false);
     return { tweets: transformedTweets, totalCount: count, error: null };
   }
-} 
+}

--- a/src/lib/twitterSyndication.ts
+++ b/src/lib/twitterSyndication.ts
@@ -1,14 +1,14 @@
 /**
  * Twitter syndication API client for transient render-time hydration of tweets that
  * have been deleted from our archive but may still be accessible via Twitter's public
- * embed CDN. Used to fill in deleted reply parents and deleted quoted tweets so the
- * thread view shows real content instead of a "[Tweet deleted]" tombstone whenever
- * Twitter still has the original.
+ * embed CDN. Used to fill in deleted reply parents and deleted quoted tweets, and
+ * to recover an avatar transiently when an archived profile image is missing or
+ * stale.
  *
  * Hard rules:
  * - Never persist the response to our DB.
- * - Never include hydrated tweets in search results, profile listings, or any other
- *   query path. Only render-time hydration of explicitly-referenced parent/quoted ids.
+ * - Never include hydrated tweet content in search results, profile listings, or any
+ *   other query path. Avatar recovery is render-only and is never persisted.
  * - Caller decides whether to render with a "(from Twitter)" marker.
  *
  * The endpoint requires a `token` query param derived from the tweet id. This is

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -202,12 +202,13 @@ export type FormattedUser = {
 // Interfaces for fetching and displaying tweets via Supabase queries
 export interface RawSupabaseProfile {
   avatar_media_url: string | null;
+  archive_upload_id?: number | null;
 }
 
 export interface RawSupabaseAccount {
   username: string;
   account_display_name: string;
-  profile: RawSupabaseProfile | null;
+  profile: RawSupabaseProfile | RawSupabaseProfile[] | null;
 }
 
 export interface RawSupabaseTweet {


### PR DESCRIPTION
## What changed

- Move Stream Monitor from desktop/mobile navigation into the shared site footer.
- Replace the standalone Search navigation item with a compact advanced-search control attached to the navbar search field, preserving the entered query.
- Omit the empty activity-summary placeholder when no summary data exists.
- Normalize profile avatar embeds, restore initial fallbacks, and recover missing or failed tweet avatars through a cacheable syndication API route.

## Why

Stream Monitor is a niche developer tool and should not compete with primary navigation. Tweet queries can receive PostgREST profile relationships as arrays, so existing avatar URLs were being dropped even when the profile image existed. Archived avatar URLs can also become stale; syndication provides a render-only recovery path without persisting external tweet data.

## User impact

Navigation is less cluttered, advanced search remains one click away, empty profile states are quieter, and tweet avatars render more reliably.

## Validation

- `pnpm type-check`
- `git diff --check origin/main...HEAD`
- `pnpm exec jest --selectProjects server --runInBand src/lib/avatar.test.ts src/lib/queries/tweetQueries.test.ts src/lib/avatarSyndicationRoute.test.ts` (19 tests passed)
- Desktop and mobile browser QA for navigation, advanced-search query forwarding, profile activity rendering, avatars, footer placement, and accessibility console output
