### PR TITLE
Fix header search filter parsing

### DIFF
--- a/src/components/HeaderSearch.tsx
+++ b/src/components/HeaderSearch.tsx
@@ -6,23 +6,17 @@ import Link from 'next/link'
 import { ListFilter, Search } from 'lucide-react'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
+import { buildSearchHref } from '@/lib/searchParams'
 
 export default function HeaderSearch() {
   const router = useRouter()
   const [query, setQuery] = useState('')
+  const searchHref = buildSearchHref(query)
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    if (query.trim()) {
-      router.push(`/search?q=${encodeURIComponent(query.trim())}`)
-    } else {
-      router.push('/search')
-    }
+    router.push(searchHref)
   }
-
-  const advancedSearchHref = query.trim()
-    ? `/search?q=${encodeURIComponent(query.trim())}`
-    : '/search'
 
   return (
     <form onSubmit={handleSubmit} className="hidden items-center sm:flex">
@@ -44,7 +38,7 @@ export default function HeaderSearch() {
           className="h-9 w-9 rounded-l-none border-l-0"
         >
           <Link
-            href={advancedSearchHref}
+            href={searchHref}
             aria-label="Open advanced search"
             title="Advanced search"
           >

--- a/src/lib/searchParams.test.ts
+++ b/src/lib/searchParams.test.ts
@@ -1,5 +1,6 @@
 import {
   buildSearchExpression,
+  buildSearchHref,
   buildSearchParams,
   parseSearchExpression,
 } from './searchParams'
@@ -32,6 +33,12 @@ describe('search parameter helpers', () => {
     expect(
       buildSearchParams('community from:alice since:2024-01-01').toString(),
     ).toBe('q=community&fromUser=alice&sinceDate=2024-01-01')
+  })
+
+  it('builds a filter-only search URL without treating the operator as text', () => {
+    expect(buildSearchHref('from:a__musingcat')).toBe(
+      '/search?fromUser=a__musingcat',
+    )
   })
 
   it('reconstructs the editable expression from URL parameters', () => {

--- a/src/lib/searchParams.ts
+++ b/src/lib/searchParams.ts
@@ -50,6 +50,11 @@ export function buildSearchParams(expression: string): URLSearchParams {
   return params
 }
 
+export function buildSearchHref(expression: string): string {
+  const params = buildSearchParams(expression)
+  return params.size > 0 ? `/search?${params.toString()}` : '/search'
+}
+
 export function buildSearchExpression(searchParams: URLSearchParams): string {
   const parts = [searchParams.get('q') || '']
   const fromUser = searchParams.get('fromUser')


### PR DESCRIPTION
## Summary

- routes header searches through the shared search-expression parser
- uses the same normalized URL for Enter submissions and the advanced-search button
- adds regression coverage for the reported `from:a__musingcat` query

## Root cause

The header encoded its entire input into the `q` parameter, while the dedicated search form separates supported operators into filter parameters. A header query such as `from:a__musingcat` therefore reached PostgreSQL `to_tsquery` as text and failed with a tsquery syntax error.

## User impact

Header searches using `from:`, `to:`, `since:`, or `until:` now behave consistently with the dedicated search form instead of failing or searching the operator as literal text.

## Stack

This PR targets `codex/improve-search-experience` because that parent PR (#413) introduces the shared search-parameter helper. After #413 merges, this PR can be retargeted to `main`.

## Verification

- `npm test -- --selectProjects server --runInBand src/lib/searchParams.test.ts` (5 tests passed)
- `npm run type-check`
- `npm run lint`
- `prettier --check` on the three changed files
