### PR TITLE
Handle X sign-ins without email addresses

### DIFF
--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { createServerAdminClient } from '@/utils/supabase'
 import { cookies } from 'next/headers'
-import { devLog } from '@/lib/devLog'
+import { buildAuthErrorUrl } from '@/lib/authCallback'
 
 // Validate host against allowed domains - prevents open redirect attacks
 function isAllowedHost(host: string): boolean {
@@ -9,10 +9,14 @@ function isAllowedHost(host: string): boolean {
   const allowedDomainsEnv = process.env.NEXT_ALLOWED_AUTH_REDIRECT_DOMAINS || ''
   const allowedDomains = allowedDomainsEnv
     .split(',')
-    .map(d => d.trim().replace(/^https?:\/\//, '')) // Strip protocol
+    .map((d) => d.trim().replace(/^https?:\/\//, '')) // Strip protocol
     .filter(Boolean)
 
-  if (allowedDomains.some(domain => host === domain || host.endsWith(`.${domain}`))) {
+  if (
+    allowedDomains.some(
+      (domain) => host === domain || host.endsWith(`.${domain}`),
+    )
+  ) {
     return true
   }
 
@@ -39,23 +43,58 @@ export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url)
   const code = searchParams.get('code')
   const next = searchParams.get('next') ?? '/'
+  const providerError = searchParams.get('error')
+  const providerErrorCode = searchParams.get('error_code')
+  const providerErrorDescription = searchParams.get('error_description')
 
   // Validate 'next' parameter to prevent redirect to external URLs
   const safeNext = next.startsWith('/') ? next : '/'
 
+  if (providerError) {
+    console.warn('OAuth provider rejected sign-in', {
+      error: providerError,
+      errorCode: providerErrorCode,
+      errorDescription: providerErrorDescription,
+    })
+
+    return NextResponse.redirect(
+      buildAuthErrorUrl(origin, {
+        error: providerError,
+        errorCode: providerErrorCode,
+        errorDescription: providerErrorDescription,
+      }),
+    )
+  }
+
   if (code) {
     const supabase = createServerAdminClient(cookies())
     const { data, error } = await supabase.auth.exchangeCodeForSession(code)
-    devLog({ data, error, next: safeNext, origin, code })
+
+    if (error) {
+      console.error('Failed to exchange OAuth code for a session', error)
+      return NextResponse.redirect(
+        buildAuthErrorUrl(origin, {
+          error: 'session_exchange_failed',
+        }),
+      )
+    }
+
     if (!error && data.user) {
       // Move provider_id to app_metadata and ensure username is lowercase
-      const { data: updateData, error: updateError } =
-        await supabase.auth.admin.updateUserById(data.user.id, {
+      const providerId = data.user.user_metadata.provider_id
+      const rawUsername = data.user.user_metadata.user_name
+      const username =
+        typeof rawUsername === 'string' ? rawUsername.toLowerCase() : null
+
+      const { error: updateError } = await supabase.auth.admin.updateUserById(
+        data.user.id,
+        {
           app_metadata: {
-            provider_id: data.user.user_metadata.provider_id,
-            user_name: data.user.user_metadata.user_name.toLowerCase(),
+            ...(providerId ? { provider_id: providerId } : {}),
+            ...(username ? { user_name: username } : {}),
           },
-        })
+        },
+      )
 
       if (updateError) {
         console.error('Failed to update app_metadata:', updateError)
@@ -77,5 +116,7 @@ export async function GET(request: Request) {
     }
   }
 
-  return NextResponse.redirect(`${origin}/auth/auth-code-error`)
+  return NextResponse.redirect(
+    buildAuthErrorUrl(origin, { error: 'missing_authorization_code' }),
+  )
 }

--- a/src/app/auth/auth-code-error/page.tsx
+++ b/src/app/auth/auth-code-error/page.tsx
@@ -1,0 +1,53 @@
+import Link from 'next/link'
+import { AlertTriangle } from 'lucide-react'
+import { getAuthErrorCopy } from '@/lib/authCallback'
+
+export default function AuthCodeErrorPage({
+  searchParams,
+}: {
+  searchParams: {
+    error?: string
+    error_code?: string
+    error_description?: string
+  }
+}) {
+  const copy = getAuthErrorCopy({
+    error: searchParams.error,
+    errorCode: searchParams.error_code,
+    errorDescription: searchParams.error_description,
+  })
+  const supportCode = searchParams.error_code || searchParams.error
+
+  return (
+    <main className="flex min-h-[calc(100vh-4rem)] items-center justify-center px-4 py-16">
+      <section className="w-full max-w-lg rounded-lg border border-border bg-card p-8 text-center shadow-lg">
+        <AlertTriangle className="mx-auto mb-5 h-10 w-10 text-amber-500" />
+        <h1 className="mb-3 text-3xl font-bold text-foreground">
+          {copy.title}
+        </h1>
+        <p className="mb-8 text-muted-foreground">{copy.description}</p>
+
+        <div className="flex flex-col justify-center gap-3 sm:flex-row">
+          <Link
+            href="/login"
+            className="rounded-md bg-brand px-5 py-2.5 font-medium text-brand-foreground transition-colors hover:bg-brand/90"
+          >
+            Try signing in again
+          </Link>
+          <Link
+            href="/"
+            className="rounded-md border border-input bg-background px-5 py-2.5 font-medium text-foreground transition-colors hover:bg-accent"
+          >
+            Return home
+          </Link>
+        </div>
+
+        {supportCode ? (
+          <p className="mt-6 text-xs text-muted-foreground">
+            Support code: {supportCode}
+          </p>
+        ) : null}
+      </section>
+    </main>
+  )
+}

--- a/src/app/opt-in/page.tsx
+++ b/src/app/opt-in/page.tsx
@@ -20,11 +20,7 @@ export default async function OptInPage() {
             </p>
           </div>
 
-          <OptInForm
-            userId={user.id}
-            userEmail={user.email || ''}
-            initialOptInStatus={optInData}
-          />
+          <OptInForm userId={user.id} initialOptInStatus={optInData} />
 
           <div className="mt-8 border-t border-border pt-6 text-center">
             <p className="text-sm text-muted-foreground">

--- a/src/app/profile/ProfileContent.tsx
+++ b/src/app/profile/ProfileContent.tsx
@@ -304,7 +304,9 @@ export default function ProfileContent({
           <div className="space-y-4">
             <div className="flex items-center space-x-2">
               <Label htmlFor="email">Email:</Label>
-              <span className="text-muted-foreground">{user.email}</span>
+              <span className="text-muted-foreground">
+                {user.email || 'Not provided by X'}
+              </span>
             </div>
           </div>
         </CardContent>

--- a/src/components/AuthButton.tsx
+++ b/src/components/AuthButton.tsx
@@ -10,6 +10,11 @@ export default async function AuthButton() {
   const {
     data: { user },
   } = await supabase.auth.getUser()
+  const displayName =
+    user?.user_metadata?.user_name ||
+    user?.app_metadata?.user_name ||
+    user?.email ||
+    'there'
 
   const signOut = async () => {
     'use server'
@@ -22,7 +27,7 @@ export default async function AuthButton() {
 
   return user ? (
     <div className="flex items-center gap-4">
-      Hey, {user.email}!
+      Hey, {displayName}!
       <form action={signOut}>
         <button className="bg-btn-background hover:bg-btn-background-hover rounded-md px-4 py-2 no-underline">
           Logout

--- a/src/components/OptInForm.tsx
+++ b/src/components/OptInForm.tsx
@@ -9,13 +9,11 @@ import { useAuthAndArchive } from '@/hooks/useAuthAndArchive'
 
 interface OptInFormProps {
   userId: string
-  userEmail: string
   initialOptInStatus: any
 }
 
 export default function OptInForm({
   userId,
-  userEmail,
   initialOptInStatus,
 }: OptInFormProps) {
   const router = useRouter()

--- a/src/lib/authCallback.test.ts
+++ b/src/lib/authCallback.test.ts
@@ -1,0 +1,39 @@
+import { buildAuthErrorUrl, getAuthErrorCopy } from './authCallback'
+
+describe('auth callback helpers', () => {
+  it('preserves provider error details on the local error page', () => {
+    const url = buildAuthErrorUrl('https://www.community-archive.org', {
+      error: 'server_error',
+      errorCode: '500',
+      errorDescription: 'Error getting user email from external provider',
+    })
+
+    expect(url.origin).toBe('https://www.community-archive.org')
+    expect(url.pathname).toBe('/auth/auth-code-error')
+    expect(url.searchParams.get('error')).toBe('server_error')
+    expect(url.searchParams.get('error_code')).toBe('500')
+    expect(url.searchParams.get('error_description')).toBe(
+      'Error getting user email from external provider',
+    )
+  })
+
+  it('caps untrusted provider error values', () => {
+    const url = buildAuthErrorUrl('https://www.community-archive.org', {
+      errorDescription: 'x'.repeat(500),
+    })
+
+    expect(url.searchParams.get('error_description')).toHaveLength(300)
+  })
+
+  it('gives missing-email failures actionable copy', () => {
+    expect(
+      getAuthErrorCopy({
+        errorDescription: 'Error getting user email from external provider',
+      }),
+    ).toEqual({
+      title: 'X did not provide an email address',
+      description:
+        'Community Archive now supports X accounts without an email address. Please try signing in again.',
+    })
+  })
+})

--- a/src/lib/authCallback.ts
+++ b/src/lib/authCallback.ts
@@ -1,0 +1,61 @@
+export type AuthErrorDetails = {
+  error?: string | null
+  errorCode?: string | null
+  errorDescription?: string | null
+}
+
+const MAX_AUTH_ERROR_LENGTH = 300
+
+const cleanAuthErrorValue = (value?: string | null) => {
+  const cleaned = value?.trim()
+  return cleaned ? cleaned.slice(0, MAX_AUTH_ERROR_LENGTH) : null
+}
+
+export function buildAuthErrorUrl(
+  origin: string,
+  { error, errorCode, errorDescription }: AuthErrorDetails,
+) {
+  const url = new URL('/auth/auth-code-error', origin)
+  const values = {
+    error: cleanAuthErrorValue(error),
+    error_code: cleanAuthErrorValue(errorCode),
+    error_description: cleanAuthErrorValue(errorDescription),
+  }
+
+  for (const [key, value] of Object.entries(values)) {
+    if (value) url.searchParams.set(key, value)
+  }
+
+  return url
+}
+
+export function getAuthErrorCopy({
+  error,
+  errorDescription,
+}: AuthErrorDetails) {
+  const normalizedDescription = errorDescription?.toLowerCase() ?? ''
+
+  if (
+    normalizedDescription.includes('getting user email from external provider')
+  ) {
+    return {
+      title: 'X did not provide an email address',
+      description:
+        'Community Archive now supports X accounts without an email address. Please try signing in again.',
+    }
+  }
+
+  if (error === 'access_denied') {
+    return {
+      title: 'Sign-in was canceled',
+      description:
+        'No changes were made. You can try again whenever you are ready.',
+    }
+  }
+
+  return {
+    title: 'We could not sign you in',
+    description:
+      'The sign-in provider returned an error. Please try again, or contact us if it keeps happening.',
+  }
+}


### PR DESCRIPTION
## Summary

- route OAuth provider and session-exchange failures to a real, actionable error page
- preserve bounded provider error details so support can identify the failure
- stop assuming authenticated X users always have an email address
- safely normalize X usernames when populating app metadata
- add focused coverage for callback error handling

## Root cause

Production Supabase auth logs showed `Error getting user email from external provider` for affected X accounts. The Twitter provider required an email even though some accounts do not expose one. The production Supabase setting `external_twitter_email_optional` has already been enabled separately and is live.

The application also redirected failures to `/auth/auth-code-error`, but that page did not exist, so affected users saw a 404 instead of a useful explanation.

## Impact

X accounts without an available email can sign in, and future OAuth failures display a retry path rather than a 404. Profile and account UI now use X identity metadata when email is absent.

## Validation

- `jest --selectProjects server --runInBand src/lib/authCallback.test.ts`
- `tsc --pretty --noEmit`
- `next lint`
- `NODE_ENV=production next build`
