### PR TITLE
Distribute homepage hero content

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -215,8 +215,10 @@ export default async function Homepage() {
   return (
     <main>
       {/* Section 1: Audience-specific hero */}
-      <section className="overflow-hidden bg-card pb-12 pt-14 dark:bg-background md:min-h-[66vh] md:pb-16 md:pt-20">
-        <div className={`${contentWrapperClasses} space-y-7 text-center`}>
+      <section className="overflow-hidden bg-card pb-12 pt-14 dark:bg-background md:flex md:min-h-[66vh] md:pb-16 md:pt-20">
+        <div
+          className={`${contentWrapperClasses} space-y-7 text-center md:flex md:flex-1 md:flex-col md:justify-evenly md:space-y-0`}
+        >
           <div className="space-y-3">
             <h1 className="text-5xl font-bold tracking-tight text-foreground md:text-6xl">
               Community Archive
@@ -268,7 +270,7 @@ export default async function Homepage() {
           ) : (
             <>
               <DynamicHeroCTAButtons initialIsOptedIn={false} />
-              <div className="pt-8 md:pt-10">
+              <div className="pt-8 md:pt-0">
                 <p className="mb-5 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground/80">
                   With archives from
                 </p>


### PR DESCRIPTION
## What changed

- Keeps the homepage hero at two-thirds of the desktop viewport in both authentication states.
- Distributes hero content evenly across the available vertical space.
- Preserves the logged-out social-proof label while letting the layout provide the separation.

## Why

The signed-in hero had the intended overall height, but its contents were clustered instead of using the full strip. The logged-out state also needed to follow that same spatial rhythm.

## Impact

Signed-in and logged-out visitors now see a more balanced hero, with the title, search or actions, and social proof placed intentionally throughout the section.

## Validation

- npm run type-check
- npm run lint
- Prettier check for src/app/page.tsx
- git diff --check