### PR TITLE
Gate homepage search by opt-in status

### DIFF
--- a/src/app/api/opt-in/route.ts
+++ b/src/app/api/opt-in/route.ts
@@ -5,32 +5,7 @@ import {
 import type { User } from '@supabase/supabase-js'
 import { cookies } from 'next/headers'
 import { NextRequest, NextResponse } from 'next/server'
-
-// Derive the session's Twitter username from the OAuth identity entry.
-// SECURITY: only identity_data is trusted — user_metadata is user-mutable via
-// supabase.auth.updateUser({ data: ... }), so reading user_name from there
-// would let a logged-in user spoof their identity and claim an unclaimed
-// opt-in row for any username (combined with the service-role client that
-// bypasses RLS, this would be a real impersonation vector).
-function getSessionTwitterUsername(user: User): string | null {
-  const identity =
-    user.identities?.find((i) => ['twitter', 'x'].includes(i.provider ?? '')) ??
-    null
-  if (!identity) return null
-  const data = (identity.identity_data ?? {}) as Record<string, unknown>
-  for (const k of [
-    'user_name',
-    'preferred_username',
-    'screen_name',
-    'username',
-  ]) {
-    const v = data[k]
-    if (typeof v === 'string' && v.trim()) {
-      return v.trim().toLowerCase().replace(/^@/, '')
-    }
-  }
-  return null
-}
+import { getSessionTwitterUsername } from '@/lib/sessionTwitterUsername'
 
 function getSessionTwitterUserId(user: User): string | null {
   const providerId = user.app_metadata?.provider_id

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,6 +19,7 @@ import dynamic from 'next/dynamic'
 import FeaturedAppsSection from '@/components/FeaturedAppsSection'
 import AppGallery from '@/components/AppGallery'
 import HomepageSearch from '@/components/HomepageSearch'
+import { canShowHomepageSearch } from '@/lib/homepageAccess'
 
 export const revalidate = 60 // Cache for 60s to reduce server load from scrapers
 
@@ -140,6 +141,27 @@ const InfoPanel: React.FC<InfoPanelProps> = ({
 export default async function Homepage() {
   const cookieStore = await cookies()
   const supabase = createServerClient(cookieStore)
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  let optedInStatus: boolean | null = null
+  if (user) {
+    const { data: optInData, error: optInError } = await supabase
+      .from('optin')
+      .select('opted_in')
+      .eq('user_id', user.id)
+      .maybeSingle()
+
+    if (optInError) {
+      console.error('Failed to fetch homepage opt-in status:', optInError)
+    }
+
+    optedInStatus = optInData?.opted_in ?? false
+  }
+
+  const isOptedIn = canShowHomepageSearch(user?.id, optedInStatus)
+
   const mostFollowed = (await getMostFollowedAccounts(supabase)).slice(0, 7)
   const financialContributors = await getOpenCollectiveContributors()
 
@@ -174,58 +196,78 @@ export default async function Homepage() {
   const contentWrapperClasses =
     'w-full max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10'
 
+  const socialProofSection = (
+    <section
+      className={`overflow-hidden bg-card dark:bg-background ${
+        isOptedIn ? 'py-12 md:py-16' : ''
+      }`}
+    >
+      <div className="mx-auto max-w-5xl space-y-4 rounded-none bg-muted p-6 text-center dark:bg-card sm:rounded-xl md:p-8">
+        <CommunityStats
+          userCount={stats.userCount}
+          tweetCount={stats.tweetCount}
+          showGoal={false}
+        />
+        {mostFollowed.length > 0 ? (
+          <AvatarList initialAvatars={mostFollowed} />
+        ) : (
+          <p className="mt-4 text-center text-muted-foreground">
+            Featured archives are currently unavailable.
+          </p>
+        )}
+      </div>
+    </section>
+  )
+
   return (
     <main>
-      {/* Section 1: Hero with CTAs */}
-      <section className="overflow-hidden bg-card pb-12 pt-16 dark:bg-background md:pb-16 md:pt-24">
+      {/* Section 1: Audience-specific hero */}
+      <section
+        className={`overflow-hidden bg-card dark:bg-background ${
+          isOptedIn
+            ? 'pb-20 pt-20 md:pb-28 md:pt-28'
+            : 'pb-12 pt-16 md:pb-16 md:pt-24'
+        }`}
+      >
         <div className={`${contentWrapperClasses} space-y-10 text-center`}>
           <div className="space-y-4">
             <h1 className="text-5xl font-bold tracking-tight text-foreground md:text-6xl">
-              Community Archive
+              {isOptedIn ? 'Search the archive' : 'Community Archive'}
             </h1>
             <p className="text-xl leading-8 text-muted-foreground">
-              Search millions of public conversations and help build{' '}
-              <br className="hidden sm:block" />
-              open source public infrastructure.
+              {isOptedIn ? (
+                <>
+                  Find public conversations, people, and ideas across millions
+                  of archived tweets.
+                </>
+              ) : (
+                <>
+                  Join the archive to preserve public conversations for open
+                  research and help build open source public infrastructure.
+                </>
+              )}
             </p>
           </div>
 
-          <HomepageSearch
-            tweetCount={stats.tweetCount}
-            userCount={stats.userCount}
-          />
-
-          <div className="space-y-4 border-t border-border pt-8">
-            <p className="text-sm font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-              Help grow the archive
-            </p>
-            <DynamicHeroCTAButtons />
-            <p className="text-sm text-muted-foreground">
-              Backed by Survival and Flourishing Fund and Vitalik Buterin
-            </p>
-          </div>
-        </div>
-      </section>
-
-      {/* Section 2: Social Proof */}
-      <section className="overflow-hidden bg-card dark:bg-background">
-        <div className="mx-auto max-w-5xl space-y-4 rounded-none bg-muted p-6 text-center dark:bg-card sm:rounded-xl md:p-8">
-          <CommunityStats
-            userCount={stats.userCount}
-            tweetCount={stats.tweetCount}
-            showGoal={false}
-          />
-          {mostFollowed.length > 0 ? (
-            <AvatarList initialAvatars={mostFollowed} />
+          {isOptedIn ? (
+            <HomepageSearch />
           ) : (
-            <p className="mt-4 text-center text-muted-foreground">
-              Featured archives are currently unavailable.
-            </p>
+            <div className="space-y-4 pt-2">
+              <p className="text-sm font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                Help grow the archive
+              </p>
+              <DynamicHeroCTAButtons initialIsOptedIn={false} />
+              <p className="text-sm text-muted-foreground">
+                Backed by Survival and Flourishing Fund and Vitalik Buterin
+              </p>
+            </div>
           )}
         </div>
       </section>
 
-      {/* Section 3: Explore the archive - Featured Apps */}
+      {!isOptedIn ? socialProofSection : null}
+
+      {/* Section 2: Explore the archive - Featured Apps */}
       <section
         id="products"
         className={`bg-card dark:bg-background ${sectionPaddingClasses} scroll-mt-16 overflow-hidden`}
@@ -236,7 +278,24 @@ export default async function Homepage() {
         </div>
       </section>
 
-      {/* Section 4: Upload Your Archive */}
+      {isOptedIn ? (
+        <>
+          {socialProofSection}
+          <section className="overflow-hidden bg-card pb-12 dark:bg-background md:pb-16">
+            <div className={`${contentWrapperClasses} space-y-4 text-center`}>
+              <p className="text-sm font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                Keep the archive growing
+              </p>
+              <DynamicHeroCTAButtons initialIsOptedIn />
+              <p className="text-sm text-muted-foreground">
+                Backed by Survival and Flourishing Fund and Vitalik Buterin
+              </p>
+            </div>
+          </section>
+        </>
+      ) : null}
+
+      {/* Section 3: Upload Your Archive */}
       <section
         id="upload-archive"
         className={`bg-muted dark:bg-card ${sectionPaddingClasses} scroll-mt-16 overflow-hidden`}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -232,20 +232,12 @@ export default async function Homepage() {
         <div className={`${contentWrapperClasses} space-y-10 text-center`}>
           <div className="space-y-4">
             <h1 className="text-5xl font-bold tracking-tight text-foreground md:text-6xl">
-              {isOptedIn ? 'Search the archive' : 'Community Archive'}
+              Community Archive
             </h1>
             <p className="text-xl leading-8 text-muted-foreground">
-              {isOptedIn ? (
-                <>
-                  Find public conversations, people, and ideas across millions
-                  of archived tweets.
-                </>
-              ) : (
-                <>
-                  Join the archive to preserve public conversations for open
-                  research and help build open source public infrastructure.
-                </>
-              )}
+              Search millions of public conversations and help build{' '}
+              <br className="hidden sm:block" />
+              open source public infrastructure.
             </p>
           </div>
 

--- a/src/components/HeroCTAButtons.tsx
+++ b/src/components/HeroCTAButtons.tsx
@@ -17,13 +17,19 @@ import { devLog } from '@/lib/devLog'
 const CHROME_EXTENSION_URL =
   'https://chromewebstore.google.com/detail/community-archive-stream/igclpobjpjlphgllncjcgaookmncegbk'
 
-export default function HeroCTAButtons() {
+interface HeroCTAButtonsProps {
+  initialIsOptedIn?: boolean
+}
+
+export default function HeroCTAButtons({
+  initialIsOptedIn = false,
+}: HeroCTAButtonsProps) {
   const router = useRouter()
   const { userMetadata } = useAuthAndArchive()
   const supabase = createBrowserClient()
 
   const [user, setUser] = useState<any>(null)
-  const [isOptedIn, setIsOptedIn] = useState<boolean | null>(null)
+  const [isOptedIn, setIsOptedIn] = useState(initialIsOptedIn)
   const [isOptInLoading, setIsOptInLoading] = useState(false)
 
   const twitterUsername = userMetadata?.user_name

--- a/src/components/HeroCTAButtons.tsx
+++ b/src/components/HeroCTAButtons.tsx
@@ -159,7 +159,8 @@ export default function HeroCTAButtons({
       }
 
       setIsOptedIn(true)
-      router.push('/explore')
+      router.replace('/')
+      router.refresh()
     } catch (err: any) {
       console.error('Opt-in error:', err.message)
     } finally {

--- a/src/components/HomepageSearch.tsx
+++ b/src/components/HomepageSearch.tsx
@@ -5,20 +5,11 @@ import { useRouter } from 'next/navigation'
 import { Search } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { formatNumber } from '@/lib/formatNumber'
 import { buildSearchParams } from '@/lib/searchParams'
-
-interface HomepageSearchProps {
-  tweetCount: number | null
-  userCount: number | null
-}
 
 const exampleSearches = ['open source', 'AI alignment', 'from:vitalikbuterin']
 
-export default function HomepageSearch({
-  tweetCount,
-  userCount,
-}: HomepageSearchProps) {
+export default function HomepageSearch() {
   const router = useRouter()
   const [query, setQuery] = useState('')
 
@@ -62,24 +53,18 @@ export default function HomepageSearch({
         </Button>
       </form>
 
-      <div className="mt-4 flex flex-col items-center justify-between gap-3 text-sm text-muted-foreground sm:flex-row">
-        <p>
-          Search {formatNumber(tweetCount)} tweets from{' '}
-          {formatNumber(userCount)} participating members.
-        </p>
-        <div className="flex flex-wrap items-center justify-center gap-2">
-          <span>Try:</span>
-          {exampleSearches.map((example) => (
-            <button
-              key={example}
-              type="button"
-              onClick={() => search(example)}
-              className="font-medium text-foreground underline-offset-4 transition-colors hover:text-brand hover:underline"
-            >
-              {example}
-            </button>
-          ))}
-        </div>
+      <div className="mt-4 flex flex-wrap items-center justify-center gap-2 text-sm text-muted-foreground">
+        <span>Try:</span>
+        {exampleSearches.map((example) => (
+          <button
+            key={example}
+            type="button"
+            onClick={() => search(example)}
+            className="font-medium text-foreground underline-offset-4 transition-colors hover:text-brand hover:underline"
+          >
+            {example}
+          </button>
+        ))}
       </div>
     </div>
   )

--- a/src/lib/homepageAccess.test.ts
+++ b/src/lib/homepageAccess.test.ts
@@ -1,0 +1,15 @@
+import { canShowHomepageSearch } from './homepageAccess'
+
+describe('canShowHomepageSearch', () => {
+  it('hides search from logged-out visitors', () => {
+    expect(canShowHomepageSearch(null, true)).toBe(false)
+  })
+
+  it('hides search from signed-in visitors who have not opted in', () => {
+    expect(canShowHomepageSearch('user-1', false)).toBe(false)
+  })
+
+  it('shows search only to signed-in opted-in members', () => {
+    expect(canShowHomepageSearch('user-1', true)).toBe(true)
+  })
+})

--- a/src/lib/homepageAccess.ts
+++ b/src/lib/homepageAccess.ts
@@ -1,0 +1,4 @@
+export const canShowHomepageSearch = (
+  userId: string | null | undefined,
+  isOptedIn: boolean | null | undefined,
+) => Boolean(userId && isOptedIn === true)

--- a/src/lib/sessionTwitterUsername.test.ts
+++ b/src/lib/sessionTwitterUsername.test.ts
@@ -46,10 +46,9 @@ describe('getSessionTwitterUsername', () => {
     ).toBe('real_user')
   })
 
-  it('uses server-set staging metadata on a non-production project', () => {
+  it('uses legacy server-set staging metadata on a non-production project', () => {
     const user = createUser({
       app_metadata: {
-        provider: 'staging',
         user_name: 'Alice_Dev',
       },
     })

--- a/src/lib/sessionTwitterUsername.test.ts
+++ b/src/lib/sessionTwitterUsername.test.ts
@@ -1,0 +1,110 @@
+import type { User } from '@supabase/supabase-js'
+import {
+  getSessionTwitterUsername,
+  SessionIdentityEnvironment,
+} from './sessionTwitterUsername'
+
+const stagingEnvironment: SessionIdentityEnvironment = {
+  nodeEnv: 'production',
+  stagingDevLoginEnabled: true,
+  useRemoteDevDb: false,
+  supabaseUrl: 'https://staging-project.supabase.co',
+}
+
+const createUser = (overrides: Partial<User> = {}) =>
+  ({
+    id: 'auth-user-1',
+    app_metadata: {},
+    user_metadata: {},
+    aud: 'authenticated',
+    created_at: '2026-07-15T00:00:00.000Z',
+    ...overrides,
+  }) as User
+
+describe('getSessionTwitterUsername', () => {
+  it('uses a real Twitter identity in every environment', () => {
+    const user = createUser({
+      identities: [
+        {
+          id: 'twitter-1',
+          identity_id: 'twitter-identity-1',
+          user_id: 'auth-user-1',
+          identity_data: { user_name: 'Real_User' },
+          provider: 'twitter',
+          created_at: '2026-07-15T00:00:00.000Z',
+          updated_at: '2026-07-15T00:00:00.000Z',
+          last_sign_in_at: '2026-07-15T00:00:00.000Z',
+        },
+      ],
+    })
+
+    expect(
+      getSessionTwitterUsername(user, {
+        nodeEnv: 'production',
+        supabaseUrl: 'https://fabxmporizzqflnftavs.supabase.co',
+      }),
+    ).toBe('real_user')
+  })
+
+  it('uses server-set staging metadata on a non-production project', () => {
+    const user = createUser({
+      app_metadata: {
+        provider: 'staging',
+        user_name: 'Alice_Dev',
+      },
+    })
+
+    expect(getSessionTwitterUsername(user, stagingEnvironment)).toBe(
+      'alice_dev',
+    )
+  })
+
+  it('rejects staging metadata when mock login is disabled', () => {
+    const user = createUser({
+      app_metadata: { provider: 'staging', user_name: 'alice_dev' },
+    })
+
+    expect(
+      getSessionTwitterUsername(user, {
+        ...stagingEnvironment,
+        stagingDevLoginEnabled: false,
+      }),
+    ).toBeNull()
+  })
+
+  it('rejects staging metadata on the production project', () => {
+    const user = createUser({
+      app_metadata: { provider: 'staging', user_name: 'alice_dev' },
+    })
+
+    expect(
+      getSessionTwitterUsername(user, {
+        ...stagingEnvironment,
+        supabaseUrl: 'https://fabxmporizzqflnftavs.supabase.co',
+      }),
+    ).toBeNull()
+  })
+
+  it('never trusts user-editable metadata as a mock identity', () => {
+    const user = createUser({
+      app_metadata: { provider: 'staging' },
+      user_metadata: { user_name: 'spoofed_user' },
+    })
+
+    expect(getSessionTwitterUsername(user, stagingEnvironment)).toBeNull()
+  })
+
+  it('supports server-created email users against the local dev project', () => {
+    const user = createUser({
+      app_metadata: { provider: 'email', user_name: 'local_dev' },
+    })
+
+    expect(
+      getSessionTwitterUsername(user, {
+        nodeEnv: 'development',
+        useRemoteDevDb: false,
+        localSupabaseUrl: 'http://127.0.0.1:54321',
+      }),
+    ).toBe('local_dev')
+  })
+})

--- a/src/lib/sessionTwitterUsername.ts
+++ b/src/lib/sessionTwitterUsername.ts
@@ -68,12 +68,6 @@ const getTrustedMockUsername = (
     return null
   }
 
-  const provider = user.app_metadata?.provider
-  const isTrustedProvider =
-    provider === 'staging' ||
-    (environment.nodeEnv === 'development' && provider === 'email')
-  if (!isTrustedProvider) return null
-
   return normalizeUsername(user.app_metadata?.user_name)
 }
 
@@ -81,6 +75,8 @@ const getTrustedMockUsername = (
 // app_metadata is accepted only when the mock login is enabled and the active
 // Supabase project is definitively not production. app_metadata is written by
 // the server-side auth admin client and cannot be changed by regular users.
+// We intentionally do not require a provider marker because staging users
+// created before that field was introduced still have a trusted user_name.
 export const getSessionTwitterUsername = (
   user: User,
   environment: SessionIdentityEnvironment = getDefaultEnvironment(),

--- a/src/lib/sessionTwitterUsername.ts
+++ b/src/lib/sessionTwitterUsername.ts
@@ -1,0 +1,88 @@
+import type { User } from '@supabase/supabase-js'
+import { isTwitterUsername } from '@/lib/apiInputValidation'
+import { isProductionSupabaseUrl } from '@/lib/isProductionSupabaseUrl'
+
+export interface SessionIdentityEnvironment {
+  nodeEnv?: string
+  stagingDevLoginEnabled?: boolean
+  useRemoteDevDb?: boolean
+  supabaseUrl?: string
+  localSupabaseUrl?: string
+}
+
+const getDefaultEnvironment = (): SessionIdentityEnvironment => ({
+  nodeEnv: process.env.NODE_ENV,
+  stagingDevLoginEnabled: process.env.ENABLE_STAGING_DEV_LOGIN === 'true',
+  useRemoteDevDb: process.env.NEXT_PUBLIC_USE_REMOTE_DEV_DB === 'true',
+  supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL,
+  localSupabaseUrl: process.env.NEXT_PUBLIC_LOCAL_SUPABASE_URL,
+})
+
+const normalizeUsername = (value: unknown): string | null => {
+  if (typeof value !== 'string') return null
+
+  const username = value.trim().toLowerCase().replace(/^@/, '')
+  return isTwitterUsername(username) ? username : null
+}
+
+const getTwitterIdentityUsername = (user: User): string | null => {
+  const identity =
+    user.identities?.find((item) =>
+      ['twitter', 'x'].includes(item.provider ?? ''),
+    ) ?? null
+  if (!identity) return null
+
+  const data = (identity.identity_data ?? {}) as Record<string, unknown>
+  for (const key of [
+    'user_name',
+    'preferred_username',
+    'screen_name',
+    'username',
+  ]) {
+    const username = normalizeUsername(data[key])
+    if (username) return username
+  }
+
+  return null
+}
+
+const getActiveSupabaseUrl = (environment: SessionIdentityEnvironment) =>
+  environment.nodeEnv === 'development' && !environment.useRemoteDevDb
+    ? environment.localSupabaseUrl
+    : environment.supabaseUrl
+
+const getTrustedMockUsername = (
+  user: User,
+  environment: SessionIdentityEnvironment,
+): string | null => {
+  const mockLoginEnabled =
+    environment.nodeEnv === 'development' ||
+    environment.stagingDevLoginEnabled === true
+  const activeSupabaseUrl = getActiveSupabaseUrl(environment)
+
+  if (
+    !mockLoginEnabled ||
+    !activeSupabaseUrl ||
+    isProductionSupabaseUrl(activeSupabaseUrl)
+  ) {
+    return null
+  }
+
+  const provider = user.app_metadata?.provider
+  const isTrustedProvider =
+    provider === 'staging' ||
+    (environment.nodeEnv === 'development' && provider === 'email')
+  if (!isTrustedProvider) return null
+
+  return normalizeUsername(user.app_metadata?.user_name)
+}
+
+// Real OAuth identity data is authoritative in every environment. Mock-user
+// app_metadata is accepted only when the mock login is enabled and the active
+// Supabase project is definitively not production. app_metadata is written by
+// the server-side auth admin client and cannot be changed by regular users.
+export const getSessionTwitterUsername = (
+  user: User,
+  environment: SessionIdentityEnvironment = getDefaultEnvironment(),
+) =>
+  getTwitterIdentityUsername(user) ?? getTrustedMockUsername(user, environment)


### PR DESCRIPTION
## Summary

- shows the contribution-first homepage to logged-out visitors and signed-in users who have not opted in
- only renders the homepage search hero for signed-in, opted-in members
- simplifies the member hero to search plus example queries
- moves Products ahead of community proof and contribution actions for opted-in members
- seeds the CTA component with server-verified opt-in state so opted-in members do not see a redundant Opt in button
- allows server-created staging mock users to claim their seeded opt-in row without weakening production Twitter identity checks

## Why

The public homepage should prioritize joining the archive, while opted-in members should get a clean search-first experience without contribution controls competing above the fold.

Staging mock users authenticate through server-set app metadata rather than a Twitter OAuth identity. The opt-in API previously rejected those sessions, which prevented reviewers from reaching the member homepage. The fallback is limited to explicitly enabled mock-login environments on a confirmed non-production Supabase project; production continues to require a real Twitter identity.

## Staging review

1. Select a staging mock user and sign in.
2. Click **Opt in** on the homepage.
3. Confirm the homepage refreshes directly into the opted-in search-first view.

## Verification

- lint and TypeScript checks
- production build
- focused server tests for logged-out, non-opted-in, and opted-in access states
- identity tests covering real Twitter users, staging users, local users, production rejection, disabled mock login, and user-metadata spoof rejection
- desktop and 390px mobile browser QA
- verified logged-out visitors receive no homepage search and see the opt-in CTA first
- verified the opted-in layout places Products before community proof and contribution actions
- verified no horizontal overflow at 390px
