### PR TITLE
Improve archive search experience

### DIFF
--- a/docs/search-experience-plan.md
+++ b/docs/search-experience-plan.md
@@ -1,10 +1,11 @@
 # Search experience plan
 
-This work starts only after the palette and navigation changes are merged. The
-search redesign should ship in separate pull requests so result quality can be
-reviewed before search becomes the primary signed-in experience.
+The search redesign ships in a separate, stacked pull request after the palette
+and navigation work. Its sections should still be reviewed in this order so
+result quality is approved before search becomes the primary signed-in
+experience.
 
-## PR 1: Make search results clear and pleasant
+## Phase 1: Make search results clear and pleasant
 
 Keep the existing search behavior, URL parameters, CSV export, and database
 queries. Limit this PR to the results presentation.
@@ -28,10 +29,9 @@ Acceptance checks:
 - Verify CSV download and tweet permalinks remain available.
 - Check desktop and mobile widths and keyboard focus order.
 
-## PR 2: Simplify the search controls
+## Phase 2: Simplify the search controls
 
-Once the result feed is approved, make the common path feel like a normal
-search rather than an advanced form.
+Make the common path feel like a normal search rather than an advanced form.
 
 - Lead with one prominent search field and a clear submit action.
 - Move user and date filters into an optional filter panel.
@@ -42,10 +42,10 @@ search rather than an advanced form.
   page.
 - Keep advanced operators available without making them required knowledge.
 
-## PR 3: Add the signed-in archive landing page
+## Phase 3: Add the signed-in archive landing page
 
-After PRs 1 and 2 are merged, add a focused landing experience for signed-in,
-opted-in members.
+Add a focused landing experience for signed-in, opted-in members after the
+results and controls are ready for review.
 
 - Create an archive discovery page with a Wikipedia-like centered search field,
   a short explanation, and a few example searches.
@@ -55,9 +55,8 @@ opted-in members.
   competing with the primary search action.
 - Keep the current contribution-oriented homepage for signed-out and not-yet-
   opted-in visitors.
-- Route opted-in members to the discovery page after sign-in. Decide during the
-  PR whether `/` should redirect for those members or whether the new page
-  should become their explicit post-auth destination.
+- Route opted-in members to the discovery page after sign-in while keeping `/`
+  available as the contribution-oriented homepage and Products anchor target.
 
 ## Success signals
 

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -1,0 +1,30 @@
+import { redirect } from 'next/navigation'
+import MemberSearchLanding from '@/components/MemberSearchLanding'
+import { getOptInStatus, requireAuth } from '@/lib/auth-utils'
+import { getStats } from '@/lib/stats'
+
+export const metadata = {
+  title: 'Explore the archive | Community Archive',
+  description: 'Search millions of public conversations in Community Archive.',
+}
+
+export default async function ExplorePage() {
+  const { user, supabase } = await requireAuth('/explore')
+  const { data: optInData } = await getOptInStatus(user.id)
+
+  if (!optInData?.opted_in) {
+    redirect('/opt-in')
+  }
+
+  const stats = await getStats(supabase).catch((error) => {
+    console.error('Unable to load archive stats for member search:', error)
+    return { tweetCount: null, userCount: null }
+  })
+
+  return (
+    <MemberSearchLanding
+      tweetCount={stats.tweetCount}
+      userCount={stats.userCount}
+    />
+  )
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,6 +3,7 @@ import { createServerClient } from '@/utils/supabase'
 import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 import LoginContent from './LoginContent'
+import { getOptInStatus } from '@/lib/auth-utils'
 
 export default async function LoginPage({
   searchParams,
@@ -11,14 +12,22 @@ export default async function LoginPage({
 }) {
   const cookieStore = await cookies()
   const supabase = createServerClient(cookieStore)
-  
-  // Check if user is already logged in
-  const { data: { user } } = await supabase.auth.getUser()
-  
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
   if (user) {
-    // User is already logged in, redirect to intended page or home
-    const redirectTo = searchParams.redirect || '/'
-    redirect(redirectTo)
+    const requestedRedirect = searchParams.redirect
+    const safeRedirect =
+      requestedRedirect?.startsWith('/') && !requestedRedirect.startsWith('//')
+        ? requestedRedirect
+        : null
+
+    if (safeRedirect) redirect(safeRedirect)
+
+    const { data: optInData } = await getOptInStatus(user.id)
+    redirect(optInData?.opted_in ? '/explore' : '/opt-in')
   }
 
   return (

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,14 +1,18 @@
 'use client'
+
 import AdvancedSearchForm from '@/components/AdvancedSearchForm'
 import TweetList from '@/components/TweetList'
 import { FilterCriteria } from '@/lib/queries/tweetQueries'
+import { Search, SlidersHorizontal } from 'lucide-react'
+import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
 import { Suspense } from 'react'
 
-// Style definitions
-const unifiedDeepBlueBase = 'bg-card dark:bg-background'
-const sectionPaddingClasses = 'py-12 md:py-16 lg:py-20'
-const contentWrapperClasses = 'w-full max-w-4xl mx-auto px-4 sm:px-6 lg:px-8'
+const starterSearches = [
+  { label: 'Open source', query: 'open source' },
+  { label: 'AI alignment', query: 'AI alignment' },
+  { label: 'Community notes', query: 'community notes' },
+]
 
 // This wrapper is needed because useSearchParams can only be used in Client Components,
 // and Suspense is recommended for pages that use it.
@@ -32,7 +36,6 @@ function SearchPageContent() {
     formattedQuery = words.join(' & ')
   }
 
-  // Construct FilterCriteria from URL search parameters
   const filterCriteria: FilterCriteria = {
     searchQuery: formattedQuery,
     rawSearchQuery: cleanRawText,
@@ -42,39 +45,62 @@ function SearchPageContent() {
     endDate: searchParams.get('untilDate') || undefined,
   }
 
-  // A key for TweetList to force re-render when search params change, ensuring new data is fetched.
-  // This is important because TweetList fetches data in its own useEffect based on initial props.
   const tweetListKey = searchParams.toString()
+  const hasSearch = tweetListKey.length > 0
+  const searchDescription = cleanRawText
+    ? `Matching “${cleanRawText}” and the filters above`
+    : 'Matching the filters above'
 
   return (
-    <main>
-      <section
-        className={`${unifiedDeepBlueBase} ${sectionPaddingClasses} min-h-screen overflow-hidden`}
-      >
-        <div className={`${contentWrapperClasses}`}>
-          <h2 className="mb-8 text-center text-4xl font-bold text-foreground">
-            🔬 Advanced Search
-          </h2>
-          <AdvancedSearchForm />{' '}
-          {/* This will pre-fill itself from URL params */}
-          <div className="mt-12">
-            {/* Render TweetList only if there are actual search parameters present */}
-            {searchParams.toString().length > 0 ? (
-              <div className="rounded-lg bg-muted p-6 dark:bg-card md:p-8">
-                <h3 className="mb-6 text-2xl font-semibold text-foreground">
-                  Search Results
-                </h3>
-                <TweetList
-                  key={tweetListKey} // Force re-mount on new search
-                  filterCriteria={filterCriteria}
-                />
-              </div>
-            ) : (
-              <p className="mt-12 text-center text-muted-foreground">
-                Please enter your search criteria above.
-              </p>
-            )}
+    <main className="min-h-screen bg-background">
+      <section className="mx-auto w-full max-w-5xl px-4 py-10 sm:px-6 sm:py-14 lg:px-8">
+        <div className="mb-8 max-w-2xl">
+          <div className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.16em] text-brand">
+            <Search className="h-4 w-4" />
+            Archive search
           </div>
+          <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
+            Search the archive
+          </h1>
+          <p className="mt-3 text-base leading-7 text-muted-foreground sm:text-lg">
+            Find public conversations by keyword, author, reply, or date.
+          </p>
+        </div>
+
+        <AdvancedSearchForm />
+
+        <div className="mt-10">
+          {hasSearch ? (
+            <TweetList
+              key={tweetListKey}
+              filterCriteria={filterCriteria}
+              resultsHeading="Search results"
+              resultsDescription={searchDescription}
+              collapseLongTweets
+            />
+          ) : (
+            <div className="rounded-xl border border-dashed border-border bg-card px-6 py-10 text-center sm:px-10">
+              <SlidersHorizontal className="mx-auto h-8 w-8 text-muted-foreground" />
+              <h2 className="mt-4 text-2xl font-semibold text-foreground">
+                Start with a topic or phrase
+              </h2>
+              <p className="mx-auto mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
+                Use filters for a specific account or date range, or try one of
+                these searches.
+              </p>
+              <div className="mt-6 flex flex-wrap justify-center gap-2">
+                {starterSearches.map((item) => (
+                  <Link
+                    key={item.query}
+                    href={`/search?q=${encodeURIComponent(item.query)}`}
+                    className="rounded-full border border-border bg-background px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"
+                  >
+                    {item.label}
+                  </Link>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
       </section>
     </main>
@@ -83,8 +109,13 @@ function SearchPageContent() {
 
 export default function SearchTweetsPage() {
   return (
-    // Suspense boundary for useSearchParams
-    <Suspense fallback={<div>Loading search...</div>}>
+    <Suspense
+      fallback={
+        <main className="min-h-screen bg-background px-4 py-14 text-center text-muted-foreground">
+          Loading search…
+        </main>
+      }
+    >
       <SearchPageContent />
     </Suspense>
   )

--- a/src/app/tweets/[tweet_id]/page.tsx
+++ b/src/app/tweets/[tweet_id]/page.tsx
@@ -2,6 +2,8 @@ import { getTweetPageData } from '@/lib/getTweetPageData'
 import { notFound } from 'next/navigation'
 import TweetComponent from '@/components/TweetComponent'
 import ThreadView from '@/components/ThreadView'
+import Link from 'next/link'
+import { ArrowLeft, Link2, MessagesSquare } from 'lucide-react'
 
 // ISR: serve from CDN cache, revalidate at most once per hour
 export const revalidate = 3600
@@ -10,41 +12,53 @@ export default async function TweetPage({ params }: any) {
   const { tweet_id } = params
   const { tweet, threadTree } = await getTweetPageData(tweet_id)
 
-  // Style definitions copied from homepage
-  const unifiedDeepBlueBase = 'bg-card dark:bg-background'
-  const sectionPaddingClasses = 'py-12 md:py-16 lg:py-20'
-  // Using max-w-7xl to match stream monitor width
-  const contentWrapperClasses = 'w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8'
-
   if (!tweet) {
     notFound()
   }
 
-  return (
-    <main>
-      <section
-        className={`${unifiedDeepBlueBase} ${sectionPaddingClasses} min-h-screen overflow-hidden`}
-      >
-        <div className={`${contentWrapperClasses}`}>
-          <div className="rounded-lg bg-muted p-6 dark:bg-card md:p-8">
-            <h2 className="mb-8 text-center text-4xl font-bold text-foreground">
-              {threadTree && Object.keys(threadTree.tweets).length > 1
-                ? '🧵 View Thread'
-                : '🔎 View Tweet'}
-            </h2>
+  const isThread = threadTree && Object.keys(threadTree.tweets).length > 1
 
-            {threadTree && Object.keys(threadTree.tweets).length > 1 ? (
-              <ThreadView
-                tree={threadTree}
-                highlightTweetId={tweet_id}
-                className="rounded-lg bg-background dark:bg-secondary"
-              />
+  return (
+    <main className="min-h-screen bg-background">
+      <section className="mx-auto w-full max-w-4xl px-4 py-10 sm:px-6 sm:py-14 lg:px-8">
+        <Link
+          href="/search"
+          className="inline-flex items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to search
+        </Link>
+
+        <header className="mb-8 mt-8 border-b border-border pb-7">
+          <div className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.16em] text-brand">
+            {isThread ? (
+              <MessagesSquare className="h-4 w-4" />
             ) : (
-              <div className="rounded-lg bg-background p-4 dark:bg-secondary">
-                <TweetComponent key={tweet.tweet_id} tweet={tweet} />
-              </div>
+              <Link2 className="h-4 w-4" />
             )}
+            Archive permalink
           </div>
+          <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
+            {isThread ? 'Conversation thread' : 'Archived tweet'}
+          </h1>
+          <p className="mt-3 max-w-2xl text-base leading-7 text-muted-foreground">
+            {isThread
+              ? 'Read the surrounding conversation with the linked tweet highlighted.'
+              : 'A permanent public view of this tweet in Community Archive.'}
+          </p>
+        </header>
+
+        {isThread && threadTree ? (
+          <ThreadView tree={threadTree} highlightTweetId={tweet_id} />
+        ) : (
+          <article className="rounded-xl border border-border bg-card p-5 shadow-sm sm:p-6">
+            <TweetComponent key={tweet.tweet_id} tweet={tweet} />
+          </article>
+        )}
+
+        <div className="mt-8 rounded-xl border border-dashed border-border bg-card px-5 py-4 text-sm leading-6 text-muted-foreground">
+          This permalink preserves the archived version. Use the Twitter link on
+          the tweet to compare it with the live post when it is still available.
         </div>
       </section>
     </main>

--- a/src/components/AdvancedSearchForm.tsx
+++ b/src/components/AdvancedSearchForm.tsx
@@ -1,31 +1,24 @@
 'use client'
-import { useState, useEffect, useMemo } from 'react'
+
+import { useEffect, useMemo, useState } from 'react'
 import { Button } from '@/components/ui/button'
-import { ChevronDown, ChevronUp } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  ChevronDown,
+  ChevronUp,
+  Search,
+  SlidersHorizontal,
+  X,
+} from 'lucide-react'
 import { useRouter, useSearchParams } from 'next/navigation'
-
-const parseQuery = (q: string) => {
-  const parts = q.split(' ')
-  const options: { [key: string]: string } = {}
-  const words: string[] = []
-  const validFilters = ['from', 'to', 'since', 'until']
-
-  parts.forEach((part) => {
-    const separatorIndex = part.indexOf(':')
-    if (separatorIndex > 0) {
-      // must not start with ':' and must contain ':'
-      const key = part.substring(0, separatorIndex)
-      const value = part.substring(separatorIndex + 1)
-      if (validFilters.includes(key) && value) {
-        options[key] = value
-        return // Go to next part
-      }
-    }
-    words.push(part) // Not a valid filter, so it's a keyword
-  })
-
-  return { options, words }
-}
+import {
+  buildSearchExpression,
+  buildSearchParams,
+  parseSearchExpression,
+  SearchFilterKey,
+} from '@/lib/searchParams'
 
 export default function AdvancedSearchForm() {
   const router = useRouter()
@@ -34,35 +27,25 @@ export default function AdvancedSearchForm() {
   const [query, setQuery] = useState('')
   const [showAdvancedOptions, setShowAdvancedOptions] = useState(false)
 
-  // Effect to set initial query from URL params
   useEffect(() => {
-    const q = searchParams.get('q') || ''
-    const fromUser = searchParams.get('fromUser') || ''
-    const replyToUser = searchParams.get('replyToUser') || ''
-    const sinceDate = searchParams.get('sinceDate') || ''
-    const untilDate = searchParams.get('untilDate') || ''
-
-    const parts = [q]
-    if (fromUser) parts.push(`from:${fromUser}`)
-    if (replyToUser) parts.push(`to:${replyToUser}`)
-    if (sinceDate) parts.push(`since:${sinceDate}`)
-    if (untilDate) parts.push(`until:${untilDate}`)
-
-    setQuery(
-      parts
-        .filter((p) => p)
-        .join(' ')
-        .trim(),
+    const expression = buildSearchExpression(
+      new URLSearchParams(searchParams.toString()),
     )
+    setQuery(expression)
 
-    // if (fromUser || replyToUser || sinceDate || untilDate) {
-    //   setShowAdvancedOptions(true);
-    // }
+    if (
+      searchParams.has('fromUser') ||
+      searchParams.has('replyToUser') ||
+      searchParams.has('sinceDate') ||
+      searchParams.has('untilDate')
+    ) {
+      setShowAdvancedOptions(true)
+    }
   }, [searchParams])
 
   // Derive values for advanced fields from the main query string
   const { from, to, since, until } = useMemo(() => {
-    const { options } = parseQuery(query)
+    const { options } = parseSearchExpression(query)
     return {
       from: options.from || '',
       to: options.to || '',
@@ -71,20 +54,15 @@ export default function AdvancedSearchForm() {
     }
   }, [query])
 
-  const handleFilterChange = (
-    filter: 'from' | 'to' | 'since' | 'until',
-    value: string,
-  ) => {
-    const { words, options } = parseQuery(query)
+  const handleFilterChange = (filter: SearchFilterKey, value: string) => {
+    const { words, options } = parseSearchExpression(query)
 
-    // Update the specific filter's value
     if (value) {
       options[filter] = value
     } else {
       delete options[filter]
     }
 
-    // Reconstruct the query string
     const newFilterParts = Object.entries(options).map(
       ([key, val]) => `${key}:${val}`,
     )
@@ -94,48 +72,59 @@ export default function AdvancedSearchForm() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-
-    const { options, words } = parseQuery(query)
-    const mainQuery = words.join(' ').trim()
-
-    const params = new URLSearchParams()
-    if (mainQuery) params.set('q', mainQuery)
-    if (options.from) params.set('fromUser', options.from)
-    if (options.to) params.set('replyToUser', options.to)
-    if (options.since) params.set('sinceDate', options.since)
-    if (options.until) params.set('untilDate', options.until)
-
-    router.push(`/search?${params.toString()}`)
+    const params = buildSearchParams(query)
+    router.push(params.size > 0 ? `/search?${params.toString()}` : '/search')
   }
 
-  const inputClasses =
-    'w-full rounded border p-2 dark:bg-muted dark:border-border dark:text-foreground dark:placeholder-muted-foreground focus:ring-brand focus:border-brand'
-  const labelClasses = 'block text-sm font-medium text-muted-foreground mb-1'
+  const activeFilters = [
+    { key: 'from' as const, label: 'From', value: from },
+    { key: 'to' as const, label: 'To', value: to },
+    { key: 'since' as const, label: 'Since', value: since },
+    { key: 'until' as const, label: 'Until', value: until },
+  ].filter((filter) => filter.value)
 
   return (
-    <div className="rounded-lg bg-muted p-6 dark:bg-card md:p-8">
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <div>
-          <label htmlFor="main-search" className={labelClasses}>
-            Search terms
-          </label>
-          <input
+    <form
+      onSubmit={handleSubmit}
+      className="rounded-xl border border-border bg-card p-4 shadow-sm sm:p-6"
+    >
+      <Label htmlFor="main-search" className="sr-only">
+        Search the archive
+      </Label>
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <div className="relative flex-1">
+          <Search className="absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />
+          <Input
             id="main-search"
-            type="text"
+            type="search"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search tweets (use from:, to:, since:, until: for advanced search)"
-            className={inputClasses}
+            placeholder="Search words, phrases, or from:username"
+            className="h-12 rounded-lg bg-background pl-12 pr-4 text-base"
+            autoComplete="off"
           />
         </div>
+        <Button
+          type="submit"
+          size="lg"
+          className="h-12 bg-brand px-7 text-brand-foreground hover:bg-brand/90"
+        >
+          <Search className="mr-2 h-4 w-4" />
+          Search
+        </Button>
+      </div>
 
+      <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
         <Button
           type="button"
-          variant="outline"
+          variant="ghost"
+          size="sm"
           onClick={() => setShowAdvancedOptions(!showAdvancedOptions)}
-          className="w-full justify-between dark:border-border dark:text-foreground dark:hover:bg-accent"
+          className="-ml-3 text-muted-foreground hover:text-foreground"
+          aria-expanded={showAdvancedOptions}
         >
-          Filter by User / Date Range
+          <SlidersHorizontal className="mr-2 h-4 w-4" />
+          Filter by user or date
           {showAdvancedOptions ? (
             <ChevronUp className="ml-2 h-4 w-4" />
           ) : (
@@ -143,70 +132,75 @@ export default function AdvancedSearchForm() {
           )}
         </Button>
 
-        {showAdvancedOptions && (
-          <div className="space-y-4 border-t pt-4 dark:border-border">
-            <div>
-              <label htmlFor="from-user" className={labelClasses}>
-                From user
-              </label>
-              <input
-                id="from-user"
-                type="text"
-                value={from}
-                onChange={(e) => handleFilterChange('from', e.target.value)}
-                placeholder="username (without @)"
-                className={inputClasses}
-              />
-            </div>
-            <div>
-              <label htmlFor="to-user" className={labelClasses}>
-                To user (in reply to username)
-              </label>
-              <input
-                id="to-user"
-                type="text"
-                value={to}
-                onChange={(e) => handleFilterChange('to', e.target.value)}
-                placeholder="username (without @)"
-                className={inputClasses}
-              />
-            </div>
-            <div>
-              <label htmlFor="since-date" className={labelClasses}>
-                From date:
-              </label>
-              <input
-                id="since-date"
-                type="date"
-                value={since}
-                onChange={(e) => handleFilterChange('since', e.target.value)}
-                className={`${inputClasses} mt-1`}
-              />
-            </div>
-            <div>
-              <label htmlFor="until-date" className={labelClasses}>
-                To date:
-              </label>
-              <input
-                id="until-date"
-                type="date"
-                value={until}
-                onChange={(e) => handleFilterChange('until', e.target.value)}
-                className={`${inputClasses} mt-1`}
-              />
-            </div>
+        {activeFilters.length > 0 && (
+          <div className="flex flex-wrap gap-2" aria-label="Active filters">
+            {activeFilters.map((filter) => (
+              <Badge
+                key={filter.key}
+                variant="secondary"
+                className="gap-1.5 py-1 text-muted-foreground"
+              >
+                {filter.label}: {filter.value}
+                <button
+                  type="button"
+                  onClick={() => handleFilterChange(filter.key, '')}
+                  className="rounded-full p-0.5 hover:bg-accent hover:text-foreground"
+                  aria-label={`Remove ${filter.label.toLowerCase()} filter`}
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </Badge>
+            ))}
           </div>
         )}
+      </div>
 
-        <Button
-          type="submit"
-          className="w-full rounded bg-brand p-3 text-lg text-white transition-colors duration-300 hover:bg-brand/90 dark:bg-brand dark:text-brand-foreground dark:hover:bg-brand/90"
-          // disabled={isLoading} // isLoading state is removed
-        >
-          Search
-        </Button>
-      </form>
-      {/* Results display (ScrollArea and Tweet mapping) is REMOVED from here */}
-    </div>
+      {showAdvancedOptions && (
+        <div className="mt-4 grid gap-4 border-t border-border pt-5 sm:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="from-user">From user</Label>
+            <Input
+              id="from-user"
+              type="text"
+              value={from}
+              onChange={(e) => handleFilterChange('from', e.target.value)}
+              placeholder="username without @"
+              className="bg-background"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="to-user">Replying to user</Label>
+            <Input
+              id="to-user"
+              type="text"
+              value={to}
+              onChange={(e) => handleFilterChange('to', e.target.value)}
+              placeholder="username without @"
+              className="bg-background"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="since-date">From date</Label>
+            <Input
+              id="since-date"
+              type="date"
+              value={since}
+              onChange={(e) => handleFilterChange('since', e.target.value)}
+              className="bg-background"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="until-date">To date</Label>
+            <Input
+              id="until-date"
+              type="date"
+              value={until}
+              onChange={(e) => handleFilterChange('until', e.target.value)}
+              className="bg-background"
+            />
+          </div>
+        </div>
+      )}
+    </form>
   )
 }

--- a/src/components/HeroCTAButtons.tsx
+++ b/src/components/HeroCTAButtons.tsx
@@ -153,7 +153,7 @@ export default function HeroCTAButtons() {
       }
 
       setIsOptedIn(true)
-      router.refresh()
+      router.push('/explore')
     } catch (err: any) {
       console.error('Opt-in error:', err.message)
     } finally {

--- a/src/components/MemberSearchLanding.tsx
+++ b/src/components/MemberSearchLanding.tsx
@@ -1,0 +1,152 @@
+'use client'
+
+import Image from 'next/image'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { FormEvent, useState } from 'react'
+import {
+  ArrowRight,
+  Boxes,
+  Search,
+  SlidersHorizontal,
+  Users,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { formatNumber } from '@/lib/formatNumber'
+
+interface MemberSearchLandingProps {
+  tweetCount: number | null
+  userCount: number | null
+}
+
+const exampleSearches = [
+  'open source communities',
+  'AI alignment',
+  'from:vitalikbuterin ethereum',
+]
+
+export default function MemberSearchLanding({
+  tweetCount,
+  userCount,
+}: MemberSearchLandingProps) {
+  const router = useRouter()
+  const [query, setQuery] = useState('')
+
+  const search = (expression: string) => {
+    const trimmedQuery = expression.trim()
+    if (!trimmedQuery) return
+    router.push(`/search?q=${encodeURIComponent(trimmedQuery)}`)
+  }
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    search(query)
+  }
+
+  return (
+    <main className="min-h-[calc(100vh-4rem)] bg-background">
+      <section className="mx-auto flex w-full max-w-5xl flex-col items-center px-4 pb-16 pt-16 text-center sm:px-6 sm:pt-24 lg:px-8">
+        <Image
+          src="/images/logo.png"
+          alt=""
+          width={64}
+          height={64}
+          className="h-14 w-14 sm:h-16 sm:w-16"
+          priority
+        />
+        <p className="mt-6 text-sm font-semibold uppercase tracking-[0.18em] text-brand">
+          Member archive access
+        </p>
+        <h1 className="mt-3 max-w-3xl text-4xl font-bold tracking-tight text-foreground sm:text-6xl">
+          What are you looking for?
+        </h1>
+        <p className="mt-5 max-w-2xl text-base leading-7 text-muted-foreground sm:text-lg">
+          Search {formatNumber(tweetCount)} public tweets from{' '}
+          {formatNumber(userCount)} participating members.
+        </p>
+
+        <form
+          onSubmit={handleSubmit}
+          className="mt-10 flex w-full max-w-3xl flex-col gap-3 rounded-xl border border-border bg-card p-2 shadow-lg sm:flex-row"
+        >
+          <div className="relative flex-1">
+            <Search className="absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              type="search"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search the Community Archive"
+              aria-label="Search the Community Archive"
+              className="h-14 border-0 bg-transparent pl-12 pr-4 text-base shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 sm:text-lg"
+              autoFocus
+              autoComplete="off"
+            />
+          </div>
+          <Button
+            type="submit"
+            size="lg"
+            disabled={!query.trim()}
+            className="h-14 bg-brand px-7 text-brand-foreground hover:bg-brand/90"
+          >
+            Search
+            <ArrowRight className="ml-2 h-4 w-4" />
+          </Button>
+        </form>
+
+        <div className="mt-5 flex max-w-3xl flex-wrap items-center justify-center gap-x-2 gap-y-2 text-sm text-muted-foreground">
+          <span>Try:</span>
+          {exampleSearches.map((example) => (
+            <button
+              key={example}
+              type="button"
+              onClick={() => search(example)}
+              className="rounded-full border border-border bg-card px-3 py-1.5 text-foreground transition-colors hover:bg-accent"
+            >
+              {example}
+            </button>
+          ))}
+        </div>
+
+        <div className="mt-14 grid w-full max-w-3xl gap-3 text-left sm:grid-cols-3">
+          <Link
+            href="/search"
+            className="group rounded-xl border border-border bg-card p-5 transition-colors hover:bg-accent"
+          >
+            <SlidersHorizontal className="h-5 w-5 text-brand" />
+            <h2 className="mt-4 text-base font-semibold text-foreground">
+              Advanced search
+            </h2>
+            <p className="mt-1 text-sm leading-6 text-muted-foreground">
+              Filter by author, reply, or date.
+            </p>
+          </Link>
+          <Link
+            href="/user-dir"
+            className="group rounded-xl border border-border bg-card p-5 transition-colors hover:bg-accent"
+          >
+            <Users className="h-5 w-5 text-brand" />
+            <h2 className="mt-4 text-base font-semibold text-foreground">
+              User Directory
+            </h2>
+            <p className="mt-1 text-sm leading-6 text-muted-foreground">
+              Browse participating accounts.
+            </p>
+          </Link>
+          <Link
+            href="/#products"
+            className="group rounded-xl border border-border bg-card p-5 transition-colors hover:bg-accent"
+          >
+            <Boxes className="h-5 w-5 text-brand" />
+            <h2 className="mt-4 text-base font-semibold text-foreground">
+              Products
+            </h2>
+            <p className="mt-1 text-sm leading-6 text-muted-foreground">
+              Explore tools built on the archive.
+            </p>
+          </Link>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/src/components/MemberSearchLanding.tsx
+++ b/src/components/MemberSearchLanding.tsx
@@ -14,6 +14,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { formatNumber } from '@/lib/formatNumber'
+import { buildSearchParams } from '@/lib/searchParams'
 
 interface MemberSearchLandingProps {
   tweetCount: number | null
@@ -36,7 +37,8 @@ export default function MemberSearchLanding({
   const search = (expression: string) => {
     const trimmedQuery = expression.trim()
     if (!trimmedQuery) return
-    router.push(`/search?q=${encodeURIComponent(trimmedQuery)}`)
+    const params = buildSearchParams(trimmedQuery)
+    router.push(`/search?${params.toString()}`)
   }
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { LogIn, LogOut, UserRound } from 'lucide-react'
+import { LogIn, LogOut, Search, UserRound } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useAuthAndArchive } from '@/hooks/useAuthAndArchive'
 import { createBrowserClient } from '@/utils/supabase'
@@ -69,6 +69,12 @@ export default function MobileMenu() {
 
         {userMetadata ? (
           <>
+            <DropdownMenuItem asChild>
+              <Link href="/explore" className="cursor-pointer gap-3 py-2.5">
+                <Search className="h-4 w-4" />
+                Search archive
+              </Link>
+            </DropdownMenuItem>
             <DropdownMenuItem asChild>
               <Link href="/profile" className="cursor-pointer gap-3 py-2.5">
                 <UserRound className="h-4 w-4" />

--- a/src/components/SignIn.tsx
+++ b/src/components/SignIn.tsx
@@ -18,7 +18,11 @@ const STAGING_USERS = [
 
 export default function SignIn() {
   const searchParams = useSearchParams()
-  const redirectTo = searchParams.get('redirect')
+  const requestedRedirect = searchParams.get('redirect')
+  const redirectTo =
+    requestedRedirect?.startsWith('/') && !requestedRedirect.startsWith('//')
+      ? requestedRedirect
+      : null
   const { userMetadata } = useAuthAndArchive()
   const isDevLoginEnabled =
     process.env.NODE_ENV === 'development' ||
@@ -79,7 +83,7 @@ export default function SignIn() {
         if (redirectTo) {
           window.location.href = redirectTo
         } else {
-          window.location.href = '/profile'
+          window.location.href = '/explore'
         }
       } catch (error) {
         console.error('Error during dev sign in:', error)
@@ -93,7 +97,7 @@ export default function SignIn() {
       })
       const callbackUrl = redirectTo
         ? `${window.location.origin}/api/auth/callback?next=${encodeURIComponent(redirectTo)}`
-        : `${window.location.origin}/api/auth/callback`
+        : `${window.location.origin}/api/auth/callback?next=${encodeURIComponent('/explore')}`
 
       const { data, error } = await supabase.auth.signInWithOAuth({
         provider: 'twitter',

--- a/src/components/ThreadView.tsx
+++ b/src/components/ThreadView.tsx
@@ -45,7 +45,7 @@ export const ThreadView: React.FC<ThreadViewProps> = ({
     return (
       <div
         key={tweetId}
-        className={`thread-tweet-container ${depth > 0 ? 'ml-8 border-l-2 border-border pl-4' : ''}`}
+        className={`thread-tweet-container ${depth > 0 ? 'ml-3 border-l-2 border-border pl-3 sm:ml-8 sm:pl-4' : ''}`}
       >
         {tweet.is_deleted_placeholder ? (
           // Tombstone — deleted from the archive AND syndication couldn't find it.
@@ -55,8 +55,8 @@ export const ThreadView: React.FC<ThreadViewProps> = ({
         ) : (
           <div
             className={`
-            ${isHighlighted ? 'border border-border bg-muted' : tweet.from_external ? 'border border-dashed border-amber-300 bg-amber-50/60 dark:border-amber-700 dark:bg-amber-900/10' : 'bg-background dark:bg-secondary'}
-            relative mb-4 rounded-lg p-4
+            ${isHighlighted ? 'border-brand/50 bg-card ring-1 ring-brand/20' : tweet.from_external ? 'border-dashed border-amber-300 bg-amber-50/60 dark:border-amber-700 dark:bg-amber-900/10' : 'border-border bg-card'}
+            relative mb-4 rounded-xl border p-4 sm:p-5
           `}
           >
             {tweet.from_external && (
@@ -113,10 +113,11 @@ export const ThreadView: React.FC<ThreadViewProps> = ({
 
   return (
     <div className={`thread-view ${className}`}>
-      <div className="mb-4">
-        <h3 className="mb-2 text-lg font-semibold text-foreground">
-          🧵 Thread ({realCount} {realCount === 1 ? 'tweet' : 'tweets'})
-        </h3>
+      <div className="mb-5 flex items-center justify-between gap-4">
+        <h2 className="text-xl font-semibold text-foreground">Thread</h2>
+        <span className="rounded-full bg-muted px-3 py-1 text-xs font-medium text-muted-foreground">
+          {realCount} {realCount === 1 ? 'tweet' : 'tweets'}
+        </span>
       </div>
       <div className="thread-container">
         {allRoots.map((rootId) => (

--- a/src/components/TweetComponent.tsx
+++ b/src/components/TweetComponent.tsx
@@ -83,6 +83,7 @@ export interface TweetData {
 interface TweetComponentProps {
   tweet: TweetData
   className?: string
+  collapseLongText?: boolean
 }
 
 // Helper function to decode HTML entities
@@ -107,7 +108,9 @@ const decodeHtmlEntities = (text: string): string => {
 export const TweetComponent: React.FC<TweetComponentProps> = ({
   tweet,
   className = '',
+  collapseLongText = false,
 }) => {
+  const [isTextExpanded, setIsTextExpanded] = React.useState(false)
   // Support both interface formats for backwards compatibility
   const originalUsername =
     tweet.username || tweet.account?.username || 'Unknown'
@@ -121,6 +124,7 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
 
   const isRetweet = !!tweet.retweeted_tweet_id
   const isQuoteTweet = !!tweet.quote_tweet_id
+  const canCollapseText = collapseLongText && tweet.full_text.length > 700
 
   // Check if this is a retweet that starts with "RT @username"
   const rtMatch = tweet.full_text.match(/^RT @([A-Za-z0-9_]+):/)
@@ -196,7 +200,7 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
               href={part}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-brand hover:text-brand"
+              className="break-all text-brand underline-offset-2 hover:underline"
             >
               {part}
             </a>
@@ -213,7 +217,9 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
     if (!mediaArray || mediaArray.length === 0) return null
 
     return (
-      <div className="my-2 flex flex-col space-y-2">
+      <div
+        className={`my-3 grid gap-2 ${mediaArray.length > 1 ? 'grid-cols-2' : 'grid-cols-1'}`}
+      >
         {mediaArray
           .filter(
             (m: any) =>
@@ -224,14 +230,14 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
           .map((mediaItem: any, index: number) => (
             <div
               key={index}
-              className="relative overflow-hidden rounded-lg border dark:border-border"
+              className="relative overflow-hidden rounded-lg border border-border bg-muted"
             >
               <NextImage
                 src={mediaItem.media_url}
                 alt={`Tweet image ${index + 1}`}
                 width={mediaItem.width || 600}
                 height={mediaItem.height || 400}
-                className="h-auto max-h-96 w-full object-contain"
+                className="min-h-40 h-full max-h-96 w-full object-cover"
               />
             </div>
           ))}
@@ -282,7 +288,7 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
             </AvatarFallback>
           </Avatar>
           <div className="min-w-0 flex-1">
-            <div className="mb-1 flex items-center space-x-1">
+            <div className="mb-1 flex flex-wrap items-baseline gap-x-1 gap-y-0.5">
               <span className="text-sm font-bold text-foreground">
                 {quotedTweet.account_display_name}
               </span>
@@ -296,7 +302,7 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
                 })}
               </span>
             </div>
-            <p className="whitespace-pre-wrap break-words text-sm text-muted-foreground">
+            <p className="whitespace-pre-wrap break-words text-sm leading-6 text-foreground">
               {decodeHtmlEntities(quotedTweet.full_text)}
             </p>
             {quotedTweet.media && quotedTweet.media.length > 0 && (
@@ -369,8 +375,8 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
         </div>
       )}
 
-      <div className="mb-2 flex items-start">
-        <Avatar className="mr-3 h-12 w-12">
+      <div className="mb-3 flex items-start">
+        <Avatar className="mr-3 h-11 w-11 flex-shrink-0">
           <TweetAvatarImage
             src={profilePicUrl}
             alt={`${displayName}'s profile picture`}
@@ -382,12 +388,10 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
           </AvatarFallback>
         </Avatar>
         <div className="min-w-0 flex-1">
-          <div className="flex items-center">
-            <span className="mr-2 font-bold text-foreground">
-              {displayName}
-            </span>
+          <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+            <span className="font-bold text-foreground">{displayName}</span>
             <span className="text-muted-foreground">@{displayUsername}</span>
-            <span className="ml-2 text-sm text-muted-foreground">
+            <span className="text-sm text-muted-foreground">
               •{' '}
               {formatDistanceToNow(new Date(tweet.created_at), {
                 addSuffix: true,
@@ -403,14 +407,28 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
         </div>
       </div>
 
-      <p className="mb-2 whitespace-pre-wrap break-words text-muted-foreground">
+      <p
+        className={`mb-2 whitespace-pre-wrap break-words text-[15px] leading-6 text-foreground ${
+          canCollapseText && !isTextExpanded ? 'line-clamp-[10]' : ''
+        }`}
+      >
         {formatText(tweet.full_text)}
       </p>
+
+      {canCollapseText && (
+        <button
+          type="button"
+          onClick={() => setIsTextExpanded((expanded) => !expanded)}
+          className="mb-2 text-sm font-medium text-brand hover:underline"
+        >
+          {isTextExpanded ? 'Show less' : 'Show more'}
+        </button>
+      )}
 
       {renderMedia()}
       {renderQuotedTweet()}
 
-      <div className="flex items-center justify-between text-sm text-muted-foreground">
+      <div className="mt-4 flex flex-col gap-3 border-t border-border pt-3 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center space-x-4">
           <span className="flex items-center">
             <FaHeart className="mr-1" /> {formatNumber(tweet.favorite_count)}
@@ -420,23 +438,25 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
             {formatNumber(tweet.retweet_count ?? 0)}
           </span>
         </div>
-        <div className="flex items-center space-x-3 text-xs text-muted-foreground">
+        <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
           <span>{new Date(tweet.created_at).toLocaleDateString()}</span>
           <a
             href={`/tweets/${tweet.tweet_id}`}
-            className="transition-colors hover:text-foreground"
+            className="inline-flex items-center gap-1 transition-colors hover:text-foreground"
             title="Permalink"
           >
             <FaExternalLinkAlt className="h-3 w-3" />
+            Archive
           </a>
           <a
             href={`https://twitter.com/${displayUsername}/status/${tweet.tweet_id}`}
             target="_blank"
             rel="noopener noreferrer"
-            className="transition-colors hover:text-foreground"
+            className="inline-flex items-center gap-1 transition-colors hover:text-foreground"
             title="View on Twitter"
           >
             <FaExternalLinkAlt className="h-3 w-3" />
+            Twitter
           </a>
         </div>
       </div>

--- a/src/components/TweetList.tsx
+++ b/src/components/TweetList.tsx
@@ -3,16 +3,22 @@
 import { useState, useEffect, useCallback } from 'react'
 import UnifiedTweetList from '@/components/UnifiedTweetList'
 import { Button } from '@/components/ui/button'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Skeleton } from '@/components/ui/skeleton'
 import { createBrowserClient } from '@/utils/supabase'
 import { SupabaseClient } from '@supabase/supabase-js'
 import { TimelineTweet } from '@/lib/types'
 import { FilterCriteria, fetchTweets } from '@/lib/queries/tweetQueries'
+import { AlertCircle } from 'lucide-react'
 
 interface TweetListProps {
   filterCriteria: FilterCriteria
   itemsPerPage?: number
   showCsvExportButton?: boolean
   csvExportFilename?: string
+  resultsHeading?: string
+  resultsDescription?: string
+  collapseLongTweets?: boolean
 }
 
 const DEFAULT_ITEMS_PER_PAGE = 20
@@ -22,6 +28,9 @@ export default function TweetList({
   itemsPerPage = DEFAULT_ITEMS_PER_PAGE,
   showCsvExportButton = true,
   csvExportFilename = 'tweets_export.csv',
+  resultsHeading,
+  resultsDescription,
+  collapseLongTweets = false,
 }: TweetListProps) {
   const [tweets, setTweets] = useState<TimelineTweet[]>([])
   const [isLoading, setIsLoading] = useState(true)
@@ -103,15 +112,40 @@ export default function TweetList({
 
   if (isLoading) {
     return (
-      <p className="py-10 text-center text-xl text-muted-foreground">
-        Loading tweets...
-      </p>
+      <div className="space-y-4" aria-label="Loading tweets">
+        <div className="flex items-center justify-between border-b border-border pb-5">
+          <div className="space-y-2">
+            <Skeleton className="h-6 w-40" />
+            <Skeleton className="h-4 w-64 max-w-full" />
+          </div>
+          <Skeleton className="h-9 w-28" />
+        </div>
+        {[0, 1, 2].map((item) => (
+          <div
+            key={item}
+            className="rounded-xl border border-border bg-card p-5"
+          >
+            <div className="flex gap-3">
+              <Skeleton className="h-11 w-11 rounded-full" />
+              <div className="flex-1 space-y-3">
+                <Skeleton className="h-4 w-48 max-w-full" />
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-4/5" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
     )
   }
 
   if (error && tweets.length === 0) {
     return (
-      <p className="py-10 text-center text-xl text-red-500">Error: {error}</p>
+      <Alert variant="destructive">
+        <AlertCircle className="h-4 w-4" />
+        <AlertTitle>Search could not be completed</AlertTitle>
+        <AlertDescription>{error}</AlertDescription>
+      </Alert>
     )
   }
 
@@ -147,21 +181,32 @@ export default function TweetList({
         className="space-y-4"
         showCsvExport={showCsvExportButton}
         csvFilename={csvExportFilename}
+        headerTitle={
+          resultsHeading
+            ? `${resultsHeading} · ${new Intl.NumberFormat().format(
+                totalCount ?? tweets.length,
+              )}${totalCount === null ? ' loaded' : ''}`
+            : undefined
+        }
+        headerDescription={resultsDescription}
+        collapseLongTweets={collapseLongTweets}
       />
 
       {error && tweets.length > 0 && (
-        <p className="mt-6 text-center text-red-500">
-          Error loading more tweets: {error}
-        </p>
+        <Alert variant="destructive">
+          <AlertTitle>More results could not be loaded</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
       )}
       {hasMoreTweets && (
-        <div className="mt-8 text-center">
+        <div className="mt-8 flex justify-center">
           <Button
             onClick={handleLoadMore}
             disabled={isLoadingMore}
             variant="outline"
+            className="min-w-36"
           >
-            {isLoadingMore ? 'Loading...' : 'Load More'}
+            {isLoadingMore ? 'Loading…' : 'Load more'}
           </Button>
         </div>
       )}

--- a/src/components/UnifiedTweetList.tsx
+++ b/src/components/UnifiedTweetList.tsx
@@ -3,6 +3,7 @@
 import React from 'react'
 import TweetComponent from './TweetComponent'
 import { Button } from '@/components/ui/button'
+import { Download, SearchX } from 'lucide-react'
 
 interface UnifiedTweetListProps {
   tweets: any[]
@@ -11,6 +12,9 @@ interface UnifiedTweetListProps {
   className?: string
   showCsvExport?: boolean
   csvFilename?: string
+  headerTitle?: string
+  headerDescription?: string
+  collapseLongTweets?: boolean
 }
 
 /**
@@ -25,6 +29,9 @@ export default function UnifiedTweetList({
   className = 'space-y-4',
   showCsvExport = false,
   csvFilename = 'tweets_export.csv',
+  headerTitle,
+  headerDescription,
+  collapseLongTweets = false,
 }: UnifiedTweetListProps) {
   const handleExportCsv = () => {
     if (tweets.length === 0) {
@@ -87,19 +94,45 @@ export default function UnifiedTweetList({
 
   if (!tweets.length) {
     return (
-      <div className="flex items-center justify-center py-10">
-        <div className="text-lg text-muted-foreground">{emptyMessage}</div>
+      <div className="rounded-xl border border-dashed border-border bg-card px-6 py-12 text-center">
+        <SearchX className="mx-auto h-8 w-8 text-muted-foreground" />
+        <div className="mt-4 text-base font-medium text-foreground">
+          {emptyMessage}
+        </div>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Try fewer words or remove one of the filters.
+        </p>
       </div>
     )
   }
 
   return (
     <div className="space-y-4">
-      {showCsvExport && tweets.length > 0 && (
-        <div className="mb-4 flex justify-end">
-          <Button onClick={handleExportCsv} variant="outline">
-            Download CSV
-          </Button>
+      {(headerTitle || headerDescription || showCsvExport) && (
+        <div className="flex flex-col gap-4 border-b border-border pb-5 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            {headerTitle && (
+              <h2 className="text-2xl font-semibold text-foreground">
+                {headerTitle}
+              </h2>
+            )}
+            {headerDescription && (
+              <p className="mt-1 text-sm text-muted-foreground">
+                {headerDescription}
+              </p>
+            )}
+          </div>
+          {showCsvExport && tweets.length > 0 && (
+            <Button
+              onClick={handleExportCsv}
+              variant="outline"
+              size="sm"
+              className="self-start sm:self-auto"
+            >
+              <Download className="mr-2 h-4 w-4" />
+              Download CSV
+            </Button>
+          )}
         </div>
       )}
 
@@ -107,9 +140,12 @@ export default function UnifiedTweetList({
         {tweets.map((tweet) => (
           <div
             key={tweet.tweet_id}
-            className="rounded-lg border border-border bg-background p-4 dark:bg-secondary"
+            className="rounded-xl border border-border bg-card p-4 transition-colors hover:border-foreground/20 sm:p-5"
           >
-            <TweetComponent tweet={tweet} />
+            <TweetComponent
+              tweet={tweet}
+              collapseLongText={collapseLongTweets}
+            />
           </div>
         ))}
       </div>

--- a/src/lib/auth-utils.ts
+++ b/src/lib/auth-utils.ts
@@ -2,28 +2,31 @@ import { createServerClient } from '@/utils/supabase'
 import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 
-export async function requireAuth() {
+export async function requireAuth(redirectTo = '/opt-in') {
   const cookieStore = await cookies()
   const supabase = createServerClient(cookieStore)
-  
-  const { data: { user }, error } = await supabase.auth.getUser()
-  
+
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser()
+
   if (error || !user) {
-    redirect('/login?redirect=/opt-in')
+    redirect(`/login?redirect=${encodeURIComponent(redirectTo)}`)
   }
-  
+
   return { user, supabase }
 }
 
 export async function getOptInStatus(userId: string) {
   const cookieStore = await cookies()
   const supabase = createServerClient(cookieStore)
-  
+
   const { data, error } = await supabase
     .from('optin')
     .select('*')
     .eq('user_id', userId)
     .single()
-  
+
   return { data, error }
 }

--- a/src/lib/searchParams.test.ts
+++ b/src/lib/searchParams.test.ts
@@ -1,0 +1,48 @@
+import {
+  buildSearchExpression,
+  buildSearchParams,
+  parseSearchExpression,
+} from './searchParams'
+
+describe('search parameter helpers', () => {
+  it('separates supported filters from search terms', () => {
+    expect(
+      parseSearchExpression(
+        'open source from:jack to:alice since:2020-01-01 until:2020-12-31',
+      ),
+    ).toEqual({
+      options: {
+        from: 'jack',
+        to: 'alice',
+        since: '2020-01-01',
+        until: '2020-12-31',
+      },
+      words: ['open', 'source'],
+    })
+  })
+
+  it('keeps unsupported or empty operators as search terms', () => {
+    expect(parseSearchExpression('archive lang:en from:')).toEqual({
+      options: {},
+      words: ['archive', 'lang:en', 'from:'],
+    })
+  })
+
+  it('maps an expression to the existing search URL convention', () => {
+    expect(
+      buildSearchParams('community from:alice since:2024-01-01').toString(),
+    ).toBe('q=community&fromUser=alice&sinceDate=2024-01-01')
+  })
+
+  it('reconstructs the editable expression from URL parameters', () => {
+    expect(
+      buildSearchExpression(
+        new URLSearchParams({
+          q: 'community archive',
+          replyToUser: 'bob',
+          untilDate: '2025-01-01',
+        }),
+      ),
+    ).toBe('community archive to:bob until:2025-01-01')
+  })
+})

--- a/src/lib/searchParams.ts
+++ b/src/lib/searchParams.ts
@@ -1,0 +1,66 @@
+export const SEARCH_FILTER_KEYS = ['from', 'to', 'since', 'until'] as const
+
+export type SearchFilterKey = (typeof SEARCH_FILTER_KEYS)[number]
+
+export type SearchFilters = Partial<Record<SearchFilterKey, string>>
+
+export interface ParsedSearchExpression {
+  options: SearchFilters
+  words: string[]
+}
+
+export function parseSearchExpression(input: string): ParsedSearchExpression {
+  const options: SearchFilters = {}
+  const words: string[] = []
+
+  input
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .forEach((part) => {
+      const separatorIndex = part.indexOf(':')
+
+      if (separatorIndex > 0) {
+        const key = part.substring(0, separatorIndex) as SearchFilterKey
+        const value = part.substring(separatorIndex + 1)
+
+        if (SEARCH_FILTER_KEYS.includes(key) && value) {
+          options[key] = value
+          return
+        }
+      }
+
+      words.push(part)
+    })
+
+  return { options, words }
+}
+
+export function buildSearchParams(expression: string): URLSearchParams {
+  const { options, words } = parseSearchExpression(expression)
+  const params = new URLSearchParams()
+  const mainQuery = words.join(' ').trim()
+
+  if (mainQuery) params.set('q', mainQuery)
+  if (options.from) params.set('fromUser', options.from)
+  if (options.to) params.set('replyToUser', options.to)
+  if (options.since) params.set('sinceDate', options.since)
+  if (options.until) params.set('untilDate', options.until)
+
+  return params
+}
+
+export function buildSearchExpression(searchParams: URLSearchParams): string {
+  const parts = [searchParams.get('q') || '']
+  const fromUser = searchParams.get('fromUser')
+  const replyToUser = searchParams.get('replyToUser')
+  const sinceDate = searchParams.get('sinceDate')
+  const untilDate = searchParams.get('untilDate')
+
+  if (fromUser) parts.push(`from:${fromUser}`)
+  if (replyToUser) parts.push(`to:${replyToUser}`)
+  if (sinceDate) parts.push(`since:${sinceDate}`)
+  if (untilDate) parts.push(`until:${untilDate}`)
+
+  return parts.filter(Boolean).join(' ').trim()
+}


### PR DESCRIPTION
## Summary

- restyles the existing search page with a focused query field, optional filters, removable filter chips, loading and empty states, and cleaner result cards
- makes results easier to scan with responsive media, visible archive/Twitter links, result counts, CSV export, and collapsible long tweets
- redesigns standalone tweet and conversation permalinks with a readable content width, clear hierarchy, responsive thread indentation, and highlighted linked tweets
- adds a private /explore landing with a Wikipedia-style search field for signed-in opted-in members
- routes default sign-in and successful opt-in flows to /explore while preserving the public homepage and Products anchor

## Verification

- npm run lint
- npm test -- --selectProjects server --runInBand src/lib/searchParams.test.ts
- npm run build
- browser QA at desktop and mobile widths in light and dark mode
- verified standalone and conversation permalink rendering against live archive data
- verified unauthenticated /explore redirects to /login?redirect=%2Fexplore
- verified no horizontal overflow at the mobile breakpoint