### PR TITLE
Refine homepage contribution hierarchy

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -201,7 +201,9 @@ export default async function Homepage() {
     'w-full max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10'
 
   const socialProof = (
-    <div className="mx-auto w-full max-w-3xl">
+    <div
+      className={`mx-auto w-full max-w-3xl ${isOptedIn ? 'pt-8 md:pt-10' : ''}`}
+    >
       {mostFollowed.length > 0 ? (
         <AvatarList initialAvatars={mostFollowed} compact />
       ) : (
@@ -273,6 +275,17 @@ export default async function Homepage() {
         </div>
       </section>
 
+      {/* Section 2: Explore the archive - Featured Apps */}
+      <section
+        id="products"
+        className={`bg-card dark:bg-background ${sectionPaddingClasses} scroll-mt-16 overflow-hidden`}
+      >
+        <div className={contentWrapperClasses}>
+          <FeaturedAppsSection />
+          <AppGallery />
+        </div>
+      </section>
+
       {isOptedIn ? (
         <section className="overflow-hidden bg-muted py-12 dark:bg-card md:py-16">
           <div className={`${contentWrapperClasses} text-center`}>
@@ -288,17 +301,6 @@ export default async function Homepage() {
           </div>
         </section>
       ) : null}
-
-      {/* Section 2: Explore the archive - Featured Apps */}
-      <section
-        id="products"
-        className={`bg-card dark:bg-background ${sectionPaddingClasses} scroll-mt-16 overflow-hidden`}
-      >
-        <div className={contentWrapperClasses}>
-          <FeaturedAppsSection />
-          <AppGallery />
-        </div>
-      </section>
 
       {/* Section 3: Upload Your Archive */}
       <section

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -215,7 +215,11 @@ export default async function Homepage() {
   return (
     <main>
       {/* Section 1: Audience-specific hero */}
-      <section className="overflow-hidden bg-card pb-12 pt-14 dark:bg-background md:pb-16 md:pt-20">
+      <section
+        className={`overflow-hidden bg-card pb-12 pt-14 dark:bg-background md:pb-16 md:pt-20 ${
+          isOptedIn ? 'md:flex md:min-h-[66vh] md:items-center' : ''
+        }`}
+      >
         <div className={`${contentWrapperClasses} space-y-7 text-center`}>
           <div className="space-y-3">
             <h1 className="text-5xl font-bold tracking-tight text-foreground md:text-6xl">
@@ -267,8 +271,8 @@ export default async function Homepage() {
             <HomepageSearch />
           ) : (
             <>
-              <div className="py-4 md:py-5">{socialProof}</div>
               <DynamicHeroCTAButtons initialIsOptedIn={false} />
+              <div className="pt-8 md:pt-10">{socialProof}</div>
             </>
           )}
         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -201,34 +201,14 @@ export default async function Homepage() {
     'w-full max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10'
 
   const socialProof = (
-    <div className="mx-auto w-full max-w-3xl space-y-4 border-t border-border/80 pt-6">
+    <div className="mx-auto w-full max-w-3xl">
       {mostFollowed.length > 0 ? (
-        <AvatarList initialAvatars={mostFollowed} />
+        <AvatarList initialAvatars={mostFollowed} compact />
       ) : (
         <p className="text-center text-sm text-muted-foreground">
           Featured archives are currently unavailable.
         </p>
       )}
-      <p className="text-sm text-muted-foreground">
-        Backed by{' '}
-        <Link
-          href="https://survivalandflourishing.fund/"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="font-medium text-brand hover:underline"
-        >
-          Survival and Flourishing Fund
-        </Link>{' '}
-        and{' '}
-        <Link
-          href="https://x.com/VitalikButerin"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="font-medium text-brand hover:underline"
-        >
-          Vitalik Buterin
-        </Link>
-      </p>
     </div>
   )
 
@@ -236,56 +216,57 @@ export default async function Homepage() {
     <main>
       {/* Section 1: Audience-specific hero */}
       <section className="overflow-hidden bg-card pb-12 pt-14 dark:bg-background md:pb-16 md:pt-20">
-        <div className={`${contentWrapperClasses} space-y-8 text-center`}>
-          <div className="space-y-4">
+        <div className={`${contentWrapperClasses} space-y-7 text-center`}>
+          <div className="space-y-3">
             <h1 className="text-5xl font-bold tracking-tight text-foreground md:text-6xl">
               Community Archive
             </h1>
             <p className="text-xl leading-8 text-muted-foreground">
               {stats.tweetCount !== null && stats.userCount !== null ? (
-                isOptedIn ? (
-                  <>
-                    Search{' '}
-                    <strong className="font-semibold text-foreground">
-                      {formatNumber(stats.tweetCount)} public tweets
-                    </strong>{' '}
-                    from{' '}
-                    <strong className="font-semibold text-foreground">
-                      {formatNumber(stats.userCount)} community members
-                    </strong>
-                    .
-                  </>
-                ) : (
-                  <>
-                    Help preserve{' '}
-                    <strong className="font-semibold text-foreground">
-                      {formatNumber(stats.tweetCount)} public tweets
-                    </strong>{' '}
-                    from{' '}
-                    <strong className="font-semibold text-foreground">
-                      {formatNumber(stats.userCount)} community members
-                    </strong>
-                    .
-                  </>
-                )
+                <>
+                  We preserve{' '}
+                  <strong className="font-semibold text-foreground">
+                    {formatNumber(stats.tweetCount)} public tweets
+                  </strong>{' '}
+                  from{' '}
+                  <strong className="font-semibold text-foreground">
+                    {formatNumber(stats.userCount)} community members
+                  </strong>
+                  .
+                </>
               ) : (
                 <>
-                  Search public conversations and help build open source public
+                  We preserve public conversations as open source public
                   infrastructure.
                 </>
               )}
+            </p>
+            <p className="text-xs text-muted-foreground/80">
+              Backed by{' '}
+              <Link
+                href="https://survivalandflourishing.fund/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium text-muted-foreground transition-colors hover:text-brand hover:underline"
+              >
+                Survival and Flourishing Fund
+              </Link>{' '}
+              and{' '}
+              <Link
+                href="https://x.com/VitalikButerin"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium text-muted-foreground transition-colors hover:text-brand hover:underline"
+              >
+                Vitalik Buterin
+              </Link>
             </p>
           </div>
 
           {isOptedIn ? (
             <HomepageSearch />
           ) : (
-            <div className="space-y-4 pt-2">
-              <p className="text-sm font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-                Help grow the archive
-              </p>
-              <DynamicHeroCTAButtons initialIsOptedIn={false} />
-            </div>
+            <DynamicHeroCTAButtons initialIsOptedIn={false} />
           )}
 
           {socialProof}
@@ -295,10 +276,7 @@ export default async function Homepage() {
       {isOptedIn ? (
         <section className="overflow-hidden bg-muted py-12 dark:bg-card md:py-16">
           <div className={`${contentWrapperClasses} text-center`}>
-            <p className="text-sm font-semibold uppercase tracking-[0.14em] text-brand">
-              Keep the archive growing
-            </p>
-            <h2 className="mt-3 text-3xl font-bold text-foreground md:text-4xl">
+            <h2 className="text-3xl font-bold text-foreground md:text-4xl">
               Fill the gaps in the public record
             </h2>
             <p className="mx-auto mb-8 mt-4 max-w-2xl text-base leading-7 text-muted-foreground">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -215,11 +215,7 @@ export default async function Homepage() {
   return (
     <main>
       {/* Section 1: Audience-specific hero */}
-      <section
-        className={`overflow-hidden bg-card pb-12 pt-14 dark:bg-background md:pb-16 md:pt-20 ${
-          isOptedIn ? 'md:flex md:min-h-[66vh] md:items-center' : ''
-        }`}
-      >
+      <section className="overflow-hidden bg-card pb-12 pt-14 dark:bg-background md:min-h-[66vh] md:pb-16 md:pt-20">
         <div className={`${contentWrapperClasses} space-y-7 text-center`}>
           <div className="space-y-3">
             <h1 className="text-5xl font-bold tracking-tight text-foreground md:text-6xl">
@@ -272,7 +268,12 @@ export default async function Homepage() {
           ) : (
             <>
               <DynamicHeroCTAButtons initialIsOptedIn={false} />
-              <div className="pt-8 md:pt-10">{socialProof}</div>
+              <div className="pt-8 md:pt-10">
+                <p className="mb-5 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground/80">
+                  With archives from
+                </p>
+                {socialProof}
+              </div>
             </>
           )}
         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -201,9 +201,7 @@ export default async function Homepage() {
     'w-full max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10'
 
   const socialProof = (
-    <div
-      className={`mx-auto w-full max-w-3xl ${isOptedIn ? 'pt-8 md:pt-10' : ''}`}
-    >
+    <div className="mx-auto w-full max-w-3xl">
       {mostFollowed.length > 0 ? (
         <AvatarList initialAvatars={mostFollowed} compact />
       ) : (
@@ -268,17 +266,18 @@ export default async function Homepage() {
           {isOptedIn ? (
             <HomepageSearch />
           ) : (
-            <DynamicHeroCTAButtons initialIsOptedIn={false} />
+            <>
+              <div className="py-4 md:py-5">{socialProof}</div>
+              <DynamicHeroCTAButtons initialIsOptedIn={false} />
+            </>
           )}
-
-          {socialProof}
         </div>
       </section>
 
       {/* Section 2: Explore the archive - Featured Apps */}
       <section
         id="products"
-        className={`bg-card dark:bg-background ${sectionPaddingClasses} scroll-mt-16 overflow-hidden`}
+        className={`bg-muted dark:bg-card ${sectionPaddingClasses} scroll-mt-16 overflow-hidden`}
       >
         <div className={contentWrapperClasses}>
           <FeaturedAppsSection />
@@ -287,7 +286,7 @@ export default async function Homepage() {
       </section>
 
       {isOptedIn ? (
-        <section className="overflow-hidden bg-muted py-12 dark:bg-card md:py-16">
+        <section className="overflow-hidden bg-card py-12 dark:bg-background md:py-16">
           <div className={`${contentWrapperClasses} text-center`}>
             <h2 className="text-3xl font-bold text-foreground md:text-4xl">
               Fill the gaps in the public record
@@ -298,6 +297,7 @@ export default async function Homepage() {
               tweets in real time while you browse.
             </p>
             <DynamicHeroCTAButtons initialIsOptedIn />
+            <div className="mt-10 md:mt-12">{socialProof}</div>
           </div>
         </section>
       ) : null}

--- a/src/components/AvatarList.tsx
+++ b/src/components/AvatarList.tsx
@@ -29,7 +29,7 @@ const AvatarList = ({
       <div className="w-full">
         <div
           className={`flex flex-wrap justify-center pb-2 ${
-            compact ? 'gap-x-3 gap-y-4' : 'gap-x-4 gap-y-6'
+            compact ? 'gap-x-2 gap-y-3' : 'gap-x-4 gap-y-6'
           }`}
         >
           {avatars.map((avatar) => (
@@ -37,10 +37,10 @@ const AvatarList = ({
               key={avatar.username}
               href={`/user/${avatar.account_id}`}
               className={`flex flex-col items-center text-center ${
-                compact ? 'w-16' : 'w-20'
+                compact ? 'w-14' : 'w-20'
               }`}
             >
-              <Avatar className={compact ? 'h-10 w-10' : 'h-12 w-12'}>
+              <Avatar className={compact ? 'h-9 w-9' : 'h-12 w-12'}>
                 <AvatarImage
                   src={avatar.avatar_media_url}
                   alt={`${avatar.username}'s avatar`}
@@ -51,14 +51,14 @@ const AvatarList = ({
               </Avatar>
               <span
                 className={`mt-1 break-words hover:underline ${
-                  compact ? 'text-[11px]' : 'text-xs'
+                  compact ? 'text-[10px]' : 'text-xs'
                 }`}
               >
                 {avatar.username}
               </span>
               <span
                 className={`mt-0.5 text-muted-foreground ${
-                  compact ? 'text-[9px]' : 'text-[10px]'
+                  compact ? 'text-[8px]' : 'text-[10px]'
                 }`}
               >
                 {avatar.num_followers &&

--- a/src/components/AvatarList.tsx
+++ b/src/components/AvatarList.tsx
@@ -29,7 +29,7 @@ const AvatarList = ({
       <div className="w-full">
         <div
           className={`flex flex-wrap justify-center pb-2 ${
-            compact ? 'gap-x-2 gap-y-3' : 'gap-x-4 gap-y-6'
+            compact ? 'gap-x-3 gap-y-4' : 'gap-x-4 gap-y-6'
           }`}
         >
           {avatars.map((avatar) => (
@@ -37,10 +37,10 @@ const AvatarList = ({
               key={avatar.username}
               href={`/user/${avatar.account_id}`}
               className={`flex flex-col items-center text-center ${
-                compact ? 'w-14' : 'w-20'
+                compact ? 'w-16' : 'w-20'
               }`}
             >
-              <Avatar className={compact ? 'h-9 w-9' : 'h-12 w-12'}>
+              <Avatar className={compact ? 'h-10 w-10' : 'h-12 w-12'}>
                 <AvatarImage
                   src={avatar.avatar_media_url}
                   alt={`${avatar.username}'s avatar`}
@@ -51,14 +51,14 @@ const AvatarList = ({
               </Avatar>
               <span
                 className={`mt-1 break-words hover:underline ${
-                  compact ? 'text-[10px]' : 'text-xs'
+                  compact ? 'text-[11px]' : 'text-xs'
                 }`}
               >
                 {avatar.username}
               </span>
               <span
                 className={`mt-0.5 text-muted-foreground ${
-                  compact ? 'text-[8px]' : 'text-[10px]'
+                  compact ? 'text-[9px]' : 'text-[10px]'
                 }`}
               >
                 {avatar.num_followers &&

--- a/src/components/AvatarList.tsx
+++ b/src/components/AvatarList.tsx
@@ -8,8 +8,13 @@ import { formatNumber } from '@/lib/formatNumber'
 type AvatarListProps = {
   initialAvatars: AvatarType[]
   title?: string
+  compact?: boolean
 }
-const AvatarList = ({ initialAvatars, title = 'Avatars' }: AvatarListProps) => {
+const AvatarList = ({
+  initialAvatars,
+  title = 'Avatars',
+  compact = false,
+}: AvatarListProps) => {
   const [avatars, setAvatars] = useState(initialAvatars)
 
   useEffect(() => {
@@ -22,14 +27,20 @@ const AvatarList = ({ initialAvatars, title = 'Avatars' }: AvatarListProps) => {
   return (
     <div>
       <div className="w-full">
-        <div className="flex flex-wrap justify-center gap-x-4 gap-y-6 pb-2">
+        <div
+          className={`flex flex-wrap justify-center pb-2 ${
+            compact ? 'gap-x-3 gap-y-4' : 'gap-x-4 gap-y-6'
+          }`}
+        >
           {avatars.map((avatar) => (
             <a
               key={avatar.username}
               href={`/user/${avatar.account_id}`}
-              className="flex w-20 flex-col items-center text-center"
+              className={`flex flex-col items-center text-center ${
+                compact ? 'w-16' : 'w-20'
+              }`}
             >
-              <Avatar className="h-12 w-12">
+              <Avatar className={compact ? 'h-10 w-10' : 'h-12 w-12'}>
                 <AvatarImage
                   src={avatar.avatar_media_url}
                   alt={`${avatar.username}'s avatar`}
@@ -38,10 +49,18 @@ const AvatarList = ({ initialAvatars, title = 'Avatars' }: AvatarListProps) => {
                   {avatar.username[0].toUpperCase()}
                 </AvatarFallback>
               </Avatar>
-              <span className="mt-1 break-words text-xs hover:underline">
+              <span
+                className={`mt-1 break-words hover:underline ${
+                  compact ? 'text-[11px]' : 'text-xs'
+                }`}
+              >
                 {avatar.username}
               </span>
-              <span className="mt-0.5 text-[10px] text-muted-foreground">
+              <span
+                className={`mt-0.5 text-muted-foreground ${
+                  compact ? 'text-[9px]' : 'text-[10px]'
+                }`}
+              >
                 {avatar.num_followers &&
                   `${formatNumber(avatar.num_followers)} followers`}
               </span>

--- a/src/components/HeroCTAButtons.tsx
+++ b/src/components/HeroCTAButtons.tsx
@@ -205,7 +205,12 @@ export default function HeroCTAButtons({
             <TooltipTrigger asChild>
               <Button
                 asChild
-                className="h-14 w-full bg-green-600 px-8 text-lg font-semibold text-white hover:bg-green-700 dark:bg-green-400 dark:text-green-950 dark:hover:bg-green-300"
+                variant={isOptedIn ? 'default' : 'outline'}
+                className={`h-14 w-full px-8 text-lg font-semibold ${
+                  isOptedIn
+                    ? 'bg-green-600 text-white hover:bg-green-700 dark:bg-green-400 dark:text-green-950 dark:hover:bg-green-300'
+                    : 'border-2'
+                }`}
                 size="lg"
               >
                 <a href="#upload-archive">

--- a/src/components/HomepageSearch.tsx
+++ b/src/components/HomepageSearch.tsx
@@ -30,7 +30,7 @@ export default function HomepageSearch() {
     <div className="mx-auto w-full max-w-3xl">
       <form
         onSubmit={handleSubmit}
-        className="relative rounded-xl border border-border bg-card p-2 text-left shadow-lg transition-[border-color,box-shadow] focus-within:border-green-500 focus-within:ring-2 focus-within:ring-green-500/25 dark:focus-within:border-green-400 dark:focus-within:ring-green-400/20"
+        className="relative rounded-xl border border-border bg-card p-2 text-left shadow-lg"
       >
         <Input
           type="search"

--- a/src/components/MemberSearchLanding.tsx
+++ b/src/components/MemberSearchLanding.tsx
@@ -70,7 +70,7 @@ export default function MemberSearchLanding({
 
         <form
           onSubmit={handleSubmit}
-          className="mt-10 flex w-full max-w-3xl flex-col gap-3 rounded-xl border border-border bg-card p-2 shadow-lg transition-[border-color,box-shadow] focus-within:border-green-500 focus-within:ring-2 focus-within:ring-green-500/25 dark:focus-within:border-green-400 dark:focus-within:ring-green-400/20 sm:flex-row"
+          className="mt-10 flex w-full max-w-3xl flex-col gap-3 rounded-xl border border-border bg-card p-2 shadow-lg sm:flex-row"
         >
           <div className="relative flex-1">
             <Search className="absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />


### PR DESCRIPTION
## Summary

- Keep Opt in as the only green contribution CTA until the member is opted in; only then promote Upload archive to green.
- Remove the green focus outline from homepage and member search containers.
- Compact the homepage avatar proof to roughly 80% of its previous size and remove its divider.
- Change the hero subtitle to “We preserve…” and move a quieter backer line directly underneath it.
- Remove the “Help grow the archive” and “Keep the archive growing” eyebrow labels.

## Why

This follow-up clarifies the contribution hierarchy and reduces competing emphasis in the homepage hero while keeping the archive’s scale and community proof visible.

## Validation

- `npm run type-check`
- `npm run lint`
- `npm run build`
