### PR TITLE
Fix cross-route Tools navigation

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,6 +14,7 @@ import HeaderSearch from '@/components/HeaderSearch'
 import MobileMenu from '@/components/MobileMenu'
 import MobileNavigation from '@/components/MobileNavigation'
 import Footer from '@/components/Footer'
+import HashScrollHandler from '@/components/HashScrollHandler'
 import { checkIsAdmin } from '@/app/admin/data'
 import { Shield } from 'lucide-react'
 
@@ -64,6 +65,7 @@ export default async function RootLayout({
           disableTransitionOnChange
         >
           <ReactQueryProvider>
+            <HashScrollHandler />
             <header className="sticky top-0 z-50 w-full border-b border-border bg-background/90 backdrop-blur-md">
               <div className="container mx-auto flex h-16 max-w-screen-xl items-center justify-between px-4 sm:px-6 lg:px-8">
                 <Link

--- a/src/components/HashScrollHandler.test.tsx
+++ b/src/components/HashScrollHandler.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { render, waitFor } from '@testing-library/react'
+import HashScrollHandler from './HashScrollHandler'
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/',
+}))
+
+describe('<HashScrollHandler />', () => {
+  afterEach(() => {
+    window.location.hash = ''
+    document.body.innerHTML = ''
+  })
+
+  it('scrolls to the current hash target', () => {
+    window.location.hash = '#products'
+    const target = document.createElement('section')
+    target.id = 'products'
+    target.scrollIntoView = jest.fn()
+    document.body.appendChild(target)
+
+    render(<HashScrollHandler />)
+
+    expect(target.scrollIntoView).toHaveBeenCalledWith({ block: 'start' })
+  })
+
+  it('scrolls when a streamed hash target is added later', async () => {
+    window.location.hash = '#products'
+    render(<HashScrollHandler />)
+
+    const target = document.createElement('section')
+    target.id = 'products'
+    target.scrollIntoView = jest.fn()
+    document.body.appendChild(target)
+
+    await waitFor(() => {
+      expect(target.scrollIntoView).toHaveBeenCalledWith({ block: 'start' })
+    })
+  })
+})

--- a/src/components/HashScrollHandler.tsx
+++ b/src/components/HashScrollHandler.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { useEffect } from 'react'
+import { usePathname } from 'next/navigation'
+
+const getHashTarget = () => {
+  const hash = window.location.hash.slice(1)
+
+  if (!hash) return null
+
+  try {
+    return document.getElementById(decodeURIComponent(hash))
+  } catch {
+    return document.getElementById(hash)
+  }
+}
+
+export default function HashScrollHandler() {
+  const pathname = usePathname()
+
+  useEffect(() => {
+    let observer: MutationObserver | undefined
+    let timeout: number | undefined
+
+    const scrollToHash = () => {
+      const target = getHashTarget()
+
+      if (!target) return false
+
+      target.scrollIntoView({ block: 'start' })
+      return true
+    }
+
+    const handleHash = () => {
+      observer?.disconnect()
+      if (timeout !== undefined) window.clearTimeout(timeout)
+
+      if (!window.location.hash || scrollToHash()) return
+
+      observer = new MutationObserver(() => {
+        if (scrollToHash()) observer?.disconnect()
+      })
+
+      observer.observe(document.body, { childList: true, subtree: true })
+      timeout = window.setTimeout(() => observer?.disconnect(), 2000)
+    }
+
+    handleHash()
+    window.addEventListener('hashchange', handleHash)
+
+    return () => {
+      window.removeEventListener('hashchange', handleHash)
+      if (timeout !== undefined) window.clearTimeout(timeout)
+      observer?.disconnect()
+    }
+  }, [pathname])
+
+  return null
+}


### PR DESCRIPTION
## What changed

- Adds a global hash-scroll handler for route transitions.
- Scrolls to the requested anchor immediately when it exists.
- Watches briefly for anchors that arrive later through streamed rendering.
- Handles subsequent same-page hash changes as well.

## Why

The Tools links already targeted /#products, but client-side navigation could attempt the browser anchor jump before the homepage Tools section finished rendering. That left visitors at the top of the homepage.

## Impact

Selecting Tools from Library, Docs, Search, or another route now reliably opens the homepage at the Tools section. Existing /#products links remain compatible.

## Validation

- npm run type-check
- npm run lint
- Focused HashScrollHandler tests: 2 passed
- Prettier check
- git diff --check