### PR TITLE
Refresh homepage search, social proof, and Library

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,3 @@
-import CommunityStats from '@/components/CommunityStats'
 import { createServerClient } from '@/utils/supabase'
 import { cookies } from 'next/headers'
 import AvatarList from '@/components/AvatarList'
@@ -20,6 +19,7 @@ import FeaturedAppsSection from '@/components/FeaturedAppsSection'
 import AppGallery from '@/components/AppGallery'
 import HomepageSearch from '@/components/HomepageSearch'
 import { canShowHomepageSearch } from '@/lib/homepageAccess'
+import { formatNumber } from '@/lib/formatNumber'
 
 export const revalidate = 60 // Cache for 60s to reduce server load from scrapers
 
@@ -200,48 +200,80 @@ export default async function Homepage() {
   const contentWrapperClasses =
     'w-full max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10'
 
-  const socialProofSection = (
-    <section
-      className={`overflow-hidden bg-card dark:bg-background ${
-        isOptedIn ? 'py-12 md:py-16' : ''
-      }`}
-    >
-      <div className="mx-auto max-w-5xl space-y-4 rounded-none bg-muted p-6 text-center dark:bg-card sm:rounded-xl md:p-8">
-        <CommunityStats
-          userCount={stats.userCount}
-          tweetCount={stats.tweetCount}
-          showGoal={false}
-        />
-        {mostFollowed.length > 0 ? (
-          <AvatarList initialAvatars={mostFollowed} />
-        ) : (
-          <p className="mt-4 text-center text-muted-foreground">
-            Featured archives are currently unavailable.
-          </p>
-        )}
-      </div>
-    </section>
+  const socialProof = (
+    <div className="mx-auto w-full max-w-3xl space-y-4 border-t border-border/80 pt-6">
+      {mostFollowed.length > 0 ? (
+        <AvatarList initialAvatars={mostFollowed} />
+      ) : (
+        <p className="text-center text-sm text-muted-foreground">
+          Featured archives are currently unavailable.
+        </p>
+      )}
+      <p className="text-sm text-muted-foreground">
+        Backed by{' '}
+        <Link
+          href="https://survivalandflourishing.fund/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium text-brand hover:underline"
+        >
+          Survival and Flourishing Fund
+        </Link>{' '}
+        and{' '}
+        <Link
+          href="https://x.com/VitalikButerin"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium text-brand hover:underline"
+        >
+          Vitalik Buterin
+        </Link>
+      </p>
+    </div>
   )
 
   return (
     <main>
       {/* Section 1: Audience-specific hero */}
-      <section
-        className={`overflow-hidden bg-card dark:bg-background ${
-          isOptedIn
-            ? 'pb-20 pt-20 md:pb-28 md:pt-28'
-            : 'pb-12 pt-16 md:pb-16 md:pt-24'
-        }`}
-      >
-        <div className={`${contentWrapperClasses} space-y-10 text-center`}>
+      <section className="overflow-hidden bg-card pb-12 pt-14 dark:bg-background md:pb-16 md:pt-20">
+        <div className={`${contentWrapperClasses} space-y-8 text-center`}>
           <div className="space-y-4">
             <h1 className="text-5xl font-bold tracking-tight text-foreground md:text-6xl">
               Community Archive
             </h1>
             <p className="text-xl leading-8 text-muted-foreground">
-              Search millions of public conversations and help build{' '}
-              <br className="hidden sm:block" />
-              open source public infrastructure.
+              {stats.tweetCount !== null && stats.userCount !== null ? (
+                isOptedIn ? (
+                  <>
+                    Search{' '}
+                    <strong className="font-semibold text-foreground">
+                      {formatNumber(stats.tweetCount)} public tweets
+                    </strong>{' '}
+                    from{' '}
+                    <strong className="font-semibold text-foreground">
+                      {formatNumber(stats.userCount)} community members
+                    </strong>
+                    .
+                  </>
+                ) : (
+                  <>
+                    Help preserve{' '}
+                    <strong className="font-semibold text-foreground">
+                      {formatNumber(stats.tweetCount)} public tweets
+                    </strong>{' '}
+                    from{' '}
+                    <strong className="font-semibold text-foreground">
+                      {formatNumber(stats.userCount)} community members
+                    </strong>
+                    .
+                  </>
+                )
+              ) : (
+                <>
+                  Search public conversations and help build open source public
+                  infrastructure.
+                </>
+              )}
             </p>
           </div>
 
@@ -253,15 +285,31 @@ export default async function Homepage() {
                 Help grow the archive
               </p>
               <DynamicHeroCTAButtons initialIsOptedIn={false} />
-              <p className="text-sm text-muted-foreground">
-                Backed by Survival and Flourishing Fund and Vitalik Buterin
-              </p>
             </div>
           )}
+
+          {socialProof}
         </div>
       </section>
 
-      {!isOptedIn ? socialProofSection : null}
+      {isOptedIn ? (
+        <section className="overflow-hidden bg-muted py-12 dark:bg-card md:py-16">
+          <div className={`${contentWrapperClasses} text-center`}>
+            <p className="text-sm font-semibold uppercase tracking-[0.14em] text-brand">
+              Keep the archive growing
+            </p>
+            <h2 className="mt-3 text-3xl font-bold text-foreground md:text-4xl">
+              Fill the gaps in the public record
+            </h2>
+            <p className="mx-auto mb-8 mt-4 max-w-2xl text-base leading-7 text-muted-foreground">
+              We refresh recent tweets every day. Upload your X archive to
+              backfill older posts, then use the extension to contribute new
+              tweets in real time while you browse.
+            </p>
+            <DynamicHeroCTAButtons initialIsOptedIn />
+          </div>
+        </section>
+      ) : null}
 
       {/* Section 2: Explore the archive - Featured Apps */}
       <section
@@ -273,23 +321,6 @@ export default async function Homepage() {
           <AppGallery />
         </div>
       </section>
-
-      {isOptedIn ? (
-        <>
-          {socialProofSection}
-          <section className="overflow-hidden bg-card pb-12 dark:bg-background md:pb-16">
-            <div className={`${contentWrapperClasses} space-y-4 text-center`}>
-              <p className="text-sm font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-                Keep the archive growing
-              </p>
-              <DynamicHeroCTAButtons initialIsOptedIn />
-              <p className="text-sm text-muted-foreground">
-                Backed by Survival and Flourishing Fund and Vitalik Buterin
-              </p>
-            </div>
-          </section>
-        </>
-      ) : null}
 
       {/* Section 3: Upload Your Archive */}
       <section

--- a/src/app/user-dir/page.tsx
+++ b/src/app/user-dir/page.tsx
@@ -57,7 +57,7 @@ export default function UserDirectoryPage() {
   const [loading, setLoading] = useState(true)
   const [loadingMore, setLoadingMore] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [sortKey, setSortKey] = useState<SortKey>('joined_at')
+  const [sortKey, setSortKey] = useState<SortKey>('num_followers')
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
   const [totalCount, setTotalCount] = useState(0)
   const [searchQuery, setSearchQuery] = useState('')
@@ -93,7 +93,7 @@ export default function UserDirectoryPage() {
         setUsers(fetchedUsers)
       } catch (err) {
         if (!isCurrentRequest) return
-        setError('We could not load the directory. Please try again.')
+        setError('We could not load the Library. Please try again.')
         console.error('Error fetching users:', err)
       } finally {
         if (isCurrentRequest) setLoading(false)
@@ -155,10 +155,11 @@ export default function UserDirectoryPage() {
       <div className="relative mx-auto w-full max-w-6xl px-4 sm:px-6 lg:px-8">
         <div className="mx-auto mb-10 max-w-2xl text-center">
           <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
-            User Directory
+            Library
           </h1>
           <p className="mt-3 text-base text-muted-foreground">
-            People preserving and participating in the Community Archive.
+            Browse the archive by contributor. More ways to explore the
+            collection are coming.
           </p>
           <p className="mt-2 text-sm font-medium text-muted-foreground">
             {loading && users.length === 0
@@ -173,7 +174,7 @@ export default function UserDirectoryPage() {
             className="absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
           />
           <Input
-            aria-label="Search the user directory"
+            aria-label="Search the Library"
             placeholder="Search by name or username…"
             value={searchQuery}
             onChange={(event) => setSearchQuery(event.target.value)}

--- a/src/components/AdvancedSearchForm.tsx
+++ b/src/components/AdvancedSearchForm.tsx
@@ -109,7 +109,7 @@ export default function AdvancedSearchForm() {
         <Button
           type="submit"
           size="lg"
-          className="h-12 bg-brand px-7 text-brand-foreground hover:bg-brand/90"
+          className="h-12 bg-green-600 px-7 text-white hover:bg-green-700 dark:bg-green-400 dark:text-green-950 dark:hover:bg-green-300"
         >
           <Search className="mr-2 h-4 w-4" />
           Search

--- a/src/components/HeaderNavigation.tsx
+++ b/src/components/HeaderNavigation.tsx
@@ -16,7 +16,7 @@ export default function HeaderNavigation() {
 
   const baseNavItems = [
     { href: '/', label: 'Home' },
-    { href: '/#products', label: 'Products' },
+    { href: '/#products', label: 'Tools' },
     { href: '/user-dir', label: 'Library' },
     { href: '/docs', label: 'Docs' },
   ]

--- a/src/components/HeaderNavigation.tsx
+++ b/src/components/HeaderNavigation.tsx
@@ -17,7 +17,7 @@ export default function HeaderNavigation() {
   const baseNavItems = [
     { href: '/', label: 'Home' },
     { href: '/#products', label: 'Products' },
-    { href: '/user-dir', label: 'User Directory' },
+    { href: '/user-dir', label: 'Library' },
     { href: '/docs', label: 'Docs' },
   ]
 

--- a/src/components/HeroCTAButtons.tsx
+++ b/src/components/HeroCTAButtons.tsx
@@ -200,6 +200,25 @@ export default function HeroCTAButtons({
             </Tooltip>
           ) : null}
 
+          {/* Upload Archive Button */}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                asChild
+                className="h-14 w-full bg-green-600 px-8 text-lg font-semibold text-white hover:bg-green-700 dark:bg-green-400 dark:text-green-950 dark:hover:bg-green-300"
+                size="lg"
+              >
+                <a href="#upload-archive">
+                  <Upload className="mr-2 h-5 w-5" />
+                  Upload archive
+                </a>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              Backfill older tweets by importing your full X archive
+            </TooltipContent>
+          </Tooltip>
+
           {/* Install Extension Button */}
           <Tooltip>
             <TooltipTrigger asChild>
@@ -219,25 +238,9 @@ export default function HeroCTAButtons({
                 </a>
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Archive as you browse</TooltipContent>
-          </Tooltip>
-
-          {/* Upload Archive Button */}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                asChild
-                variant="outline"
-                className="h-14 w-full border-2 px-8 text-lg font-semibold"
-                size="lg"
-              >
-                <a href="#upload-archive">
-                  <Upload className="mr-2 h-5 w-5" />
-                  Upload archive
-                </a>
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Import your X data export</TooltipContent>
+            <TooltipContent>
+              Contribute tweets in real time while you browse
+            </TooltipContent>
           </Tooltip>
         </div>
       </div>

--- a/src/components/HomepageSearch.tsx
+++ b/src/components/HomepageSearch.tsx
@@ -30,7 +30,7 @@ export default function HomepageSearch() {
     <div className="mx-auto w-full max-w-3xl">
       <form
         onSubmit={handleSubmit}
-        className="relative rounded-xl border border-border bg-card p-2 text-left shadow-lg"
+        className="relative rounded-xl border border-border bg-card p-2 text-left shadow-lg transition-[border-color,box-shadow] focus-within:border-green-500 focus-within:ring-2 focus-within:ring-green-500/25 dark:focus-within:border-green-400 dark:focus-within:ring-green-400/20"
       >
         <Input
           type="search"
@@ -39,14 +39,13 @@ export default function HomepageSearch() {
           placeholder="Search tweets, people, and ideas"
           aria-label="Search Community Archive"
           className="h-14 border-0 bg-transparent pl-4 pr-14 text-base shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 sm:text-lg"
+          autoFocus
           autoComplete="off"
         />
         <Button
           type="submit"
           size="icon"
-          variant="ghost"
-          disabled={!query.trim()}
-          className="absolute right-3 top-1/2 h-10 w-10 -translate-y-1/2 rounded-full text-muted-foreground hover:bg-accent hover:text-foreground"
+          className="absolute right-3 top-1/2 h-10 w-10 -translate-y-1/2 rounded-full bg-green-600 text-white shadow-sm hover:bg-green-700 focus-visible:ring-green-600 dark:bg-green-400 dark:text-green-950 dark:hover:bg-green-300 dark:focus-visible:ring-green-400"
           aria-label="Search archive"
         >
           <Search className="h-5 w-5" />

--- a/src/components/MemberSearchLanding.tsx
+++ b/src/components/MemberSearchLanding.tsx
@@ -141,7 +141,7 @@ export default function MemberSearchLanding({
           >
             <Boxes className="h-5 w-5 text-brand" />
             <h2 className="mt-4 text-base font-semibold text-foreground">
-              Products
+              Tools
             </h2>
             <p className="mt-1 text-sm leading-6 text-muted-foreground">
               Explore tools built on the archive.

--- a/src/components/MemberSearchLanding.tsx
+++ b/src/components/MemberSearchLanding.tsx
@@ -70,7 +70,7 @@ export default function MemberSearchLanding({
 
         <form
           onSubmit={handleSubmit}
-          className="mt-10 flex w-full max-w-3xl flex-col gap-3 rounded-xl border border-border bg-card p-2 shadow-lg sm:flex-row"
+          className="mt-10 flex w-full max-w-3xl flex-col gap-3 rounded-xl border border-border bg-card p-2 shadow-lg transition-[border-color,box-shadow] focus-within:border-green-500 focus-within:ring-2 focus-within:ring-green-500/25 dark:focus-within:border-green-400 dark:focus-within:ring-green-400/20 sm:flex-row"
         >
           <div className="relative flex-1">
             <Search className="absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />
@@ -89,7 +89,7 @@ export default function MemberSearchLanding({
             type="submit"
             size="lg"
             disabled={!query.trim()}
-            className="h-14 bg-brand px-7 text-brand-foreground hover:bg-brand/90"
+            className="h-14 bg-green-600 px-7 text-white hover:bg-green-700 dark:bg-green-400 dark:text-green-950 dark:hover:bg-green-300"
           >
             Search
             <ArrowRight className="ml-2 h-4 w-4" />
@@ -129,10 +129,10 @@ export default function MemberSearchLanding({
           >
             <Users className="h-5 w-5 text-brand" />
             <h2 className="mt-4 text-base font-semibold text-foreground">
-              User Directory
+              Library
             </h2>
             <p className="mt-1 text-sm leading-6 text-muted-foreground">
-              Browse participating accounts.
+              Browse the archive by contributor.
             </p>
           </Link>
           <Link

--- a/src/components/MobileNavigation.tsx
+++ b/src/components/MobileNavigation.tsx
@@ -15,7 +15,7 @@ import {
 const navigationItems = [
   { href: '/', label: 'Home' },
   { href: '/#products', label: 'Products' },
-  { href: '/user-dir', label: 'User Directory' },
+  { href: '/user-dir', label: 'Library' },
   { href: '/search', label: 'Search' },
   { href: '/docs', label: 'Docs' },
 ]

--- a/src/components/MobileNavigation.tsx
+++ b/src/components/MobileNavigation.tsx
@@ -14,7 +14,7 @@ import {
 
 const navigationItems = [
   { href: '/', label: 'Home' },
-  { href: '/#products', label: 'Products' },
+  { href: '/#products', label: 'Tools' },
   { href: '/user-dir', label: 'Library' },
   { href: '/search', label: 'Search' },
   { href: '/docs', label: 'Docs' },

--- a/src/components/TieredSupportersDisplay.tsx
+++ b/src/components/TieredSupportersDisplay.tsx
@@ -67,7 +67,7 @@ const TieredSupportersDisplay: React.FC<TieredSupportersDisplayProps> = ({
         {/* Column 1: Money Raised */}
         <div className="order-1 flex h-full flex-col items-center justify-center text-center">
           <div>
-            <p className="text-2xl font-bold text-green-600 dark:text-green-400 lg:text-3xl">
+            <p className="text-2xl font-bold text-brand lg:text-3xl">
               ${formatNumber(totalAmountRaised)}
             </p>
             <p className="mt-1 text-xs text-muted-foreground">Raised</p>

--- a/src/components/UploadArchiveSection.tsx
+++ b/src/components/UploadArchiveSection.tsx
@@ -185,7 +185,7 @@ export default function UploadArchiveSection() {
                 <Button
                   onClick={handleUploadClick}
                   disabled={isUploadProcessing}
-                  className="bg-brand text-white hover:bg-brand/90 dark:bg-brand dark:text-brand-foreground dark:hover:bg-brand/90"
+                  className="bg-green-600 text-white hover:bg-green-700 dark:bg-green-400 dark:text-green-950 dark:hover:bg-green-300"
                 >
                   <Upload className="mr-2 h-4 w-4" />
                   {isUploadProcessing ? 'Processing...' : 'Upload .zip'}

--- a/src/lib/queries/fetchUsers.ts
+++ b/src/lib/queries/fetchUsers.ts
@@ -27,7 +27,7 @@ export const fetchUsers = async (
   const {
     limit,
     offset = 0,
-    sortBy = 'joined_at',
+    sortBy = 'num_followers',
     sortOrder = 'desc',
     search,
   } = options || {}


### PR DESCRIPTION
## Summary

- Give the opted-in homepage search a green primary icon button, autofocus, and green focus treatment.
- Move archive totals, contributor avatars, and major-backer proof into the hero above Explore the Archive.
- Expand the “Keep the archive growing” section with clearer daily-refresh, archive-backfill, and real-time extension guidance.
- Prioritize Opt in → Upload archive → Get extension, and make upload actions green while keeping links and supporter metrics blue.
- Rename User Directory to Library and sort contributors by follower count descending by default.
- Apply the green primary treatment to the main archive search buttons for consistency.

## Why

The homepage’s search and contribution hierarchy was too easy to miss, while the archive’s strongest social proof sat below the fold. This makes the primary actions clearer, surfaces the archive’s scale earlier, and gives the people-organized directory a name that better matches the archive mental model.

## Validation

- `npm run type-check`
- `npm run lint`
- `npm test -- --selectProjects server --runInBand src/lib/searchParams.test.ts src/lib/homepageAccess.test.ts src/lib/queries/fetchUsers.test.ts`
- `npm run build`
- Verified the logged-out homepage and Library in the local browser at desktop and mobile widths; confirmed follower sorting is descending and no browser console errors were present.
