### PR TITLE
Support search operators in URLs

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -3,6 +3,7 @@
 import AdvancedSearchForm from '@/components/AdvancedSearchForm'
 import TweetList from '@/components/TweetList'
 import { FilterCriteria } from '@/lib/queries/tweetQueries'
+import { normalizeSearchParams } from '@/lib/searchParams'
 import { Search, SlidersHorizontal } from 'lucide-react'
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
@@ -18,8 +19,11 @@ const starterSearches = [
 // and Suspense is recommended for pages that use it.
 function SearchPageContent() {
   const searchParams = useSearchParams()
+  const normalizedSearchParams = normalizeSearchParams(
+    new URLSearchParams(searchParams.toString()),
+  )
 
-  const rawQuery = searchParams.get('q')
+  const rawQuery = normalizedSearchParams.get('q')
   let formattedQuery: string | undefined
   // Strip quotes if present, keep the clean text for two-query exact-match-first logic
   let cleanRawText: string | undefined
@@ -39,13 +43,13 @@ function SearchPageContent() {
   const filterCriteria: FilterCriteria = {
     searchQuery: formattedQuery,
     rawSearchQuery: cleanRawText,
-    fromUsername: searchParams.get('fromUser') || undefined,
-    replyToUsername: searchParams.get('replyToUser') || undefined,
-    startDate: searchParams.get('sinceDate') || undefined,
-    endDate: searchParams.get('untilDate') || undefined,
+    fromUsername: normalizedSearchParams.get('fromUser') || undefined,
+    replyToUsername: normalizedSearchParams.get('replyToUser') || undefined,
+    startDate: normalizedSearchParams.get('sinceDate') || undefined,
+    endDate: normalizedSearchParams.get('untilDate') || undefined,
   }
 
-  const tweetListKey = searchParams.toString()
+  const tweetListKey = normalizedSearchParams.toString()
   const hasSearch = tweetListKey.length > 0
   const searchDescription = cleanRawText
     ? `Matching “${cleanRawText}” and the filters above`

--- a/src/components/AdvancedSearchForm.tsx
+++ b/src/components/AdvancedSearchForm.tsx
@@ -16,6 +16,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import {
   buildSearchExpression,
   buildSearchParams,
+  normalizeSearchParams,
   parseSearchExpression,
   SearchFilterKey,
 } from '@/lib/searchParams'
@@ -28,16 +29,17 @@ export default function AdvancedSearchForm() {
   const [showAdvancedOptions, setShowAdvancedOptions] = useState(false)
 
   useEffect(() => {
-    const expression = buildSearchExpression(
+    const normalizedSearchParams = normalizeSearchParams(
       new URLSearchParams(searchParams.toString()),
     )
+    const expression = buildSearchExpression(normalizedSearchParams)
     setQuery(expression)
 
     if (
-      searchParams.has('fromUser') ||
-      searchParams.has('replyToUser') ||
-      searchParams.has('sinceDate') ||
-      searchParams.has('untilDate')
+      normalizedSearchParams.has('fromUser') ||
+      normalizedSearchParams.has('replyToUser') ||
+      normalizedSearchParams.has('sinceDate') ||
+      normalizedSearchParams.has('untilDate')
     ) {
       setShowAdvancedOptions(true)
     }

--- a/src/lib/searchParams.test.ts
+++ b/src/lib/searchParams.test.ts
@@ -2,6 +2,7 @@ import {
   buildSearchExpression,
   buildSearchHref,
   buildSearchParams,
+  normalizeSearchParams,
   parseSearchExpression,
 } from './searchParams'
 
@@ -51,5 +52,25 @@ describe('search parameter helpers', () => {
         }),
       ),
     ).toBe('community archive to:bob until:2025-01-01')
+  })
+
+  it('normalizes inline and explicit URL filters to the same search', () => {
+    const inlineFilter = normalizeSearchParams(
+      new URLSearchParams('q=from%3Acuriousgustaf+perplexity'),
+    )
+    const explicitFilter = normalizeSearchParams(
+      new URLSearchParams('q=perplexity&fromUser=curiousgustaf'),
+    )
+
+    expect(inlineFilter.toString()).toBe('q=perplexity&fromUser=curiousgustaf')
+    expect(inlineFilter.toString()).toBe(explicitFilter.toString())
+  })
+
+  it('gives explicit URL filters precedence over inline filters', () => {
+    expect(
+      normalizeSearchParams(
+        new URLSearchParams('q=from%3Abob+archive&fromUser=alice'),
+      ).toString(),
+    ).toBe('q=archive&fromUser=alice')
   })
 })

--- a/src/lib/searchParams.ts
+++ b/src/lib/searchParams.ts
@@ -69,3 +69,15 @@ export function buildSearchExpression(searchParams: URLSearchParams): string {
 
   return parts.filter(Boolean).join(' ').trim()
 }
+
+/**
+ * Resolve both supported search URL styles to the same parameter shape.
+ *
+ * Filters in explicit URL parameters take precedence over filters embedded in
+ * `q`, so a shared link can override an inline operator without ambiguity.
+ */
+export function normalizeSearchParams(
+  searchParams: URLSearchParams,
+): URLSearchParams {
+  return buildSearchParams(buildSearchExpression(searchParams))
+}


### PR DESCRIPTION
## What changed

- Normalize search filters embedded in the `q` URL parameter into the existing explicit URL parameter shape.
- Use the normalized parameters for tweet queries and the advanced search form.
- Cover inline and explicit filter URLs, including precedence when both are present.

## Why

Opening a direct link such as `/search?q=from:curiousgustaf+perplexity` skipped the parser used by form submissions, so `from:` was treated as search text instead of an author filter. Direct links and submitted searches now share the same interpretation.

This applies to all currently supported operators: `from:`, `to:`, `since:`, and `until:`.

## Validation

- Search parameter tests: 7 passing
- TypeScript: `tsc --noEmit`
- Prettier check
- Local browser verification of both URL forms returning the same filtered result
