### PR TITLE
Try a search-first homepage

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,7 @@ import dynamic from 'next/dynamic'
 import HeaderNavigation from '@/components/HeaderNavigation'
 import HeaderSearch from '@/components/HeaderSearch'
 import MobileMenu from '@/components/MobileMenu'
+import MobileNavigation from '@/components/MobileNavigation'
 import Footer from '@/components/Footer'
 import { checkIsAdmin } from '@/app/admin/data'
 import { Shield } from 'lucide-react'
@@ -95,6 +96,7 @@ export default async function RootLayout({
                   <div className="text-sm">
                     <DynamicSignIn />
                   </div>
+                  <MobileNavigation />
                   <ThemeToggle side="bottom" />
                   {isAdmin ? (
                     <Link

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,6 +18,7 @@ import TieredSupportersDisplay, {
 import dynamic from 'next/dynamic'
 import FeaturedAppsSection from '@/components/FeaturedAppsSection'
 import AppGallery from '@/components/AppGallery'
+import HomepageSearch from '@/components/HomepageSearch'
 
 export const revalidate = 60 // Cache for 60s to reduce server load from scrapers
 
@@ -177,19 +178,27 @@ export default async function Homepage() {
     <main>
       {/* Section 1: Hero with CTAs */}
       <section className="overflow-hidden bg-card pb-12 pt-16 dark:bg-background md:pb-16 md:pt-24">
-        <div className={`${contentWrapperClasses} space-y-11 text-center`}>
+        <div className={`${contentWrapperClasses} space-y-10 text-center`}>
           <div className="space-y-4">
             <h1 className="text-5xl font-bold tracking-tight text-foreground md:text-6xl">
               Community Archive
             </h1>
-            <p className="text-xl text-muted-foreground">
-              An open Twitter database. Join the archive to{' '}
+            <p className="text-xl leading-8 text-muted-foreground">
+              Search millions of public conversations and help build{' '}
               <br className="hidden sm:block" />
-              contribute to open source public infrastructure.
+              open source public infrastructure.
             </p>
           </div>
 
-          <div className="space-y-4">
+          <HomepageSearch
+            tweetCount={stats.tweetCount}
+            userCount={stats.userCount}
+          />
+
+          <div className="space-y-4 border-t border-border pt-8">
+            <p className="text-sm font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+              Help grow the archive
+            </p>
             <DynamicHeroCTAButtons />
             <p className="text-sm text-muted-foreground">
               Backed by Survival and Flourishing Fund and Vitalik Buterin

--- a/src/components/HomepageSearch.tsx
+++ b/src/components/HomepageSearch.tsx
@@ -2,7 +2,7 @@
 
 import { FormEvent, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { ArrowRight, Search } from 'lucide-react'
+import { Search } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { formatNumber } from '@/lib/formatNumber'
@@ -39,28 +39,26 @@ export default function HomepageSearch({
     <div className="mx-auto w-full max-w-3xl">
       <form
         onSubmit={handleSubmit}
-        className="flex flex-col gap-2 rounded-xl border border-border bg-card p-2 text-left shadow-lg sm:flex-row"
+        className="relative rounded-xl border border-border bg-card p-2 text-left shadow-lg"
       >
-        <div className="relative flex-1">
-          <Search className="absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            type="search"
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder="Search tweets, people, and ideas"
-            aria-label="Search Community Archive"
-            className="h-14 border-0 bg-transparent pl-12 pr-4 text-base shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 sm:text-lg"
-            autoComplete="off"
-          />
-        </div>
+        <Input
+          type="search"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search tweets, people, and ideas"
+          aria-label="Search Community Archive"
+          className="h-14 border-0 bg-transparent pl-4 pr-14 text-base shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 sm:text-lg"
+          autoComplete="off"
+        />
         <Button
           type="submit"
-          size="lg"
+          size="icon"
+          variant="ghost"
           disabled={!query.trim()}
-          className="h-14 bg-brand px-7 text-brand-foreground hover:bg-brand/90"
+          className="absolute right-3 top-1/2 h-10 w-10 -translate-y-1/2 rounded-full text-muted-foreground hover:bg-accent hover:text-foreground"
+          aria-label="Search archive"
         >
-          Search
-          <ArrowRight className="ml-2 h-4 w-4" />
+          <Search className="h-5 w-5" />
         </Button>
       </form>
 

--- a/src/components/HomepageSearch.tsx
+++ b/src/components/HomepageSearch.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { FormEvent, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { ArrowRight, Search } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { formatNumber } from '@/lib/formatNumber'
+import { buildSearchParams } from '@/lib/searchParams'
+
+interface HomepageSearchProps {
+  tweetCount: number | null
+  userCount: number | null
+}
+
+const exampleSearches = ['open source', 'AI alignment', 'from:vitalikbuterin']
+
+export default function HomepageSearch({
+  tweetCount,
+  userCount,
+}: HomepageSearchProps) {
+  const router = useRouter()
+  const [query, setQuery] = useState('')
+
+  const search = (expression: string) => {
+    const trimmedQuery = expression.trim()
+    if (!trimmedQuery) return
+
+    const params = buildSearchParams(trimmedQuery)
+    router.push(`/search?${params.toString()}`)
+  }
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    search(query)
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-3xl">
+      <form
+        onSubmit={handleSubmit}
+        className="flex flex-col gap-2 rounded-xl border border-border bg-card p-2 text-left shadow-lg sm:flex-row"
+      >
+        <div className="relative flex-1">
+          <Search className="absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search tweets, people, and ideas"
+            aria-label="Search Community Archive"
+            className="h-14 border-0 bg-transparent pl-12 pr-4 text-base shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 sm:text-lg"
+            autoComplete="off"
+          />
+        </div>
+        <Button
+          type="submit"
+          size="lg"
+          disabled={!query.trim()}
+          className="h-14 bg-brand px-7 text-brand-foreground hover:bg-brand/90"
+        >
+          Search
+          <ArrowRight className="ml-2 h-4 w-4" />
+        </Button>
+      </form>
+
+      <div className="mt-4 flex flex-col items-center justify-between gap-3 text-sm text-muted-foreground sm:flex-row">
+        <p>
+          Search {formatNumber(tweetCount)} tweets from{' '}
+          {formatNumber(userCount)} participating members.
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          <span>Try:</span>
+          {exampleSearches.map((example) => (
+            <button
+              key={example}
+              type="button"
+              onClick={() => search(example)}
+              className="font-medium text-foreground underline-offset-4 transition-colors hover:text-brand hover:underline"
+            >
+              {example}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { usePathname } from 'next/navigation'
-import { LogIn, LogOut, Search, UserRound } from 'lucide-react'
+import { LogIn, LogOut, UserRound } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useAuthAndArchive } from '@/hooks/useAuthAndArchive'
 import { createBrowserClient } from '@/utils/supabase'
@@ -10,20 +9,10 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 
-const mobileNavItems = [
-  { href: '/', label: 'Home' },
-  { href: '/#products', label: 'Products' },
-  { href: '/user-dir', label: 'User Directory' },
-  { href: '/search', label: 'Search' },
-]
-
 export default function MobileMenu() {
-  const pathname = usePathname()
   const { userMetadata } = useAuthAndArchive()
 
   const handleSignOut = async () => {
@@ -48,33 +37,8 @@ export default function MobileMenu() {
         sideOffset={8}
         className="w-56 rounded-lg p-2"
       >
-        <div className="lg:hidden">
-          <DropdownMenuLabel className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-            Navigation
-          </DropdownMenuLabel>
-          {mobileNavItems.map((item) => (
-            <DropdownMenuItem key={item.href} asChild>
-              <Link
-                href={item.href}
-                className={`cursor-pointer py-2.5 ${
-                  pathname === item.href ? 'bg-muted font-medium' : ''
-                }`}
-              >
-                {item.label}
-              </Link>
-            </DropdownMenuItem>
-          ))}
-          <DropdownMenuSeparator />
-        </div>
-
         {userMetadata ? (
           <>
-            <DropdownMenuItem asChild>
-              <Link href="/explore" className="cursor-pointer gap-3 py-2.5">
-                <Search className="h-4 w-4" />
-                Search archive
-              </Link>
-            </DropdownMenuItem>
             <DropdownMenuItem asChild>
               <Link href="/profile" className="cursor-pointer gap-3 py-2.5">
                 <UserRound className="h-4 w-4" />

--- a/src/components/MobileNavigation.tsx
+++ b/src/components/MobileNavigation.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { Menu } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+
+const navigationItems = [
+  { href: '/', label: 'Home' },
+  { href: '/#products', label: 'Products' },
+  { href: '/user-dir', label: 'User Directory' },
+  { href: '/search', label: 'Search' },
+]
+
+export default function MobileNavigation() {
+  const pathname = usePathname()
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="icon" className="lg:hidden">
+          <Menu className="h-5 w-5" />
+          <span className="sr-only">Open navigation menu</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        sideOffset={8}
+        className="w-56 rounded-lg p-2 lg:hidden"
+      >
+        <DropdownMenuLabel className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Navigation
+        </DropdownMenuLabel>
+        {navigationItems.map((item) => {
+          const isActive =
+            item.href === '/#products'
+              ? false
+              : pathname === item.href ||
+                (item.href !== '/' && pathname.startsWith(`${item.href}/`))
+
+          return (
+            <DropdownMenuItem key={item.href} asChild>
+              <Link
+                href={item.href}
+                aria-current={isActive ? 'page' : undefined}
+                className={`cursor-pointer py-2.5 ${
+                  isActive ? 'bg-muted font-medium' : ''
+                }`}
+              >
+                {item.label}
+              </Link>
+            </DropdownMenuItem>
+          )
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}


### PR DESCRIPTION
## Summary

- makes archive search the primary action in the public homepage hero
- adds a responsive search field with a compact magnifying-glass action and preserves advanced operators such as `from:username`
- shows the current tweet and participant counts alongside example searches
- keeps opt-in, extension installation, and archive upload directly below as the contribution path
- separates mobile site navigation into its own hamburger dropdown while keeping the person menu limited to account actions

## Why

This is an isolated experiment so the search-first homepage can be reviewed independently now that the underlying search and tweet-permalink improvements from #413 are on `main`.

## Verification

- type-check and lint
- production build
- desktop and mobile browser QA
- verified homepage submission navigates to `/search` with the expected query
- verified mobile navigation and account dropdowns contain the appropriate actions
- verified no horizontal overflow at 390px
