### PR TITLE
Simplify site palette and navigation

### DIFF
--- a/context_for_llms/style-guide.md
+++ b/context_for_llms/style-guide.md
@@ -10,123 +10,137 @@ Colors are defined using CSS variables and applied with Tailwind CSS utility cla
 
 These variables automatically adapt to light and dark modes.
 
-*   **Background**:
-    *   Page Background: `bg-background` (e.g., `hsl(var(--background))`)
-    *   Card/Component Background: `bg-card` (e.g., `hsl(var(--card))`)
-*   **Foreground (Text)**:
-    *   Primary Text: `text-foreground` (e.g., `hsl(var(--foreground))`)
-    *   Card Text: `text-card-foreground` (e.g., `hsl(var(--card-foreground))`)
-*   **Primary Accent (Buttons, active elements)**:
-    *   Background: `bg-primary` (e.g., `hsl(var(--primary))`)
-    *   Text: `text-primary-foreground` (e.g., `hsl(var(--primary-foreground))`)
-*   **Secondary Accent (Less prominent interactive elements)**:
-    *   Background: `bg-secondary` (e.g., `hsl(var(--secondary))`)
-    *   Text: `text-secondary-foreground` (e.g., `hsl(var(--secondary-foreground))`)
-*   **Muted (Subtle backgrounds and text)**:
-    *   Background: `bg-muted` (e.g., `hsl(var(--muted))`)
-    *   Text: `text-muted-foreground` (e.g., `hsl(var(--muted-foreground))`)
-*   **Accent (Hover states, focus indicators)**:
-    *   Background: `bg-accent` (e.g., `hsl(var(--accent))`)
-    *   Text: `text-accent-foreground` (e.g., `hsl(var(--accent-foreground))`)
-*   **Destructive (Error states, delete actions)**:
-    *   Background: `bg-destructive` (e.g., `hsl(var(--destructive))`)
-    *   Text: `text-destructive-foreground` (e.g., `hsl(var(--destructive-foreground))`)
-*   **Borders**: `border-border` (e.g., `hsl(var(--border))`)
-*   **Input Fields**: `bg-input` (e.g., `hsl(var(--input))`), text often `text-foreground`.
-*   **Focus Ring**: `ring-ring` (e.g., `hsl(var(--ring))`)
+Both themes intentionally use only three neutral surfaces:
 
-### 1.2. Specific Usage Notes from Previous Palette (To be refactored or verified if still custom)
+- `bg-background` for the page canvas.
+- `bg-card` / `bg-popover` for raised content.
+- `bg-muted` / `bg-secondary` / `bg-accent` for subdued sections,
+  controls, active navigation, and hover states.
 
-The following were previously defined with specific Tailwind classes. Their current equivalents using the semantic color system should be preferred. Some page layouts may still use direct color classes for broader page sectioning.
+Use `border-border`, `text-foreground`, and `text-muted-foreground` with
+those surfaces. Do not introduce direct `gray`, `slate`, `zinc`, or `sky`
+classes for general UI. Status colors remain appropriate when they communicate
+success, warning, or failure.
 
-*   **Unified Base Background for Main Page Sections (e.g., `src/app/page.tsx`, `src/app/tweets/page.tsx`):**
-    *   Uses a local constant: `const unifiedDeepBlueBase = "bg-slate-200 dark:bg-slate-900";`. This provides a distinct background from the default `bg-background` for these specific page structures.
-*   **Secondary Accent Background (e.g., "Upload Your Data", "Data & Source Code" sections on homepage):**
-    *   Previously `bg-sky-100` (light) and `dark:bg-slate-800` (dark).
-    *   Verify if these sections now use `bg-secondary`, `bg-muted`, or `bg-accent`. `src/app/page.tsx` indicates a move to `bg-slate-100 dark:bg-slate-700` for info panels, which are closer to `bg-secondary` or `bg-muted`.
-*   **Tertiary Accent Background (e.g., "Showcased Apps", "Our Supporters" sections on homepage):**
-    *   Previously `bg-white` (light) and `dark:bg-slate-900` (dark).
-    *   Consider `bg-card` or `bg-background` for light mode, and `bg-card` or a slightly off-background color for dark mode (e.g. `bg-muted`).
-*   **Link Text:**
-    *   Standard links typically use browser defaults or can be styled with `text-primary` or `text-blue-600 dark:text-blue-400` and `hover:underline`. Specific components might have their own link styling.
+- **Background**:
+  - Page Background: `bg-background` (e.g., `hsl(var(--background))`)
+  - Card/Component Background: `bg-card` (e.g., `hsl(var(--card))`)
+- **Foreground (Text)**:
+  - Primary Text: `text-foreground` (e.g., `hsl(var(--foreground))`)
+  - Card Text: `text-card-foreground` (e.g., `hsl(var(--card-foreground))`)
+- **Primary Accent (Buttons, active elements)**:
+  - Background: `bg-primary` (e.g., `hsl(var(--primary))`)
+  - Text: `text-primary-foreground` (e.g., `hsl(var(--primary-foreground))`)
+- **Secondary Accent (Less prominent interactive elements)**:
+  - Background: `bg-secondary` (e.g., `hsl(var(--secondary))`)
+  - Text: `text-secondary-foreground` (e.g., `hsl(var(--secondary-foreground))`)
+- **Muted (Subtle backgrounds and text)**:
+  - Background: `bg-muted` (e.g., `hsl(var(--muted))`)
+  - Text: `text-muted-foreground` (e.g., `hsl(var(--muted-foreground))`)
+- **Accent (Hover states, focus indicators)**:
+  - Background: `bg-accent` (e.g., `hsl(var(--accent))`)
+  - Text: `text-accent-foreground` (e.g., `hsl(var(--accent-foreground))`)
+- **Destructive (Error states, delete actions)**:
+  - Background: `bg-destructive` (e.g., `hsl(var(--destructive))`)
+  - Text: `text-destructive-foreground` (e.g., `hsl(var(--destructive-foreground))`)
+- **Borders**: `border-border` (e.g., `hsl(var(--border))`)
+- **Input Fields**: `bg-input` (e.g., `hsl(var(--input))`), text often `text-foreground`.
+- **Focus Ring**: `ring-ring` (e.g., `hsl(var(--ring))`)
+- **Brand Accent (links and blue actions)**:
+  - Background: `bg-brand`
+  - Text: `text-brand`
+  - Contrasting text: `text-brand-foreground`
+
+### 1.2. Palette rules
+
+- Full-page and full-width base sections use `bg-background`.
+- Cards and raised panels use `bg-card`.
+- Alternating homepage sections, active navigation, table headers, and input
+  fills use `bg-muted` or `bg-accent`.
+- Blue links, icons, and actions use the single `brand` token instead of
+  separate light/dark blue utilities.
+- Do not add a fourth neutral surface to create subtle differentiation. Use a
+  border, spacing, or typography first.
 
 ### 1.3. Glow Effects
 
-*   Glow effects previously implemented using custom JavaScript styles (`glowStyleStrong`, `glowBaseColor`, etc.) have been largely **removed** from the project to simplify the visual design. Any remaining glow effects are likely minimal and part of specific component libraries or very targeted CSS.
+- Glow effects previously implemented using custom JavaScript styles (`glowStyleStrong`, `glowBaseColor`, etc.) have been largely **removed** from the project to simplify the visual design. Any remaining glow effects are likely minimal and part of specific component libraries or very targeted CSS.
 
 ## 2. Layout
 
-*   **Main Page Structure**:
-    *   Pages are typically wrapped in a `<main>` tag.
-    *   Content is often divided into full-width `<section>` elements.
-    *   Specific pages (e.g., homepage, user pages) use the `unifiedDeepBlueBase` (`bg-slate-200 dark:bg-slate-900`) for main section backgrounds. Other content typically resides on `bg-background` or `bg-card`.
-    *   Padding: `sectionPaddingClasses = "py-12 md:py-16 lg:py-20"` (example, verify actual common values).
-    *   Content within sections is usually centered and constrained by a `div` with `contentWrapperClasses`:
-        *   Example: `w-full max-w-5xl mx-auto px-4 sm:px-6 lg:px-8` (adjust `max-w-*` as needed).
-*   **Sticky Header**: The main header is sticky (`sticky top-0 z-50`) with a blurred background (`bg-background/80 backdrop-blur-md` - verify exact opacity and color).
-*   **Flexbox and Grid**: Tailwind's flexbox and grid utilities are used extensively for component layout.
-*   **Border Radius**: Governed by CSS variable `--radius: 0.3rem;`. Applied as `rounded-lg` (`var(--radius)`), `rounded-md` (`calc(var(--radius) - 2px)`), `rounded-sm` (`calc(var(--radius) - 4px)`).
+- **Main Page Structure**:
+  - Pages are typically wrapped in a `<main>` tag.
+  - Content is often divided into full-width `<section>` elements.
+- Main sections use `bg-background`; subdued alternating sections use
+  `bg-muted`; content panels use `bg-card`.
+  - Padding: `sectionPaddingClasses = "py-12 md:py-16 lg:py-20"` (example, verify actual common values).
+  - Content within sections is usually centered and constrained by a `div` with `contentWrapperClasses`:
+    - Example: `w-full max-w-5xl mx-auto px-4 sm:px-6 lg:px-8` (adjust `max-w-*` as needed).
+- **Sticky Header**: The main header is sticky (`sticky top-0 z-50`) with a blurred background (`bg-background/80 backdrop-blur-md` - verify exact opacity and color).
+- **Flexbox and Grid**: Tailwind's flexbox and grid utilities are used extensively for component layout.
+- **Border Radius**: Governed by CSS variable `--radius: 0.3rem;`. Applied as `rounded-lg` (`var(--radius)`), `rounded-md` (`calc(var(--radius) - 2px)`), `rounded-sm` (`calc(var(--radius) - 4px)`).
 
 ## 3. Typography
 
-*   **Font Family**: `GeistSans` (applied globally in `src/app/layout.tsx`). Anti-aliased (`antialiased`).
-*   **Headings** (general guidance, may vary by component and page context):
-    *   **H1 (Page Title/Hero)**: Example: `text-4xl lg:text-5xl font-bold tracking-tight`.
-    *   **H2 (Section Titles)**: Example: `text-3xl font-semibold`.
-    *   **H3 (Sub-headings/Card Titles)**: Example: `text-xl font-semibold`.
-*   **Paragraph Text**: Generally `text-base`. Larger descriptive text might use `text-lg`.
-*   **Muted Text**: Use `text-muted-foreground` for less emphasis.
+- **Font Family**: `GeistSans` (applied globally in `src/app/layout.tsx`). Anti-aliased (`antialiased`).
+- **Headings** (general guidance, may vary by component and page context):
+  - **H1 (Page Title/Hero)**: Example: `text-4xl lg:text-5xl font-bold tracking-tight`.
+  - **H2 (Section Titles)**: Example: `text-3xl font-semibold`.
+  - **H3 (Sub-headings/Card Titles)**: Example: `text-xl font-semibold`.
+- **Paragraph Text**: Generally `text-base`. Larger descriptive text might use `text-lg`.
+- **Muted Text**: Use `text-muted-foreground` for less emphasis.
 
 ## 4. Card Component Styling
 
 Cards are a common UI element for grouping content, typically using `bg-card` and `text-card-foreground`.
 
-*   **Standard Card (e.g., `shadcn/ui` Card component):**
-    *   Background: `bg-card`
-    *   Padding: Common values include `p-4`, `p-6`.
-    *   Border Radius: `rounded-lg` (uses `--radius`).
-    *   Shadows: Custom large shadows like `shadow-lg` or `shadow-xl` have been mostly removed from general cards. `shadcn/ui` components (Dialogs, Popovers, Dropdown Menus, etc.) may have their own built-in, more subtle shadows (e.g., `shadow-md` or `shadow-lg` as part of their default styles). `TieredSupportersDisplay` uses `shadow-xl` for specific decorative effect on avatars.
-*   **Info Panels / App Cards (Homepage):**
-    *   These have moved away from gradient backgrounds and heavy shadows.
-    *   Current: `bg-slate-100 dark:bg-slate-700` (as per comment in `src/app/page.tsx`). This is closer to `bg-muted` or `bg-secondary`.
-    *   Padding and border radius should be consistent.
+- **Standard Card (e.g., `shadcn/ui` Card component):**
+  - Background: `bg-card`
+  - Padding: Common values include `p-4`, `p-6`.
+  - Border Radius: `rounded-lg` (uses `--radius`).
+  - Shadows: Custom large shadows like `shadow-lg` or `shadow-xl` have been mostly removed from general cards. `shadcn/ui` components (Dialogs, Popovers, Dropdown Menus, etc.) may have their own built-in, more subtle shadows (e.g., `shadow-md` or `shadow-lg` as part of their default styles). `TieredSupportersDisplay` uses `shadow-xl` for specific decorative effect on avatars.
+- **Info Panels / App Cards (Homepage):**
+  - These have moved away from gradient backgrounds and heavy shadows.
+- Current: `bg-card` with `border-border`, or `bg-muted` for a deliberately
+  subdued panel.
+  - Padding and border radius should be consistent.
 
 ## 5. Buttons
 
 Primarily uses the `shadcn/ui` Button component (`src/components/ui/button.tsx`), styled with variants.
 
-*   **Default Button (Primary Action):**
-    *   `bg-primary text-primary-foreground hover:bg-primary/90`
-*   **Secondary Button:**
-    *   `bg-secondary text-secondary-foreground hover:bg-secondary/80`
-*   **Outline Button:**
-    *   `border border-input bg-background hover:bg-accent hover:text-accent-foreground`
-*   **Ghost Button (for icon buttons, subtle actions):**
-    *   `hover:bg-accent hover:text-accent-foreground`
-*   **Link Button (styled as text):**
-    *   `text-primary underline-offset-4 hover:underline`
-*   **Destructive Button:**
-    *   `bg-destructive text-destructive-foreground hover:bg-destructive/90`
-*   Shadows on buttons (e.g. `shadow-md`, `shadow-lg`) have been generally removed for a flatter look.
+- **Default Button (Primary Action):**
+  - `bg-primary text-primary-foreground hover:bg-primary/90`
+- **Secondary Button:**
+  - `bg-secondary text-secondary-foreground hover:bg-secondary/80`
+- **Outline Button:**
+  - `border border-input bg-background hover:bg-accent hover:text-accent-foreground`
+- **Ghost Button (for icon buttons, subtle actions):**
+  - `hover:bg-accent hover:text-accent-foreground`
+- **Link Button (styled as text):**
+  - `text-primary underline-offset-4 hover:underline`
+- **Destructive Button:**
+  - `bg-destructive text-destructive-foreground hover:bg-destructive/90`
+- Shadows on buttons (e.g. `shadow-md`, `shadow-lg`) have been generally removed for a flatter look.
 
 ## 6. Navigation
 
-*   **Desktop Header (`src/components/HeaderNavigation.tsx`):**
-    *   Uses `shadcn/ui NavigationMenu`.
-    *   Links likely use `bg-accent` or `bg-muted` for hover/active states. Verify specific classes.
-    *   Hidden below `md` breakpoint (`hidden md:flex`).
-*   **Mobile Menu (`src/components/MobileMenu.tsx`):**
-    *   Uses `shadcn/ui Sheet` (drawer).
-    *   Triggered by a hamburger icon, visible only below `md` breakpoint (`md:hidden`).
-    *   Links should use appropriate hover/active states with semantic colors (e.g., `hover:bg-accent`, active: `bg-muted` or `bg-accent`).
+- **Desktop Header (`src/components/HeaderNavigation.tsx`):**
+  - Uses `shadcn/ui NavigationMenu`.
+  - Links likely use `bg-accent` or `bg-muted` for hover/active states. Verify specific classes.
+  - Hidden below `md` breakpoint (`hidden md:flex`).
+- **Mobile Menu (`src/components/MobileMenu.tsx`):**
+  - Uses `shadcn/ui Sheet` (drawer).
+  - Triggered by a hamburger icon, visible only below `md` breakpoint (`md:hidden`).
+  - Links should use appropriate hover/active states with semantic colors (e.g., `hover:bg-accent`, active: `bg-muted` or `bg-accent`).
 
 ## 7. Responsive Design
 
-*   **Approach**: Primarily uses Tailwind CSS responsive prefixes (e.g., `sm:`, `md:`, `lg:`).
-*   **Key Examples**:
-    *   Navigation (as described above).
-    *   `AvatarList`: Uses `flex-wrap justify-center`.
-    *   Grid layouts often change column count (e.g., `grid-cols-1 md:grid-cols-3`).
-    *   Text sizes and padding are often adjusted for different breakpoints.
+- **Approach**: Primarily uses Tailwind CSS responsive prefixes (e.g., `sm:`, `md:`, `lg:`).
+- **Key Examples**:
+  - Navigation (as described above).
+  - `AvatarList`: Uses `flex-wrap justify-center`.
+  - Grid layouts often change column count (e.g., `grid-cols-1 md:grid-cols-3`).
+  - Text sizes and padding are often adjusted for different breakpoints.
 
-This guide should help in creating new pages or modifying existing ones while keeping the visual style consistent. 
+This guide should help in creating new pages or modifying existing ones while keeping the visual style consistent.

--- a/docs/search-experience-plan.md
+++ b/docs/search-experience-plan.md
@@ -1,0 +1,68 @@
+# Search experience plan
+
+This work starts only after the palette and navigation changes are merged. The
+search redesign should ship in separate pull requests so result quality can be
+reviewed before search becomes the primary signed-in experience.
+
+## PR 1: Make search results clear and pleasant
+
+Keep the existing search behavior, URL parameters, CSV export, and database
+queries. Limit this PR to the results presentation.
+
+- Replace the large nested results panel with a simple results header and a
+  clean, single-column feed.
+- Give every tweet a consistent hierarchy: author, handle, timestamp, text,
+  media, engagement, and permalink.
+- Constrain oversized media and use a predictable gallery treatment for one or
+  multiple attachments.
+- Improve spacing, line length, link treatment, and contrast in both themes.
+- Add intentional loading skeletons plus useful empty, no-results, and error
+  states.
+- Preserve responsive behavior and make the narrow layout the baseline.
+
+Acceptance checks:
+
+- Review text-only tweets, long tweets, replies, tweets with links, and tweets
+  with one or several media items.
+- Verify empty, loading, error, and populated states in light and dark modes.
+- Verify CSV download and tweet permalinks remain available.
+- Check desktop and mobile widths and keyboard focus order.
+
+## PR 2: Simplify the search controls
+
+Once the result feed is approved, make the common path feel like a normal
+search rather than an advanced form.
+
+- Lead with one prominent search field and a clear submit action.
+- Move user and date filters into an optional filter panel.
+- Show active filters as removable chips above the results.
+- Keep filters encoded in the URL so searches remain shareable and browser
+  navigation continues to work.
+- Reuse the same query conventions in the header search and the full search
+  page.
+- Keep advanced operators available without making them required knowledge.
+
+## PR 3: Add the signed-in archive landing page
+
+After PRs 1 and 2 are merged, add a focused landing experience for signed-in,
+opted-in members.
+
+- Create an archive discovery page with a Wikipedia-like centered search field,
+  a short explanation, and a few example searches.
+- Send submitted searches to the improved results page with the query encoded
+  in the URL.
+- Add secondary paths to browse the User Directory and Products without
+  competing with the primary search action.
+- Keep the current contribution-oriented homepage for signed-out and not-yet-
+  opted-in visitors.
+- Route opted-in members to the discovery page after sign-in. Decide during the
+  PR whether `/` should redirect for those members or whether the new page
+  should become their explicit post-auth destination.
+
+## Success signals
+
+- More searches reach a populated results state.
+- Fewer users open and immediately close the advanced filters.
+- Search-to-permalink clicks increase.
+- The signed-in landing page does not reduce visits to archive upload, User
+  Directory, or Products.

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -4,72 +4,75 @@ import { FaTwitter, FaGithub, FaDiscord } from 'react-icons/fa'
 
 export default function AboutPage() {
   return (
-    <div className="container mx-auto px-4 py-8 max-w-3xl">
+    <div className="container mx-auto max-w-3xl px-4 py-8">
       <h1 className="mb-6 text-3xl font-bold">About Community Archive</h1>
 
       <section className="mb-12">
-        <h2 className="mt-8 mb-4 text-2xl font-semibold">Our Mission</h2>
-        <p className="mb-4 text-lg text-gray-700 dark:text-gray-300">
-          We believe in the immense cultural, historical, and economic value embedded in our collective digital data.
+        <h2 className="mb-4 mt-8 text-2xl font-semibold">Our Mission</h2>
+        <p className="mb-4 text-lg text-muted-foreground">
+          We believe in the immense cultural, historical, and economic value
+          embedded in our collective digital data.
         </p>
-        <p className="mb-4 text-gray-700 dark:text-gray-300">
-          Our goal is to build open-source, public infrastructure to <strong>collect, host, and serve</strong> this data,
-          empowering communities to use it for any purpose they choose.
+        <p className="mb-4 text-muted-foreground">
+          Our goal is to build open-source, public infrastructure to{' '}
+          <strong>collect, host, and serve</strong> this data, empowering
+          communities to use it for any purpose they choose.
         </p>
-        <p className="text-gray-700 dark:text-gray-300">
-          Twitter conversations represent a unique record of how ideas spread, communities form, and culture evolves.
-          By preserving this data openly, we enable researchers, developers, and communities to learn from and build upon
-          this shared history.
+        <p className="text-muted-foreground">
+          Twitter conversations represent a unique record of how ideas spread,
+          communities form, and culture evolves. By preserving this data openly,
+          we enable researchers, developers, and communities to learn from and
+          build upon this shared history.
         </p>
       </section>
 
       <section className="mb-12">
-        <h2 className="mt-8 mb-4 text-2xl font-semibold">The Team</h2>
+        <h2 className="mb-4 mt-8 text-2xl font-semibold">The Team</h2>
 
         <div className="space-y-6">
-          <div className="flex items-start gap-4 p-4 bg-slate-100 dark:bg-gray-900 rounded-lg">
+          <div className="flex items-start gap-4 rounded-lg bg-muted p-4 dark:bg-card">
             <div className="flex-1">
-              <h3 className="text-xl font-semibold mb-1">
+              <h3 className="mb-1 text-xl font-semibold">
                 <a
                   href="https://x.com/exgenesis"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="hover:text-blue-500 transition-colors"
+                  className="transition-colors hover:text-brand"
                 >
                   @exgenesis
                 </a>
               </h3>
-              <p className="text-gray-600 dark:text-gray-400">Creator & Lead</p>
+              <p className="text-muted-foreground">Creator & Lead</p>
             </div>
             <a
               href="https://x.com/exgenesis"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-2xl text-gray-500 hover:text-blue-500 transition-colors"
+              className="text-2xl text-muted-foreground transition-colors hover:text-brand"
             >
               <FaTwitter />
             </a>
           </div>
 
-          <div className="flex items-start gap-4 p-4 bg-slate-100 dark:bg-gray-900 rounded-lg">
+          <div className="flex items-start gap-4 rounded-lg bg-muted p-4 dark:bg-card">
             <div className="flex-1">
-              <h3 className="text-xl font-semibold mb-1">
+              <h3 className="mb-1 text-xl font-semibold">
                 <a
                   href="https://x.com/IaimforGOAT"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="hover:text-blue-500 transition-colors"
+                  className="transition-colors hover:text-brand"
                 >
                   @IaimforGOAT
                 </a>
               </h3>
-              <p className="text-gray-600 dark:text-gray-400">Core Contributor</p>
+              <p className="text-muted-foreground">Core Contributor</p>
             </div>
             <a
               href="https://x.com/IaimforGOAT"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-2xl text-gray-500 hover:text-blue-500 transition-colors"
+              className="text-2xl text-muted-foreground transition-colors hover:text-brand"
             >
               <FaTwitter />
             </a>
@@ -78,9 +81,10 @@ export default function AboutPage() {
       </section>
 
       <section className="mb-12">
-        <h2 className="mt-8 mb-4 text-2xl font-semibold">Get Involved</h2>
-        <p className="mb-6 text-gray-700 dark:text-gray-300">
-          Community Archive is open source and community-driven. Here&apos;s how you can participate:
+        <h2 className="mb-4 mt-8 text-2xl font-semibold">Get Involved</h2>
+        <p className="mb-6 text-muted-foreground">
+          Community Archive is open source and community-driven. Here&apos;s how
+          you can participate:
         </p>
 
         <div className="grid gap-4 md:grid-cols-3">
@@ -88,12 +92,14 @@ export default function AboutPage() {
             href="https://github.com/TheExGenesis/community-archive"
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center gap-3 p-4 bg-slate-100 dark:bg-gray-900 rounded-lg hover:bg-slate-200 dark:hover:bg-gray-800 transition-colors"
+            className="flex items-center gap-3 rounded-lg bg-muted p-4 transition-colors hover:bg-accent dark:bg-card"
           >
             <FaGithub className="text-2xl" />
             <div>
               <div className="font-semibold">GitHub</div>
-              <div className="text-sm text-gray-600 dark:text-gray-400">Contribute code</div>
+              <div className="text-sm text-muted-foreground">
+                Contribute code
+              </div>
             </div>
           </a>
 
@@ -101,12 +107,14 @@ export default function AboutPage() {
             href="https://discord.gg/RArTGrUawX"
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center gap-3 p-4 bg-slate-100 dark:bg-gray-900 rounded-lg hover:bg-slate-200 dark:hover:bg-gray-800 transition-colors"
+            className="flex items-center gap-3 rounded-lg bg-muted p-4 transition-colors hover:bg-accent dark:bg-card"
           >
             <FaDiscord className="text-2xl text-indigo-500" />
             <div>
               <div className="font-semibold">Discord</div>
-              <div className="text-sm text-gray-600 dark:text-gray-400">Join the community</div>
+              <div className="text-sm text-muted-foreground">
+                Join the community
+              </div>
             </div>
           </a>
 
@@ -114,36 +122,38 @@ export default function AboutPage() {
             href="https://opencollective.com/community-archive/donate"
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center gap-3 p-4 bg-slate-100 dark:bg-gray-900 rounded-lg hover:bg-slate-200 dark:hover:bg-gray-800 transition-colors"
+            className="flex items-center gap-3 rounded-lg bg-muted p-4 transition-colors hover:bg-accent dark:bg-card"
           >
             <span className="text-2xl">💖</span>
             <div>
               <div className="font-semibold">Donate</div>
-              <div className="text-sm text-gray-600 dark:text-gray-400">Support the project</div>
+              <div className="text-sm text-muted-foreground">
+                Support the project
+              </div>
             </div>
           </a>
         </div>
       </section>
 
       <section className="mb-8">
-        <h2 className="mt-8 mb-4 text-2xl font-semibold">Learn More</h2>
+        <h2 className="mb-4 mt-8 text-2xl font-semibold">Learn More</h2>
         <ul className="space-y-2">
           <li>
-            <Link href="/data-policy" className="text-blue-500 hover:underline">
+            <Link href="/data-policy" className="text-brand hover:underline">
               Data Policy
-            </Link>
-            {' '}- How we handle your data
+            </Link>{' '}
+            - How we handle your data
           </li>
           <li>
             <a
               href="https://github.com/TheExGenesis/community-archive/tree/main/docs"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-blue-500 hover:underline"
+              className="text-brand hover:underline"
             >
               Documentation
-            </a>
-            {' '}- API docs and examples
+            </a>{' '}
+            - API docs and examples
           </li>
         </ul>
       </section>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -35,7 +35,7 @@ export default async function AdminPage({
   const twitterUsername = getDisplayUsername(user)
 
   return (
-    <main className="min-h-screen bg-white dark:bg-background">
+    <main className="min-h-screen bg-card dark:bg-background">
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-10 sm:px-6 lg:px-8">
         <section className="flex flex-col gap-3">
           <div className="flex flex-wrap items-start justify-between gap-4">
@@ -67,12 +67,12 @@ export default async function AdminPage({
             <CardDescription>
               Every public.optin row is pinned at the top, followed by accounts
               with archive data sorted by most recently updated. The manual
-              opt-in input below creates an opt-in row by Twitter username;
-              if we already have an archive account for that username the
-              opt-in row is linked to it, otherwise it&apos;s stored without a
-              Twitter id and gets linked the next time that user signs in or
-              uploads an archive. Search runs against the full database; the
-              table updates in place.
+              opt-in input below creates an opt-in row by Twitter username; if
+              we already have an archive account for that username the opt-in
+              row is linked to it, otherwise it&apos;s stored without a Twitter
+              id and gets linked the next time that user signs in or uploads an
+              archive. Search runs against the full database; the table updates
+              in place.
             </CardDescription>
           </CardHeader>
           <CardContent>

--- a/src/app/data-policy/page.tsx
+++ b/src/app/data-policy/page.tsx
@@ -2,59 +2,65 @@ import React from 'react'
 
 export default function DataPolicyPage() {
   return (
-    <div className="container mx-auto px-4 py-8 max-w-3xl">
+    <div className="container mx-auto max-w-3xl px-4 py-8">
       <h1 className="mb-6 text-3xl font-bold">
         Community Archive Privacy Policy
       </h1>
 
       <p className="mb-6">
-        We are committed to preserving the public
-        history of Twitter conversations while respecting your privacy. This
-        policy outlines how we handle your data and the options available to
-        you.
+        We are committed to preserving the public history of Twitter
+        conversations while respecting your privacy. This policy outlines how we
+        handle your data and the options available to you.
       </p>
 
-      <h2 className="mt-8 mb-4 text-2xl font-semibold">Data Collection Methods</h2>
+      <h2 className="mb-4 mt-8 text-2xl font-semibold">
+        Data Collection Methods
+      </h2>
 
+      <p className="mb-4">We collect Twitter/X data through two methods:</p>
+
+      <h3 className="mb-3 mt-6 text-xl font-semibold">
+        1. Twitter Archive Upload
+      </h3>
       <p className="mb-4">
-        We collect Twitter/X data through two methods:
+        You can upload your complete Twitter archive file. The information we
+        collect includes:
       </p>
 
-      <h3 className="mt-6 mb-3 text-xl font-semibold">1. Twitter Archive Upload</h3>
-      <p className="mb-4">
-        You can upload your complete Twitter archive file. The information we collect includes:
-      </p>
-
-      <ol className="list-inside list-decimal space-y-2 my-5 pl-4">
+      <ol className="my-5 list-inside list-decimal space-y-2 pl-4">
         <li>Profile information</li>
         <li>Tweets</li>
         <li>Likes</li>
         <li>Followers/following lists</li>
       </ol>
 
-      <h3 className="mt-6 mb-3 text-xl font-semibold">2. Browser Extension (Real-time Streaming)</h3>
+      <h3 className="mb-3 mt-6 text-xl font-semibold">
+        2. Browser Extension (Real-time Streaming)
+      </h3>
       <p className="mb-4">
-        With your explicit consent, our browser extension can automatically collect your public tweets in real-time. This includes:
+        With your explicit consent, our browser extension can automatically
+        collect your public tweets in real-time. This includes:
       </p>
 
-      <ul className="list-inside list-disc space-y-2 my-5 pl-4">
+      <ul className="my-5 list-inside list-disc space-y-2 pl-4">
         <li>Public tweets as they are posted</li>
         <li>Tweet metadata (timestamps, engagement metrics)</li>
         <li>Media URLs and attachments</li>
         <li>Reply chains and quote tweets</li>
       </ul>
 
-      <p className="mb-4 p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-800">
-        <strong>Important:</strong> The browser extension only works with users who have explicitly opted in to tweet streaming. 
-        You maintain full control and can opt out at any time through this website.
+      <p className="mb-4 rounded-lg border border-border bg-muted p-4">
+        <strong>Important:</strong> The browser extension only works with users
+        who have explicitly opted in to tweet streaming. You maintain full
+        control and can opt out at any time through this website.
       </p>
 
-      <h3 className="mt-6 mb-3 text-xl font-semibold">What We Do Not Collect</h3>
-      <p className="mb-4">
-        Regardless of the method, we never access:
-      </p>
+      <h3 className="mb-3 mt-6 text-xl font-semibold">
+        What We Do Not Collect
+      </h3>
+      <p className="mb-4">Regardless of the method, we never access:</p>
 
-      <ul className="list-inside list-disc space-y-2 my-5 pl-4">
+      <ul className="my-5 list-inside list-disc space-y-2 pl-4">
         <li>Direct messages</li>
         <li>Email addresses</li>
         <li>Private account data</li>
@@ -62,14 +68,16 @@ export default function DataPolicyPage() {
         <li>Personal information beyond what&apos;s publicly visible</li>
       </ul>
 
-      <h2 className="mt-8 mb-4 text-2xl font-semibold">Public Database and API</h2>
+      <h2 className="mb-4 mt-8 text-2xl font-semibold">
+        Public Database and API
+      </h2>
 
       <p className="mb-4">
         By default, your uploaded archive becomes part of our public database
         and API. This means:
       </p>
 
-      <ul className="list-inside list-disc space-y-2 my-5 pl-4">
+      <ul className="my-5 list-inside list-disc space-y-2 pl-4">
         <li>Your tweets and likes will be visible to anyone.</li>
         <li>
           Researchers, developers, and other users can access and analyze this
@@ -82,12 +90,20 @@ export default function DataPolicyPage() {
       </ul>
 
       <p className="mb-6">
-        API docs & instructions for downloading the data <a href='https://github.com/TheExGenesis/community-archive/tree/main/docs#docs' className='text-blue-500 hover:underline'>are in the GitHub repo.</a>
+        API docs & instructions for downloading the data{' '}
+        <a
+          href="https://github.com/TheExGenesis/community-archive/tree/main/docs#docs"
+          className="text-brand hover:underline"
+        >
+          are in the GitHub repo.
+        </a>
       </p>
 
-      <h2 className="mt-8 mb-4 text-2xl font-semibold">Important Considerations</h2>
+      <h2 className="mb-4 mt-8 text-2xl font-semibold">
+        Important Considerations
+      </h2>
 
-      <ul className="list-inside list-disc space-y-2 my-5 pl-4">
+      <ul className="my-5 list-inside list-disc space-y-2 pl-4">
         <li>
           <strong>Data Accessibility</strong>: While your tweets are already
           public on Twitter, our platform makes them more easily accessible to a
@@ -95,74 +111,99 @@ export default function DataPolicyPage() {
         </li>
         <li>
           <strong>Potential Risks</strong>: Be aware that malicious actors could
-          potentially use this data in various ways, such as making inferences about your psychology or
-          for targeted phishing attempts, among other potential risks.
+          potentially use this data in various ways, such as making inferences
+          about your psychology or for targeted phishing attempts, among other
+          potential risks.
         </li>
       </ul>
 
-      <h2 className="mt-8 mb-4 text-2xl font-semibold">Frequently Asked Questions</h2>
+      <h2 className="mb-4 mt-8 text-2xl font-semibold">
+        Frequently Asked Questions
+      </h2>
 
       <div className="mb-8">
-        <h3 className="mt-6 mb-3 text-xl font-semibold">Do we stream every single tweet?</h3>
+        <h3 className="mb-3 mt-6 text-xl font-semibold">
+          Do we stream every single tweet?
+        </h3>
         <p className="mb-4">
-          No. We have a temporary policy, and one we&apos;re aiming to adopt eventually.
+          No. We have a temporary policy, and one we&apos;re aiming to adopt
+          eventually.
         </p>
         <p className="mb-2">
-          <strong>The policy we&apos;re currently running:</strong> streaming tweets from people who&apos;ve been mentioned in the community archive.
+          <strong>The policy we&apos;re currently running:</strong> streaming
+          tweets from people who&apos;ve been mentioned in the community
+          archive.
         </p>
         <p className="mb-4">
-          <strong>The policy we&apos;re moving towards:</strong> only streaming tweets written by people who have explicitly opted in.
+          <strong>The policy we&apos;re moving towards:</strong> only streaming
+          tweets written by people who have explicitly opted in.
         </p>
         <p className="mb-4">
-          The reasoning for this is that streaming only opted-in users would severely affect utility at the beginning, as this would be very few tweets.
+          The reasoning for this is that streaming only opted-in users would
+          severely affect utility at the beginning, as this would be very few
+          tweets.
         </p>
 
-        <h3 className="mt-6 mb-3 text-xl font-semibold">Will the stream be exhaustive?</h3>
+        <h3 className="mb-3 mt-6 text-xl font-semibold">
+          Will the stream be exhaustive?
+        </h3>
         <p className="mb-4">
-          The stream won&apos;t be exhaustive because it only knows about tweets if an extension user has seen them.
+          The stream won&apos;t be exhaustive because it only knows about tweets
+          if an extension user has seen them.
         </p>
 
-        <h3 className="mt-6 mb-3 text-xl font-semibold">Will others know what my feed looks like?</h3>
+        <h3 className="mb-3 mt-6 text-xl font-semibold">
+          Will others know what my feed looks like?
+        </h3>
         <p className="mb-4">
-          No. We keep the ids of scrapers so we can detect and remove bad actors but these are not public.
+          No. We keep the ids of scrapers so we can detect and remove bad actors
+          but these are not public.
         </p>
       </div>
 
-      <h2 className="mt-8 mb-4 text-2xl font-semibold">Browser Extension: How It Works</h2>
+      <h2 className="mb-4 mt-8 text-2xl font-semibold">
+        Browser Extension: How It Works
+      </h2>
 
       <p className="mb-4">
-        Our browser extension is designed with privacy and consent as core principles:
+        Our browser extension is designed with privacy and consent as core
+        principles:
       </p>
 
-      <ol className="list-inside list-decimal space-y-2 my-5 pl-4">
+      <ol className="my-5 list-inside list-decimal space-y-2 pl-4">
         <li>
-          <strong>Explicit Opt-In Required</strong>: The extension only collects tweets from users who have 
-          explicitly opted in through this website after signing in with Twitter.
+          <strong>Explicit Opt-In Required</strong>: The extension only collects
+          tweets from users who have explicitly opted in through this website
+          after signing in with Twitter.
         </li>
         <li>
-          <strong>Public API Check</strong>: Before collecting any tweet, the extension checks our public API 
-          to verify the user has opted in and their consent is current.
+          <strong>Public API Check</strong>: Before collecting any tweet, the
+          extension checks our public API to verify the user has opted in and
+          their consent is current.
         </li>
         <li>
-          <strong>Real-time Collection</strong>: When you post a public tweet, users with the extension 
-          installed can automatically save it to the Community Archive.
+          <strong>Real-time Collection</strong>: When you post a public tweet,
+          users with the extension installed can automatically save it to the
+          Community Archive.
         </li>
         <li>
-          <strong>Distributed Preservation</strong>: This creates a distributed network of tweet preservation, 
-          helping maintain historical records even if tweets are later deleted.
+          <strong>Distributed Preservation</strong>: This creates a distributed
+          network of tweet preservation, helping maintain historical records
+          even if tweets are later deleted.
         </li>
       </ol>
 
-      <h2 className="mt-8 mb-4 text-2xl font-semibold">Privacy Options</h2>
+      <h2 className="mb-4 mt-8 text-2xl font-semibold">Privacy Options</h2>
 
       <p className="mb-4">
         We offer several options to give you more control over your data:
       </p>
 
-      <ol className="list-inside list-decimal space-y-2 my-5 pl-4">
+      <ol className="my-5 list-inside list-decimal space-y-2 pl-4">
         <li>
-          <strong>Tweet Streaming Opt-In/Opt-Out</strong>: You can enable or disable real-time tweet 
-          collection through the extension at any time via your account settings.
+          <strong>Tweet Streaming Opt-In/Opt-Out</strong>: You can enable or
+          disable real-time tweet collection through the extension at any time
+          via your account settings.
         </li>
         <li>
           <strong>Exclude Likes</strong>: You can opt to leave out your likes
@@ -173,8 +214,9 @@ export default function DataPolicyPage() {
           specific date range of your archive public.
         </li>
         <li>
-          <strong>Manual Deletion</strong>: We are planning to implement the ability to delete specific tweets from the archive, 
-          but this feature is not yet active.
+          <strong>Manual Deletion</strong>: We are planning to implement the
+          ability to delete specific tweets from the archive, but this feature
+          is not yet active.
         </li>
         <li>
           <strong>Future Controls</strong>: We plan to implement more granular
@@ -183,7 +225,7 @@ export default function DataPolicyPage() {
         </li>
       </ol>
 
-      <h2 className="mt-8 mb-4 text-2xl font-semibold">Contact Us</h2>
+      <h2 className="mb-4 mt-8 text-2xl font-semibold">Contact Us</h2>
 
       <p className="mb-4">
         {`If you have any questions or concerns about our data policy, please
@@ -196,11 +238,24 @@ export default function DataPolicyPage() {
           href="https://x.com/exgenesis"
           target="_blank"
           rel="noopener noreferrer"
-          className="text-blue-500 hover:underline"
+          className="text-brand hover:underline"
         >
           @exgenesis
         </a>
-        . Or find us on <a href="https://discord.gg/RArTGrUawX" className="text-blue-500 hover:underline">Discord</a> or <a href="https://github.com/TheExGenesis/community-archive" className="text-blue-500 hover:underline">GitHub</a>  
+        . Or find us on{' '}
+        <a
+          href="https://discord.gg/RArTGrUawX"
+          className="text-brand hover:underline"
+        >
+          Discord
+        </a>{' '}
+        or{' '}
+        <a
+          href="https://github.com/TheExGenesis/community-archive"
+          className="text-brand hover:underline"
+        >
+          GitHub
+        </a>
       </p>
 
       <p className="mb-8">
@@ -208,22 +263,22 @@ export default function DataPolicyPage() {
         agree to this privacy policy.
       </p>
 
-      <div className="mt-8 pt-6 border-t border-gray-200 dark:border-gray-700">
-        <p className="text-md text-gray-700 dark:text-gray-300">
-          For more detailed information on the specific data fields processed from your Twitter archive, including examples,
-          please see our documentation:{' '}
+      <div className="mt-8 border-t border-border pt-6">
+        <p className="text-md text-muted-foreground">
+          For more detailed information on the specific data fields processed
+          from your Twitter archive, including examples, please see our
+          documentation:{' '}
           <a
             href="https://github.com/TheExGenesis/community-archive/blob/main/docs/archive_data.md"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-blue-500 hover:underline font-medium"
+            className="font-medium text-brand hover:underline"
           >
             Twitter Archive Data Details
           </a>
           .
         </p>
       </div>
-
     </div>
   )
 }

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -14,17 +14,17 @@ export default function Error({
   }, [error])
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-white dark:bg-background">
-      <div className="max-w-md w-full mx-auto px-4 py-8 text-center">
-        <h2 className="text-3xl font-bold text-gray-900 dark:text-white mb-4">
+    <div className="flex min-h-screen items-center justify-center bg-card dark:bg-background">
+      <div className="mx-auto w-full max-w-md px-4 py-8 text-center">
+        <h2 className="mb-4 text-3xl font-bold text-foreground">
           Something went wrong!
         </h2>
-        <p className="text-gray-600 dark:text-gray-400 mb-6">
+        <p className="mb-6 text-muted-foreground">
           An error occurred while loading this page. Please try again.
         </p>
         <button
           onClick={reset}
-          className="bg-blue-500 hover:bg-blue-600 text-white dark:bg-blue-400 dark:hover:bg-blue-300 dark:text-blue-950 font-medium py-2 px-4 rounded-lg transition-colors"
+          className="rounded-lg bg-brand px-4 py-2 font-medium text-white transition-colors hover:bg-brand/90 dark:bg-brand dark:text-brand-foreground dark:hover:bg-brand/90"
         >
           Try again
         </button>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,6 +4,7 @@
 
 @layer base {
   :root {
+    /* Light mode uses the same three neutral surfaces as dark mode. */
     --background: 0 0% 100%;
     --foreground: 240 10% 3.9%;
     --card: 0 0% 100%;
@@ -23,29 +24,34 @@
     --border: 240 5.9% 90%;
     --input: 240 5.9% 90%;
     --ring: 240 5.9% 10%;
+    --brand: 217 91% 60%;
+    --brand-foreground: 0 0% 100%;
     --radius: 0.3rem;
   }
 
   .dark {
-    --background: 240 10% 3.9%;
-    --foreground: 0 0% 98%;
-    --card: 240 10% 3.9%;
-    --card-foreground: 0 0% 98%;
-    --popover: 240 10% 3.9%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
-    --primary-foreground: 240 5.9% 10%;
-    --secondary: 240 3.7% 10%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 240 3.7% 15.9%;
-    --muted-foreground: 240 5% 64.9%;
-    --accent: 240 3.7% 15.9%;
-    --accent-foreground: 0 0% 98%;
+    /* Keep dark mode deliberately small: page, raised surface, interactive surface. */
+    --background: 240 5% 7%;
+    --foreground: 0 0% 96%;
+    --card: 240 4% 11%;
+    --card-foreground: 0 0% 96%;
+    --popover: 240 4% 11%;
+    --popover-foreground: 0 0% 96%;
+    --primary: 0 0% 96%;
+    --primary-foreground: 240 5% 9%;
+    --secondary: 240 4% 16%;
+    --secondary-foreground: 0 0% 96%;
+    --muted: 240 4% 16%;
+    --muted-foreground: 240 5% 68%;
+    --accent: 240 4% 16%;
+    --accent-foreground: 0 0% 96%;
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 98%;
-    --border: 240 3.7% 15.9%;
-    --input: 240 3.7% 15.9%;
-    --ring: 240 4.9% 83.9%;
+    --border: 240 4% 16%;
+    --input: 240 4% 16%;
+    --ring: 0 0% 80%;
+    --brand: 217 91% 60%;
+    --brand-foreground: 0 0% 100%;
   }
 }
 
@@ -55,6 +61,9 @@
   }
   body {
     @apply bg-background text-foreground;
+  }
+  html {
+    scroll-behavior: smooth;
   }
   /* Petrona is reserved for the hero (h1) and section headers (h2).
      Smaller headings (card titles, etc.) stay on the Manrope body font. */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,6 +13,7 @@ import HeaderNavigation from '@/components/HeaderNavigation'
 import HeaderSearch from '@/components/HeaderSearch'
 import MobileMenu from '@/components/MobileMenu'
 import { checkIsAdmin } from '@/app/admin/data'
+import { Shield } from 'lucide-react'
 
 const DynamicSignIn = dynamic(() => import('@/components/SignIn'), {
   ssr: false,
@@ -50,10 +51,9 @@ export default async function RootLayout({
     <html
       lang="en"
       className={`${manrope.className} ${petrona.variable} antialiased`}
-      style={{ colorScheme: 'dark' }}
       suppressHydrationWarning={true}
     >
-      <body className="bg-gray-50 text-gray-900 dark:bg-gray-950 dark:text-gray-100 transition-colors duration-300">
+      <body className="bg-background text-foreground transition-colors duration-300">
         <NextTopLoader showSpinner={false} height={3} color="#2acf80" />
         <ThemeProvider
           attribute="class"
@@ -62,9 +62,12 @@ export default async function RootLayout({
           disableTransitionOnChange
         >
           <ReactQueryProvider>
-            <header className="sticky top-0 z-50 w-full border-b border-gray-200 dark:border-gray-800 bg-white/80 dark:bg-gray-950/80 backdrop-blur-md">
+            <header className="sticky top-0 z-50 w-full border-b border-border bg-background/90 backdrop-blur-md">
               <div className="container mx-auto flex h-16 max-w-screen-xl items-center justify-between px-4 sm:px-6 lg:px-8">
-                <Link href="/" className="flex items-center space-x-2 flex-shrink-0">
+                <Link
+                  href="/"
+                  className="flex flex-shrink-0 items-center space-x-2"
+                >
                   <Image
                     src="/images/logo.png"
                     alt="Community Archive logo"
@@ -74,22 +77,35 @@ export default async function RootLayout({
                     priority
                   />
                   <span
-                    className="font-bold text-lg text-gray-800 dark:text-gray-200 whitespace-nowrap"
-                    style={{ fontFamily: 'var(--font-petrona), Georgia, "Times New Roman", serif' }}
+                    className="hidden whitespace-nowrap text-lg font-bold text-foreground sm:inline"
+                    style={{
+                      fontFamily:
+                        'var(--font-petrona), Georgia, "Times New Roman", serif',
+                    }}
                   >
                     Community Archive
                   </span>
                 </Link>
-                <HeaderNavigation isAdmin={isAdmin} />
+                <HeaderNavigation />
                 <div className="flex items-center space-x-3">
                   <HeaderSearch />
                 </div>
                 <div className="flex items-center space-x-3">
-                  <ThemeToggle side="bottom" />
                   <div className="text-sm">
                     <DynamicSignIn />
                   </div>
-                  <MobileMenu isAdmin={isAdmin} />
+                  <ThemeToggle side="bottom" />
+                  {isAdmin ? (
+                    <Link
+                      href="/admin"
+                      aria-label="Admin dashboard"
+                      title="Admin dashboard"
+                      className="inline-flex h-10 w-10 items-center justify-center rounded-md border border-input bg-background transition-colors hover:bg-accent hover:text-accent-foreground"
+                    >
+                      <Shield className="h-5 w-5" />
+                    </Link>
+                  ) : null}
+                  <MobileMenu />
                 </div>
               </div>
             </header>

--- a/src/app/login/LoginContent.tsx
+++ b/src/app/login/LoginContent.tsx
@@ -8,20 +8,19 @@ interface LoginContentProps {
 
 export default function LoginContent({ redirectUrl }: LoginContentProps) {
   const isDev = process.env.NODE_ENV === 'development'
-  
+
   return (
-    <main className="min-h-screen bg-white dark:bg-background">
-      <div className="max-w-md mx-auto px-4 py-12 sm:px-6 lg:px-8">
-        <div className="bg-white dark:bg-card rounded-lg shadow-lg p-6 md:p-8">
-          <div className="text-center mb-8">
-            <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
-              Sign In
-            </h1>
-            <p className="text-gray-600 dark:text-gray-400">
-              Sign in to access your account and manage your tweet streaming preferences
+    <main className="min-h-screen bg-card dark:bg-background">
+      <div className="mx-auto max-w-md px-4 py-12 sm:px-6 lg:px-8">
+        <div className="rounded-lg bg-card p-6 shadow-lg md:p-8">
+          <div className="mb-8 text-center">
+            <h1 className="mb-2 text-3xl font-bold text-foreground">Sign In</h1>
+            <p className="text-muted-foreground">
+              Sign in to access your account and manage your tweet streaming
+              preferences
             </p>
             {redirectUrl && (
-              <p className="text-sm text-blue-600 dark:text-blue-300 mt-2">
+              <p className="mt-2 text-sm text-brand">
                 You&apos;ll be redirected to: {decodeURIComponent(redirectUrl)}
               </p>
             )}
@@ -29,11 +28,12 @@ export default function LoginContent({ redirectUrl }: LoginContentProps) {
 
           <div className="space-y-6">
             <SignIn />
-            
+
             {isDev && (
-              <div className="mt-4 p-3 bg-yellow-50 dark:bg-yellow-900/20 rounded-lg border border-yellow-200 dark:border-yellow-800">
+              <div className="mt-4 rounded-lg border border-yellow-200 bg-yellow-50 p-3 dark:border-yellow-800 dark:bg-yellow-900/20">
                 <p className="text-xs text-yellow-800 dark:text-yellow-200">
-                  <strong>Dev Mode:</strong> Clicking the button above will sign you in with a test account instead of Twitter OAuth.
+                  <strong>Dev Mode:</strong> Clicking the button above will sign
+                  you in with a test account instead of Twitter OAuth.
                 </p>
               </div>
             )}

--- a/src/app/mission-control/page.tsx
+++ b/src/app/mission-control/page.tsx
@@ -1,15 +1,15 @@
 import CommunityStats from '@/components/CommunityStats'
 import TopMentionedUsers from '@/components/TopMentionedMissingUsers'
 import { getArchiveMostMentionedAccounts } from '@/lib/queries/getMostMentionedAccounts'
-import { getStats } from '@/lib/stats';
-import { createServerClient } from '@/utils/supabase';
-import { cookies } from 'next/headers';
+import { getStats } from '@/lib/stats'
+import { createServerClient } from '@/utils/supabase'
+import { cookies } from 'next/headers'
 
 // export const revalidate = 0; // TODO: Decide on revalidation strategy
 
 export default async function MissionControlPage() {
-  const cookieStore = await cookies();
-  const supabase = createServerClient(cookieStore);
+  const cookieStore = await cookies()
+  const supabase = createServerClient(cookieStore)
   const stats = await getStats(supabase).catch((error) => {
     console.error('Failed to fetch stats for mission control:', error)
     return {
@@ -18,7 +18,7 @@ export default async function MissionControlPage() {
       likedTweetCount: null,
       userMentionsCount: null, // Ensure all potential fields from getStats are handled
     }
-  });
+  })
 
   const topMentionedMissingUsers = await getArchiveMostMentionedAccounts()
 
@@ -26,13 +26,13 @@ export default async function MissionControlPage() {
     <div className="container mx-auto px-4 py-8">
       <h1 className="mb-6 text-3xl font-bold">Mission Control</h1>
 
-      <CommunityStats 
+      <CommunityStats
         accountCount={stats.accountCount}
         tweetCount={stats.tweetCount}
         likedTweetCount={stats.likedTweetCount}
       />
 
-      <div className="rounded-lg bg-gray-100 p-4 shadow dark:bg-gray-800">
+      <div className="rounded-lg bg-muted p-4 shadow dark:bg-muted">
         <h2 className="mb-4 text-xl font-semibold">Most Wanted</h2>
         <p className="mb-4">Top mentioned users who are not in the archive</p>
         <TopMentionedUsers

--- a/src/app/opt-in/page.tsx
+++ b/src/app/opt-in/page.tsx
@@ -6,37 +6,39 @@ export default async function OptInPage() {
   const { data: optInData } = await getOptInStatus(user.id)
 
   return (
-    <main className="min-h-screen bg-white dark:bg-background">
-      <div className="max-w-4xl mx-auto px-4 py-12 sm:px-6 lg:px-8">
-        <div className="bg-white dark:bg-card rounded-lg shadow-lg p-6 md:p-8">
-          <div className="text-center mb-8">
-            <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-4">
+    <main className="min-h-screen bg-card dark:bg-background">
+      <div className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
+        <div className="rounded-lg bg-card p-6 shadow-lg md:p-8">
+          <div className="mb-8 text-center">
+            <h1 className="mb-4 text-4xl font-bold text-foreground">
               Tweet Streaming Opt-In
             </h1>
-            <p className="text-lg text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">
-              Allow your public tweets to be automatically preserved in the Community Archive 
-              through our browser extension for historical and research purposes.
+            <p className="mx-auto max-w-2xl text-lg text-muted-foreground">
+              Allow your public tweets to be automatically preserved in the
+              Community Archive through our browser extension for historical and
+              research purposes.
             </p>
           </div>
 
-          <OptInForm 
-            userId={user.id} 
-            userEmail={user.email || ''} 
+          <OptInForm
+            userId={user.id}
+            userEmail={user.email || ''}
             initialOptInStatus={optInData}
           />
 
-          <div className="mt-8 pt-6 border-t border-gray-200 dark:border-gray-700 text-center">
-            <p className="text-sm text-gray-500 dark:text-gray-400">
+          <div className="mt-8 border-t border-border pt-6 text-center">
+            <p className="text-sm text-muted-foreground">
               By opting in, you agree to our{' '}
-              <a 
-                href="/data-policy" 
-                className="text-blue-600 dark:text-blue-300 hover:underline"
+              <a
+                href="/data-policy"
+                className="text-brand hover:underline"
                 target="_blank"
                 rel="noopener noreferrer"
               >
                 Data Policy
               </a>
-              . Your public tweets will be archived and may persist even after deletion from Twitter/X.
+              . Your public tweets will be archived and may persist even after
+              deletion from Twitter/X.
             </p>
           </div>
         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,11 +3,19 @@ import { createServerClient } from '@/utils/supabase'
 import { cookies } from 'next/headers'
 import AvatarList from '@/components/AvatarList'
 import { SupabaseClient } from '@supabase/supabase-js'
-import { FaGithub, FaDiscord, FaBook, FaHeart, FaDatabase } from 'react-icons/fa'
+import {
+  FaGithub,
+  FaDiscord,
+  FaBook,
+  FaHeart,
+  FaDatabase,
+} from 'react-icons/fa'
 import Footer from '@/components/Footer'
 import Link from 'next/link'
 import { getStats } from '@/lib/stats'
-import TieredSupportersDisplay, { Contributor } from '@/components/TieredSupportersDisplay'
+import TieredSupportersDisplay, {
+  Contributor,
+} from '@/components/TieredSupportersDisplay'
 import dynamic from 'next/dynamic'
 import FeaturedAppsSection from '@/components/FeaturedAppsSection'
 import AppGallery from '@/components/AppGallery'
@@ -15,23 +23,29 @@ import AppGallery from '@/components/AppGallery'
 export const revalidate = 60 // Cache for 60s to reduce server load from scrapers
 
 // Dynamically import client components with ssr disabled
-const DynamicHeroCTAButtons = dynamic(() => import('@/components/HeroCTAButtons'), {
-  ssr: false,
-  loading: () => (
-    <div className="flex flex-col sm:flex-row gap-4 sm:gap-6 justify-center">
-      <div className="h-14 w-48 bg-gray-200 dark:bg-slate-700 rounded-xl animate-pulse" />
-      <div className="h-14 w-48 bg-gray-200 dark:bg-slate-700 rounded-xl animate-pulse" />
-      <div className="h-14 w-48 bg-gray-200 dark:bg-slate-700 rounded-xl animate-pulse" />
-    </div>
-  ),
-})
+const DynamicHeroCTAButtons = dynamic(
+  () => import('@/components/HeroCTAButtons'),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex flex-col justify-center gap-4 sm:flex-row sm:gap-6">
+        <div className="h-14 w-48 animate-pulse rounded-xl bg-muted" />
+        <div className="h-14 w-48 animate-pulse rounded-xl bg-muted" />
+        <div className="h-14 w-48 animate-pulse rounded-xl bg-muted" />
+      </div>
+    ),
+  },
+)
 
-const DynamicUploadArchiveSection = dynamic(() => import('@/components/UploadArchiveSection'), {
-  ssr: false,
-  loading: () => (
-    <div className="w-full h-48 bg-gray-100 dark:bg-gray-900 rounded-xl animate-pulse" />
-  ),
-})
+const DynamicUploadArchiveSection = dynamic(
+  () => import('@/components/UploadArchiveSection'),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-48 w-full animate-pulse rounded-xl bg-muted dark:bg-card" />
+    ),
+  },
+)
 
 const getMostFollowedAccounts = async (supabase: SupabaseClient) => {
   let { data, error } = await supabase
@@ -48,7 +62,10 @@ const getMostFollowedAccounts = async (supabase: SupabaseClient) => {
 
 async function getOpenCollectiveContributors(): Promise<Contributor[]> {
   try {
-    const res = await fetch('https://opencollective.com/community-archive/members/all.json', { next: { revalidate: 3600 } })
+    const res = await fetch(
+      'https://opencollective.com/community-archive/members/all.json',
+      { next: { revalidate: 3600 } },
+    )
     if (!res.ok) {
       console.error(`Failed to fetch Open Collective data: ${res.status}`)
       return []
@@ -56,8 +73,10 @@ async function getOpenCollectiveContributors(): Promise<Contributor[]> {
     const members: any[] = await res.json()
 
     members.sort((a, b) => {
-      const amountA = typeof a.totalAmountDonated === 'number' ? a.totalAmountDonated : 0
-      const amountB = typeof b.totalAmountDonated === 'number' ? b.totalAmountDonated : 0
+      const amountA =
+        typeof a.totalAmountDonated === 'number' ? a.totalAmountDonated : 0
+      const amountB =
+        typeof b.totalAmountDonated === 'number' ? b.totalAmountDonated : 0
       if (amountB !== amountA) {
         return amountB - amountA
       }
@@ -65,12 +84,16 @@ async function getOpenCollectiveContributors(): Promise<Contributor[]> {
     })
 
     return members
-      .filter(m =>
-        m.isActive &&
-        m.role !== 'ADMIN' &&
-        (m.role === 'BACKER' || (m.role === 'MEMBER' && typeof m.totalAmountDonated === 'number' && m.totalAmountDonated > 0))
+      .filter(
+        (m) =>
+          m.isActive &&
+          m.role !== 'ADMIN' &&
+          (m.role === 'BACKER' ||
+            (m.role === 'MEMBER' &&
+              typeof m.totalAmountDonated === 'number' &&
+              m.totalAmountDonated > 0)),
       )
-      .map(m => ({
+      .map((m) => ({
         name: m.name,
         role: m.role,
         type: m.type,
@@ -78,10 +101,11 @@ async function getOpenCollectiveContributors(): Promise<Contributor[]> {
         profile: m.profile,
         image: m.image || null,
         slug: m.slug,
-        totalAmountDonated: typeof m.totalAmountDonated === 'number' ? m.totalAmountDonated : 0
+        totalAmountDonated:
+          typeof m.totalAmountDonated === 'number' ? m.totalAmountDonated : 0,
       }))
   } catch (error) {
-    console.error("Error fetching Open Collective contributors:", error)
+    console.error('Error fetching Open Collective contributors:', error)
     return []
   }
 }
@@ -93,19 +117,22 @@ interface InfoPanelProps {
   href: string
 }
 
-const InfoPanel: React.FC<InfoPanelProps> = ({ icon, title, description, href }) => (
+const InfoPanel: React.FC<InfoPanelProps> = ({
+  icon,
+  title,
+  description,
+  href,
+}) => (
   <Link
     href={href}
     target="_blank"
     rel="noopener noreferrer"
-    className="group flex items-center gap-4 p-4 bg-white dark:bg-gray-900 rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors border border-gray-200 dark:border-slate-700"
+    className="group flex items-center gap-4 rounded-xl border border-border bg-card p-4 transition-colors hover:bg-accent"
   >
-    <div className="text-2xl text-blue-500 dark:text-blue-300 flex-shrink-0">
-      {icon}
-    </div>
-    <div className="flex-1 min-w-0">
-      <h3 className="font-semibold text-gray-900 dark:text-white">{title}</h3>
-      <p className="text-sm text-gray-600 dark:text-gray-400">{description}</p>
+    <div className="flex-shrink-0 text-2xl text-brand">{icon}</div>
+    <div className="min-w-0 flex-1">
+      <h3 className="font-semibold text-foreground">{title}</h3>
+      <p className="text-sm text-muted-foreground">{description}</p>
     </div>
   </Link>
 )
@@ -116,16 +143,23 @@ export default async function Homepage() {
   const mostFollowed = (await getMostFollowedAccounts(supabase)).slice(0, 7)
   const financialContributors = await getOpenCollectiveContributors()
 
-  const totalAmountRaised = financialContributors.reduce((sum, contributor) => sum + contributor.totalAmountDonated, 0)
+  const totalAmountRaised = financialContributors.reduce(
+    (sum, contributor) => sum + contributor.totalAmountDonated,
+    0,
+  )
   const totalSupportersCount = financialContributors.length
 
-  const contributorsWithImages = financialContributors.filter(c => c.image)
-  const highestDonorWithImage = contributorsWithImages.length > 0 ? contributorsWithImages[0] : null
+  const contributorsWithImages = financialContributors.filter((c) => c.image)
+  const highestDonorWithImage =
+    contributorsWithImages.length > 0 ? contributorsWithImages[0] : null
   const otherDonorsForStack = contributorsWithImages.slice(1, 10)
 
   const topTenFinancialContributors = financialContributors.slice(0, 10)
-  const topTenNames = topTenFinancialContributors.map(c => c.name)
-  const additionalSupportersCount = Math.max(0, financialContributors.length - topTenNames.length)
+  const topTenNames = topTenFinancialContributors.map((c) => c.name)
+  const additionalSupportersCount = Math.max(
+    0,
+    financialContributors.length - topTenNames.length,
+  )
 
   const stats = await getStats(supabase).catch((error) => {
     console.error('Failed to fetch stats for homepage:', error)
@@ -137,19 +171,20 @@ export default async function Homepage() {
     }
   })
 
-  const sectionPaddingClasses = "py-12 md:py-16 lg:py-20"
-  const contentWrapperClasses = "w-full max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10"
+  const sectionPaddingClasses = 'py-12 md:py-16 lg:py-20'
+  const contentWrapperClasses =
+    'w-full max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10'
 
   return (
     <main>
       {/* Section 1: Hero with CTAs */}
-      <section className="bg-white dark:bg-gray-950 pt-16 md:pt-24 pb-12 md:pb-16 overflow-hidden">
-        <div className={`${contentWrapperClasses} text-center space-y-11`}>
+      <section className="overflow-hidden bg-card pb-12 pt-16 dark:bg-background md:pb-16 md:pt-24">
+        <div className={`${contentWrapperClasses} space-y-11 text-center`}>
           <div className="space-y-4">
-            <h1 className="text-5xl md:text-6xl font-bold tracking-tight text-gray-900 dark:text-white">
+            <h1 className="text-5xl font-bold tracking-tight text-foreground md:text-6xl">
               Community Archive
             </h1>
-            <p className="text-xl text-gray-600 dark:text-gray-300">
+            <p className="text-xl text-muted-foreground">
               An open Twitter database. Join the archive to{' '}
               <br className="hidden sm:block" />
               contribute to open source public infrastructure.
@@ -158,7 +193,7 @@ export default async function Homepage() {
 
           <div className="space-y-4">
             <DynamicHeroCTAButtons />
-            <p className="text-sm text-gray-500 dark:text-gray-400">
+            <p className="text-sm text-muted-foreground">
               Backed by Survival and Flourishing Fund and Vitalik Buterin
             </p>
           </div>
@@ -166,10 +201,8 @@ export default async function Homepage() {
       </section>
 
       {/* Section 2: Social Proof */}
-      <section className="bg-white dark:bg-gray-950 overflow-hidden">
-        <div
-          className="max-w-5xl mx-auto rounded-none sm:rounded-xl p-6 md:p-8 space-y-4 text-center bg-slate-100 dark:bg-gray-900"
-        >
+      <section className="overflow-hidden bg-card dark:bg-background">
+        <div className="mx-auto max-w-5xl space-y-4 rounded-none bg-muted p-6 text-center dark:bg-card sm:rounded-xl md:p-8">
           <CommunityStats
             accountCount={stats.accountCount}
             tweetCount={stats.tweetCount}
@@ -179,7 +212,7 @@ export default async function Homepage() {
           {mostFollowed.length > 0 ? (
             <AvatarList initialAvatars={mostFollowed} />
           ) : (
-            <p className="text-center text-gray-500 dark:text-gray-400 mt-4">
+            <p className="mt-4 text-center text-muted-foreground">
               Featured archives are currently unavailable.
             </p>
           )}
@@ -187,7 +220,10 @@ export default async function Homepage() {
       </section>
 
       {/* Section 3: Explore the archive - Featured Apps */}
-      <section className={`bg-white dark:bg-gray-950 ${sectionPaddingClasses} overflow-hidden`}>
+      <section
+        id="products"
+        className={`bg-card dark:bg-background ${sectionPaddingClasses} scroll-mt-16 overflow-hidden`}
+      >
         <div className={contentWrapperClasses}>
           <FeaturedAppsSection />
           <AppGallery />
@@ -195,72 +231,127 @@ export default async function Homepage() {
       </section>
 
       {/* Section 4: Upload Your Archive */}
-      <section id="upload-archive" className={`bg-sky-100 dark:bg-gray-900 ${sectionPaddingClasses} scroll-mt-16 overflow-hidden`}>
+      <section
+        id="upload-archive"
+        className={`bg-muted dark:bg-card ${sectionPaddingClasses} scroll-mt-16 overflow-hidden`}
+      >
         <div className={contentWrapperClasses}>
           <DynamicUploadArchiveSection />
         </div>
       </section>
 
       {/* Section 4: Data & Source Code */}
-      <section className={`bg-white dark:bg-gray-950 ${sectionPaddingClasses} overflow-hidden`}>
+      <section
+        className={`bg-card dark:bg-background ${sectionPaddingClasses} overflow-hidden`}
+      >
         <div className={`${contentWrapperClasses} space-y-8`}>
           <div className="text-center">
-            <h2 className="text-3xl font-bold text-gray-900 dark:text-white">Data & Source Code</h2>
-            <p className="mt-3 text-base text-gray-600 dark:text-gray-300 max-w-xl mx-auto px-4 md:px-0">
+            <h2 className="text-3xl font-bold text-foreground">
+              Data & Source Code
+            </h2>
+            <p className="mx-auto mt-3 max-w-xl px-4 text-base text-muted-foreground md:px-0">
               Access the data, explore the code, and see how everything works.
             </p>
           </div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 max-w-4xl mx-auto">
-            <InfoPanel icon={<FaGithub />} title="GitHub" description="Source code and contributions" href="https://github.com/TheExGenesis/community-archive" />
-            <InfoPanel icon={<FaDiscord />} title="Discord" description="Join the community" href="https://discord.gg/RArTGrUawX" />
-            <InfoPanel icon={<FaBook />} title="Documentation" description="API docs and examples" href="https://github.com/TheExGenesis/community-archive/tree/main/docs" />
-            <InfoPanel icon={<FaDatabase />} title="Data Dump" description="Download the full dataset" href="https://github.com/TheExGenesis/community-archive/releases/tag/data_export" />
+          <div className="mx-auto grid max-w-4xl grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <InfoPanel
+              icon={<FaGithub />}
+              title="GitHub"
+              description="Source code and contributions"
+              href="https://github.com/TheExGenesis/community-archive"
+            />
+            <InfoPanel
+              icon={<FaDiscord />}
+              title="Discord"
+              description="Join the community"
+              href="https://discord.gg/RArTGrUawX"
+            />
+            <InfoPanel
+              icon={<FaBook />}
+              title="Documentation"
+              description="API docs and examples"
+              href="https://github.com/TheExGenesis/community-archive/tree/main/docs"
+            />
+            <InfoPanel
+              icon={<FaDatabase />}
+              title="Data Dump"
+              description="Download the full dataset"
+              href="https://github.com/TheExGenesis/community-archive/releases/tag/data_export"
+            />
           </div>
         </div>
       </section>
 
       {/* Section 5: Our Supporters */}
-      <section className={`bg-sky-100 dark:bg-gray-900 ${sectionPaddingClasses} overflow-hidden`}>
+      <section
+        className={`bg-muted dark:bg-card ${sectionPaddingClasses} overflow-hidden`}
+      >
         <div className={`${contentWrapperClasses} space-y-8`}>
           <div className="text-center">
-            <h2 className="text-3xl font-bold text-gray-900 dark:text-white">Our Supporters</h2>
-            <p className="mt-3 text-base text-gray-600 dark:text-gray-300">
+            <h2 className="text-3xl font-bold text-foreground">
+              Our Supporters
+            </h2>
+            <p className="mt-3 text-base text-muted-foreground">
               Thanks to everyone who makes this possible
             </p>
           </div>
 
           {/* Main supporters card */}
-          <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 md:p-8 border border-gray-200 dark:border-slate-700 max-w-4xl mx-auto">
+          <div className="mx-auto max-w-4xl rounded-2xl border border-border bg-card p-6 md:p-8">
             {/* Major Backers */}
-            <div className="text-center mb-6">
-              <p className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-4">Major Backers</p>
-              <div className="flex flex-wrap justify-center items-center gap-x-6 gap-y-3">
-                <Link href="https://survivalandflourishing.fund/" target="_blank" rel="noopener noreferrer" className="text-base font-medium text-gray-700 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-300 transition-colors">
+            <div className="mb-6 text-center">
+              <p className="mb-4 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                Major Backers
+              </p>
+              <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-3">
+                <Link
+                  href="https://survivalandflourishing.fund/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-base font-medium text-muted-foreground transition-colors hover:text-brand"
+                >
                   Survival and Flourishing Fund
                 </Link>
-                <span className="text-gray-300 dark:text-gray-600">•</span>
-                <span className="text-base font-medium text-gray-700 dark:text-gray-300">
-                  <Link href="https://x.com/VitalikButerin" target="_blank" rel="noopener noreferrer" className="hover:text-blue-600 dark:hover:text-blue-300 transition-colors">
+                <span className="text-muted-foreground">•</span>
+                <span className="text-base font-medium text-muted-foreground">
+                  <Link
+                    href="https://x.com/VitalikButerin"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="transition-colors hover:text-brand"
+                  >
                     Vitalik Buterin
-                  </Link>
-                  {' '}via{' '}
-                  <Link href="https://kanro.fi/" target="_blank" rel="noopener noreferrer" className="hover:text-blue-600 dark:hover:text-blue-300 transition-colors">
+                  </Link>{' '}
+                  via{' '}
+                  <Link
+                    href="https://kanro.fi/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="transition-colors hover:text-brand"
+                  >
                     Kanro
                   </Link>
                 </span>
-                <span className="text-gray-300 dark:text-gray-600">•</span>
-                <Link href="https://x.com/pwang" target="_blank" rel="noopener noreferrer" className="text-base font-medium text-gray-700 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-300 transition-colors">
+                <span className="text-muted-foreground">•</span>
+                <Link
+                  href="https://x.com/pwang"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-base font-medium text-muted-foreground transition-colors hover:text-brand"
+                >
                   Peter Wang
                 </Link>
               </div>
             </div>
 
             {/* Divider */}
-            <div className="border-t border-gray-200 dark:border-gray-700 my-6"></div>
+            <div className="my-6 border-t border-border"></div>
 
             {/* Community Supporters */}
-            <div className="text-center mb-4">
-              <p className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-4">Community Backers</p>
+            <div className="mb-4 text-center">
+              <p className="mb-4 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                Community Backers
+              </p>
             </div>
             <TieredSupportersDisplay
               highestDonorWithImage={highestDonorWithImage}
@@ -274,8 +365,12 @@ export default async function Homepage() {
 
           {/* Donate button */}
           <div className="text-center">
-            <Link href="https://opencollective.com/community-archive/donate" target="_blank" rel="noopener noreferrer">
-              <button className="inline-flex items-center justify-center px-6 py-3 text-base font-medium rounded-xl text-white bg-green-600 hover:bg-green-700 dark:bg-green-400 dark:hover:bg-green-300 dark:text-green-950 transition-colors">
+            <Link
+              href="https://opencollective.com/community-archive/donate"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <button className="inline-flex items-center justify-center rounded-xl bg-green-600 px-6 py-3 text-base font-medium text-white transition-colors hover:bg-green-700 dark:bg-green-400 dark:text-green-950 dark:hover:bg-green-300">
                 <FaHeart className="mr-2" /> Support the Project
               </button>
             </Link>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -3,7 +3,9 @@ import { createServerAdminClient, createServerClient } from '@/utils/supabase'
 import { cookies } from 'next/headers'
 import ProfileContent from './ProfileContent'
 
-const getTwitterUsername = (user: Awaited<ReturnType<typeof requireAuth>>['user']) =>
+const getTwitterUsername = (
+  user: Awaited<ReturnType<typeof requireAuth>>['user'],
+) =>
   (
     user.user_metadata?.user_name ||
     user.user_metadata?.preferred_username ||
@@ -24,7 +26,8 @@ export default async function ProfilePage() {
   const admin = createServerAdminClient(cookieStore)
 
   // Get the Twitter provider_id from user metadata (this is the account_id in archive_upload)
-  const twitterAccountId = user.user_metadata?.provider_id || user.app_metadata?.provider_id
+  const twitterAccountId =
+    user.user_metadata?.provider_id || user.app_metadata?.provider_id
   const twitterUsername = getTwitterUsername(user)
   const optInQuery = twitterUsername
     ? admin
@@ -42,7 +45,8 @@ export default async function ProfilePage() {
     twitterAccountId
       ? supabase
           .from('archive_upload')
-          .select(`
+          .select(
+            `
             id,
             account_id,
             upload_phase,
@@ -56,15 +60,16 @@ export default async function ProfilePage() {
               num_tweets,
               profile:all_profile(avatar_media_url)
             )
-          `)
+          `,
+          )
           .eq('account_id', twitterAccountId)
           .order('created_at', { ascending: false })
-      : Promise.resolve({ data: [], error: null })
+      : Promise.resolve({ data: [], error: null }),
   ])
 
   return (
-    <main className="min-h-screen bg-white dark:bg-background">
-      <div className="max-w-4xl mx-auto px-4 py-12 sm:px-6 lg:px-8">
+    <main className="min-h-screen bg-card dark:bg-background">
+      <div className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
         <ProfileContent
           user={user}
           initialOptInData={optInResponse.data}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,35 +1,35 @@
 'use client'
 import AdvancedSearchForm from '@/components/AdvancedSearchForm'
-import TweetList from '@/components/TweetList';
-import { FilterCriteria } from '@/lib/queries/tweetQueries';
-import { useSearchParams } from 'next/navigation';
-import { Suspense } from 'react';
+import TweetList from '@/components/TweetList'
+import { FilterCriteria } from '@/lib/queries/tweetQueries'
+import { useSearchParams } from 'next/navigation'
+import { Suspense } from 'react'
 
 // Style definitions
-const unifiedDeepBlueBase = "bg-white dark:bg-background";
-const sectionPaddingClasses = "py-12 md:py-16 lg:py-20";
-const contentWrapperClasses = "w-full max-w-4xl mx-auto px-4 sm:px-6 lg:px-8";
+const unifiedDeepBlueBase = 'bg-card dark:bg-background'
+const sectionPaddingClasses = 'py-12 md:py-16 lg:py-20'
+const contentWrapperClasses = 'w-full max-w-4xl mx-auto px-4 sm:px-6 lg:px-8'
 
 // This wrapper is needed because useSearchParams can only be used in Client Components,
 // and Suspense is recommended for pages that use it.
 function SearchPageContent() {
-  const searchParams = useSearchParams();
+  const searchParams = useSearchParams()
 
-  const rawQuery = searchParams.get('q');
-  let formattedQuery: string | undefined;
+  const rawQuery = searchParams.get('q')
+  let formattedQuery: string | undefined
   // Strip quotes if present, keep the clean text for two-query exact-match-first logic
-  let cleanRawText: string | undefined;
+  let cleanRawText: string | undefined
 
   if (rawQuery) {
-    const trimmedQuery = rawQuery.trim();
+    const trimmedQuery = rawQuery.trim()
     if (trimmedQuery.startsWith('"') && trimmedQuery.endsWith('"')) {
-      cleanRawText = trimmedQuery.substring(1, trimmedQuery.length - 1).trim();
+      cleanRawText = trimmedQuery.substring(1, trimmedQuery.length - 1).trim()
     } else {
-      cleanRawText = trimmedQuery;
+      cleanRawText = trimmedQuery
     }
     // For single-word queries or fallback, still provide a formatted query
-    const words = cleanRawText.split(/\s+/).filter(Boolean);
-    formattedQuery = words.join(' & ');
+    const words = cleanRawText.split(/\s+/).filter(Boolean)
+    formattedQuery = words.join(' & ')
   }
 
   // Construct FilterCriteria from URL search parameters
@@ -40,46 +40,52 @@ function SearchPageContent() {
     replyToUsername: searchParams.get('replyToUser') || undefined,
     startDate: searchParams.get('sinceDate') || undefined,
     endDate: searchParams.get('untilDate') || undefined,
-  };
-  
+  }
+
   // A key for TweetList to force re-render when search params change, ensuring new data is fetched.
   // This is important because TweetList fetches data in its own useEffect based on initial props.
-  const tweetListKey = searchParams.toString();
+  const tweetListKey = searchParams.toString()
 
   return (
-    <main> 
-      <section 
-        className={`${unifiedDeepBlueBase} ${sectionPaddingClasses} overflow-hidden min-h-screen`}
+    <main>
+      <section
+        className={`${unifiedDeepBlueBase} ${sectionPaddingClasses} min-h-screen overflow-hidden`}
       >
-        <div className={`${contentWrapperClasses}`}> 
-          <h2 className="mb-8 text-4xl font-bold text-center text-gray-900 dark:text-white">🔬 Advanced Search</h2>
-          <AdvancedSearchForm /> {/* This will pre-fill itself from URL params */}
-          
+        <div className={`${contentWrapperClasses}`}>
+          <h2 className="mb-8 text-center text-4xl font-bold text-foreground">
+            🔬 Advanced Search
+          </h2>
+          <AdvancedSearchForm />{' '}
+          {/* This will pre-fill itself from URL params */}
           <div className="mt-12">
-            {/* Render TweetList only if there are actual search parameters present */} 
+            {/* Render TweetList only if there are actual search parameters present */}
             {searchParams.toString().length > 0 ? (
-              <div className="bg-slate-100 dark:bg-card p-6 md:p-8 rounded-lg">
-                <h3 className="text-2xl font-semibold mb-6 text-gray-900 dark:text-white">Search Results</h3>
-                <TweetList 
+              <div className="rounded-lg bg-muted p-6 dark:bg-card md:p-8">
+                <h3 className="mb-6 text-2xl font-semibold text-foreground">
+                  Search Results
+                </h3>
+                <TweetList
                   key={tweetListKey} // Force re-mount on new search
-                  filterCriteria={filterCriteria} 
+                  filterCriteria={filterCriteria}
                 />
               </div>
             ) : (
-              <p className="text-center text-gray-500 dark:text-gray-400 mt-12">Please enter your search criteria above.</p>
+              <p className="mt-12 text-center text-muted-foreground">
+                Please enter your search criteria above.
+              </p>
             )}
           </div>
         </div>
       </section>
     </main>
-  );
+  )
 }
 
 export default function SearchTweetsPage() {
   return (
     // Suspense boundary for useSearchParams
-    <Suspense fallback={<div>Loading search...</div>}> 
+    <Suspense fallback={<div>Loading search...</div>}>
       <SearchPageContent />
     </Suspense>
-  );
+  )
 }

--- a/src/app/stream-monitor/page.tsx
+++ b/src/app/stream-monitor/page.tsx
@@ -4,10 +4,20 @@ import React, { useState, useEffect } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import Link from 'next/link'
 import { createBrowserClient } from '@/utils/supabase'
-import { ChartContainer, ChartTooltip, ChartTooltipContent } from '@/components/ui/chart'
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from '@/components/ui/chart'
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid } from 'recharts'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Switch } from '@/components/ui/switch'
 import { Label } from '@/components/ui/label'
@@ -50,52 +60,70 @@ const StreamMonitor = () => {
   const [tweetOffset, setTweetOffset] = useState(0)
   const [showBanner, setShowBanner] = useState(true)
   const tweetsPerPage = 20
-  
+
   const supabase = createBrowserClient()
 
   // Query for scraping stats based on view mode and offset
-  const { data: scrapingStats, isLoading: statsLoading, error: statsError } = useQuery({
+  const {
+    data: scrapingStats,
+    isLoading: statsLoading,
+    error: statsError,
+  } = useQuery({
     queryKey: ['scrapingStats', viewMode, timeOffset, showStreamedOnly],
     queryFn: async () => {
       const now = new Date()
       let startDate, endDate, granularity, periods
-      
+
       if (viewMode === '24h') {
         periods = 24
-        startDate = new Date(now.getTime() - (periods + timeOffset * periods) * 60 * 60 * 1000)
-        endDate = new Date(now.getTime() - timeOffset * periods * 60 * 60 * 1000)
+        startDate = new Date(
+          now.getTime() - (periods + timeOffset * periods) * 60 * 60 * 1000,
+        )
+        endDate = new Date(
+          now.getTime() - timeOffset * periods * 60 * 60 * 1000,
+        )
         granularity = 'hour'
       } else if (viewMode === '7d') {
         periods = 7
-        startDate = new Date(now.getTime() - (periods + timeOffset * periods) * 24 * 60 * 60 * 1000)
-        endDate = new Date(now.getTime() - timeOffset * periods * 24 * 60 * 60 * 1000)
+        startDate = new Date(
+          now.getTime() -
+            (periods + timeOffset * periods) * 24 * 60 * 60 * 1000,
+        )
+        endDate = new Date(
+          now.getTime() - timeOffset * periods * 24 * 60 * 60 * 1000,
+        )
         granularity = 'day'
-      } else { // 1y
+      } else {
+        // 1y
         periods = 52 // 52 weeks
-        startDate = new Date(now.getTime() - (periods + timeOffset * periods) * 7 * 24 * 60 * 60 * 1000)
-        endDate = new Date(now.getTime() - timeOffset * periods * 7 * 24 * 60 * 60 * 1000)
+        startDate = new Date(
+          now.getTime() -
+            (periods + timeOffset * periods) * 7 * 24 * 60 * 60 * 1000,
+        )
+        endDate = new Date(
+          now.getTime() - timeOffset * periods * 7 * 24 * 60 * 60 * 1000,
+        )
         granularity = 'week'
       }
-      
+
       // Use the new API with custom date ranges
       const params = new URLSearchParams({
         startDate: startDate.toISOString(),
         endDate: endDate.toISOString(),
         granularity,
-        streamedOnly: showStreamedOnly.toString()
+        streamedOnly: showStreamedOnly.toString(),
       })
-      
+
       const response = await fetch(`/api/scraping-stats?${params}`)
       if (!response.ok) {
         throw new Error('Failed to fetch scraping stats')
       }
-      
+
       return response.json()
     },
     refetchInterval: viewMode === '24h' && timeOffset === 0 ? 300000 : 0, // Only refresh current 24h view
-    staleTime: 60000 // 1 minute stale time
+    staleTime: 60000, // 1 minute stale time
   })
-
 
   // Extract chart data and summary from scraping stats
   const chartData = scrapingStats?.data
@@ -105,14 +133,25 @@ const StreamMonitor = () => {
   const scraperLoading = statsLoading
 
   // Query for latest tweets with pagination
-  const { data: tweetsData, isLoading: tweetsLoading, error: tweetsError, refetch: refetchTweets } = useQuery({
+  const {
+    data: tweetsData,
+    isLoading: tweetsLoading,
+    error: tweetsError,
+    refetch: refetchTweets,
+  } = useQuery({
     queryKey: ['streamMonitorTweets', tweetOffset],
     queryFn: async () => {
-      return await getLatestTweets(supabase, tweetsPerPage, undefined, tweetOffset, {
-        includeEnrichments: false,
-      })
+      return await getLatestTweets(
+        supabase,
+        tweetsPerPage,
+        undefined,
+        tweetOffset,
+        {
+          includeEnrichments: false,
+        },
+      )
     },
-    refetchInterval: tweetOffset === 0 ? 60000 : 0 // Only auto-refresh latest tweets
+    refetchInterval: tweetOffset === 0 ? 60000 : 0, // Only auto-refresh latest tweets
   })
 
   // Update loaded tweets when new data arrives
@@ -123,15 +162,15 @@ const StreamMonitor = () => {
         setLoadedTweets(tweetsData)
       } else {
         // Load more - append to existing tweets
-        setLoadedTweets(prev => [...prev, ...tweetsData])
+        setLoadedTweets((prev) => [...prev, ...tweetsData])
       }
     }
   }, [tweetsData, tweetOffset])
 
   const chartConfig = {
     tweet_count: {
-      label: showStreamedOnly ? "Tweets Streamed" : "Total Tweets",
-      color: "hsl(var(--chart-1))",
+      label: showStreamedOnly ? 'Tweets Streamed' : 'Total Tweets',
+      color: 'hsl(var(--chart-1))',
     },
   }
 
@@ -163,15 +202,15 @@ const StreamMonitor = () => {
     }
     return label
   }
-  
+
   const handlePrevious = () => {
-    setTimeOffset(prev => prev + 1)
+    setTimeOffset((prev) => prev + 1)
   }
-  
+
   const handleNext = () => {
-    setTimeOffset(prev => Math.max(0, prev - 1))
+    setTimeOffset((prev) => Math.max(0, prev - 1))
   }
-  
+
   const getTimeRangeLabel = () => {
     if (viewMode === '24h') {
       if (timeOffset === 0) return 'Last 24 Hours'
@@ -194,7 +233,7 @@ const StreamMonitor = () => {
   }
 
   const loadMoreTweets = () => {
-    setTweetOffset(prev => prev + tweetsPerPage)
+    setTweetOffset((prev) => prev + tweetsPerPage)
   }
 
   const refreshLatestTweets = async () => {
@@ -225,15 +264,16 @@ const StreamMonitor = () => {
   }
 
   return (
-    <div className="w-full max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <div className="mx-auto w-full max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
       <div className="mb-8">
-        <div className="flex items-center justify-between mb-4">
+        <div className="mb-4 flex items-center justify-between">
           <div>
-            <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+            <h1 className="mb-2 text-3xl font-bold text-foreground">
               Stream Monitor
             </h1>
-            <p className="text-gray-600 dark:text-gray-400">
-              Real-time monitoring of tweet {showStreamedOnly ? 'streaming' : 'activity (including archives)'}
+            <p className="text-muted-foreground">
+              Real-time monitoring of tweet{' '}
+              {showStreamedOnly ? 'streaming' : 'activity (including archives)'}
             </p>
           </div>
           <div className="flex items-center space-x-2">
@@ -252,23 +292,28 @@ const StreamMonitor = () => {
       {/* Compact call-to-action banner */}
       {showBanner && (
         <div className="mb-6">
-          <div className="flex items-center justify-between gap-4 p-4 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-xl">
-            <div className="flex items-center gap-3 flex-1 min-w-0">
-              <span className="text-xl flex-shrink-0">📡</span>
-              <p className="text-sm text-blue-800 dark:text-blue-200 truncate">
-                Help grow the archive! Opt in and install the extension to stream tweets.
+          <div className="flex items-center justify-between gap-4 rounded-xl border border-border bg-muted p-4">
+            <div className="flex min-w-0 flex-1 items-center gap-3">
+              <span className="flex-shrink-0 text-xl">📡</span>
+              <p className="truncate text-sm text-brand">
+                Help grow the archive! Opt in and install the extension to
+                stream tweets.
               </p>
             </div>
-            <div className="flex items-center gap-2 flex-shrink-0">
+            <div className="flex flex-shrink-0 items-center gap-2">
               <Link href="/">
-                <Button size="sm" variant="outline" className="border-blue-300 text-blue-700 hover:bg-blue-100 dark:border-blue-600 dark:text-blue-300 dark:hover:bg-blue-800">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="border-brand text-brand hover:bg-brand/10 dark:border-border dark:text-brand dark:hover:bg-brand/90"
+                >
                   Get Started
                 </Button>
               </Link>
               <Button
                 variant="ghost"
                 size="icon"
-                className="h-8 w-8 text-blue-700 hover:text-blue-900 dark:text-blue-300 dark:hover:text-blue-100"
+                className="h-8 w-8 text-brand hover:text-brand"
                 onClick={handleDismissBanner}
               >
                 <X className="h-4 w-4" />
@@ -279,18 +324,20 @@ const StreamMonitor = () => {
         </div>
       )}
 
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
+      <div className="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
         <Card>
           <CardHeader className="pb-2">
             <CardTitle className="text-base">
               {showStreamedOnly ? 'Total Streamed' : 'Total Tweets'}
             </CardTitle>
             <CardDescription>
-              {showStreamedOnly ? 'Streamed in time range' : 'All tweets in time range'}
+              {showStreamedOnly
+                ? 'Streamed in time range'
+                : 'All tweets in time range'}
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-blue-600 dark:text-blue-300">
+            <div className="text-2xl font-bold text-brand">
               {getTotalTweets().toLocaleString()}
             </div>
           </CardContent>
@@ -314,12 +361,14 @@ const StreamMonitor = () => {
           <CardHeader className="pb-2">
             <CardTitle className="text-base">Unique Sources</CardTitle>
             <CardDescription>
-              {showStreamedOnly ? 'Active streaming scrapers' : 'All data sources'}
+              {showStreamedOnly
+                ? 'Active streaming scrapers'
+                : 'All data sources'}
             </CardDescription>
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold text-purple-600 dark:text-purple-400">
-              {scraperLoading ? '...' : (scraperCount || 0)}
+              {scraperLoading ? '...' : scraperCount || 0}
             </div>
           </CardContent>
         </Card>
@@ -327,21 +376,17 @@ const StreamMonitor = () => {
 
       <Card className="mb-8">
         <CardHeader>
-          <div className="flex items-center justify-between mb-4">
+          <div className="mb-4 flex items-center justify-between">
             <div>
               <CardTitle>
-                {showStreamedOnly ? 'Tweet Streaming Activity' : 'Tweet Activity (All Sources)'}
+                {showStreamedOnly
+                  ? 'Tweet Streaming Activity'
+                  : 'Tweet Activity (All Sources)'}
               </CardTitle>
-              <CardDescription>
-                {getTimeRangeLabel()}
-              </CardDescription>
+              <CardDescription>{getTimeRangeLabel()}</CardDescription>
             </div>
             <div className="flex items-center gap-2">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handlePrevious}
-              >
+              <Button variant="outline" size="sm" onClick={handlePrevious}>
                 <ChevronLeft className="h-4 w-4" />
               </Button>
               <Button
@@ -354,7 +399,13 @@ const StreamMonitor = () => {
               </Button>
             </div>
           </div>
-          <Tabs value={viewMode} onValueChange={(v) => { setViewMode(v as any); setTimeOffset(0); }}>
+          <Tabs
+            value={viewMode}
+            onValueChange={(v) => {
+              setViewMode(v as any)
+              setTimeOffset(0)
+            }}
+          >
             <TabsList className="grid w-full grid-cols-3">
               <TabsTrigger value="24h">24 Hours</TabsTrigger>
               <TabsTrigger value="7d">7 Days</TabsTrigger>
@@ -364,19 +415,19 @@ const StreamMonitor = () => {
         </CardHeader>
         <CardContent>
           {chartLoading ? (
-            <div className="flex items-center justify-center h-64">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+            <div className="flex h-64 items-center justify-center">
+              <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-brand"></div>
             </div>
           ) : chartError ? (
-            <div className="flex items-center justify-center h-64 text-red-600 dark:text-red-400">
+            <div className="flex h-64 items-center justify-center text-red-600 dark:text-red-400">
               Error loading chart data
             </div>
           ) : (
             <ChartContainer config={chartConfig}>
               <BarChart data={Array.isArray(chartData) ? chartData : []}>
                 <CartesianGrid strokeDasharray="3 3" />
-                <XAxis 
-                  dataKey="period_start" 
+                <XAxis
+                  dataKey="period_start"
                   tickFormatter={formatXAxisLabel}
                   angle={-45}
                   textAnchor="end"
@@ -385,11 +436,13 @@ const StreamMonitor = () => {
                 <YAxis />
                 <ChartTooltip
                   content={<ChartTooltipContent />}
-                  labelFormatter={(label) => formatTooltipLabel(label as string)}
+                  labelFormatter={(label) =>
+                    formatTooltipLabel(label as string)
+                  }
                 />
-                <Bar 
-                  dataKey="tweet_count" 
-                  fill="hsl(var(--foreground))" 
+                <Bar
+                  dataKey="tweet_count"
+                  fill="hsl(var(--foreground))"
                   radius={[4, 4, 0, 0]}
                 />
               </BarChart>
@@ -402,7 +455,7 @@ const StreamMonitor = () => {
         <CardHeader>
           <CardTitle className="flex items-center justify-between">
             Latest Tweets
-            <Button 
+            <Button
               onClick={refreshLatestTweets}
               variant="outline"
               size="sm"
@@ -412,13 +465,14 @@ const StreamMonitor = () => {
             </Button>
           </CardTitle>
           <CardDescription>
-            Recently streamed top-level tweets (no replies) - refreshes automatically
+            Recently streamed top-level tweets (no replies) - refreshes
+            automatically
           </CardDescription>
         </CardHeader>
         <CardContent>
           {tweetsLoading ? (
             <div className="flex items-center justify-center py-8">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+              <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-brand"></div>
             </div>
           ) : tweetsError ? (
             <div className="flex items-center justify-center py-8 text-red-600 dark:text-red-400">
@@ -426,17 +480,17 @@ const StreamMonitor = () => {
             </div>
           ) : (
             <>
-              <UnifiedTweetList 
+              <UnifiedTweetList
                 tweets={loadedTweets}
                 isLoading={false}
                 emptyMessage="No tweets available"
                 showCsvExport={true}
                 csvFilename="stream_monitor_tweets.csv"
               />
-              
+
               {loadedTweets.length > 0 && (
                 <div className="flex justify-center pt-4">
-                  <Button 
+                  <Button
                     onClick={loadMoreTweets}
                     variant="outline"
                     disabled={tweetsLoading}

--- a/src/app/tweets/[tweet_id]/page.tsx
+++ b/src/app/tweets/[tweet_id]/page.tsx
@@ -11,10 +11,10 @@ export default async function TweetPage({ params }: any) {
   const { tweet, threadTree } = await getTweetPageData(tweet_id)
 
   // Style definitions copied from homepage
-  const unifiedDeepBlueBase = "bg-white dark:bg-background";
-  const sectionPaddingClasses = "py-12 md:py-16 lg:py-20"
+  const unifiedDeepBlueBase = 'bg-card dark:bg-background'
+  const sectionPaddingClasses = 'py-12 md:py-16 lg:py-20'
   // Using max-w-7xl to match stream monitor width
-  const contentWrapperClasses = "w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8"
+  const contentWrapperClasses = 'w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8'
 
   if (!tweet) {
     notFound()
@@ -23,22 +23,24 @@ export default async function TweetPage({ params }: any) {
   return (
     <main>
       <section
-        className={`${unifiedDeepBlueBase} ${sectionPaddingClasses} overflow-hidden min-h-screen`}
+        className={`${unifiedDeepBlueBase} ${sectionPaddingClasses} min-h-screen overflow-hidden`}
       >
         <div className={`${contentWrapperClasses}`}>
-          <div className="bg-slate-100 dark:bg-card p-6 md:p-8 rounded-lg">
-            <h2 className="mb-8 text-4xl font-bold text-center text-gray-900 dark:text-white">
-              {threadTree && Object.keys(threadTree.tweets).length > 1 ? '🧵 View Thread' : '🔎 View Tweet'}
+          <div className="rounded-lg bg-muted p-6 dark:bg-card md:p-8">
+            <h2 className="mb-8 text-center text-4xl font-bold text-foreground">
+              {threadTree && Object.keys(threadTree.tweets).length > 1
+                ? '🧵 View Thread'
+                : '🔎 View Tweet'}
             </h2>
 
             {threadTree && Object.keys(threadTree.tweets).length > 1 ? (
               <ThreadView
                 tree={threadTree}
                 highlightTweetId={tweet_id}
-                className="bg-background dark:bg-secondary rounded-lg"
+                className="rounded-lg bg-background dark:bg-secondary"
               />
             ) : (
-              <div className="bg-background dark:bg-secondary p-4 rounded-lg">
+              <div className="rounded-lg bg-background p-4 dark:bg-secondary">
                 <TweetComponent key={tweet.tweet_id} tweet={tweet} />
               </div>
             )}

--- a/src/app/tweets/page.tsx
+++ b/src/app/tweets/page.tsx
@@ -1,32 +1,37 @@
 'use client'
 
-import TweetList from '@/components/TweetList';
-import { FilterCriteria } from '@/lib/queries/tweetQueries';
+import TweetList from '@/components/TweetList'
+import { FilterCriteria } from '@/lib/queries/tweetQueries'
 
 // Basic styling, can be enhanced
-const unifiedDeepBlueBase = "bg-white dark:bg-background";
-const sectionPaddingClasses = "py-8 md:py-10 lg:py-12";
-const contentWrapperClasses = "w-full max-w-3xl mx-auto px-4 sm:px-6 lg:px-8";
+const unifiedDeepBlueBase = 'bg-card dark:bg-background'
+const sectionPaddingClasses = 'py-8 md:py-10 lg:py-12'
+const contentWrapperClasses = 'w-full max-w-3xl mx-auto px-4 sm:px-6 lg:px-8'
 
-export default function TweetsPage() { // Renamed from TimelinePage
+export default function TweetsPage() {
+  // Renamed from TimelinePage
   // Define the filter criteria for the main timeline
   // We want root tweets (not replies)
   const timelineFilterCriteria: FilterCriteria = {
-    isRootTweet: true, 
+    isRootTweet: true,
     // No specific userId, searchQuery, etc., so it fetches all root tweets
-  };
+  }
 
   return (
-    <main className={`${unifiedDeepBlueBase} ${sectionPaddingClasses} min-h-screen flex flex-col items-center`}>
+    <main
+      className={`${unifiedDeepBlueBase} ${sectionPaddingClasses} flex min-h-screen flex-col items-center`}
+    >
       <div className={`${contentWrapperClasses}`}>
-        <div className="bg-slate-100 dark:bg-card p-6 md:p-8 rounded-lg">
-          <h1 className="text-4xl font-bold text-center text-gray-900 dark:text-white mb-12">Recent Tweets</h1> 
-          <TweetList 
-            filterCriteria={timelineFilterCriteria} 
+        <div className="rounded-lg bg-muted p-6 dark:bg-card md:p-8">
+          <h1 className="mb-12 text-center text-4xl font-bold text-foreground">
+            Recent Tweets
+          </h1>
+          <TweetList
+            filterCriteria={timelineFilterCriteria}
             itemsPerPage={50} // Or use the default in TweetList
           />
         </div>
       </div>
     </main>
-  );
+  )
 }

--- a/src/app/user-dir/page.tsx
+++ b/src/app/user-dir/page.tsx
@@ -146,16 +146,16 @@ export default function UserDirectoryPage() {
   }
 
   return (
-    <main className="min-h-screen bg-white py-12 dark:bg-background md:py-16">
+    <main className="min-h-screen bg-card py-12 dark:bg-background md:py-16">
       <div className="relative mx-auto w-full max-w-6xl px-4 sm:px-6 lg:px-8">
         <div className="mx-auto mb-10 max-w-2xl text-center">
-          <h1 className="text-4xl font-bold tracking-tight text-gray-950 dark:text-white sm:text-5xl">
+          <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
             User Directory
           </h1>
-          <p className="mt-3 text-base text-gray-600 dark:text-gray-400">
+          <p className="mt-3 text-base text-muted-foreground">
             People preserving and participating in the Community Archive.
           </p>
-          <p className="mt-2 text-sm font-medium text-gray-500 dark:text-gray-500">
+          <p className="mt-2 text-sm font-medium text-muted-foreground">
             {loading && users.length === 0
               ? 'Loading members…'
               : `${users.length} of ${totalCount.toLocaleString()} members`}
@@ -165,23 +165,23 @@ export default function UserDirectoryPage() {
         <div className="relative mx-auto mb-6 max-w-xl">
           <Search
             aria-hidden="true"
-            className="absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+            className="absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
           />
           <Input
             aria-label="Search the user directory"
             placeholder="Search by name or username…"
             value={searchQuery}
             onChange={(event) => setSearchQuery(event.target.value)}
-            className="h-12 rounded-xl border-gray-300 bg-white pl-11 shadow-sm dark:border-gray-700 dark:bg-gray-950"
+            className="h-12 rounded-xl border-border bg-card pl-11 shadow-sm dark:border-border dark:bg-background"
           />
         </div>
 
         <div
-          className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-card"
+          className="overflow-hidden rounded-2xl border border-border bg-card shadow-sm dark:border-border dark:bg-card"
           aria-busy={loading}
         >
           <Table>
-            <TableHeader className="bg-gray-50/80 dark:bg-gray-900/60">
+            <TableHeader className="bg-muted/50 dark:bg-card">
               <TableRow className="hover:bg-transparent">
                 <TableHead
                   className="w-[42%] py-2"
@@ -197,7 +197,7 @@ export default function UserDirectoryPage() {
                     variant="ghost"
                     onClick={() => handleSort('account_display_name')}
                     aria-label="Sort by member name"
-                    className="-ml-3 h-8 px-3 text-xs font-semibold uppercase tracking-wider hover:bg-gray-200/70 dark:hover:bg-gray-800"
+                    className="-ml-3 h-8 px-3 text-xs font-semibold uppercase tracking-wider hover:bg-accent"
                   >
                     Member {renderSortIcon('account_display_name')}
                   </Button>
@@ -219,7 +219,7 @@ export default function UserDirectoryPage() {
                     variant="ghost"
                     onClick={() => handleSort('num_followers')}
                     aria-label="Sort by follower count"
-                    className="-mr-3 h-8 px-3 text-xs font-semibold uppercase tracking-wider hover:bg-gray-200/70 dark:hover:bg-gray-800"
+                    className="-mr-3 h-8 px-3 text-xs font-semibold uppercase tracking-wider hover:bg-accent"
                   >
                     Followers {renderSortIcon('num_followers')}
                   </Button>
@@ -238,7 +238,7 @@ export default function UserDirectoryPage() {
                     variant="ghost"
                     onClick={() => handleSort('joined_at')}
                     aria-label="Sort by join date"
-                    className="-mr-3 h-8 px-3 text-xs font-semibold uppercase tracking-wider hover:bg-gray-200/70 dark:hover:bg-gray-800"
+                    className="-mr-3 h-8 px-3 text-xs font-semibold uppercase tracking-wider hover:bg-accent"
                   >
                     Joined {renderSortIcon('joined_at')}
                   </Button>
@@ -249,7 +249,7 @@ export default function UserDirectoryPage() {
               {loading ? (
                 <TableRow>
                   <TableCell colSpan={4} className="h-40 text-center">
-                    <span className="inline-flex items-center text-sm text-gray-500 dark:text-gray-400">
+                    <span className="inline-flex items-center text-sm text-muted-foreground">
                       <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                       Loading members…
                     </span>
@@ -268,7 +268,7 @@ export default function UserDirectoryPage() {
                 <TableRow>
                   <TableCell
                     colSpan={4}
-                    className="h-40 text-center text-sm text-gray-500 dark:text-gray-400"
+                    className="h-40 text-center text-sm text-muted-foreground"
                   >
                     No members match “{debouncedSearch}”.
                   </TableCell>
@@ -277,7 +277,7 @@ export default function UserDirectoryPage() {
                 users.map((user) => {
                   const identity = (
                     <div className="flex min-w-0 items-center gap-3">
-                      <Avatar className="h-11 w-11 border border-gray-200 dark:border-gray-700">
+                      <Avatar className="h-11 w-11 border border-border">
                         <AvatarImage
                           src={user.avatar_media_url || '/placeholder.jpg'}
                           alt={`${user.account_display_name}'s avatar`}
@@ -287,10 +287,10 @@ export default function UserDirectoryPage() {
                         </AvatarFallback>
                       </Avatar>
                       <div className="min-w-0">
-                        <div className="truncate font-semibold text-gray-950 dark:text-gray-100">
+                        <div className="truncate font-semibold text-foreground">
                           {user.account_display_name}
                         </div>
-                        <div className="truncate text-sm text-gray-500 dark:text-gray-400">
+                        <div className="truncate text-sm text-muted-foreground">
                           @{user.username}
                         </div>
                       </div>
@@ -300,7 +300,7 @@ export default function UserDirectoryPage() {
                   return (
                     <TableRow
                       key={user.directory_id}
-                      className="group border-gray-200 hover:bg-gray-50/80 dark:border-gray-800 dark:hover:bg-gray-900/60"
+                      className="group border-border hover:bg-accent dark:border-border dark:hover:bg-accent"
                     >
                       <TableCell className="py-4">
                         <Link
@@ -316,7 +316,7 @@ export default function UserDirectoryPage() {
                             <Badge
                               variant="outline"
                               title="Contributed a Twitter archive"
-                              className="gap-1.5 border-blue-200 bg-blue-50 px-2.5 py-1 font-medium text-blue-700 dark:border-blue-900 dark:bg-blue-950/50 dark:text-blue-300"
+                              className="gap-1.5 border-border bg-muted px-2.5 py-1 font-medium text-brand dark:border-border dark:bg-muted dark:text-brand"
                             >
                               <Archive
                                 aria-hidden="true"
@@ -340,12 +340,12 @@ export default function UserDirectoryPage() {
                           )}
                         </div>
                       </TableCell>
-                      <TableCell className="whitespace-nowrap text-right text-sm font-medium tabular-nums text-gray-700 dark:text-gray-300">
+                      <TableCell className="whitespace-nowrap text-right text-sm font-medium tabular-nums text-muted-foreground">
                         {user.num_followers == null
                           ? '—'
                           : formatNumber(user.num_followers)}
                       </TableCell>
-                      <TableCell className="whitespace-nowrap text-right text-sm font-medium text-gray-700 dark:text-gray-300">
+                      <TableCell className="whitespace-nowrap text-right text-sm font-medium text-muted-foreground">
                         <time dateTime={user.joined_at || undefined}>
                           {formatJoinedDate(user.joined_at)}
                         </time>

--- a/src/app/user/[account_id]/AccountTopTweetsClient.tsx
+++ b/src/app/user/[account_id]/AccountTopTweetsClient.tsx
@@ -90,7 +90,7 @@ const AccountTopTweetsClient: React.FC<Props> = ({
           ))}
         </div> */}
         <div>
-          <span className="mr-4 text-sm text-gray-600">
+          <span className="mr-4 text-sm text-muted-foreground">
             Copy all tweets as text
           </span>
           <CopyButton textToCopy={getTweetsAsText()} />
@@ -125,12 +125,16 @@ const AccountTopTweetsClient: React.FC<Props> = ({
                     account_display_name: displayName,
                     media: [],
                     urls: [],
-                    reply_to_username: popularTweet.reply_to_username || undefined,
+                    reply_to_username:
+                      popularTweet.reply_to_username || undefined,
                     mentioned_users: [],
                   }
 
                   return (
-                    <div key={popularTweet.tweet_id} className="bg-background dark:bg-secondary p-4 rounded-lg border border-gray-200 dark:border-gray-700 mb-4">
+                    <div
+                      key={popularTweet.tweet_id}
+                      className="mb-4 rounded-lg border border-border bg-background p-4 dark:bg-secondary"
+                    >
                       <TweetComponent
                         tweet={tweetForTweetComponent} // Pass the constructed object
                       />

--- a/src/app/user/[account_id]/DownloadArchiveButton.tsx
+++ b/src/app/user/[account_id]/DownloadArchiveButton.tsx
@@ -11,17 +11,17 @@ export function DownloadArchiveButton({ username }: { username: string }) {
       // Fetch the file
       const response = await fetch(archiveUrl)
       const blob = await response.blob()
-      
+
       // Create a temporary link element
       const downloadUrl = window.URL.createObjectURL(blob)
       const link = document.createElement('a')
       link.href = downloadUrl
       link.download = `${username}_twitter_archive.json` // Set filename
-      
+
       // Trigger download
       document.body.appendChild(link)
       link.click()
-      
+
       // Cleanup
       document.body.removeChild(link)
       window.URL.revokeObjectURL(downloadUrl)
@@ -32,17 +32,17 @@ export function DownloadArchiveButton({ username }: { username: string }) {
 
   return (
     <div className="mt-4">
-      <Button 
-        variant="outline" 
+      <Button
+        variant="outline"
         onClick={handleDownload}
         className="flex items-center gap-2"
       >
         <FileDown size={16} />
         Download Raw Archive
       </Button>
-      <p className="mt-1 text-xs text-gray-500">
+      <p className="mt-1 text-xs text-muted-foreground">
         Downloads the complete Twitter archive in JSON format
       </p>
     </div>
   )
-} 
+}

--- a/src/app/user/[account_id]/page.tsx
+++ b/src/app/user/[account_id]/page.tsx
@@ -18,7 +18,7 @@ import { FilterCriteria } from '@/lib/queries/tweetQueries'
 import { Archive, Radio } from 'lucide-react'
 
 // Style constants (glows removed)
-const unifiedDeepBlueBase = 'bg-white dark:bg-background'
+const unifiedDeepBlueBase = 'bg-card dark:bg-background'
 const sectionPaddingClasses = 'py-12 md:py-16 lg:py-20'
 const contentWrapperClasses =
   'w-full max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10'
@@ -27,9 +27,9 @@ const UserProfile = ({ userData }: { userData: FormattedUser }) => {
   const account = userData
   return (
     // Profile info card - Removed shadow
-    <div className="mb-8 rounded-lg bg-slate-100 p-6 dark:bg-card sm:p-8">
+    <div className="mb-8 rounded-lg bg-muted p-6 dark:bg-card sm:p-8">
       <div className="flex flex-col items-center space-y-4 sm:flex-row sm:items-start sm:space-x-6 sm:space-y-0">
-        <Avatar className="h-24 w-24 ring-2 ring-blue-500 ring-offset-2 dark:ring-offset-slate-800 sm:h-28 sm:w-28">
+        <Avatar className="h-24 w-24 ring-2 ring-brand ring-offset-2 dark:ring-offset-background sm:h-28 sm:w-28">
           <AvatarImage
             src={account.avatar_media_url || '/placeholder.jpg'}
             alt={`${account.account_display_name}'s avatar`}
@@ -39,12 +39,10 @@ const UserProfile = ({ userData }: { userData: FormattedUser }) => {
           </AvatarFallback>
         </Avatar>
         <div className="flex-grow text-center sm:text-left">
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white sm:text-4xl">
+          <h1 className="text-3xl font-bold text-foreground sm:text-4xl">
             {account.account_display_name}
           </h1>
-          <p className="text-lg text-gray-600 dark:text-gray-400">
-            @{account.username}
-          </p>
+          <p className="text-lg text-muted-foreground">@{account.username}</p>
           <div className="mt-3 flex flex-wrap justify-center gap-2 sm:justify-start">
             {account.has_archive && (
               <Badge variant="outline" className="gap-1.5">
@@ -60,11 +58,11 @@ const UserProfile = ({ userData }: { userData: FormattedUser }) => {
             )}
           </div>
           {account.bio && (
-            <p className="mt-3 text-sm text-gray-700 dark:text-gray-300 sm:text-base">
+            <p className="mt-3 text-sm text-muted-foreground sm:text-base">
               {account.bio}
             </p>
           )}
-          <div className="mt-3 space-y-1 text-sm text-gray-500 dark:text-gray-400">
+          <div className="mt-3 space-y-1 text-sm text-muted-foreground">
             {account.location && <p>📍 {account.location}</p>}
             {account.created_at && (
               <p>
@@ -86,27 +84,27 @@ const UserProfile = ({ userData }: { userData: FormattedUser }) => {
           </div>
         </div>
       </div>
-      <div className="mt-6 flex flex-wrap justify-center gap-x-6 gap-y-3 border-t border-gray-200 pt-6 text-sm text-gray-700 dark:border-gray-700 dark:text-gray-300 sm:justify-start">
+      <div className="mt-6 flex flex-wrap justify-center gap-x-6 gap-y-3 border-t border-border pt-6 text-sm text-muted-foreground dark:border-border dark:text-muted-foreground sm:justify-start">
         <p>
-          <strong className="font-semibold text-gray-800 dark:text-white">
+          <strong className="font-semibold text-foreground">
             {formatNumber(account.num_tweets)}
           </strong>{' '}
           Tweets
         </p>
         <p>
-          <strong className="font-semibold text-gray-800 dark:text-white">
+          <strong className="font-semibold text-foreground">
             {formatNumber(account.num_followers)}
           </strong>{' '}
           Followers
         </p>
         <p>
-          <strong className="font-semibold text-gray-800 dark:text-white">
+          <strong className="font-semibold text-foreground">
             {formatNumber(account.num_following)}
           </strong>{' '}
           Following
         </p>
         <p>
-          <strong className="font-semibold text-gray-800 dark:text-white">
+          <strong className="font-semibold text-foreground">
             {formatNumber(account.num_likes)}
           </strong>{' '}
           Likes
@@ -140,11 +138,11 @@ export default async function User({
       >
         <div className={`${contentWrapperClasses} text-center`}>
           {/* Error card - Removed shadow */}
-          <div className="rounded-lg bg-slate-100 p-8 dark:bg-card">
+          <div className="rounded-lg bg-muted p-8 dark:bg-card">
             <h1 className="text-2xl font-bold text-red-600 dark:text-red-400">
               Error Fetching User Data
             </h1>
-            <p className="mt-2 text-gray-600 dark:text-gray-300">
+            <p className="mt-2 text-muted-foreground">
               Could not retrieve information for this user. Please try again
               later.
             </p>
@@ -188,7 +186,7 @@ export default async function User({
         {/* UserProfile Suspense - Removed shadow from Skeleton */}
         <Suspense
           fallback={
-            <Skeleton className="h-60 w-full rounded-lg bg-slate-100 p-8 dark:bg-card" />
+            <Skeleton className="h-60 w-full rounded-lg bg-muted p-8 dark:bg-card" />
           }
         >
           <UserProfile userData={userData} />
@@ -197,13 +195,13 @@ export default async function User({
         {showingSummaryData ? (
           <>
             {/* Most Mentioned Accounts card - Removed shadow */}
-            <div className="rounded-lg bg-slate-100 p-6 dark:bg-card sm:p-8">
-              <h2 className="mb-4 text-2xl font-semibold text-gray-900 dark:text-white">
+            <div className="rounded-lg bg-muted p-6 dark:bg-card sm:p-8">
+              <h2 className="mb-4 text-2xl font-semibold text-foreground">
                 Most Mentioned Accounts
               </h2>
               <Suspense
                 fallback={
-                  <Skeleton className="h-[20vh] w-full rounded bg-slate-200 dark:bg-slate-700" />
+                  <Skeleton className="h-[20vh] w-full rounded bg-muted" />
                 }
               >
                 <TopMentionedUsers
@@ -214,28 +212,26 @@ export default async function User({
             </div>
 
             {/* Top Tweets card - Removed shadow */}
-            <div className="rounded-lg bg-slate-100 p-6 dark:bg-card sm:p-8">
-              <h2 className="mb-4 text-2xl font-semibold text-gray-900 dark:text-white">
+            <div className="rounded-lg bg-muted p-6 dark:bg-card sm:p-8">
+              <h2 className="mb-4 text-2xl font-semibold text-foreground">
                 Top Tweets
               </h2>
               <Suspense
-                fallback={
-                  <Skeleton className="h-96 w-full rounded bg-slate-200 dark:bg-slate-700" />
-                }
+                fallback={<Skeleton className="h-96 w-full rounded bg-muted" />}
               >
                 <AccountTopTweets userData={userData} />
               </Suspense>
             </div>
           </>
         ) : (
-          <div className="rounded-lg bg-slate-100 p-8 text-center dark:bg-card">
+          <div className="rounded-lg bg-muted p-8 text-center dark:bg-card">
             {/* Activity summary placeholder card - Removed shadow */}
-            <h3 className="text-xl font-semibold text-gray-800 dark:text-gray-200">
+            <h3 className="text-xl font-semibold text-foreground">
               {userData.account_id
                 ? 'Activity summary not yet available.'
                 : 'Activity is not linked yet.'}
             </h3>
-            <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+            <p className="mt-2 text-sm text-muted-foreground">
               {userData.account_id
                 ? 'Detailed activity data like top tweets and mentions is currently being processed or is not available for this user. Basic profile information is still shown above.'
                 : 'This member has opted in, but their Twitter account ID has not been connected to archived or streamed activity yet.'}
@@ -244,8 +240,8 @@ export default async function User({
         )}
 
         {userData.account_id && (
-          <div className="rounded-lg bg-slate-100 p-6 dark:bg-card sm:p-8">
-            <h2 className="mb-6 text-2xl font-semibold text-gray-900 dark:text-white">
+          <div className="rounded-lg bg-muted p-6 dark:bg-card sm:p-8">
+            <h2 className="mb-6 text-2xl font-semibold text-foreground">
               Recent Tweets
             </h2>
             <TweetList

--- a/src/components/AdvancedSearchForm.tsx
+++ b/src/components/AdvancedSearchForm.tsx
@@ -5,122 +5,135 @@ import { ChevronDown, ChevronUp } from 'lucide-react'
 import { useRouter, useSearchParams } from 'next/navigation'
 
 const parseQuery = (q: string) => {
-  const parts = q.split(' ');
-  const options: { [key: string]: string } = {};
-  const words: string[] = [];
-  const validFilters = ['from', 'to', 'since', 'until'];
+  const parts = q.split(' ')
+  const options: { [key: string]: string } = {}
+  const words: string[] = []
+  const validFilters = ['from', 'to', 'since', 'until']
 
   parts.forEach((part) => {
-    const separatorIndex = part.indexOf(':');
-    if (separatorIndex > 0) { // must not start with ':' and must contain ':'
-      const key = part.substring(0, separatorIndex);
-      const value = part.substring(separatorIndex + 1);
+    const separatorIndex = part.indexOf(':')
+    if (separatorIndex > 0) {
+      // must not start with ':' and must contain ':'
+      const key = part.substring(0, separatorIndex)
+      const value = part.substring(separatorIndex + 1)
       if (validFilters.includes(key) && value) {
-        options[key] = value;
-        return; // Go to next part
+        options[key] = value
+        return // Go to next part
       }
     }
-    words.push(part); // Not a valid filter, so it's a keyword
-  });
+    words.push(part) // Not a valid filter, so it's a keyword
+  })
 
-  return { options, words };
-};
+  return { options, words }
+}
 
 export default function AdvancedSearchForm() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
+  const router = useRouter()
+  const searchParams = useSearchParams()
 
-  const [query, setQuery] = useState('');
-  const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
+  const [query, setQuery] = useState('')
+  const [showAdvancedOptions, setShowAdvancedOptions] = useState(false)
 
   // Effect to set initial query from URL params
   useEffect(() => {
-    const q = searchParams.get('q') || '';
-    const fromUser = searchParams.get('fromUser') || '';
-    const replyToUser = searchParams.get('replyToUser') || '';
-    const sinceDate = searchParams.get('sinceDate') || '';
-    const untilDate = searchParams.get('untilDate') || '';
-    
-    const parts = [q];
-    if (fromUser) parts.push(`from:${fromUser}`);
-    if (replyToUser) parts.push(`to:${replyToUser}`);
-    if (sinceDate) parts.push(`since:${sinceDate}`);
-    if (untilDate) parts.push(`until:${untilDate}`);
-    
-    setQuery(parts.filter(p => p).join(' ').trim());
+    const q = searchParams.get('q') || ''
+    const fromUser = searchParams.get('fromUser') || ''
+    const replyToUser = searchParams.get('replyToUser') || ''
+    const sinceDate = searchParams.get('sinceDate') || ''
+    const untilDate = searchParams.get('untilDate') || ''
+
+    const parts = [q]
+    if (fromUser) parts.push(`from:${fromUser}`)
+    if (replyToUser) parts.push(`to:${replyToUser}`)
+    if (sinceDate) parts.push(`since:${sinceDate}`)
+    if (untilDate) parts.push(`until:${untilDate}`)
+
+    setQuery(
+      parts
+        .filter((p) => p)
+        .join(' ')
+        .trim(),
+    )
 
     // if (fromUser || replyToUser || sinceDate || untilDate) {
     //   setShowAdvancedOptions(true);
     // }
-  }, [searchParams]);
+  }, [searchParams])
 
   // Derive values for advanced fields from the main query string
   const { from, to, since, until } = useMemo(() => {
-    const { options } = parseQuery(query);
+    const { options } = parseQuery(query)
     return {
       from: options.from || '',
       to: options.to || '',
       since: options.since || '',
       until: options.until || '',
-    };
-  }, [query]);
+    }
+  }, [query])
 
-  const handleFilterChange = (filter: 'from' | 'to' | 'since' | 'until', value: string) => {
-    const { words, options } = parseQuery(query);
+  const handleFilterChange = (
+    filter: 'from' | 'to' | 'since' | 'until',
+    value: string,
+  ) => {
+    const { words, options } = parseQuery(query)
 
     // Update the specific filter's value
     if (value) {
-      options[filter] = value;
+      options[filter] = value
     } else {
-      delete options[filter];
+      delete options[filter]
     }
 
     // Reconstruct the query string
-    const newFilterParts = Object.entries(options).map(([key, val]) => `${key}:${val}`);
-    const newQuery = [...words, ...newFilterParts].join(' ');
-    setQuery(newQuery.trim().replace(/\s+/g, ' '));
-  };
-
+    const newFilterParts = Object.entries(options).map(
+      ([key, val]) => `${key}:${val}`,
+    )
+    const newQuery = [...words, ...newFilterParts].join(' ')
+    setQuery(newQuery.trim().replace(/\s+/g, ' '))
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    
-    const { options, words } = parseQuery(query);
-    const mainQuery = words.join(' ').trim();
+    e.preventDefault()
 
-    const params = new URLSearchParams();
-    if (mainQuery) params.set('q', mainQuery);
-    if (options.from) params.set('fromUser', options.from);
-    if (options.to) params.set('replyToUser', options.to);
-    if (options.since) params.set('sinceDate', options.since);
-    if (options.until) params.set('untilDate', options.until);
+    const { options, words } = parseQuery(query)
+    const mainQuery = words.join(' ').trim()
 
-    router.push(`/search?${params.toString()}`);
-  };
+    const params = new URLSearchParams()
+    if (mainQuery) params.set('q', mainQuery)
+    if (options.from) params.set('fromUser', options.from)
+    if (options.to) params.set('replyToUser', options.to)
+    if (options.since) params.set('sinceDate', options.since)
+    if (options.until) params.set('untilDate', options.until)
 
-  const inputClasses = "w-full rounded border p-2 dark:bg-slate-700 dark:border-slate-600 dark:text-white dark:placeholder-slate-400 focus:ring-blue-500 focus:border-blue-500";
-  const labelClasses = "block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1";
+    router.push(`/search?${params.toString()}`)
+  }
+
+  const inputClasses =
+    'w-full rounded border p-2 dark:bg-muted dark:border-border dark:text-foreground dark:placeholder-muted-foreground focus:ring-brand focus:border-brand'
+  const labelClasses = 'block text-sm font-medium text-muted-foreground mb-1'
 
   return (
-    <div className="bg-slate-100 dark:bg-card p-6 md:p-8 rounded-lg">
+    <div className="rounded-lg bg-muted p-6 dark:bg-card md:p-8">
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
-          <label htmlFor="main-search" className={labelClasses}>Search terms</label>
-        <input
+          <label htmlFor="main-search" className={labelClasses}>
+            Search terms
+          </label>
+          <input
             id="main-search"
-          type="text"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
             placeholder="Search tweets (use from:, to:, since:, until: for advanced search)"
             className={inputClasses}
-        />
+          />
         </div>
 
         <Button
           type="button"
           variant="outline"
           onClick={() => setShowAdvancedOptions(!showAdvancedOptions)}
-          className="w-full justify-between dark:text-white dark:border-slate-600 dark:hover:bg-slate-700"
+          className="w-full justify-between dark:border-border dark:text-foreground dark:hover:bg-accent"
         >
           Filter by User / Date Range
           {showAdvancedOptions ? (
@@ -131,34 +144,35 @@ export default function AdvancedSearchForm() {
         </Button>
 
         {showAdvancedOptions && (
-          <div className="space-y-4 border-t dark:border-slate-700 pt-4">
+          <div className="space-y-4 border-t pt-4 dark:border-border">
             <div>
-              <label htmlFor="from-user" className={labelClasses}>From user</label>
-            <input
+              <label htmlFor="from-user" className={labelClasses}>
+                From user
+              </label>
+              <input
                 id="from-user"
-              type="text"
-              value={from}
-              onChange={(e) => handleFilterChange('from', e.target.value)}
+                type="text"
+                value={from}
+                onChange={(e) => handleFilterChange('from', e.target.value)}
                 placeholder="username (without @)"
                 className={inputClasses}
-            />
+              />
             </div>
             <div>
-              <label htmlFor="to-user" className={labelClasses}>To user (in reply to username)</label>
-            <input
+              <label htmlFor="to-user" className={labelClasses}>
+                To user (in reply to username)
+              </label>
+              <input
                 id="to-user"
-              type="text"
-              value={to}
-              onChange={(e) => handleFilterChange('to', e.target.value)}
+                type="text"
+                value={to}
+                onChange={(e) => handleFilterChange('to', e.target.value)}
                 placeholder="username (without @)"
                 className={inputClasses}
-            />
+              />
             </div>
             <div>
-              <label
-                htmlFor="since-date"
-                className={labelClasses}
-              >
+              <label htmlFor="since-date" className={labelClasses}>
                 From date:
               </label>
               <input
@@ -170,10 +184,7 @@ export default function AdvancedSearchForm() {
               />
             </div>
             <div>
-              <label
-                htmlFor="until-date"
-                className={labelClasses}
-              >
+              <label htmlFor="until-date" className={labelClasses}>
                 To date:
               </label>
               <input
@@ -189,7 +200,7 @@ export default function AdvancedSearchForm() {
 
         <Button
           type="submit"
-          className="w-full rounded bg-blue-600 p-3 text-lg text-white hover:bg-blue-700 dark:bg-blue-400 dark:hover:bg-blue-300 dark:text-blue-950 transition-colors duration-300"
+          className="w-full rounded bg-brand p-3 text-lg text-white transition-colors duration-300 hover:bg-brand/90 dark:bg-brand dark:text-brand-foreground dark:hover:bg-brand/90"
           // disabled={isLoading} // isLoading state is removed
         >
           Search

--- a/src/components/AppGallery.tsx
+++ b/src/components/AppGallery.tsx
@@ -63,17 +63,15 @@ function GalleryAppCard({ app }: { app: GalleryApp }) {
       href={app.link}
       target="_blank"
       rel="noopener noreferrer"
-      className="group flex items-center gap-4 p-4 bg-white dark:bg-gray-900 rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors border border-gray-200 dark:border-slate-700"
+      className="group flex items-center gap-4 rounded-xl border border-border bg-card p-4 transition-colors hover:bg-accent"
     >
-      <div className="text-2xl text-blue-500 dark:text-blue-300 flex-shrink-0">
-        {app.icon}
-      </div>
-      <div className="flex-1 min-w-0">
-        <h3 className="font-semibold text-gray-900 dark:text-white flex items-center gap-2">
+      <div className="flex-shrink-0 text-2xl text-brand">{app.icon}</div>
+      <div className="min-w-0 flex-1">
+        <h3 className="flex items-center gap-2 font-semibold text-foreground">
           {app.name}
-          <FaExternalLinkAlt className="w-2.5 h-2.5 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0" />
+          <FaExternalLinkAlt className="h-2.5 w-2.5 flex-shrink-0 opacity-0 transition-opacity group-hover:opacity-100" />
         </h3>
-        <p className="text-sm text-gray-600 dark:text-gray-400 truncate">
+        <p className="truncate text-sm text-muted-foreground">
           {app.description}
         </p>
       </div>
@@ -84,10 +82,10 @@ function GalleryAppCard({ app }: { app: GalleryApp }) {
 export default function AppGallery() {
   return (
     <div className="mt-8">
-      <h3 className="text-lg font-medium text-gray-700 dark:text-gray-300 mb-4 text-center">
+      <h3 className="mb-4 text-center text-lg font-medium text-muted-foreground">
         More Tools & Projects
       </h3>
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 max-w-4xl mx-auto">
+      <div className="mx-auto grid max-w-4xl grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {galleryApps.map((app) => (
           <GalleryAppCard key={app.name} app={app} />
         ))}

--- a/src/components/AvatarList.tsx
+++ b/src/components/AvatarList.tsx
@@ -27,7 +27,7 @@ const AvatarList = ({ initialAvatars, title = 'Avatars' }: AvatarListProps) => {
             <a
               key={avatar.username}
               href={`/user/${avatar.account_id}`}
-              className="flex flex-col items-center text-center w-20"
+              className="flex w-20 flex-col items-center text-center"
             >
               <Avatar className="h-12 w-12">
                 <AvatarImage
@@ -38,14 +38,10 @@ const AvatarList = ({ initialAvatars, title = 'Avatars' }: AvatarListProps) => {
                   {avatar.username[0].toUpperCase()}
                 </AvatarFallback>
               </Avatar>
-              <span
-                className="mt-1 text-xs hover:underline break-words"
-              >
+              <span className="mt-1 break-words text-xs hover:underline">
                 {avatar.username}
               </span>
-              <span
-                className="mt-0.5 text-[10px] text-zinc-500 dark:text-zinc-400"
-              >
+              <span className="mt-0.5 text-[10px] text-muted-foreground">
                 {avatar.num_followers &&
                   `${formatNumber(avatar.num_followers)} followers`}
               </span>

--- a/src/components/CommunityStats.tsx
+++ b/src/components/CommunityStats.tsx
@@ -13,26 +13,33 @@ interface CommunityStatsProps {
   showGoal?: boolean
 }
 
-const CommunityStats = ({ 
+const CommunityStats = ({
   accountCount,
   tweetCount,
   likedTweetCount,
-  showGoal = false
+  showGoal = false,
 }: CommunityStatsProps) => {
-
-  if (accountCount === null || tweetCount === null || likedTweetCount === null) {
-    return <p className="text-lg sm:text-xl text-center text-gray-700 dark:text-gray-300">Community statistics are currently unavailable.</p>
+  if (
+    accountCount === null ||
+    tweetCount === null ||
+    likedTweetCount === null
+  ) {
+    return (
+      <p className="text-center text-lg text-muted-foreground sm:text-xl">
+        Community statistics are currently unavailable.
+      </p>
+    )
   }
 
   const goal = calculateGoal(accountCount || 0)
 
   return (
-    <p className="text-xl text-gray-800 dark:text-gray-200">
+    <p className="text-xl text-foreground">
       We have <strong>{formatNumber(tweetCount)}</strong> tweets and{' '}
       <strong>{formatNumber(likedTweetCount)}</strong> liked tweets from{' '}
       <strong>{formatNumber(accountCount)}</strong> accounts.
       {showGoal && goal && (
-        <span className="italic ml-1">
+        <span className="ml-1 italic">
           Next milestone: <strong>{formatNumber(goal)}</strong> accounts.
         </span>
       )}

--- a/src/components/FeaturedAppsSection.tsx
+++ b/src/components/FeaturedAppsSection.tsx
@@ -19,7 +19,7 @@ const featuredApps: FeaturedApp[] = [
     name: 'Strand Atlas',
     description: 'Explore the best conversation threads',
     link: 'https://bangers.community-archive.org/detailed-strand-atlas',
-    icon: <FaProjectDiagram className="w-8 h-8" />,
+    icon: <FaProjectDiagram className="h-8 w-8" />,
     color: 'from-purple-500 to-pink-500',
     image: '/images/featured/strand-atlas.png',
   },
@@ -27,7 +27,7 @@ const featuredApps: FeaturedApp[] = [
     name: 'Bangers',
     description: 'Browse the most impactful tweets',
     link: 'https://bangers.community-archive.org',
-    icon: <FaFire className="w-8 h-8" />,
+    icon: <FaFire className="h-8 w-8" />,
     color: 'from-orange-500 to-red-500',
     image: '/images/featured/bangers.png',
   },
@@ -44,10 +44,12 @@ function FeaturedAppCard({ app }: { app: FeaturedApp }) {
       href={app.link}
       target="_blank"
       rel="noopener noreferrer"
-      className="group flex flex-col bg-white dark:bg-gray-900 rounded-2xl overflow-hidden shadow-sm hover:shadow-lg transition-all duration-300 border border-gray-200 dark:border-slate-700"
+      className="group flex flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-sm transition-all duration-300 hover:shadow-lg"
     >
       {/* Thumbnail header — gradient + icon stay behind as a fallback if the image is missing */}
-      <div className={`relative h-40 bg-gradient-to-br ${app.color} flex items-center justify-center text-white`}>
+      <div
+        className={`relative h-40 bg-gradient-to-br ${app.color} flex items-center justify-center text-white`}
+      >
         {app.icon}
         {app.image && imageOk && (
           <Image
@@ -62,12 +64,12 @@ function FeaturedAppCard({ app }: { app: FeaturedApp }) {
       </div>
 
       {/* Content */}
-      <div className="p-5 flex-1 flex flex-col">
-        <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-2 flex items-center gap-2">
+      <div className="flex flex-1 flex-col p-5">
+        <h3 className="mb-2 flex items-center gap-2 text-xl font-semibold text-foreground">
           {app.name}
-          <FaExternalLinkAlt className="w-3 h-3 opacity-0 group-hover:opacity-100 transition-opacity" />
+          <FaExternalLinkAlt className="h-3 w-3 opacity-0 transition-opacity group-hover:opacity-100" />
         </h3>
-        <p className="text-gray-600 dark:text-gray-400 text-sm flex-1">
+        <p className="flex-1 text-sm text-muted-foreground">
           {app.description}
         </p>
       </div>
@@ -79,15 +81,16 @@ export default function FeaturedAppsSection() {
   return (
     <section className="space-y-8">
       <div className="text-center">
-        <h2 className="text-3xl font-bold text-gray-900 dark:text-white">
+        <h2 className="text-3xl font-bold text-foreground">
           Explore the archive
         </h2>
-        <p className="mt-3 text-base text-gray-600 dark:text-gray-300 max-w-xl mx-auto">
-          Browse the evolution of Twitter narratives, ideas, memes, and stories that shape our culture today.
+        <p className="mx-auto mt-3 max-w-xl text-base text-muted-foreground">
+          Browse the evolution of Twitter narratives, ideas, memes, and stories
+          that shape our culture today.
         </p>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-3xl mx-auto">
+      <div className="mx-auto grid max-w-3xl grid-cols-1 gap-6 md:grid-cols-2">
         {featuredApps.map((app) => (
           <FeaturedAppCard key={app.name} app={app} />
         ))}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 
 const Footer = () => {
   return (
-    <footer className="mt-auto py-4 text-center text-sm text-gray-600 dark:text-gray-400">
+    <footer className="mt-auto py-4 text-center text-sm text-muted-foreground">
       <Link href="/about" className="hover:underline">
         About
       </Link>

--- a/src/components/HeaderNavigation.tsx
+++ b/src/components/HeaderNavigation.tsx
@@ -2,7 +2,6 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { Shield } from 'lucide-react'
 import {
   NavigationMenu,
   NavigationMenuList,
@@ -12,16 +11,13 @@ import {
 } from '@/components/ui/navigation-menu'
 import { cn } from '@/utils/tailwind'
 
-export default function HeaderNavigation({
-  isAdmin = false,
-}: {
-  isAdmin?: boolean
-}) {
+export default function HeaderNavigation() {
   const pathname = usePathname()
 
   const baseNavItems = [
     { href: '/', label: 'Home' },
-    { href: '/user-dir', label: 'Directory' },
+    { href: '/#products', label: 'Products' },
+    { href: '/user-dir', label: 'User Directory' },
     { href: '/search', label: 'Search' },
   ]
 
@@ -29,13 +25,10 @@ export default function HeaderNavigation({
     { href: '/stream-monitor', label: 'Stream Monitor' },
   ]
 
-  const userNavItems = [{ href: '/profile', label: 'Profile' }]
-
-  // Include all navigation items
-  const navItems = [...baseNavItems, ...streamingNavItems, ...userNavItems]
+  const navItems = [...baseNavItems, ...streamingNavItems]
 
   return (
-    <NavigationMenu className="hidden md:flex">
+    <NavigationMenu className="hidden lg:flex">
       <NavigationMenuList>
         {navItems.map((item) => (
           <NavigationMenuItem key={item.href}>
@@ -43,10 +36,8 @@ export default function HeaderNavigation({
               <NavigationMenuLink
                 className={cn(
                   navigationMenuTriggerStyle(),
-                  'transition-colors duration-150 hover:bg-gray-100 dark:hover:bg-gray-800',
-                  pathname === item.href
-                    ? 'bg-gray-100 font-semibold dark:bg-gray-800' // Enhanced active style
-                    : '',
+                  'transition-colors duration-150 hover:bg-accent',
+                  pathname === item.href ? 'bg-muted font-semibold' : '',
                 )}
               >
                 {item.label}
@@ -54,25 +45,6 @@ export default function HeaderNavigation({
             </Link>
           </NavigationMenuItem>
         ))}
-        {isAdmin ? (
-          <NavigationMenuItem>
-            <Link href="/admin" legacyBehavior passHref>
-              <NavigationMenuLink
-                aria-label="Admin dashboard"
-                title="Admin"
-                className={cn(
-                  navigationMenuTriggerStyle(),
-                  'w-10 px-0 hover:bg-gray-100 dark:hover:bg-gray-800',
-                  pathname === '/admin'
-                    ? 'bg-gray-100 font-semibold dark:bg-gray-800'
-                    : '',
-                )}
-              >
-                <Shield className="h-4 w-4" />
-              </NavigationMenuLink>
-            </Link>
-          </NavigationMenuItem>
-        ) : null}
       </NavigationMenuList>
     </NavigationMenu>
   )

--- a/src/components/HeaderSearch.tsx
+++ b/src/components/HeaderSearch.tsx
@@ -19,15 +19,15 @@ export default function HeaderSearch() {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="hidden sm:flex items-center">
+    <form onSubmit={handleSubmit} className="hidden items-center xl:flex">
       <div className="relative">
-        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+        <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
         <Input
           type="search"
           placeholder="Search tweets..."
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          className="pl-8 pr-3 py-1.5 h-9 w-40 lg:w-56 text-sm bg-gray-100 dark:bg-gray-800 border-gray-200 dark:border-gray-700 focus:ring-blue-500"
+          className="h-9 w-40 border-border bg-muted py-1.5 pl-8 pr-3 text-sm focus:ring-brand lg:w-56"
         />
       </div>
     </form>

--- a/src/components/HeroCTAButtons.tsx
+++ b/src/components/HeroCTAButtons.tsx
@@ -14,7 +14,8 @@ import { createBrowserClient } from '@/utils/supabase'
 import { Users, Puzzle, Upload } from 'lucide-react'
 import { devLog } from '@/lib/devLog'
 
-const CHROME_EXTENSION_URL = 'https://chromewebstore.google.com/detail/community-archive-stream/igclpobjpjlphgllncjcgaookmncegbk'
+const CHROME_EXTENSION_URL =
+  'https://chromewebstore.google.com/detail/community-archive-stream/igclpobjpjlphgllncjcgaookmncegbk'
 
 export default function HeroCTAButtons() {
   const router = useRouter()
@@ -31,13 +32,17 @@ export default function HeroCTAButtons() {
   // Get current user session
   useEffect(() => {
     const getCurrentUser = async () => {
-      const { data: { session } } = await supabase.auth.getSession()
+      const {
+        data: { session },
+      } = await supabase.auth.getSession()
       setUser(session?.user || null)
     }
 
     getCurrentUser()
 
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((event, session) => {
       setUser(session?.user || null)
     })
 
@@ -80,7 +85,7 @@ export default function HeroCTAButtons() {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             email: 'dev@example.com',
-            password: 'devpassword123'
+            password: 'devpassword123',
           }),
         })
 
@@ -137,7 +142,7 @@ export default function HeroCTAButtons() {
           username: twitterUsername.toLowerCase(),
           twitterUserId: twitterUserId || null,
           optedIn: true,
-          termsVersion: 'v1.0'
+          termsVersion: 'v1.0',
         }),
       })
 
@@ -158,39 +163,35 @@ export default function HeroCTAButtons() {
 
   const getOptInButtonText = () => {
     if (isOptInLoading) return 'Processing...'
-    if (isOptedIn) return 'Opted in'
     if (!user) return 'Opt in'
     return 'Opt in'
   }
 
   const getOptInButtonStyle = () => {
-    if (isOptedIn) {
-      return 'bg-green-100 text-green-700 border-green-300 dark:bg-green-900/30 dark:text-green-400 dark:border-green-700 cursor-default'
-    }
     return 'bg-green-600 hover:bg-green-700 text-white dark:bg-green-400 dark:hover:bg-green-300 dark:text-green-950'
   }
 
   return (
     <TooltipProvider delayDuration={150}>
       <div className="flex flex-col items-center gap-4">
-        <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 w-full sm:w-auto">
+        <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:gap-4">
           {/* Opt In Button */}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                onClick={handleOptIn}
-                disabled={isOptInLoading || isOptedIn === true}
-                className={`h-14 px-8 text-lg font-semibold w-full ${getOptInButtonStyle()}`}
-                size="lg"
-              >
-                <Users className="w-5 h-5 mr-2" />
-                {getOptInButtonText()}
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              {isOptedIn ? 'Your tweets are being archived' : 'Archive your public tweets'}
-            </TooltipContent>
-          </Tooltip>
+          {isOptedIn !== true ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  onClick={handleOptIn}
+                  disabled={isOptInLoading}
+                  className={`h-14 w-full px-8 text-lg font-semibold ${getOptInButtonStyle()}`}
+                  size="lg"
+                >
+                  <Users className="mr-2 h-5 w-5" />
+                  {getOptInButtonText()}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Archive your public tweets</TooltipContent>
+            </Tooltip>
+          ) : null}
 
           {/* Install Extension Button */}
           <Tooltip>
@@ -198,11 +199,15 @@ export default function HeroCTAButtons() {
               <Button
                 asChild
                 variant="outline"
-                className="h-14 px-8 text-lg font-semibold border-2 w-full"
+                className="h-14 w-full border-2 px-8 text-lg font-semibold"
                 size="lg"
               >
-                <a href={CHROME_EXTENSION_URL} target="_blank" rel="noopener noreferrer">
-                  <Puzzle className="w-5 h-5 mr-2" />
+                <a
+                  href={CHROME_EXTENSION_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <Puzzle className="mr-2 h-5 w-5" />
                   Get extension
                 </a>
               </Button>
@@ -216,11 +221,11 @@ export default function HeroCTAButtons() {
               <Button
                 asChild
                 variant="outline"
-                className="h-14 px-8 text-lg font-semibold border-2 w-full"
+                className="h-14 w-full border-2 px-8 text-lg font-semibold"
                 size="lg"
               >
                 <a href="#upload-archive">
-                  <Upload className="w-5 h-5 mr-2" />
+                  <Upload className="mr-2 h-5 w-5" />
                   Upload archive
                 </a>
               </Button>

--- a/src/components/HomeOptInWidget.tsx
+++ b/src/components/HomeOptInWidget.tsx
@@ -28,7 +28,9 @@ export default function HomeOptInWidget() {
   // Get current user session
   useEffect(() => {
     const getCurrentUser = async () => {
-      const { data: { session } } = await supabase.auth.getSession()
+      const {
+        data: { session },
+      } = await supabase.auth.getSession()
       setUser(session?.user || null)
     }
 
@@ -97,7 +99,7 @@ export default function HomeOptInWidget() {
           username: twitterUsername.toLowerCase(),
           twitterUserId: twitterUserId || null,
           optedIn: true,
-          termsVersion: 'v1.0'
+          termsVersion: 'v1.0',
         }),
       })
 
@@ -123,7 +125,7 @@ export default function HomeOptInWidget() {
       <Card className="border-green-200 dark:border-green-700">
         <CardContent className="pt-6 text-center">
           <div className="animate-pulse">
-            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-32 mx-auto"></div>
+            <div className="mx-auto h-4 w-32 rounded bg-muted"></div>
           </div>
         </CardContent>
       </Card>
@@ -134,13 +136,16 @@ export default function HomeOptInWidget() {
   if (!user) {
     return (
       <Card className="border-green-200 dark:border-green-700">
-        <CardContent className="pt-6 text-center space-y-4">
+        <CardContent className="space-y-4 pt-6 text-center">
           <div className="text-4xl">🙋‍♂️</div>
-          <h3 className="text-xl font-semibold text-gray-900 dark:text-white">Step 1: Opt In</h3>
-          <p className="text-gray-600 dark:text-gray-400">
-            Sign in and give permission to include your public tweets in the community archive.
+          <h3 className="text-xl font-semibold text-foreground">
+            Step 1: Opt In
+          </h3>
+          <p className="text-muted-foreground">
+            Sign in and give permission to include your public tweets in the
+            community archive.
           </p>
-          <p className="text-sm text-gray-500 dark:text-gray-400">
+          <p className="text-sm text-muted-foreground">
             Please sign in above to get started
           </p>
         </CardContent>
@@ -152,11 +157,14 @@ export default function HomeOptInWidget() {
   if (!twitterUsername) {
     return (
       <Card className="border-red-200 dark:border-red-700">
-        <CardContent className="pt-6 text-center space-y-4">
+        <CardContent className="space-y-4 pt-6 text-center">
           <div className="text-4xl">⚠️</div>
-          <h3 className="text-xl font-semibold text-gray-900 dark:text-white">Twitter Account Required</h3>
+          <h3 className="text-xl font-semibold text-foreground">
+            Twitter Account Required
+          </h3>
           <p className="text-red-600 dark:text-red-400">
-            No Twitter account found. Please sign in with Twitter to use the opt-in feature.
+            No Twitter account found. Please sign in with Twitter to use the
+            opt-in feature.
           </p>
         </CardContent>
       </Card>
@@ -166,19 +174,25 @@ export default function HomeOptInWidget() {
   // If already opted in, show success state
   if (isOptedIn) {
     return (
-      <Card className="border-green-200 dark:border-green-700 bg-green-50 dark:bg-green-900/20">
-        <CardContent className="pt-6 text-center space-y-4">
+      <Card className="border-green-200 bg-green-50 dark:border-green-700 dark:bg-green-900/20">
+        <CardContent className="space-y-4 pt-6 text-center">
           <div className="text-4xl">✅</div>
-          <h3 className="text-xl font-semibold text-green-900 dark:text-green-100">You&apos;re Opted In!</h3>
+          <h3 className="text-xl font-semibold text-green-900 dark:text-green-100">
+            You&apos;re Opted In!
+          </h3>
           <p className="text-green-800 dark:text-green-200">
             Your public tweets are now being preserved in the community archive.
           </p>
           <div className="flex items-center justify-center text-sm text-green-700 dark:text-green-300">
-            <CheckCircle className="w-4 h-4 mr-2" />
-            @{twitterUsername} is contributing to the archive
+            <CheckCircle className="mr-2 h-4 w-4" />@{twitterUsername} is
+            contributing to the archive
           </div>
           <Link href="/profile">
-            <Button variant="outline" size="sm" className="border-green-300 text-green-700 hover:bg-green-100 dark:border-green-600 dark:text-green-300">
+            <Button
+              variant="outline"
+              size="sm"
+              className="border-green-300 text-green-700 hover:bg-green-100 dark:border-green-600 dark:text-green-300"
+            >
               Manage Settings
             </Button>
           </Link>
@@ -190,19 +204,26 @@ export default function HomeOptInWidget() {
   // Show opt-in form
   return (
     <Card className="border-green-200 dark:border-green-700">
-      <CardContent className="pt-6 text-center space-y-4">
+      <CardContent className="space-y-4 pt-6 text-center">
         <div className="text-4xl">🙋‍♂️</div>
-        <h3 className="text-xl font-semibold text-gray-900 dark:text-white">Step 1: Opt In</h3>
-        <p className="text-gray-600 dark:text-gray-400">
-          Give permission to include your public tweets in the community archive.
+        <h3 className="text-xl font-semibold text-foreground">
+          Step 1: Opt In
+        </h3>
+        <p className="text-muted-foreground">
+          Give permission to include your public tweets in the community
+          archive.
         </p>
-        
+
         {/* Current status */}
-        <p className="text-sm text-gray-600 dark:text-gray-400">
-          Signed in as <span className="font-medium text-blue-600 dark:text-blue-300">@{twitterUsername}</span>
+        <p className="text-sm text-muted-foreground">
+          Signed in as{' '}
+          <span className="font-medium text-brand">@{twitterUsername}</span>
         </p>
-        <p className="text-sm text-gray-700 dark:text-gray-300">
-          Current Status: <span className="font-semibold text-gray-600 dark:text-gray-400">Not Opted In</span>
+        <p className="text-sm text-muted-foreground">
+          Current Status:{' '}
+          <span className="font-semibold text-muted-foreground">
+            Not Opted In
+          </span>
         </p>
 
         {/* Error and success messages */}
@@ -223,9 +244,9 @@ export default function HomeOptInWidget() {
         <Button
           onClick={handleOptIn}
           disabled={isLoading}
-          className="bg-green-600 hover:bg-green-700 text-white dark:bg-green-400 dark:hover:bg-green-300 dark:text-green-950"
+          className="bg-green-600 text-white hover:bg-green-700 dark:bg-green-400 dark:text-green-950 dark:hover:bg-green-300"
         >
-          <Users className="w-4 h-4 mr-2" />
+          <Users className="mr-2 h-4 w-4" />
           {isLoading ? 'Processing...' : 'Opt In to Tweet Streaming'}
         </Button>
       </CardContent>

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -3,8 +3,10 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useState } from 'react'
-import { Menu as MenuIcon } from 'lucide-react'
+import { LogIn, LogOut, Menu as MenuIcon, UserRound } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { useAuthAndArchive } from '@/hooks/useAuthAndArchive'
+import { createBrowserClient } from '@/utils/supabase'
 import {
   Sheet,
   SheetContent,
@@ -15,61 +17,96 @@ import {
 
 const baseNavItems = [
   { href: '/', label: 'Home' },
+  { href: '/#products', label: 'Products' },
   { href: '/user-dir', label: 'User Directory' },
-  { href: '/search', label: 'Advanced Search' },
+  { href: '/search', label: 'Search' },
 ]
 
 const streamingNavItems = [{ href: '/stream-monitor', label: 'Stream Monitor' }]
 
-const userNavItems = [{ href: '/profile', label: 'Profile' }]
-const adminNavItems = [{ href: '/admin', label: 'Admin' }]
-
-export default function MobileMenu({
-  isAdmin = false,
-}: {
-  isAdmin?: boolean
-}) {
+export default function MobileMenu() {
   const pathname = usePathname()
   const [isOpen, setIsOpen] = useState(false)
+  const { userMetadata } = useAuthAndArchive()
 
-  const navItems = [
-    ...baseNavItems,
-    ...streamingNavItems,
-    ...userNavItems,
-    ...(isAdmin ? adminNavItems : []),
-  ]
+  const navItems = [...baseNavItems, ...streamingNavItems]
+
+  const handleSignOut = async () => {
+    const supabase = createBrowserClient()
+    const { error } = await supabase.auth.signOut()
+
+    if (!error) {
+      setIsOpen(false)
+      window.location.href = '/'
+    }
+  }
 
   return (
     <Sheet open={isOpen} onOpenChange={setIsOpen}>
       <SheetTrigger asChild>
-        <Button variant="ghost" size="icon" className="md:hidden">
-          <MenuIcon className="h-6 w-6" />
-          <span className="sr-only">Open menu</span>
+        <Button variant="outline" size="icon">
+          <MenuIcon className="h-5 w-5" />
+          <span className="sr-only">Open account menu</span>
         </Button>
       </SheetTrigger>
-      <SheetContent side="left" className="w-full max-w-xs sm:max-w-sm">
+      <SheetContent side="right" className="w-full max-w-xs sm:max-w-sm">
         <SheetHeader className="mb-6">
           <SheetTitle className="text-left text-lg font-semibold">
-            Navigation
+            Menu
           </SheetTitle>
         </SheetHeader>
-        <nav className="flex flex-col space-y-2">
-          {navItems.map((item) => (
-            <Link
-              key={item.href}
-              href={item.href}
-              className={`block rounded-md px-3 py-2 text-base font-medium transition-colors duration-150
-                ${
-                  pathname === item.href
-                    ? 'bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-100'
-                    : 'text-gray-600 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700'
-                }`}
-              onClick={() => setIsOpen(false)} // Close sheet on link click
-            >
-              {item.label}
-            </Link>
-          ))}
-        </nav>
+        <div className="flex h-[calc(100%-3rem)] flex-col">
+          <nav className="flex flex-col space-y-2 lg:hidden">
+            {navItems.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={`block rounded-md px-3 py-2 text-base font-medium transition-colors duration-150
+                  ${
+                    pathname === item.href
+                      ? 'bg-muted text-foreground'
+                      : 'text-muted-foreground hover:bg-accent'
+                  }`}
+                onClick={() => setIsOpen(false)}
+              >
+                {item.label}
+              </Link>
+            ))}
+            <div className="my-3 border-t" />
+          </nav>
+
+          <div className="flex flex-col space-y-2">
+            {userMetadata ? (
+              <>
+                <Link
+                  href="/profile"
+                  className="flex items-center gap-3 rounded-md px-3 py-2 text-base font-medium text-foreground transition-colors hover:bg-accent"
+                  onClick={() => setIsOpen(false)}
+                >
+                  <UserRound className="h-5 w-5" />
+                  Profile
+                </Link>
+                <button
+                  type="button"
+                  className="flex items-center gap-3 rounded-md px-3 py-2 text-left text-base font-medium text-foreground transition-colors hover:bg-accent"
+                  onClick={handleSignOut}
+                >
+                  <LogOut className="h-5 w-5" />
+                  Sign out
+                </button>
+              </>
+            ) : (
+              <Link
+                href="/login"
+                className="flex items-center gap-3 rounded-md px-3 py-2 text-base font-medium text-foreground transition-colors hover:bg-accent"
+                onClick={() => setIsOpen(false)}
+              >
+                <LogIn className="h-5 w-5" />
+                Sign in
+              </Link>
+            )}
+          </div>
+        </div>
       </SheetContent>
     </Sheet>
   )

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -2,21 +2,20 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { useState } from 'react'
-import { LogIn, LogOut, Menu as MenuIcon, UserRound } from 'lucide-react'
+import { LogIn, LogOut, UserRound } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useAuthAndArchive } from '@/hooks/useAuthAndArchive'
 import { createBrowserClient } from '@/utils/supabase'
 import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-  SheetTrigger,
-} from '@/components/ui/sheet'
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 
-const baseNavItems = [
+const mobileNavItems = [
   { href: '/', label: 'Home' },
   { href: '/#products', label: 'Products' },
   { href: '/user-dir', label: 'User Directory' },
@@ -25,91 +24,74 @@ const baseNavItems = [
 
 export default function MobileMenu() {
   const pathname = usePathname()
-  const [isOpen, setIsOpen] = useState(false)
   const { userMetadata } = useAuthAndArchive()
-
-  const navItems = baseNavItems
 
   const handleSignOut = async () => {
     const supabase = createBrowserClient()
     const { error } = await supabase.auth.signOut()
 
     if (!error) {
-      setIsOpen(false)
       window.location.href = '/'
     }
   }
 
   return (
-    <Sheet open={isOpen} onOpenChange={setIsOpen}>
-      <SheetTrigger asChild>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
         <Button variant="outline" size="icon">
-          <MenuIcon className="h-5 w-5" />
+          <UserRound className="h-5 w-5" />
           <span className="sr-only">Open account menu</span>
         </Button>
-      </SheetTrigger>
-      <SheetContent side="right" className="w-full max-w-xs sm:max-w-sm">
-        <SheetHeader className="mb-6">
-          <SheetTitle className="text-left text-lg font-semibold">
-            Menu
-          </SheetTitle>
-          <SheetDescription className="sr-only">
-            Browse Community Archive pages.
-          </SheetDescription>
-        </SheetHeader>
-        <div className="flex h-[calc(100%-3rem)] flex-col">
-          <nav className="flex flex-col space-y-2 lg:hidden">
-            {navItems.map((item) => (
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        sideOffset={8}
+        className="w-56 rounded-lg p-2"
+      >
+        <div className="lg:hidden">
+          <DropdownMenuLabel className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Navigation
+          </DropdownMenuLabel>
+          {mobileNavItems.map((item) => (
+            <DropdownMenuItem key={item.href} asChild>
               <Link
-                key={item.href}
                 href={item.href}
-                className={`block rounded-md px-3 py-2 text-base font-medium transition-colors duration-150
-                  ${
-                    pathname === item.href
-                      ? 'bg-muted text-foreground'
-                      : 'text-muted-foreground hover:bg-accent'
-                  }`}
-                onClick={() => setIsOpen(false)}
+                className={`cursor-pointer py-2.5 ${
+                  pathname === item.href ? 'bg-muted font-medium' : ''
+                }`}
               >
                 {item.label}
               </Link>
-            ))}
-            <div className="my-3 border-t" />
-          </nav>
-
-          <div className="flex flex-col space-y-2">
-            {userMetadata ? (
-              <>
-                <Link
-                  href="/profile"
-                  className="flex items-center gap-3 rounded-md px-3 py-2 text-base font-medium text-foreground transition-colors hover:bg-accent"
-                  onClick={() => setIsOpen(false)}
-                >
-                  <UserRound className="h-5 w-5" />
-                  Profile
-                </Link>
-                <button
-                  type="button"
-                  className="flex items-center gap-3 rounded-md px-3 py-2 text-left text-base font-medium text-foreground transition-colors hover:bg-accent"
-                  onClick={handleSignOut}
-                >
-                  <LogOut className="h-5 w-5" />
-                  Sign out
-                </button>
-              </>
-            ) : (
-              <Link
-                href="/login"
-                className="flex items-center gap-3 rounded-md px-3 py-2 text-base font-medium text-foreground transition-colors hover:bg-accent"
-                onClick={() => setIsOpen(false)}
-              >
-                <LogIn className="h-5 w-5" />
-                Sign in
-              </Link>
-            )}
-          </div>
+            </DropdownMenuItem>
+          ))}
+          <DropdownMenuSeparator />
         </div>
-      </SheetContent>
-    </Sheet>
+
+        {userMetadata ? (
+          <>
+            <DropdownMenuItem asChild>
+              <Link href="/profile" className="cursor-pointer gap-3 py-2.5">
+                <UserRound className="h-4 w-4" />
+                Profile
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className="cursor-pointer gap-3 py-2.5"
+              onSelect={() => void handleSignOut()}
+            >
+              <LogOut className="h-4 w-4" />
+              Sign out
+            </DropdownMenuItem>
+          </>
+        ) : (
+          <DropdownMenuItem asChild>
+            <Link href="/login" className="cursor-pointer gap-3 py-2.5">
+              <LogIn className="h-4 w-4" />
+              Sign in
+            </Link>
+          </DropdownMenuItem>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }

--- a/src/components/OpenCollectiveContributors.tsx
+++ b/src/components/OpenCollectiveContributors.tsx
@@ -19,55 +19,70 @@ interface OpenCollectiveContributorsProps {
   contributors: Contributor[]
 }
 
-const OpenCollectiveContributors: React.FC<OpenCollectiveContributorsProps> = ({ contributors }) => {
+const OpenCollectiveContributors: React.FC<OpenCollectiveContributorsProps> = ({
+  contributors,
+}) => {
   // --- BEGIN DEBUG LOG ---
-  if (typeof window !== 'undefined') { // Ensure this runs only on the client-side
-    console.log("Open Collective Contributors - Image URLS:");
-    const uniqueHostnames = new Set<string>();
-    contributors.forEach(c => {
+  if (typeof window !== 'undefined') {
+    // Ensure this runs only on the client-side
+    console.log('Open Collective Contributors - Image URLS:')
+    const uniqueHostnames = new Set<string>()
+    contributors.forEach((c) => {
       if (c.image) {
         try {
-          const url = new URL(c.image);
-          uniqueHostnames.add(url.hostname);
+          const url = new URL(c.image)
+          uniqueHostnames.add(url.hostname)
         } catch (e) {
-          console.warn(`Invalid image URL for ${c.name}: ${c.image}`);
+          console.warn(`Invalid image URL for ${c.name}: ${c.image}`)
         }
       }
-    });
+    })
     if (uniqueHostnames.size > 0) {
-      console.log("Unique image hostnames found:", Array.from(uniqueHostnames));
+      console.log('Unique image hostnames found:', Array.from(uniqueHostnames))
     }
   }
   // --- END DEBUG LOG ---
 
   if (!contributors || contributors.length === 0) {
-    return <p className="text-gray-600 dark:text-gray-400">No active contributors to display at the moment.</p>
+    return (
+      <p className="text-muted-foreground">
+        No active contributors to display at the moment.
+      </p>
+    )
   }
 
   return (
-    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-6 md:gap-8">
+    <div className="grid grid-cols-2 gap-6 sm:grid-cols-3 md:grid-cols-4 md:gap-8 lg:grid-cols-5 xl:grid-cols-6">
       {contributors.map((contributor) => (
-        <Link href={contributor.profile} key={contributor.slug || contributor.profile} passHref target="_blank" rel="noopener noreferrer">
-          <div className="flex flex-col items-center text-center space-y-2 p-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700/50 transition-colors duration-200">
-            <div className="relative w-20 h-20 md:w-24 md:h-24 rounded-full overflow-hidden shadow-md">
+        <Link
+          href={contributor.profile}
+          key={contributor.slug || contributor.profile}
+          passHref
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <div className="flex flex-col items-center space-y-2 rounded-lg p-3 text-center transition-colors duration-200 hover:bg-accent">
+            <div className="relative h-20 w-20 overflow-hidden rounded-full shadow-md md:h-24 md:w-24">
               {contributor.image ? (
-                <Image 
-                  src={contributor.image} 
-                  alt={`${contributor.name}'s avatar`} 
-                  fill 
+                <Image
+                  src={contributor.image}
+                  alt={`${contributor.name}'s avatar`}
+                  fill
                   sizes="(max-width: 768px) 80px, 96px"
                   style={{ objectFit: 'cover' }}
                   unoptimized={contributor.image.endsWith('.gif')} // Basic unoptimization for gifs
                 />
               ) : (
-                <div className="w-full h-full bg-gray-300 dark:bg-gray-600 flex items-center justify-center text-gray-500 dark:text-gray-400 text-xs">
+                <div className="flex h-full w-full items-center justify-center bg-muted text-xs text-muted-foreground">
                   No Image
                 </div>
               )}
             </div>
-            <p className="text-sm font-medium text-gray-800 dark:text-gray-200 truncate w-full">{contributor.name}</p>
+            <p className="w-full truncate text-sm font-medium text-foreground">
+              {contributor.name}
+            </p>
             {/* Optional: Display role if needed */}
-            {/* <p className="text-xs text-gray-500 dark:text-gray-400">{contributor.role}</p> */}
+            {/* <p className="text-xs text-muted-foreground">{contributor.role}</p> */}
           </div>
         </Link>
       ))}
@@ -75,4 +90,4 @@ const OpenCollectiveContributors: React.FC<OpenCollectiveContributorsProps> = ({
   )
 }
 
-export default OpenCollectiveContributors 
+export default OpenCollectiveContributors

--- a/src/components/OptInForm.tsx
+++ b/src/components/OptInForm.tsx
@@ -13,10 +13,16 @@ interface OptInFormProps {
   initialOptInStatus: any
 }
 
-export default function OptInForm({ userId, userEmail, initialOptInStatus }: OptInFormProps) {
+export default function OptInForm({
+  userId,
+  userEmail,
+  initialOptInStatus,
+}: OptInFormProps) {
   const router = useRouter()
   const { userMetadata } = useAuthAndArchive()
-  const [isOptedIn, setIsOptedIn] = useState(initialOptInStatus?.opted_in || false)
+  const [isOptedIn, setIsOptedIn] = useState(
+    initialOptInStatus?.opted_in || false,
+  )
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState('')
   const [success, setSuccess] = useState('')
@@ -30,7 +36,9 @@ export default function OptInForm({ userId, userEmail, initialOptInStatus }: Opt
     setSuccess('')
 
     if (!twitterUsername) {
-      setError('Twitter username not found. Please make sure you signed in with Twitter.')
+      setError(
+        'Twitter username not found. Please make sure you signed in with Twitter.',
+      )
       return
     }
 
@@ -47,7 +55,7 @@ export default function OptInForm({ userId, userEmail, initialOptInStatus }: Opt
           username: twitterUsername.toLowerCase(),
           twitterUserId: twitterUserId || null,
           optedIn: !isOptedIn,
-          termsVersion: 'v1.0'
+          termsVersion: 'v1.0',
         }),
       })
 
@@ -59,11 +67,11 @@ export default function OptInForm({ userId, userEmail, initialOptInStatus }: Opt
 
       setIsOptedIn(!isOptedIn)
       setSuccess(
-        !isOptedIn 
-          ? 'Successfully opted in to tweet streaming!' 
-          : 'Successfully opted out of tweet streaming.'
+        !isOptedIn
+          ? 'Successfully opted in to tweet streaming!'
+          : 'Successfully opted out of tweet streaming.',
       )
-      
+
       router.refresh()
     } catch (err: any) {
       setError(err.message || 'An error occurred. Please try again.')
@@ -74,23 +82,28 @@ export default function OptInForm({ userId, userEmail, initialOptInStatus }: Opt
 
   if (!twitterUsername) {
     return (
-      <div className="p-4 bg-red-50 dark:bg-red-900/20 rounded-lg border border-red-200 dark:border-red-800">
+      <div className="rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-900/20">
         <p className="text-red-800 dark:text-red-200">
-          No Twitter account found. Please sign in with Twitter to use the opt-in feature.
+          No Twitter account found. Please sign in with Twitter to use the
+          opt-in feature.
         </p>
       </div>
     )
   }
 
   return (
-    <div className="text-center space-y-8">
-
+    <div className="space-y-8 text-center">
       {/* Current status as simple text */}
       <div className="text-center">
-        <p className="text-lg text-gray-700 dark:text-gray-300">
-          Current Status: <span className={`font-semibold ${
-            isOptedIn ? 'text-green-600 dark:text-green-400' : 'text-gray-600 dark:text-gray-400'
-          }`}>
+        <p className="text-lg text-muted-foreground">
+          Current Status:{' '}
+          <span
+            className={`font-semibold ${
+              isOptedIn
+                ? 'text-green-600 dark:text-green-400'
+                : 'text-muted-foreground'
+            }`}
+          >
             {isOptedIn ? 'Opted In' : 'Not Opted In'}
           </span>
         </p>
@@ -98,13 +111,13 @@ export default function OptInForm({ userId, userEmail, initialOptInStatus }: Opt
 
       {/* Error and success messages */}
       {error && (
-        <Alert variant="destructive" className="max-w-md mx-auto">
+        <Alert variant="destructive" className="mx-auto max-w-md">
           <AlertDescription>{error}</AlertDescription>
         </Alert>
       )}
 
       {success && (
-        <Alert className="border-green-500 bg-green-50 dark:bg-green-900/20 max-w-md mx-auto">
+        <Alert className="mx-auto max-w-md border-green-500 bg-green-50 dark:bg-green-900/20">
           <AlertDescription className="text-green-800 dark:text-green-200">
             {success}
           </AlertDescription>
@@ -118,13 +131,13 @@ export default function OptInForm({ userId, userEmail, initialOptInStatus }: Opt
             onClick={handleSubmit}
             disabled={isLoading}
             size="lg"
-            className="px-12 py-6 text-xl font-semibold min-w-[280px]"
+            className="min-w-[280px] px-12 py-6 text-xl font-semibold"
           >
             {isLoading ? 'Processing...' : 'Opt In to Tweet Streaming'}
           </Button>
         ) : (
           <div className="space-y-4">
-            <p className="text-lg text-green-600 dark:text-green-400 font-semibold">
+            <p className="text-lg font-semibold text-green-600 dark:text-green-400">
               ✓ You&apos;re opted in to tweet streaming!
             </p>
             <Link href="/profile">

--- a/src/components/SearchTweets.tsx
+++ b/src/components/SearchTweets.tsx
@@ -118,7 +118,7 @@ export default function SearchTweets({
           />
           <button
             onClick={handleSearch}
-            className="rounded bg-blue-500 px-4 py-2 text-white"
+            className="rounded bg-brand px-4 py-2 text-white"
             disabled={isLoading}
           >
             {isLoading ? 'Searching...' : 'Search'}
@@ -127,7 +127,7 @@ export default function SearchTweets({
       </div>
       <ScrollArea className="flex-grow">
         <div className="pr-4">
-          <UnifiedTweetList 
+          <UnifiedTweetList
             tweets={allTweets}
             isLoading={isLoading}
             emptyMessage="No tweets found"

--- a/src/components/ShowcasedApps.tsx
+++ b/src/components/ShowcasedApps.tsx
@@ -17,7 +17,7 @@ import {
   CarouselItem,
   CarouselNext,
   CarouselPrevious,
-} from "@/components/ui/carousel" // Import new carousel components
+} from '@/components/ui/carousel' // Import new carousel components
 
 interface AppItem {
   icon: React.ReactElement
@@ -49,13 +49,15 @@ const appsData: AppItem[] = [
   {
     icon: <FaRobot />,
     name: 'Banger Bot',
-    description: 'Write tweets based on RAG from the most liked tweets in the archive.',
+    description:
+      'Write tweets based on RAG from the most liked tweets in the archive.',
     link: 'https://theexgenesis--text-rag-ui-run.modal.run/',
   },
   {
     icon: <FaEye />,
     name: 'Birdseye',
-    description: 'Top down view of your tweets by topic and over time, with LLM analysis.',
+    description:
+      'Top down view of your tweets by topic and over time, with LLM analysis.',
     link: 'https://theexgenesis--community-archive-birdseye-run.modal.run/?username=romeostevens76',
   },
   {
@@ -67,18 +69,27 @@ const appsData: AppItem[] = [
   {
     icon: <FaHistory />,
     name: 'Historical Highlights Bot',
-    description: 'Posts highlights from the current day from past years (@ca_highlights).',
+    description:
+      'Posts highlights from the current day from past years (@ca_highlights).',
     link: 'https://www.val.town/v/exgenesis/ca_highlights',
   },
 ]
 
 const AppCard: React.FC<AppItem> = ({ icon, name, description, link }) => (
   <Link href={link} passHref legacyBehavior>
-    <a target="_blank" rel="noopener noreferrer" className="flex flex-col items-center p-6 bg-slate-100 dark:bg-gray-900 rounded-xl transition-shadow duration-300 h-full cursor-pointer">
-      <div className="text-4xl mb-4 text-blue-500 dark:text-blue-300">{icon}</div>
-      <h3 className="text-xl font-semibold mb-2 text-center text-gray-800 dark:text-gray-200">{name}</h3>
-      <p className="text-sm text-gray-600 dark:text-gray-400 text-center flex-grow">{description}</p>
-      <div className="mt-4 flex items-center text-xs text-gray-500 dark:text-gray-400">
+    <a
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex h-full cursor-pointer flex-col items-center rounded-xl bg-muted p-6 transition-shadow duration-300 dark:bg-card"
+    >
+      <div className="mb-4 text-4xl text-brand">{icon}</div>
+      <h3 className="mb-2 text-center text-xl font-semibold text-foreground">
+        {name}
+      </h3>
+      <p className="flex-grow text-center text-sm text-muted-foreground">
+        {description}
+      </p>
+      <div className="mt-4 flex items-center text-xs text-muted-foreground">
         View App <FaExternalLinkAlt className="ml-1.5" />
       </div>
     </a>
@@ -91,32 +102,38 @@ export default function ShowcasedApps() {
   }
 
   return (
-    <section className="space-y-8 w-full">
+    <section className="w-full space-y-8">
       <div className="text-center">
-        <h2 className="text-3xl font-semibold text-gray-900 dark:text-white">Built with the Archive</h2>
-        <p className="mt-3 text-lg text-gray-600 dark:text-gray-300 max-w-xl mx-auto">
-          Explore apps and tools developed by the community using this open data.
+        <h2 className="text-3xl font-semibold text-foreground">
+          Built with the Archive
+        </h2>
+        <p className="mx-auto mt-3 max-w-xl text-lg text-muted-foreground">
+          Explore apps and tools developed by the community using this open
+          data.
         </p>
       </div>
       <Carousel
         opts={{
-          align: "center",
+          align: 'center',
           loop: true,
         }}
-        className="w-full max-w-xs sm:max-w-xl md:max-w-2xl lg:max-w-4xl xl:max-w-5xl mx-auto"
+        className="mx-auto w-full max-w-xs sm:max-w-xl md:max-w-2xl lg:max-w-4xl xl:max-w-5xl"
       >
         <CarouselContent className="-ml-1">
           {appsData.map((app, index) => (
-            <CarouselItem key={index} className="pl-1 basis-4/5 md:basis-2/5 lg:basis-[26.66%]">
-              <div className="p-1 h-full">
+            <CarouselItem
+              key={index}
+              className="basis-4/5 pl-1 md:basis-2/5 lg:basis-[26.66%]"
+            >
+              <div className="h-full p-1">
                 <AppCard {...app} />
               </div>
             </CarouselItem>
           ))}
         </CarouselContent>
-        <CarouselPrevious className="ml-[-10px] sm:ml-[-20px] md:ml-2 lg:ml-4 xl:ml-6"/>
-        <CarouselNext className="mr-[-10px] sm:mr-[-20px] md:mr-2 lg:mr-4 xl:mr-6"/>
+        <CarouselPrevious className="ml-[-10px] sm:ml-[-20px] md:ml-2 lg:ml-4 xl:ml-6" />
+        <CarouselNext className="mr-[-10px] sm:mr-[-20px] md:mr-2 lg:mr-4 xl:mr-6" />
       </Carousel>
     </section>
   )
-} 
+}

--- a/src/components/SignIn.tsx
+++ b/src/components/SignIn.tsx
@@ -8,14 +8,18 @@ import { useState } from 'react'
 // Seeded mock users available for staging dev-login bypass.
 // Keep in sync with supabase/seed.sql.
 const STAGING_USERS = [
-  { username: 'alice_dev', providerId: 'mock_alice', displayName: 'Alice Developer' },
-  { username: 'xiq_dev',   providerId: 'mock_xiq',   displayName: 'XIQ Dev' },
+  {
+    username: 'alice_dev',
+    providerId: 'mock_alice',
+    displayName: 'Alice Developer',
+  },
+  { username: 'xiq_dev', providerId: 'mock_xiq', displayName: 'XIQ Dev' },
 ] as const
 
 export default function SignIn() {
   const searchParams = useSearchParams()
   const redirectTo = searchParams.get('redirect')
-  const { userMetadata, isArchiveUploaded } = useAuthAndArchive()
+  const { userMetadata } = useAuthAndArchive()
   const isDevLoginEnabled =
     process.env.NODE_ENV === 'development' ||
     process.env.NEXT_PUBLIC_ENABLE_STAGING_DEV_LOGIN === 'true'
@@ -27,9 +31,8 @@ export default function SignIn() {
   const asParam = searchParams.get('as')
   const initialUser =
     STAGING_USERS.find((u) => u.username === asParam) ?? STAGING_USERS[0]
-  const [selectedUser, setSelectedUser] = useState<(typeof STAGING_USERS)[number]>(
-    initialUser,
-  )
+  const [selectedUser, setSelectedUser] =
+    useState<(typeof STAGING_USERS)[number]>(initialUser)
 
   const signIn = async () => {
     const supabase = createBrowserClient()
@@ -106,34 +109,18 @@ export default function SignIn() {
     }
   }
 
-  const handleSignOut = async () => {
-    const supabase = createBrowserClient()
-    const { error } = await supabase.auth.signOut()
-    devLog('sign out', { error })
-    if (!error) {
-      window.location.reload()
-    }
-  }
-
-  return userMetadata ? (
-    <form action={handleSignOut} className="inline-block">
-      <button
-        type="submit"
-        className="whitespace-nowrap rounded-md bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
-      >
-        Sign Out
-      </button>
-    </form>
-  ) : (
+  return userMetadata ? null : (
     <div className="inline-flex items-center gap-2">
       {isStagingLogin && (
         <select
           value={selectedUser.username}
           onChange={(e) => {
-            const next = STAGING_USERS.find((u) => u.username === e.target.value)
+            const next = STAGING_USERS.find(
+              (u) => u.username === e.target.value,
+            )
             if (next) setSelectedUser(next)
           }}
-          className="rounded-md border border-yellow-700 bg-white px-2 py-1.5 text-sm font-medium text-yellow-900 focus:outline-none focus:ring-2 focus:ring-yellow-500 dark:border-yellow-500 dark:bg-gray-800 dark:text-yellow-200"
+          className="rounded-md border border-yellow-700 bg-card px-2 py-1.5 text-sm font-medium text-yellow-900 focus:outline-none focus:ring-2 focus:ring-yellow-500 dark:border-yellow-500 dark:bg-card dark:text-yellow-200"
           aria-label="Pick staging mock user"
         >
           {STAGING_USERS.map((u) => (
@@ -146,21 +133,21 @@ export default function SignIn() {
       <form action={signIn} className="inline-block">
         <button
           type="submit"
-          className={`rounded-[8px] border border-transparent px-4 py-2 text-sm font-medium text-white transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-gray-800 ${
+          className={`rounded-[8px] border border-transparent px-4 py-2 text-sm font-medium text-white transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-background ${
             isDevLoginEnabled
               ? 'bg-yellow-600 hover:bg-yellow-700 focus:ring-yellow-500 dark:bg-yellow-500 dark:hover:bg-yellow-600'
-              : 'bg-green-600 hover:bg-green-700 focus:ring-green-500 dark:bg-green-400 dark:hover:bg-green-300 dark:text-green-950'
+              : 'bg-green-600 hover:bg-green-700 focus:ring-green-500 dark:bg-green-400 dark:text-green-950 dark:hover:bg-green-300'
           }`}
         >
-          {isStagingLogin
-            ? `Sign in as ${selectedUser.displayName}`
-            : isDevLoginEnabled
-              ? 'Sign in (Dev Mode)'
-              : (
-                <>
-                  Sign in<span className="hidden sm:inline"> with Twitter</span>
-                </>
-              )}
+          {isStagingLogin ? (
+            `Sign in as ${selectedUser.displayName}`
+          ) : isDevLoginEnabled ? (
+            'Sign in (Dev Mode)'
+          ) : (
+            <>
+              Sign in<span className="hidden sm:inline"> with Twitter</span>
+            </>
+          )}
         </button>
       </form>
     </div>

--- a/src/components/ThreadView.tsx
+++ b/src/components/ThreadView.tsx
@@ -8,10 +8,10 @@ interface ThreadViewProps {
   className?: string
 }
 
-export const ThreadView: React.FC<ThreadViewProps> = ({ 
-  tree, 
+export const ThreadView: React.FC<ThreadViewProps> = ({
+  tree,
   highlightTweetId,
-  className = "" 
+  className = '',
 }) => {
   // Convert ThreadTweet to TweetData format for TweetComponent
   const convertToTweetData = (tweet: ThreadTweet) => ({
@@ -30,47 +30,58 @@ export const ThreadView: React.FC<ThreadViewProps> = ({
     account_display_name: tweet.account_display_name,
     media: tweet.media || [],
     urls: [],
-    reply_to_username: tweet.reply_to_username || undefined
+    reply_to_username: tweet.reply_to_username || undefined,
   })
 
   // Render tweet with children recursively
-  const renderTweetWithThread = (tweetId: string, depth: number = 0): JSX.Element => {
+  const renderTweetWithThread = (
+    tweetId: string,
+    depth: number = 0,
+  ): JSX.Element => {
     const tweet = tree.tweets[tweetId]
     const children = tree.children[tweetId] || []
     const isHighlighted = highlightTweetId === tweetId
 
     return (
-      <div key={tweetId} className={`thread-tweet-container ${depth > 0 ? 'ml-8 pl-4 border-l-2 border-gray-200 dark:border-gray-700' : ''}`}>
+      <div
+        key={tweetId}
+        className={`thread-tweet-container ${depth > 0 ? 'ml-8 border-l-2 border-border pl-4' : ''}`}
+      >
         {tweet.is_deleted_placeholder ? (
           // Tombstone — deleted from the archive AND syndication couldn't find it.
-          <div className="border border-dashed border-gray-300 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/40 text-gray-500 dark:text-gray-400 italic p-4 rounded-lg mb-4 text-sm">
+          <div className="mb-4 rounded-lg border border-dashed border-border bg-muted p-4 text-sm italic text-muted-foreground dark:bg-card">
             [Tweet deleted]
           </div>
         ) : (
-          <div className={`
-            ${isHighlighted ? 'bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800' : tweet.from_external ? 'bg-amber-50/60 dark:bg-amber-900/10 border border-dashed border-amber-300 dark:border-amber-700' : 'bg-background dark:bg-secondary'}
-            p-4 rounded-lg mb-4 relative
-          `}>
+          <div
+            className={`
+            ${isHighlighted ? 'border border-border bg-muted' : tweet.from_external ? 'border border-dashed border-amber-300 bg-amber-50/60 dark:border-amber-700 dark:bg-amber-900/10' : 'bg-background dark:bg-secondary'}
+            relative mb-4 rounded-lg p-4
+          `}
+          >
             {tweet.from_external && (
               // Hydrated at render time from Twitter syndication — not stored in our
               // archive, not returned in search.
-              <span className="absolute right-3 top-3 text-[10px] uppercase tracking-wide text-amber-700 dark:text-amber-300 bg-amber-100 dark:bg-amber-900/40 px-1.5 py-0.5 rounded">
+              <span className="absolute right-3 top-3 rounded bg-amber-100 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
                 from Twitter · not archived
               </span>
             )}
             <TweetComponent tweet={convertToTweetData(tweet)} />
           </div>
         )}
-        
+
         {children.length > 0 && (
           <div className="thread-children">
             {children
               .sort((a, b) => {
                 const tweetA = tree.tweets[a]
                 const tweetB = tree.tweets[b]
-                return new Date(tweetA.created_at).getTime() - new Date(tweetB.created_at).getTime()
+                return (
+                  new Date(tweetA.created_at).getTime() -
+                  new Date(tweetB.created_at).getTime()
+                )
               })
-              .map(childId => renderTweetWithThread(childId, depth + 1))}
+              .map((childId) => renderTweetWithThread(childId, depth + 1))}
           </div>
         )}
       </div>
@@ -80,14 +91,17 @@ export const ThreadView: React.FC<ThreadViewProps> = ({
   // Render all roots. When some parent tweets in the conversation were deleted, each
   // surviving orphan reply gets a synthesized placeholder parent that becomes its own
   // root, so the tree can have more than one.
-  const allRoots = tree.roots && tree.roots.length > 0
-    ? tree.roots
-    : tree.root ? [tree.root] : []
+  const allRoots =
+    tree.roots && tree.roots.length > 0
+      ? tree.roots
+      : tree.root
+        ? [tree.root]
+        : []
 
   if (allRoots.length === 0) {
     return (
-      <div className={`${className} text-center py-8`}>
-        <p className="text-gray-500 dark:text-gray-400">No thread structure found</p>
+      <div className={`${className} py-8 text-center`}>
+        <p className="text-muted-foreground">No thread structure found</p>
       </div>
     )
   }
@@ -100,7 +114,7 @@ export const ThreadView: React.FC<ThreadViewProps> = ({
   return (
     <div className={`thread-view ${className}`}>
       <div className="mb-4">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+        <h3 className="mb-2 text-lg font-semibold text-foreground">
           🧵 Thread ({realCount} {realCount === 1 ? 'tweet' : 'tweets'})
         </h3>
       </div>

--- a/src/components/TieredSupportersDisplay.tsx
+++ b/src/components/TieredSupportersDisplay.tsx
@@ -23,53 +23,67 @@ interface TieredSupportersDisplayProps {
   totalSupportersCount: number
 }
 
-const TieredSupportersDisplay: React.FC<TieredSupportersDisplayProps> = ({ 
+const TieredSupportersDisplay: React.FC<TieredSupportersDisplayProps> = ({
   highestDonorWithImage,
   otherDonorsForStack,
   topTenNames,
-  additionalSupportersCount, 
+  additionalSupportersCount,
   totalAmountRaised,
-  totalSupportersCount
+  totalSupportersCount,
 }) => {
-
-  const imageStack = highestDonorWithImage 
-    ? [highestDonorWithImage, ...otherDonorsForStack.slice(0,9)] 
-    : otherDonorsForStack.slice(0,10);
+  const imageStack = highestDonorWithImage
+    ? [highestDonorWithImage, ...otherDonorsForStack.slice(0, 9)]
+    : otherDonorsForStack.slice(0, 10)
 
   // --- BEGIN DEBUG LOG ---
-  if (typeof window !== 'undefined') { 
-    console.log('[TieredSupportersDisplay] highestDonorWithImage:', highestDonorWithImage ? highestDonorWithImage.name : 'None');
-    console.log('[TieredSupportersDisplay] otherDonorsForStack received length:', otherDonorsForStack.length);
-    console.log('[TieredSupportersDisplay] otherDonorsForStack names:', otherDonorsForStack.map(c=>c.name));
-    console.log('[TieredSupportersDisplay] Final imageStack length:', imageStack.length);
-    console.log('[TieredSupportersDisplay] Final imageStack names:', imageStack.map(c=>c.name));
+  if (typeof window !== 'undefined') {
+    console.log(
+      '[TieredSupportersDisplay] highestDonorWithImage:',
+      highestDonorWithImage ? highestDonorWithImage.name : 'None',
+    )
+    console.log(
+      '[TieredSupportersDisplay] otherDonorsForStack received length:',
+      otherDonorsForStack.length,
+    )
+    console.log(
+      '[TieredSupportersDisplay] otherDonorsForStack names:',
+      otherDonorsForStack.map((c) => c.name),
+    )
+    console.log(
+      '[TieredSupportersDisplay] Final imageStack length:',
+      imageStack.length,
+    )
+    console.log(
+      '[TieredSupportersDisplay] Final imageStack names:',
+      imageStack.map((c) => c.name),
+    )
   }
   // --- END DEBUG LOG ---
 
   return (
-    <div className="w-full flex flex-col items-center space-y-6">
+    <div className="flex w-full flex-col items-center space-y-6">
       {/* Top Row: Money, Icons, Count */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-x-6 gap-y-4 items-center w-full max-w-3xl">
-        
+      <div className="grid w-full max-w-3xl grid-cols-1 items-center gap-x-6 gap-y-4 md:grid-cols-3">
         {/* Column 1: Money Raised */}
-        <div className="flex flex-col justify-center items-center text-center order-1 h-full">
+        <div className="order-1 flex h-full flex-col items-center justify-center text-center">
           <div>
-            <p className="text-2xl lg:text-3xl font-bold text-green-600 dark:text-green-400">
+            <p className="text-2xl font-bold text-green-600 dark:text-green-400 lg:text-3xl">
               ${formatNumber(totalAmountRaised)}
             </p>
-            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">Raised</p>
+            <p className="mt-1 text-xs text-muted-foreground">Raised</p>
           </div>
         </div>
 
         {/* Column 2: Image Stack (Centered) */}
-        <div className="flex flex-col items-center justify-center order-3 md:order-2 mt-4 md:mt-0 h-full">
+        <div className="order-3 mt-4 flex h-full flex-col items-center justify-center md:order-2 md:mt-0">
           {imageStack.length > 0 && (
-            <div className="relative h-24 md:h-28 w-full min-w-[240px]">
+            <div className="relative h-24 w-full min-w-[240px] md:h-28">
               {imageStack.map((contributor, index) => {
-                const numImages = imageStack.length;
-                const itemOffset = 36;
-                const groupCenterOffset = (numImages - 1) * itemOffset / 2;
-                const positionWithinStack = (index * itemOffset) - groupCenterOffset;
+                const numImages = imageStack.length
+                const itemOffset = 36
+                const groupCenterOffset = ((numImages - 1) * itemOffset) / 2
+                const positionWithinStack =
+                  index * itemOffset - groupCenterOffset
 
                 return (
                   <Link
@@ -78,7 +92,7 @@ const TieredSupportersDisplay: React.FC<TieredSupportersDisplayProps> = ({
                     passHref
                     target="_blank"
                     rel="noopener noreferrer"
-                    className={`absolute rounded-full overflow-hidden shadow-lg border-2 border-white dark:border-slate-700 hover:scale-105 hover:z-20 transition-all duration-300 ease-in-out bg-white dark:bg-slate-600`}
+                    className={`absolute overflow-hidden rounded-full border-2 border-white bg-card shadow-lg transition-all duration-300 ease-in-out hover:z-20 hover:scale-105 dark:border-border dark:bg-muted`}
                     style={{
                       zIndex: imageStack.length - index,
                       left: `calc(50% + ${positionWithinStack}px)`,
@@ -90,16 +104,16 @@ const TieredSupportersDisplay: React.FC<TieredSupportersDisplayProps> = ({
                     title={contributor.name}
                   >
                     {contributor.image ? (
-                      <Image 
-                        src={contributor.image} 
-                        alt={`${contributor.name}'s avatar`} 
-                        fill 
+                      <Image
+                        src={contributor.image}
+                        alt={`${contributor.name}'s avatar`}
+                        fill
                         sizes="(max-width: 768px) 50vw, (max-width: 1200px) 80px, 96px"
                         style={{ objectFit: 'cover' }}
                         unoptimized={contributor.image.endsWith('.gif')}
                       />
                     ) : (
-                      <div className="w-full h-full bg-gray-300 dark:bg-gray-600 flex items-center justify-center text-white text-xs">
+                      <div className="flex h-full w-full items-center justify-center bg-muted text-xs text-white">
                         {contributor.name.charAt(0)}
                       </div>
                     )}
@@ -111,12 +125,12 @@ const TieredSupportersDisplay: React.FC<TieredSupportersDisplayProps> = ({
         </div>
 
         {/* Column 3: Supporter Count */}
-        <div className="flex flex-col justify-center items-center text-center order-2 md:order-3 h-full">
+        <div className="order-2 flex h-full flex-col items-center justify-center text-center md:order-3">
           <div>
-            <p className="text-2xl lg:text-3xl font-bold text-blue-600 dark:text-blue-300">
+            <p className="text-2xl font-bold text-brand lg:text-3xl">
               {formatNumber(totalSupportersCount)}
             </p>
-            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">Supporters</p>
+            <p className="mt-1 text-xs text-muted-foreground">Supporters</p>
           </div>
         </div>
       </div>
@@ -124,22 +138,32 @@ const TieredSupportersDisplay: React.FC<TieredSupportersDisplayProps> = ({
       {/* Bottom Row: Textual Acknowledgment (Centered) */}
       <div className="w-full max-w-xl text-center">
         {topTenNames.length > 0 && (
-          <p className="text-gray-600 dark:text-gray-400 text-sm">
+          <p className="text-sm text-muted-foreground">
             {topTenNames.join(', ')}
             {additionalSupportersCount > 0 && (
-              <span className="text-gray-500 dark:text-gray-500">, +{additionalSupportersCount} more</span>
+              <span className="text-muted-foreground">
+                , +{additionalSupportersCount} more
+              </span>
             )}
           </p>
         )}
-        {(imageStack.length === 0 && topTenNames.length === 0 && totalSupportersCount > 0) && (
-           <p className="text-gray-600 dark:text-gray-400 text-sm">We are grateful for all {totalSupportersCount} of our supporters!</p>
-        )}
-         {(imageStack.length === 0 && topTenNames.length === 0 && totalSupportersCount === 0) && (
-           <p className="text-gray-600 dark:text-gray-400 text-sm">Become our first supporter!</p>
-        )}
+        {imageStack.length === 0 &&
+          topTenNames.length === 0 &&
+          totalSupportersCount > 0 && (
+            <p className="text-sm text-muted-foreground">
+              We are grateful for all {totalSupportersCount} of our supporters!
+            </p>
+          )}
+        {imageStack.length === 0 &&
+          topTenNames.length === 0 &&
+          totalSupportersCount === 0 && (
+            <p className="text-sm text-muted-foreground">
+              Become our first supporter!
+            </p>
+          )}
       </div>
     </div>
   )
 }
 
-export default TieredSupportersDisplay 
+export default TieredSupportersDisplay

--- a/src/components/TopMentionedMissingUsers.tsx
+++ b/src/components/TopMentionedMissingUsers.tsx
@@ -162,7 +162,7 @@ export default function TopMentionedUsers({
                     {user.account_display_name && (
                       <div
                         key={`screen-name-${user.mentioned_user_id}`}
-                        className="text-sm text-gray-500"
+                        className="text-sm text-muted-foreground"
                       >
                         @{user.screen_name}
                       </div>

--- a/src/components/TweetComponent.tsx
+++ b/src/components/TweetComponent.tsx
@@ -55,18 +55,18 @@ export interface TweetData {
     from_external?: boolean
   }
   // Support both interface styles for compatibility
-  account?: { 
+  account?: {
     profile?: {
       avatar_media_url?: string
-    },
-    username?: string, 
-    account_display_name?: string 
+    }
+    username?: string
+    account_display_name?: string
   }
   // For RT tweets with mentioned user data
   mentioned_users?: {
     mentioned_user: {
       user_id: string
-      name: string 
+      name: string
       screen_name: string
       account?: {
         username: string
@@ -103,37 +103,49 @@ const decodeHtmlEntities = (text: string): string => {
   return textarea.value
 }
 
-export const TweetComponent: React.FC<TweetComponentProps> = ({ tweet, className = "" }) => {
+export const TweetComponent: React.FC<TweetComponentProps> = ({
+  tweet,
+  className = '',
+}) => {
   // Support both interface formats for backwards compatibility
-  const originalUsername = tweet.username || tweet.account?.username || 'Unknown'
-  const originalDisplayName = tweet.account_display_name || tweet.account?.account_display_name || 'Unknown'
-  const originalProfilePicUrl = tweet.avatar_media_url || tweet.account?.profile?.avatar_media_url || '/placeholder.jpg'
+  const originalUsername =
+    tweet.username || tweet.account?.username || 'Unknown'
+  const originalDisplayName =
+    tweet.account_display_name ||
+    tweet.account?.account_display_name ||
+    'Unknown'
+  const originalProfilePicUrl =
+    tweet.avatar_media_url ||
+    tweet.account?.profile?.avatar_media_url ||
+    '/placeholder.jpg'
   const replyToUsername = tweet.reply_to_username
 
   const isRetweet = !!tweet.retweeted_tweet_id
   const isQuoteTweet = !!tweet.quote_tweet_id
-  
+
   // Check if this is a retweet that starts with "RT @username"
   const rtMatch = tweet.full_text.match(/^RT @([A-Za-z0-9_]+):/)
   const isRtFormat = !!rtMatch
-  
+
   // For RT tweets, we want to show the retweeted user's info, not the retweeter's
   let displayUsername = originalUsername
-  let displayName = originalDisplayName  
+  let displayName = originalDisplayName
   let profilePicUrl = originalProfilePicUrl
-  
+
   if (isRtFormat && rtMatch) {
     const rtUsername = rtMatch[1]
     // Look for the retweeted user in mentioned_users to get their data
-    const mentionedUserRecord = tweet.mentioned_users?.find(userRecord => 
-      userRecord.mentioned_user.screen_name.toLowerCase() === rtUsername.toLowerCase()
+    const mentionedUserRecord = tweet.mentioned_users?.find(
+      (userRecord) =>
+        userRecord.mentioned_user.screen_name.toLowerCase() ===
+        rtUsername.toLowerCase(),
     )
-    
+
     if (mentionedUserRecord) {
       const mentionedUser = mentionedUserRecord.mentioned_user
       displayUsername = mentionedUser.screen_name
       displayName = mentionedUser.name
-      
+
       // Use the mentioned user's avatar if available, otherwise use placeholder
       if (mentionedUser.account?.profile?.avatar_media_url) {
         profilePicUrl = mentionedUser.account.profile.avatar_media_url
@@ -149,20 +161,22 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({ tweet, className
     }
   }
 
-  
-
   const formatText = (text: string) => {
     // First decode HTML entities
     let formattedText = decodeHtmlEntities(text)
 
     // Replace t.co URLs with their expanded versions or display URLs
     if (tweet.urls) {
-      tweet.urls.forEach(url => {
+      tweet.urls.forEach((url) => {
         if (url.display_url) {
           const tcoRegex = new RegExp('https://t\\.co/\\w+', 'g')
           formattedText = formattedText.replace(tcoRegex, () => {
             // For quote tweets, don't show the Twitter URL inline
-            if (url.expanded_url && url.expanded_url.includes('twitter.com/') && url.expanded_url.includes('/status/')) {
+            if (
+              url.expanded_url &&
+              url.expanded_url.includes('twitter.com/') &&
+              url.expanded_url.includes('/status/')
+            ) {
               return ''
             }
             return url.expanded_url || url.display_url
@@ -173,22 +187,25 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({ tweet, className
 
     // Simple URL detection and conversion to links for any remaining URLs
     const urlRegex = /(https?:\/\/[^\s]+)/g
-    return formattedText.split(urlRegex).map((part, index) => {
-      if (urlRegex.test(part)) {
-        return (
-          <a 
-            key={index} 
-            href={part} 
-            target="_blank" 
-            rel="noopener noreferrer"
-            className="text-blue-500 hover:text-blue-600 dark:text-blue-300 dark:hover:text-blue-300"
-          >
-            {part}
-          </a>
-        )
-      }
-      return part
-    }).filter(part => part !== '') // Remove empty strings
+    return formattedText
+      .split(urlRegex)
+      .map((part, index) => {
+        if (urlRegex.test(part)) {
+          return (
+            <a
+              key={index}
+              href={part}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-brand hover:text-brand"
+            >
+              {part}
+            </a>
+          )
+        }
+        return part
+      })
+      .filter((part) => part !== '') // Remove empty strings
   }
 
   const renderMedia = () => {
@@ -199,15 +216,23 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({ tweet, className
     return (
       <div className="my-2 flex flex-col space-y-2">
         {mediaArray
-          .filter((m: any) => m.media_type === 'photo' || m.media_type.startsWith('image/') || m.media_type === 'video')
+          .filter(
+            (m: any) =>
+              m.media_type === 'photo' ||
+              m.media_type.startsWith('image/') ||
+              m.media_type === 'video',
+          )
           .map((mediaItem: any, index: number) => (
-            <div key={index} className="relative overflow-hidden rounded-lg border dark:border-gray-700">
-              <NextImage 
-                src={mediaItem.media_url} 
+            <div
+              key={index}
+              className="relative overflow-hidden rounded-lg border dark:border-border"
+            >
+              <NextImage
+                src={mediaItem.media_url}
                 alt={`Tweet image ${index + 1}`}
                 width={mediaItem.width || 600}
                 height={mediaItem.height || 400}
-                className="object-contain w-full h-auto max-h-96"
+                className="h-auto max-h-96 w-full object-contain"
               />
             </div>
           ))}
@@ -224,7 +249,7 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({ tweet, className
     // show an empty card.
     if (quotedTweet.is_deleted) {
       return (
-        <div className="mt-3 border border-dashed border-gray-300 dark:border-gray-700 rounded-lg p-3 bg-gray-50 dark:bg-gray-900/40 text-sm italic text-gray-500 dark:text-gray-400">
+        <div className="mt-3 rounded-lg border border-dashed border-border bg-muted p-3 text-sm italic text-muted-foreground dark:bg-card">
           [Quoted tweet deleted]
         </div>
       )
@@ -234,12 +259,12 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({ tweet, className
     // from this archive.
     const externalClasses = quotedTweet.from_external
       ? 'border-dashed border-amber-300 dark:border-amber-700 bg-amber-50/60 dark:bg-amber-900/10'
-      : 'border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-card'
-    
+      : 'border-border bg-muted dark:bg-card'
+
     return (
-      <div className={`mt-3 border rounded-lg p-3 relative ${externalClasses}`}>
+      <div className={`relative mt-3 rounded-lg border p-3 ${externalClasses}`}>
         {quotedTweet.from_external && (
-          <span className="absolute right-2 top-2 text-[10px] uppercase tracking-wide text-amber-700 dark:text-amber-300 bg-amber-100 dark:bg-amber-900/40 px-1.5 py-0.5 rounded">
+          <span className="absolute right-2 top-2 rounded bg-amber-100 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
             from Twitter · not archived
           </span>
         )}
@@ -249,65 +274,82 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({ tweet, className
               src={quotedProfilePic}
               alt={`${quotedTweet.account_display_name}'s profile picture`}
             />
-            <AvatarFallback>{quotedTweet.account_display_name?.charAt(0) || quotedTweet.username?.charAt(0) || 'U'}</AvatarFallback>
+            <AvatarFallback>
+              {quotedTweet.account_display_name?.charAt(0) ||
+                quotedTweet.username?.charAt(0) ||
+                'U'}
+            </AvatarFallback>
           </Avatar>
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center space-x-1 mb-1">
-              <span className="font-bold text-sm text-gray-900 dark:text-white">
+          <div className="min-w-0 flex-1">
+            <div className="mb-1 flex items-center space-x-1">
+              <span className="text-sm font-bold text-foreground">
                 {quotedTweet.account_display_name}
               </span>
-              <span className="text-gray-500 dark:text-gray-400 text-sm">
+              <span className="text-sm text-muted-foreground">
                 @{quotedTweet.username}
               </span>
-              <span className="text-gray-500 dark:text-gray-400 text-xs">
-                • {formatDistanceToNow(new Date(quotedTweet.created_at), { addSuffix: true })}
+              <span className="text-xs text-muted-foreground">
+                •{' '}
+                {formatDistanceToNow(new Date(quotedTweet.created_at), {
+                  addSuffix: true,
+                })}
               </span>
             </div>
-            <p className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap break-words">
+            <p className="whitespace-pre-wrap break-words text-sm text-muted-foreground">
               {decodeHtmlEntities(quotedTweet.full_text)}
             </p>
             {quotedTweet.media && quotedTweet.media.length > 0 && (
               <div className="mt-2 flex flex-col space-y-1">
                 {quotedTweet.media
-                  .filter((m: any) => m.media_type === 'photo' || m.media_type.startsWith('image/') || m.media_type === 'video')
+                  .filter(
+                    (m: any) =>
+                      m.media_type === 'photo' ||
+                      m.media_type.startsWith('image/') ||
+                      m.media_type === 'video',
+                  )
                   .map((mediaItem: any, index: number) => (
-                    <div key={index} className="relative overflow-hidden rounded-md border dark:border-gray-600">
-                      <NextImage 
-                        src={mediaItem.media_url} 
+                    <div
+                      key={index}
+                      className="relative overflow-hidden rounded-md border dark:border-border"
+                    >
+                      <NextImage
+                        src={mediaItem.media_url}
                         alt={`Quoted tweet image ${index + 1}`}
                         width={300}
                         height={200}
-                        className="object-contain w-full h-auto max-h-48"
+                        className="h-auto max-h-48 w-full object-contain"
                       />
                     </div>
                   ))}
               </div>
             )}
-            <div className="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400 mt-2">
+            <div className="mt-2 flex items-center justify-between text-xs text-muted-foreground">
               <div className="flex items-center space-x-4">
                 <span className="flex items-center">
-                  <FaHeart className="mr-1" /> {formatNumber(quotedTweet.favorite_count)}
+                  <FaHeart className="mr-1" />{' '}
+                  {formatNumber(quotedTweet.favorite_count)}
                 </span>
                 <span className="flex items-center">
-                  <FaRetweet className="mr-1" /> {formatNumber(quotedTweet.retweet_count ?? 0)}
+                  <FaRetweet className="mr-1" />{' '}
+                  {formatNumber(quotedTweet.retweet_count ?? 0)}
                 </span>
               </div>
               <div className="flex items-center space-x-3">
                 <a
                   href={`/tweets/${quotedTweet.tweet_id}`}
-                  className="hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                  className="transition-colors hover:text-foreground"
                   title="Permalink to quoted tweet"
                 >
-                  <FaExternalLinkAlt className="w-3 h-3" />
+                  <FaExternalLinkAlt className="h-3 w-3" />
                 </a>
                 <a
                   href={`https://twitter.com/${quotedTweet.username}/status/${quotedTweet.tweet_id}`}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                  className="transition-colors hover:text-foreground"
                   title="View quoted tweet on Twitter"
                 >
-                  <FaExternalLinkAlt className="w-3 h-3" />
+                  <FaExternalLinkAlt className="h-3 w-3" />
                 </a>
               </div>
             </div>
@@ -320,7 +362,7 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({ tweet, className
   return (
     <div className={className}>
       {(isRetweet || isRtFormat) && (
-        <div className="flex items-center mb-2 text-sm text-gray-500 dark:text-gray-400">
+        <div className="mb-2 flex items-center text-sm text-muted-foreground">
           <FaRetweet className="mr-2" />
           {originalUsername} retweeted
         </div>
@@ -332,22 +374,25 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({ tweet, className
             src={profilePicUrl}
             alt={`${displayName}'s profile picture`}
           />
-          <AvatarFallback>{displayName?.charAt(0) || displayUsername?.charAt(0) || 'U'}</AvatarFallback>
+          <AvatarFallback>
+            {displayName?.charAt(0) || displayUsername?.charAt(0) || 'U'}
+          </AvatarFallback>
         </Avatar>
-        <div className="flex-1 min-w-0">
+        <div className="min-w-0 flex-1">
           <div className="flex items-center">
-            <span className="mr-2 font-bold text-gray-900 dark:text-white">
+            <span className="mr-2 font-bold text-foreground">
               {displayName}
             </span>
-            <span className="text-gray-500 dark:text-gray-400">
-              @{displayUsername}
-            </span>
-            <span className="text-gray-500 dark:text-gray-400 text-sm ml-2">
-              • {formatDistanceToNow(new Date(tweet.created_at), { addSuffix: true })}
+            <span className="text-muted-foreground">@{displayUsername}</span>
+            <span className="ml-2 text-sm text-muted-foreground">
+              •{' '}
+              {formatDistanceToNow(new Date(tweet.created_at), {
+                addSuffix: true,
+              })}
             </span>
           </div>
           {replyToUsername && (
-            <div className="flex items-center text-sm text-gray-500 dark:text-gray-400">
+            <div className="flex items-center text-sm text-muted-foreground">
               <FaReply className="mr-1" />
               Replying to @{replyToUsername}
             </div>
@@ -355,39 +400,40 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({ tweet, className
         </div>
       </div>
 
-      <p className="mb-2 text-gray-700 dark:text-gray-300 whitespace-pre-wrap break-words">
+      <p className="mb-2 whitespace-pre-wrap break-words text-muted-foreground">
         {formatText(tweet.full_text)}
       </p>
-      
+
       {renderMedia()}
       {renderQuotedTweet()}
 
-      <div className="flex items-center justify-between text-sm text-gray-500 dark:text-gray-400">
+      <div className="flex items-center justify-between text-sm text-muted-foreground">
         <div className="flex items-center space-x-4">
           <span className="flex items-center">
             <FaHeart className="mr-1" /> {formatNumber(tweet.favorite_count)}
           </span>
           <span className="flex items-center">
-            <FaRetweet className="mr-1" /> {formatNumber(tweet.retweet_count ?? 0)}
+            <FaRetweet className="mr-1" />{' '}
+            {formatNumber(tweet.retweet_count ?? 0)}
           </span>
         </div>
-        <div className="flex items-center space-x-3 text-xs text-gray-400 dark:text-gray-500">
+        <div className="flex items-center space-x-3 text-xs text-muted-foreground">
           <span>{new Date(tweet.created_at).toLocaleDateString()}</span>
           <a
             href={`/tweets/${tweet.tweet_id}`}
-            className="hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+            className="transition-colors hover:text-foreground"
             title="Permalink"
           >
-            <FaExternalLinkAlt className="w-3 h-3" />
+            <FaExternalLinkAlt className="h-3 w-3" />
           </a>
           <a
             href={`https://twitter.com/${displayUsername}/status/${tweet.tweet_id}`}
             target="_blank"
             rel="noopener noreferrer"
-            className="hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+            className="transition-colors hover:text-foreground"
             title="View on Twitter"
           >
-            <FaExternalLinkAlt className="w-3 h-3" />
+            <FaExternalLinkAlt className="h-3 w-3" />
           </a>
         </div>
       </div>

--- a/src/components/TweetList.tsx
+++ b/src/components/TweetList.tsx
@@ -1,108 +1,122 @@
-'use client';
+'use client'
 
-import { useState, useEffect, useCallback } from 'react';
-import UnifiedTweetList from '@/components/UnifiedTweetList';
-import { Button } from '@/components/ui/button';
-import { createBrowserClient } from '@/utils/supabase';
-import { SupabaseClient } from '@supabase/supabase-js';
-import { TimelineTweet } from '@/lib/types';
-import { FilterCriteria, fetchTweets } from '@/lib/queries/tweetQueries';
+import { useState, useEffect, useCallback } from 'react'
+import UnifiedTweetList from '@/components/UnifiedTweetList'
+import { Button } from '@/components/ui/button'
+import { createBrowserClient } from '@/utils/supabase'
+import { SupabaseClient } from '@supabase/supabase-js'
+import { TimelineTweet } from '@/lib/types'
+import { FilterCriteria, fetchTweets } from '@/lib/queries/tweetQueries'
 
 interface TweetListProps {
-  filterCriteria: FilterCriteria;
-  itemsPerPage?: number;
-  showCsvExportButton?: boolean;
-  csvExportFilename?: string;
+  filterCriteria: FilterCriteria
+  itemsPerPage?: number
+  showCsvExportButton?: boolean
+  csvExportFilename?: string
 }
 
-const DEFAULT_ITEMS_PER_PAGE = 20;
+const DEFAULT_ITEMS_PER_PAGE = 20
 
-export default function TweetList({ 
+export default function TweetList({
   filterCriteria,
   itemsPerPage = DEFAULT_ITEMS_PER_PAGE,
   showCsvExportButton = true,
-  csvExportFilename = 'tweets_export.csv' 
+  csvExportFilename = 'tweets_export.csv',
 }: TweetListProps) {
-  const [tweets, setTweets] = useState<TimelineTweet[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [currentPage, setCurrentPage] = useState(1);
-  const [totalCount, setTotalCount] = useState<number | null>(null);
-  const [supabase, setSupabase] = useState<SupabaseClient | null>(null);
-  const [lastFetchCount, setLastFetchCount] = useState<number>(0);
+  const [tweets, setTweets] = useState<TimelineTweet[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [currentPage, setCurrentPage] = useState(1)
+  const [totalCount, setTotalCount] = useState<number | null>(null)
+  const [supabase, setSupabase] = useState<SupabaseClient | null>(null)
+  const [lastFetchCount, setLastFetchCount] = useState<number>(0)
 
   useEffect(() => {
-    setSupabase(createBrowserClient());
-  }, []);
+    setSupabase(createBrowserClient())
+  }, [])
 
-  const loadTweets = useCallback(async (pageToLoad: number, criteria: FilterCriteria) => {
-    if (!supabase) return;
+  const loadTweets = useCallback(
+    async (pageToLoad: number, criteria: FilterCriteria) => {
+      if (!supabase) return
 
-    if (pageToLoad === 1) {
-      setIsLoading(true);
-      setTweets([]); 
-    } else {
-      setIsLoadingMore(true);
-    }
-    setError(null);
-
-    try {
-      const { tweets: fetchedTweets, error: fetchError, totalCount: fetchedTotalCount } = 
-        await fetchTweets(supabase, criteria, pageToLoad, itemsPerPage);
-      
-      if (fetchError) {
-        throw fetchError;
-      }
-
-      setTweets(prevTweets => pageToLoad === 1 ? fetchedTweets : [...prevTweets, ...fetchedTweets]);
-      setLastFetchCount(fetchedTweets.length);
-      if (fetchedTotalCount !== null) {
-        setTotalCount(fetchedTotalCount);
-      }
-      setCurrentPage(pageToLoad);
-    } catch (e: any) {
-      console.error("Failed to load tweets for list:", e);
-      setError(e.message || 'Failed to load tweets.');
-    } finally {
       if (pageToLoad === 1) {
-        setIsLoading(false);
+        setIsLoading(true)
+        setTweets([])
       } else {
-        setIsLoadingMore(false);
+        setIsLoadingMore(true)
       }
-    }
-  }, [supabase, itemsPerPage]);
+      setError(null)
+
+      try {
+        const {
+          tweets: fetchedTweets,
+          error: fetchError,
+          totalCount: fetchedTotalCount,
+        } = await fetchTweets(supabase, criteria, pageToLoad, itemsPerPage)
+
+        if (fetchError) {
+          throw fetchError
+        }
+
+        setTweets((prevTweets) =>
+          pageToLoad === 1 ? fetchedTweets : [...prevTweets, ...fetchedTweets],
+        )
+        setLastFetchCount(fetchedTweets.length)
+        if (fetchedTotalCount !== null) {
+          setTotalCount(fetchedTotalCount)
+        }
+        setCurrentPage(pageToLoad)
+      } catch (e: any) {
+        console.error('Failed to load tweets for list:', e)
+        setError(e.message || 'Failed to load tweets.')
+      } finally {
+        if (pageToLoad === 1) {
+          setIsLoading(false)
+        } else {
+          setIsLoadingMore(false)
+        }
+      }
+    },
+    [supabase, itemsPerPage],
+  )
 
   useEffect(() => {
     if (supabase) {
-      setCurrentPage(1); 
-      setTotalCount(null);
-      setLastFetchCount(0);
-      loadTweets(1, filterCriteria);
+      setCurrentPage(1)
+      setTotalCount(null)
+      setLastFetchCount(0)
+      loadTweets(1, filterCriteria)
     }
-  }, [supabase, filterCriteria, loadTweets]);
+  }, [supabase, filterCriteria, loadTweets])
 
   const handleLoadMore = () => {
     if (!isLoadingMore && hasMoreTweets) {
-      loadTweets(currentPage + 1, filterCriteria);
+      loadTweets(currentPage + 1, filterCriteria)
     }
-  };
+  }
 
-
-  const hasMoreTweets = totalCount !== null 
-    ? (currentPage * itemsPerPage) < totalCount 
-    : lastFetchCount === itemsPerPage;
+  const hasMoreTweets =
+    totalCount !== null
+      ? currentPage * itemsPerPage < totalCount
+      : lastFetchCount === itemsPerPage
 
   if (isLoading) {
-    return <p className="text-xl text-gray-700 dark:text-gray-300 text-center py-10">Loading tweets...</p>;
+    return (
+      <p className="py-10 text-center text-xl text-muted-foreground">
+        Loading tweets...
+      </p>
+    )
   }
 
   if (error && tweets.length === 0) {
-    return <p className="text-xl text-red-500 text-center py-10">Error: {error}</p>;
+    return (
+      <p className="py-10 text-center text-xl text-red-500">Error: {error}</p>
+    )
   }
 
   // Convert TimelineTweet to raw tweet format for consistency
-  const rawTweets = tweets.map(tweet => ({
+  const rawTweets = tweets.map((tweet) => ({
     tweet_id: tweet.tweet_id,
     account_id: '', // TimelineTweet doesn't have this
     created_at: tweet.created_at,
@@ -114,9 +128,11 @@ export default function TweetList({
     account: {
       username: tweet.account.username,
       account_display_name: tweet.account.account_display_name,
-      profile: tweet.account.profile ? {
-        avatar_media_url: tweet.account.profile.avatar_media_url
-      } : undefined
+      profile: tweet.account.profile
+        ? {
+            avatar_media_url: tweet.account.profile.avatar_media_url,
+          }
+        : undefined,
     },
     media: tweet.media || [],
     mentioned_users: [], // TimelineTweet doesn't have this
@@ -124,7 +140,7 @@ export default function TweetList({
 
   return (
     <div className="space-y-8">
-      <UnifiedTweetList 
+      <UnifiedTweetList
         tweets={rawTweets}
         isLoading={isLoading}
         emptyMessage="No tweets to display for the current filters."
@@ -132,17 +148,23 @@ export default function TweetList({
         showCsvExport={showCsvExportButton}
         csvFilename={csvExportFilename}
       />
-      
+
       {error && tweets.length > 0 && (
-        <p className="text-red-500 text-center mt-6">Error loading more tweets: {error}</p>
+        <p className="mt-6 text-center text-red-500">
+          Error loading more tweets: {error}
+        </p>
       )}
       {hasMoreTweets && (
-        <div className="text-center mt-8">
-          <Button onClick={handleLoadMore} disabled={isLoadingMore} variant="outline">
+        <div className="mt-8 text-center">
+          <Button
+            onClick={handleLoadMore}
+            disabled={isLoadingMore}
+            variant="outline"
+          >
             {isLoadingMore ? 'Loading...' : 'Load More'}
           </Button>
         </div>
       )}
     </div>
-  );
-} 
+  )
+}

--- a/src/components/UnifiedTweetList.tsx
+++ b/src/components/UnifiedTweetList.tsx
@@ -24,51 +24,63 @@ export default function UnifiedTweetList({
   emptyMessage = 'No tweets found',
   className = 'space-y-4',
   showCsvExport = false,
-  csvFilename = 'tweets_export.csv'
+  csvFilename = 'tweets_export.csv',
 }: UnifiedTweetListProps) {
   const handleExportCsv = () => {
     if (tweets.length === 0) {
-      alert("No tweets to export.");
-      return;
+      alert('No tweets to export.')
+      return
     }
 
-    const headers = ['tweet_id', 'created_at', 'full_text', 'favorite_count', 'retweet_count', 'username', 'account_display_name', 'reply_to_tweet_id'];
+    const headers = [
+      'tweet_id',
+      'created_at',
+      'full_text',
+      'favorite_count',
+      'retweet_count',
+      'username',
+      'account_display_name',
+      'reply_to_tweet_id',
+    ]
     const csvRows = [
       headers.join(','),
-      ...tweets.map(tweet => {
+      ...tweets.map((tweet) => {
         // Extract username and display name from either flattened or nested format
-        const username = tweet.username || tweet.account?.username || '';
-        const displayName = tweet.account_display_name || tweet.account?.account_display_name || '';
-        
+        const username = tweet.username || tweet.account?.username || ''
+        const displayName =
+          tweet.account_display_name ||
+          tweet.account?.account_display_name ||
+          ''
+
         return [
-          `"${tweet.tweet_id}"`, 
-          `"${tweet.created_at}"`, 
-          `"${tweet.full_text?.replace(/"/g, '""')?.replace(/\n/g, '\\n') || ''}"`, 
+          `"${tweet.tweet_id}"`,
+          `"${tweet.created_at}"`,
+          `"${tweet.full_text?.replace(/"/g, '""')?.replace(/\n/g, '\\n') || ''}"`,
           tweet.favorite_count || 0,
           tweet.retweet_count || 0,
-          `"${username}"`, 
-          `"${displayName}"`, 
-          `"${tweet.reply_to_tweet_id || ''}"`
+          `"${username}"`,
+          `"${displayName}"`,
+          `"${tweet.reply_to_tweet_id || ''}"`,
         ].join(',')
-      })
-    ];
-    const csvString = csvRows.join('\r\n');
-    const blob = new Blob([csvString], { type: 'text/csv;charset=utf-8;' });
-    const link = document.createElement('a');
+      }),
+    ]
+    const csvString = csvRows.join('\r\n')
+    const blob = new Blob([csvString], { type: 'text/csv;charset=utf-8;' })
+    const link = document.createElement('a')
     if (link.download !== undefined) {
-      const url = URL.createObjectURL(blob);
-      link.setAttribute('href', url);
-      link.setAttribute('download', csvFilename);
-      link.style.visibility = 'hidden';
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
+      const url = URL.createObjectURL(blob)
+      link.setAttribute('href', url)
+      link.setAttribute('download', csvFilename)
+      link.style.visibility = 'hidden'
+      document.body.appendChild(link)
+      link.click()
+      document.body.removeChild(link)
     }
-  };
+  }
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-10">
-        <div className="text-xl text-gray-700 dark:text-gray-300">Loading tweets...</div>
+        <div className="text-xl text-muted-foreground">Loading tweets...</div>
       </div>
     )
   }
@@ -76,7 +88,7 @@ export default function UnifiedTweetList({
   if (!tweets.length) {
     return (
       <div className="flex items-center justify-center py-10">
-        <div className="text-lg text-gray-600 dark:text-gray-400">{emptyMessage}</div>
+        <div className="text-lg text-muted-foreground">{emptyMessage}</div>
       </div>
     )
   }
@@ -84,16 +96,18 @@ export default function UnifiedTweetList({
   return (
     <div className="space-y-4">
       {showCsvExport && tweets.length > 0 && (
-        <div className="flex justify-end mb-4">
-          <Button onClick={handleExportCsv} variant="outline">Download CSV</Button>
+        <div className="mb-4 flex justify-end">
+          <Button onClick={handleExportCsv} variant="outline">
+            Download CSV
+          </Button>
         </div>
       )}
-      
+
       <div className={className}>
         {tweets.map((tweet) => (
-          <div 
-            key={tweet.tweet_id} 
-            className="bg-background dark:bg-secondary p-4 rounded-lg border border-gray-200 dark:border-gray-700"
+          <div
+            key={tweet.tweet_id}
+            className="rounded-lg border border-border bg-background p-4 dark:bg-secondary"
           >
             <TweetComponent tweet={tweet} />
           </div>

--- a/src/components/UploadArchiveSection.tsx
+++ b/src/components/UploadArchiveSection.tsx
@@ -25,13 +25,17 @@ export default function UploadArchiveSection() {
   // Get current user session
   useEffect(() => {
     const getCurrentUser = async () => {
-      const { data: { session } } = await supabase.auth.getSession()
+      const {
+        data: { session },
+      } = await supabase.auth.getSession()
       setUser(session?.user || null)
     }
 
     getCurrentUser()
 
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((event, session) => {
       setUser(session?.user || null)
     })
 
@@ -56,7 +60,7 @@ export default function UploadArchiveSection() {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             email: 'dev@example.com',
-            password: 'devpassword123'
+            password: 'devpassword123',
           }),
         })
 
@@ -98,7 +102,10 @@ export default function UploadArchiveSection() {
     setIsUploadProcessing(true)
 
     try {
-      const uploadedArchive = await handleFileUpload(event, setIsUploadProcessing)
+      const uploadedArchive = await handleFileUpload(
+        event,
+        setIsUploadProcessing,
+      )
       devLog('archive', uploadedArchive)
       setArchive(uploadedArchive)
     } catch (error) {
@@ -116,7 +123,8 @@ export default function UploadArchiveSection() {
     {
       number: '1',
       title: 'Request your data',
-      description: 'Go to X Settings and request your archive. It takes 1-2 days.',
+      description:
+        'Go to X Settings and request your archive. It takes 1-2 days.',
       link: 'https://x.com/settings/download_your_data',
       linkText: 'Request Archive',
     },
@@ -135,36 +143,40 @@ export default function UploadArchiveSection() {
 
   return (
     <div className="w-full">
-      <div className="text-center mb-8">
-        <h2 className="text-3xl font-bold text-gray-900 dark:text-white">Upload your tweets</h2>
-        <p className="mt-3 text-base text-gray-600 dark:text-gray-300">
+      <div className="mb-8 text-center">
+        <h2 className="text-3xl font-bold text-foreground">
+          Upload your tweets
+        </h2>
+        <p className="mt-3 text-base text-muted-foreground">
           Contribute to collective intelligence research{' '}
           <br className="hidden sm:block" />
           to build on top of our data and access our tools.
         </p>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6 max-w-4xl mx-auto">
+      <div className="mx-auto grid max-w-4xl grid-cols-1 gap-6 md:grid-cols-3">
         {steps.map((step) => (
           <div
             key={step.number}
-            className="bg-white dark:bg-gray-900 rounded-xl p-6 border border-gray-200 dark:border-slate-700 text-center"
+            className="rounded-xl border border-border bg-card p-6 text-center"
           >
-            <div className="w-10 h-10 rounded-full bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-300 font-bold text-lg flex items-center justify-center mx-auto mb-4">
+            <div className="mx-auto mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-muted text-lg font-bold text-brand">
               {step.number}
             </div>
-            <h3 className="font-semibold text-gray-900 dark:text-white mb-2">{step.title}</h3>
-            <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">{step.description}</p>
+            <h3 className="mb-2 font-semibold text-foreground">{step.title}</h3>
+            <p className="mb-4 text-sm text-muted-foreground">
+              {step.description}
+            </p>
 
             {step.link && (
               <a
                 href={step.link}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center text-sm text-blue-600 dark:text-blue-300 hover:underline"
+                className="inline-flex items-center text-sm text-brand hover:underline"
               >
                 {step.linkText}
-                <ExternalLink className="w-3 h-3 ml-1" />
+                <ExternalLink className="ml-1 h-3 w-3" />
               </a>
             )}
 
@@ -173,9 +185,9 @@ export default function UploadArchiveSection() {
                 <Button
                   onClick={handleUploadClick}
                   disabled={isUploadProcessing}
-                  className="bg-blue-600 hover:bg-blue-700 text-white dark:bg-blue-400 dark:hover:bg-blue-300 dark:text-blue-950"
+                  className="bg-brand text-white hover:bg-brand/90 dark:bg-brand dark:text-brand-foreground dark:hover:bg-brand/90"
                 >
-                  <Upload className="w-4 h-4 mr-2" />
+                  <Upload className="mr-2 h-4 w-4" />
                   {isUploadProcessing ? 'Processing...' : 'Upload .zip'}
                 </Button>
                 <input
@@ -193,17 +205,17 @@ export default function UploadArchiveSection() {
         ))}
       </div>
 
-      <p className="text-center mt-6 text-sm text-gray-500 dark:text-gray-400">
+      <p className="mt-6 text-center text-sm text-muted-foreground">
         See{' '}
         <a
           href="https://github.com/TheExGenesis/community-archive/blob/main/docs/archive_data.md"
           target="_blank"
           rel="noopener noreferrer"
-          className="text-blue-600 dark:text-blue-300 hover:underline"
+          className="text-brand hover:underline"
         >
           what data we use
-        </a>
-        {' '}from your archive
+        </a>{' '}
+        from your archive
       </p>
 
       {/* Upload Dialog */}

--- a/src/components/UploadHomepageSection.tsx
+++ b/src/components/UploadHomepageSection.tsx
@@ -130,10 +130,10 @@ export default function UploadHomepageSection() {
 
   return (
     userMetadata && (
-      <div className="text-sm dark:text-gray-300">
+      <div className="text-sm dark:text-muted-foreground">
         {state.archiveUpload && (
           <>
-            <p className="mb-2 text-xs text-zinc-400 dark:text-zinc-500">
+            <p className="mb-2 text-xs text-muted-foreground">
               Your last archive upload was from{' '}
               {formatDate(state.archiveUpload.archive_at)}.
             </p>
@@ -141,24 +141,24 @@ export default function UploadHomepageSection() {
         )}
         {state.archiveUpload && !state.showUploadButton ? (
           <div
-            className="transition-colsors rounded-md bg-zinc-100 p-4 duration-200 hover:bg-zinc-50 dark:bg-gray-900 dark:hover:bg-gray-800"
+            className="transition-colsors rounded-md bg-muted p-4 duration-200 hover:bg-accent dark:bg-card dark:hover:bg-accent"
             onClick={() =>
               setState((prev) => ({ ...prev, showUploadButton: true }))
             }
           >
-            <button className="cursor-pointer text-sm font-bold text-blue-500 hover:underline dark:text-blue-300">
+            <button className="cursor-pointer text-sm font-bold text-brand hover:underline dark:text-brand">
               Upload a new archive, or delete your data. :)
             </button>
           </div>
         ) : (
-          <div className="transition-colsors rounded-md bg-zinc-100 p-4 duration-200 hover:bg-zinc-50 dark:bg-gray-900 dark:hover:bg-gray-800">
+          <div className="transition-colsors rounded-md bg-muted p-4 duration-200 hover:bg-accent dark:bg-card dark:hover:bg-accent">
             {state.archiveUpload && (
               <div>
                 <button
                   onClick={() =>
                     setState((prev) => ({ ...prev, showUploadButton: false }))
                   }
-                  className="cursor-pointer text-sm text-blue-500 underline dark:text-blue-300"
+                  className="cursor-pointer text-sm text-brand underline dark:text-brand"
                 >
                   Close
                 </button>
@@ -167,11 +167,11 @@ export default function UploadHomepageSection() {
             <div className="flex flex-col">
               <div className="flex justify-between">
                 <div className="mb-4 flex-1">
-                  <p className="mb-6 text-xs text-center dark:text-gray-300">
+                  <p className="mb-6 text-center text-xs dark:text-muted-foreground">
                     Please upload your Twitter archive as a .zip file.
                   </p>
                   <div className="flex justify-center">
-                    <label className="mb-4 cursor-pointer rounded bg-zinc-500 px-4 py-3 text-sm text-white hover:bg-zinc-600 disabled:opacity-50 dark:bg-zinc-600 dark:hover:bg-zinc-700">
+                    <label className="mb-4 cursor-pointer rounded bg-primary px-4 py-3 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50">
                       Choose Files
                       <input
                         type="file"
@@ -186,9 +186,9 @@ export default function UploadHomepageSection() {
                   {state.isProcessing && (
                     <div className="mt-4">
                       <p className="mb-2">{`Processing archive...`}</p>
-                      <div className="w-full rounded bg-gray-200">
+                      <div className="w-full rounded bg-muted">
                         <div
-                          className="rounded bg-blue-500 py-1 text-center text-xs leading-none text-white"
+                          className="rounded bg-brand py-1 text-center text-xs leading-none text-white"
                           style={{ width: '0%' }}
                         >
                           0%
@@ -200,7 +200,7 @@ export default function UploadHomepageSection() {
                 <div>
                   {state.archiveUpload && (
                     <>
-                      <p className="mb-4 text-xs dark:text-gray-300">
+                      <p className="mb-4 text-xs dark:text-muted-foreground">
                         This will delete all your data
                       </p>
                       <button

--- a/src/components/activity-tracker.tsx
+++ b/src/components/activity-tracker.tsx
@@ -35,7 +35,7 @@ const colorIntensity = (
   isBeforeStart: boolean,
 ) => {
   if (isBeforeStart) return 'bg-transparent'
-  if (count === 0) return 'bg-gray-200 dark:bg-gray-800'
+  if (count === 0) return 'bg-muted'
   const intensity = Math.ceil((count / maxCount) * 10)
   switch (intensity) {
     case 1:
@@ -154,7 +154,7 @@ export function ActivityTracker({ data = {} }: ActivityTrackerProps) {
                             maxCount,
                             isBeforeStart,
                           )} ${
-                            isBeforeStart ? '' : 'border border-gray-300'
+                            isBeforeStart ? '' : 'border border-border'
                           } cursor-pointer`}
                         />
                       </TooltipTrigger>

--- a/src/components/file-upload-dialog.tsx
+++ b/src/components/file-upload-dialog.tsx
@@ -140,13 +140,13 @@ export function FileUploadDialog({
 
   return (
     <Dialog open={isOpen} onOpenChange={resetDialog}>
-      <DialogContent 
+      <DialogContent
         className="sm:max-w-[425px]"
         onInteractOutside={(event) => {
-          event.preventDefault();
+          event.preventDefault()
         }}
         onEscapeKeyDown={(event) => {
-          event.preventDefault();
+          event.preventDefault()
         }}
       >
         <DialogHeader>
@@ -165,7 +165,7 @@ export function FileUploadDialog({
             <p className="mb-2 text-sm text-red-600">
               Sorry, there was an error:
             </p>
-            <pre className="whitespace-pre-wrap break-words rounded bg-gray-100 p-2 font-mono text-sm text-gray-900 dark:bg-gray-800 dark:text-gray-100">
+            <pre className="whitespace-pre-wrap break-words rounded bg-muted p-2 font-mono text-sm text-foreground dark:bg-muted dark:text-foreground">
               {state.error}
             </pre>
           </div>
@@ -191,12 +191,16 @@ export function FileUploadDialog({
             </div>
 
             {/* Circle Tweet Warning */}
-            {new Date(archiveStats.earliestTweetDate) < new Date('2023-10-31') && (
-              <div className="my-2 p-3 bg-yellow-100 dark:bg-yellow-900 border border-yellow-400 dark:border-yellow-700 text-yellow-700 dark:text-yellow-200 rounded">
-                <p className="font-bold">Important Notice Regarding Twitter Circle Tweets:</p>
+            {new Date(archiveStats.earliestTweetDate) <
+              new Date('2023-10-31') && (
+              <div className="my-2 rounded border border-yellow-400 bg-yellow-100 p-3 text-yellow-700 dark:border-yellow-700 dark:bg-yellow-900 dark:text-yellow-200">
+                <p className="font-bold">
+                  Important Notice Regarding Twitter Circle Tweets:
+                </p>
                 <p className="text-sm">
-                  Your archive may contain tweets from before October 31, 2023. 
-                  Any Twitter Circle tweets from this period will be treated as public tweets and will be visible to everyone in this archive. 
+                  Your archive may contain tweets from before October 31, 2023.
+                  Any Twitter Circle tweets from this period will be treated as
+                  public tweets and will be visible to everyone in this archive.
                   By proceeding, you acknowledge this.
                 </p>
               </div>
@@ -234,7 +238,7 @@ export function FileUploadDialog({
                           <TooltipTrigger asChild>
                             <Info className="ml-1 h-4 w-4 cursor-pointer text-muted-foreground hover:text-primary" />
                           </TooltipTrigger>
-                          <TooltipContent className="bg-gray-800 text-white">
+                          <TooltipContent>
                             <p>Upload likes and liked tweets.</p>
                           </TooltipContent>
                         </Tooltip>
@@ -257,7 +261,7 @@ export function FileUploadDialog({
                           <TooltipTrigger asChild>
                             <Info className="ml-1 h-4 w-4 cursor-pointer text-muted-foreground hover:text-primary" />
                           </TooltipTrigger>
-                          <TooltipContent className="bg-gray-800 text-white">
+                          <TooltipContent>
                             <p>
                               Select a date range to filter tweets for upload
                             </p>

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,27 +1,28 @@
-import * as React from "react"
+import * as React from 'react'
 
 interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
-  variant?: "default" | "destructive"
+  variant?: 'default' | 'destructive'
 }
 
 const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
-  ({ className, variant = "default", ...props }, ref) => {
-    const baseClasses = "relative w-full rounded-lg border p-4"
-    const variantClasses = variant === "destructive" 
-      ? "border-red-500 bg-red-50 text-red-900 dark:border-red-400 dark:bg-red-900/20 dark:text-red-200"
-      : "border-gray-200 bg-gray-50 text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
-    
+  ({ className, variant = 'default', ...props }, ref) => {
+    const baseClasses = 'relative w-full rounded-lg border p-4'
+    const variantClasses =
+      variant === 'destructive'
+        ? 'border-red-500 bg-red-50 text-red-900 dark:border-red-400 dark:bg-red-900/20 dark:text-red-200'
+        : 'border-border bg-muted text-foreground dark:border-border dark:bg-muted dark:text-foreground'
+
     return (
       <div
         ref={ref}
         role="alert"
-        className={`${baseClasses} ${variantClasses} ${className || ""}`}
+        className={`${baseClasses} ${variantClasses} ${className || ''}`}
         {...props}
       />
     )
-  }
+  },
 )
-Alert.displayName = "Alert"
+Alert.displayName = 'Alert'
 
 const AlertTitle = React.forwardRef<
   HTMLParagraphElement,
@@ -29,22 +30,18 @@ const AlertTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <h5
     ref={ref}
-    className={`mb-1 font-medium leading-none tracking-tight ${className || ""}`}
+    className={`mb-1 font-medium leading-none tracking-tight ${className || ''}`}
     {...props}
   />
 ))
-AlertTitle.displayName = "AlertTitle"
+AlertTitle.displayName = 'AlertTitle'
 
 const AlertDescription = React.forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLParagraphElement>
 >(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={`text-sm ${className || ""}`}
-    {...props}
-  />
+  <div ref={ref} className={`text-sm ${className || ''}`} {...props} />
 ))
-AlertDescription.displayName = "AlertDescription"
+AlertDescription.displayName = 'AlertDescription'
 
 export { Alert, AlertTitle, AlertDescription }

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -43,7 +43,7 @@ const ScrollBar = React.forwardRef<
     <ScrollAreaPrimitive.ScrollAreaThumb
       className={cn(
         'relative flex-1 rounded-full bg-border',
-        'dark:bg-gray-600', // Add this line for dark mode
+        'dark:bg-muted', // Add this line for dark mode
       )}
     />
   </ScrollAreaPrimitive.ScrollAreaScrollbar>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,6 +14,10 @@ module.exports = {
         border: 'hsl(var(--border))',
         input: 'hsl(var(--input))',
         ring: 'hsl(var(--ring))',
+        brand: {
+          DEFAULT: 'hsl(var(--brand))',
+          foreground: 'hsl(var(--brand-foreground))',
+        },
         background: 'hsl(var(--background))',
         foreground: 'hsl(var(--foreground))',
         primary: {


### PR DESCRIPTION
## What changed

- consolidate light and dark mode around shared background, card, muted, border, text, and brand tokens across all pages
- replace the direct gray, slate, sky, zinc, and blue UI palette classes with semantic theme tokens
- add Products navigation that scrolls to Explore the archive and rename Directory to User Directory
- move Profile and Sign out into a right-side hamburger menu, with the admin shortcut beside it
- remove the disabled Opted in hero CTA after a member has already opted in
- document the follow-up search experience sequence without implementing it in this PR

## Why

The site accumulated many near-duplicate neutral and dark-blue shades, making both themes feel inconsistent. Account actions were also split across the main navigation and header. This gives the app one small, reusable visual system and a clearer navigation hierarchy.

## User impact

The palette is calmer and consistent across the homepage, directory, profiles, search, tweets, admin, and supporting pages. Desktop and mobile navigation now share the same labels, while account actions live in one predictable menu.

## Validation

- `npm run lint`
- `./node_modules/.bin/tsc --pretty --noEmit`
- `npm run build`
- `git diff --check`
- browser QA in light and dark mode on the homepage, User Directory, and current search results
- responsive browser QA at 1440px and 390px widths
- verified the Products anchor lands below the sticky header
