### PR TITLE
Return signed-in users to the homepage

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,7 +3,6 @@ import { createServerClient } from '@/utils/supabase'
 import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 import LoginContent from './LoginContent'
-import { getOptInStatus } from '@/lib/auth-utils'
 
 export default async function LoginPage({
   searchParams,
@@ -26,8 +25,7 @@ export default async function LoginPage({
 
     if (safeRedirect) redirect(safeRedirect)
 
-    const { data: optInData } = await getOptInStatus(user.id)
-    redirect(optInData?.opted_in ? '/explore' : '/opt-in')
+    redirect('/')
   }
 
   return (

--- a/src/components/SignIn.tsx
+++ b/src/components/SignIn.tsx
@@ -83,7 +83,7 @@ export default function SignIn() {
         if (redirectTo) {
           window.location.href = redirectTo
         } else {
-          window.location.href = '/explore'
+          window.location.href = '/'
         }
       } catch (error) {
         console.error('Error during dev sign in:', error)
@@ -97,7 +97,7 @@ export default function SignIn() {
       })
       const callbackUrl = redirectTo
         ? `${window.location.origin}/api/auth/callback?next=${encodeURIComponent(redirectTo)}`
-        : `${window.location.origin}/api/auth/callback?next=${encodeURIComponent('/explore')}`
+        : `${window.location.origin}/api/auth/callback?next=${encodeURIComponent('/')}`
 
       const { data, error } = await supabase.auth.signInWithOAuth({
         provider: 'twitter',


### PR DESCRIPTION
## Summary

- sends staging/dev sign-ins to the homepage by default
- sends Twitter OAuth sign-ins to the homepage by default
- sends already-authenticated visitors from `/login` to the homepage
- preserves explicit safe redirect destinations for protected pages

## Why

The homepage now chooses the correct CTA-first or search-first experience from the authenticated user's opt-in status. Legacy sign-in defaults still sent users to `/explore`, bypassing that new homepage experience.

## Impact

After a normal sign-in, users land on `/`. Non-opted-in users see the opt-in CTA, while opted-in users see the homepage search experience.

## Verification

- `npm run lint`
- `npm run type-check`
- `npx jest --selectProjects server --runInBand src/lib/authCallback.test.ts src/lib/homepageAccess.test.ts src/lib/sessionTwitterUsername.test.ts`
