### PR TITLE
Add username suggestions to archive search

### DIFF
--- a/src/components/AdvancedSearchForm.tsx
+++ b/src/components/AdvancedSearchForm.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import UserSearchInput from '@/components/UserSearchInput'
 import {
   ChevronDown,
   ChevronUp,
@@ -96,11 +97,10 @@ export default function AdvancedSearchForm() {
       <div className="flex flex-col gap-3 sm:flex-row">
         <div className="relative flex-1">
           <Search className="absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />
-          <Input
+          <UserSearchInput
             id="main-search"
-            type="search"
             value={query}
-            onChange={(e) => setQuery(e.target.value)}
+            onValueChange={setQuery}
             placeholder="Search words, phrases, or from:username"
             className="h-12 rounded-lg bg-background pl-12 pr-4 text-base"
             autoComplete="off"

--- a/src/components/HeaderSearch.tsx
+++ b/src/components/HeaderSearch.tsx
@@ -4,8 +4,8 @@ import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { ListFilter, Search } from 'lucide-react'
-import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
+import UserSearchInput from '@/components/UserSearchInput'
 import { buildSearchHref } from '@/lib/searchParams'
 
 export default function HeaderSearch() {
@@ -23,12 +23,13 @@ export default function HeaderSearch() {
       <div className="flex items-center">
         <div className="relative">
           <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            type="search"
+          <UserSearchInput
             placeholder="Search tweets..."
             value={query}
-            onChange={(e) => setQuery(e.target.value)}
+            onValueChange={setQuery}
             className="h-9 w-40 rounded-r-none border-border bg-muted py-1.5 pl-8 pr-3 text-sm focus:ring-brand lg:w-56"
+            aria-label="Search Community Archive"
+            autoComplete="off"
           />
         </div>
         <Button

--- a/src/components/HomepageSearch.tsx
+++ b/src/components/HomepageSearch.tsx
@@ -4,7 +4,7 @@ import { FormEvent, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { Search } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
+import UserSearchInput from '@/components/UserSearchInput'
 import { buildSearchParams } from '@/lib/searchParams'
 
 const exampleSearches = ['open source', 'AI alignment', 'from:vitalikbuterin']
@@ -32,10 +32,9 @@ export default function HomepageSearch() {
         onSubmit={handleSubmit}
         className="relative rounded-xl border border-border bg-card p-2 text-left shadow-lg"
       >
-        <Input
-          type="search"
+        <UserSearchInput
           value={query}
-          onChange={(event) => setQuery(event.target.value)}
+          onValueChange={setQuery}
           placeholder="Search tweets, people, and ideas"
           aria-label="Search Community Archive"
           className="h-14 border-0 bg-transparent pl-4 pr-14 text-base shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 sm:text-lg"

--- a/src/components/MemberSearchLanding.tsx
+++ b/src/components/MemberSearchLanding.tsx
@@ -12,7 +12,7 @@ import {
   Users,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
+import UserSearchInput from '@/components/UserSearchInput'
 import { formatNumber } from '@/lib/formatNumber'
 import { buildSearchParams } from '@/lib/searchParams'
 
@@ -74,10 +74,9 @@ export default function MemberSearchLanding({
         >
           <div className="relative flex-1">
             <Search className="absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />
-            <Input
-              type="search"
+            <UserSearchInput
               value={query}
-              onChange={(event) => setQuery(event.target.value)}
+              onValueChange={setQuery}
               placeholder="Search the Community Archive"
               aria-label="Search the Community Archive"
               className="h-14 border-0 bg-transparent pl-12 pr-4 text-base shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 sm:text-lg"

--- a/src/components/UserSearchInput.test.tsx
+++ b/src/components/UserSearchInput.test.tsx
@@ -1,0 +1,92 @@
+import React, { useState } from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom'
+import UserSearchInput from './UserSearchInput'
+import { fetchUserSuggestions } from '@/lib/queries/fetchUsers'
+
+jest.mock('@/utils/supabase', () => ({
+  createBrowserClient: () => ({}),
+}))
+
+jest.mock('@/lib/queries/fetchUsers', () => ({
+  fetchUserSuggestions: jest.fn(),
+}))
+
+const mockedFetchUserSuggestions = fetchUserSuggestions as jest.MockedFunction<
+  typeof fetchUserSuggestions
+>
+
+function SearchHarness() {
+  const [value, setValue] = useState('')
+
+  return (
+    <div className="relative">
+      <UserSearchInput
+        aria-label="Search Community Archive"
+        value={value}
+        onValueChange={setValue}
+      />
+    </div>
+  )
+}
+
+describe('UserSearchInput', () => {
+  beforeEach(() => {
+    mockedFetchUserSuggestions.mockReset()
+  })
+
+  it('offers matching users and inserts a from: filter when selected', async () => {
+    mockedFetchUserSuggestions.mockResolvedValue([
+      {
+        directory_id: 'archive:123',
+        username: 'exgenesis',
+        account_display_name: 'Ex Genesis',
+        avatar_media_url: null,
+        num_followers: 100,
+      },
+    ])
+
+    render(<SearchHarness />)
+    const input = screen.getByRole('combobox', {
+      name: 'Search Community Archive',
+    })
+    await userEvent.type(input, 'exg')
+
+    const option = await screen.findByRole('option', {
+      name: /Ex Genesis @exgenesis from:exgenesis/,
+    })
+    expect(mockedFetchUserSuggestions).toHaveBeenLastCalledWith(
+      expect.anything(),
+      'exg',
+      6,
+    )
+
+    await userEvent.click(option)
+
+    expect(input).toHaveValue('from:exgenesis')
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('supports arrow-key selection without submitting the parent form', async () => {
+    mockedFetchUserSuggestions.mockResolvedValue([
+      {
+        directory_id: 'archive:123',
+        username: 'exgenesis',
+        account_display_name: 'Ex Genesis',
+        avatar_media_url: null,
+        num_followers: 100,
+      },
+    ])
+
+    render(<SearchHarness />)
+    const input = screen.getByRole('combobox', {
+      name: 'Search Community Archive',
+    })
+    await userEvent.type(input, 'exg')
+    await screen.findByRole('option')
+    await userEvent.keyboard('{ArrowDown}{Enter}')
+
+    expect(input).toHaveValue('from:exgenesis')
+  })
+})

--- a/src/components/UserSearchInput.tsx
+++ b/src/components/UserSearchInput.tsx
@@ -1,0 +1,237 @@
+'use client'
+
+import React, { useEffect, useId, useMemo, useRef, useState } from 'react'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Input, InputProps } from '@/components/ui/input'
+import { fetchUserSuggestions } from '@/lib/queries/fetchUsers'
+import {
+  getUsernameSearchToken,
+  replaceUsernameTokenWithFromFilter,
+} from '@/lib/searchSuggestions'
+import type {
+  UsernameSearchToken,
+  UserSuggestion,
+} from '@/lib/searchSuggestions'
+import { createBrowserClient } from '@/utils/supabase'
+import { cn } from '@/utils/tailwind'
+
+interface UserSearchInputProps extends Omit<InputProps, 'onChange' | 'value'> {
+  value: string
+  onValueChange: (value: string) => void
+}
+
+const SUGGESTION_LIMIT = 6
+const SUGGESTION_DELAY_MS = 200
+
+export default function UserSearchInput({
+  value,
+  onValueChange,
+  onBlur,
+  onClick,
+  onFocus,
+  onKeyDown,
+  onKeyUp,
+  type = 'search',
+  ...inputProps
+}: UserSearchInputProps) {
+  const supabase = useMemo(() => createBrowserClient(), [])
+  const inputRef = useRef<HTMLInputElement>(null)
+  const requestIdRef = useRef(0)
+  const listboxId = `user-search-${useId().replace(/:/g, '')}`
+  const [activeIndex, setActiveIndex] = useState(-1)
+  const [suggestions, setSuggestions] = useState<UserSuggestion[]>([])
+  const [token, setToken] = useState<UsernameSearchToken | null>(null)
+  const isOpen = suggestions.length > 0 && token !== null
+
+  const updateToken = (nextValue: string, caretPosition: number | null) => {
+    setToken(getUsernameSearchToken(nextValue, caretPosition))
+    setActiveIndex(-1)
+  }
+
+  const closeSuggestions = () => {
+    requestIdRef.current += 1
+    setSuggestions([])
+    setToken(null)
+    setActiveIndex(-1)
+  }
+
+  useEffect(() => {
+    const requestId = ++requestIdRef.current
+    setSuggestions([])
+    setActiveIndex(-1)
+    if (!token) return
+
+    const timer = window.setTimeout(() => {
+      fetchUserSuggestions(supabase, token.fragment, SUGGESTION_LIMIT)
+        .then((users) => {
+          if (
+            requestId === requestIdRef.current &&
+            document.activeElement === inputRef.current
+          ) {
+            setSuggestions(users)
+          }
+        })
+        .catch(() => {
+          if (requestId === requestIdRef.current) setSuggestions([])
+        })
+    }, SUGGESTION_DELAY_MS)
+
+    return () => window.clearTimeout(timer)
+  }, [supabase, token])
+
+  useEffect(() => {
+    if (activeIndex < 0) return
+    document
+      .getElementById(`${listboxId}-option-${activeIndex}`)
+      ?.scrollIntoView?.({ block: 'nearest' })
+  }, [activeIndex, listboxId])
+
+  const selectSuggestion = (suggestion: UserSuggestion) => {
+    if (!token) return
+    const replacement = replaceUsernameTokenWithFromFilter(
+      value,
+      token,
+      suggestion.username,
+    )
+
+    onValueChange(replacement.value)
+    closeSuggestions()
+    const restoreCaret = () => {
+      inputRef.current?.focus()
+      inputRef.current?.setSelectionRange(
+        replacement.caretPosition,
+        replacement.caretPosition,
+      )
+    }
+    if (typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(restoreCaret)
+    } else {
+      window.setTimeout(restoreCaret, 0)
+    }
+  }
+
+  return (
+    <>
+      <Input
+        {...inputProps}
+        ref={inputRef}
+        type={type}
+        value={value}
+        role="combobox"
+        aria-autocomplete="list"
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        aria-controls={listboxId}
+        aria-activedescendant={
+          activeIndex >= 0 ? `${listboxId}-option-${activeIndex}` : undefined
+        }
+        onChange={(event) => {
+          onValueChange(event.target.value)
+          updateToken(event.target.value, event.target.selectionStart)
+        }}
+        onFocus={(event) => {
+          onFocus?.(event)
+          updateToken(
+            event.currentTarget.value,
+            event.currentTarget.selectionStart,
+          )
+        }}
+        onBlur={(event) => {
+          onBlur?.(event)
+          closeSuggestions()
+        }}
+        onClick={(event) => {
+          onClick?.(event)
+          updateToken(
+            event.currentTarget.value,
+            event.currentTarget.selectionStart,
+          )
+        }}
+        onKeyUp={(event) => {
+          onKeyUp?.(event)
+          if (['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) {
+            updateToken(
+              event.currentTarget.value,
+              event.currentTarget.selectionStart,
+            )
+          }
+        }}
+        onKeyDown={(event) => {
+          onKeyDown?.(event)
+          if (event.defaultPrevented || !isOpen) return
+
+          if (event.key === 'ArrowDown') {
+            event.preventDefault()
+            setActiveIndex((current) => (current + 1) % suggestions.length)
+          } else if (event.key === 'ArrowUp') {
+            event.preventDefault()
+            setActiveIndex((current) =>
+              current <= 0 ? suggestions.length - 1 : current - 1,
+            )
+          } else if (event.key === 'Enter' && activeIndex >= 0) {
+            event.preventDefault()
+            selectSuggestion(suggestions[activeIndex])
+          } else if (event.key === 'Escape') {
+            event.preventDefault()
+            closeSuggestions()
+          }
+        }}
+      />
+
+      {isOpen && (
+        <div
+          id={listboxId}
+          role="listbox"
+          aria-label="User suggestions"
+          className="absolute left-0 top-full z-50 mt-2 max-h-80 w-full min-w-[18rem] overflow-y-auto rounded-xl border border-border bg-popover p-1.5 text-popover-foreground shadow-xl"
+        >
+          {suggestions.map((suggestion, index) => {
+            const displayName =
+              suggestion.account_display_name || suggestion.username
+            const isActive = index === activeIndex
+
+            return (
+              <button
+                key={suggestion.directory_id}
+                id={`${listboxId}-option-${index}`}
+                type="button"
+                role="option"
+                aria-selected={isActive}
+                onPointerDown={(event) => event.preventDefault()}
+                onMouseEnter={() => setActiveIndex(index)}
+                onClick={() => selectSuggestion(suggestion)}
+                className={cn(
+                  'flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left outline-none transition-colors',
+                  isActive
+                    ? 'bg-accent text-accent-foreground'
+                    : 'hover:bg-accent',
+                )}
+              >
+                <Avatar className="h-9 w-9 border border-border">
+                  <AvatarImage
+                    src={suggestion.avatar_media_url || undefined}
+                    alt=""
+                  />
+                  <AvatarFallback className="text-xs font-semibold uppercase">
+                    {(displayName || '@').slice(0, 1)}
+                  </AvatarFallback>
+                </Avatar>
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-sm font-medium">
+                    {displayName}
+                  </span>
+                  <span className="block truncate text-xs text-muted-foreground">
+                    @{suggestion.username}
+                  </span>
+                </span>
+                <span className="shrink-0 rounded-md bg-muted px-2 py-1 font-mono text-[11px] text-muted-foreground">
+                  from:{suggestion.username}
+                </span>
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/lib/queries/fetchUsers.ts
+++ b/src/lib/queries/fetchUsers.ts
@@ -1,6 +1,8 @@
 import { DirectoryUser, FormattedUser, SortKey } from '@/lib/types'
 import { SupabaseClient } from '@supabase/supabase-js'
 import { devLog } from '@/lib/devLog'
+import { rankUserSuggestions } from '@/lib/searchSuggestions'
+import type { UserSuggestion } from '@/lib/searchSuggestions'
 
 export interface FetchUsersOptions {
   limit?: number
@@ -89,6 +91,37 @@ export const fetchUsersCount = async (
 
   if (error) throw error
   return count || 0
+}
+
+export const fetchUserSuggestions = async (
+  supabase: SupabaseClient,
+  fragment: string,
+  limit = 6,
+): Promise<UserSuggestion[]> => {
+  const normalizedFragment = fragment
+    .trim()
+    .replace(/^@/, '')
+    .toLocaleLowerCase()
+  if (!/^[a-z0-9_]{2,15}$/.test(normalizedFragment)) return []
+
+  const escapedFragment = normalizedFragment.replace(/[\\%_]/g, '\\$&')
+  const { data, error } = await supabase
+    .schema('public')
+    .from('user_directory')
+    .select(
+      'directory_id, username, account_display_name, avatar_media_url, num_followers',
+    )
+    .ilike('username', `%${escapedFragment}%`)
+    .order('num_followers', { ascending: false, nullsFirst: false })
+    .limit(Math.max(limit * 5, 30))
+
+  if (error) throw error
+
+  return rankUserSuggestions(
+    (data as UserSuggestion[]) || [],
+    normalizedFragment,
+    limit,
+  )
 }
 
 export const getUserData = async (

--- a/src/lib/searchSuggestions.test.ts
+++ b/src/lib/searchSuggestions.test.ts
@@ -1,0 +1,65 @@
+import {
+  getUsernameSearchToken,
+  rankUserSuggestions,
+  replaceUsernameTokenWithFromFilter,
+  UserSuggestion,
+} from './searchSuggestions'
+
+const suggestion = (
+  username: string,
+  numFollowers: number | null = null,
+): UserSuggestion => ({
+  directory_id: `archive:${username}`,
+  username,
+  account_display_name: username,
+  avatar_media_url: null,
+  num_followers: numFollowers,
+})
+
+describe('username search suggestions', () => {
+  it('finds plain, @-prefixed, and partial from: username tokens', () => {
+    expect(getUsernameSearchToken('archive exg', 11)).toEqual({
+      start: 8,
+      end: 11,
+      fragment: 'exg',
+    })
+    expect(getUsernameSearchToken('@ExGenesis', 11)?.fragment).toBe('exgenesis')
+    expect(getUsernameSearchToken('future from:ExG', 15)).toEqual({
+      start: 7,
+      end: 15,
+      fragment: 'exg',
+    })
+  })
+
+  it('ignores punctuation, one-character words, and other operators', () => {
+    expect(getUsernameSearchToken('a', 1)).toBeNull()
+    expect(getUsernameSearchToken('local-first', 11)).toBeNull()
+    expect(getUsernameSearchToken('since:2024', 10)).toBeNull()
+  })
+
+  it('replaces only the active token with a from: filter', () => {
+    const value = 'archive exg research'
+    const token = getUsernameSearchToken(value, 10)
+
+    expect(
+      replaceUsernameTokenWithFromFilter(value, token!, 'exgenesis'),
+    ).toEqual({
+      value: 'archive from:exgenesis research',
+      caretPosition: 22,
+    })
+  })
+
+  it('ranks exact and prefix username matches before popular infix matches', () => {
+    expect(
+      rankUserSuggestions(
+        [
+          suggestion('alexgenesis', 10_000),
+          suggestion('exgenesis_notes', 50),
+          suggestion('exgenesis', 10),
+        ],
+        'exgenesis',
+        3,
+      ).map((user) => user.username),
+    ).toEqual(['exgenesis', 'exgenesis_notes', 'alexgenesis'])
+  })
+})

--- a/src/lib/searchSuggestions.ts
+++ b/src/lib/searchSuggestions.ts
@@ -1,0 +1,82 @@
+import type { DirectoryUser } from '@/lib/types'
+
+export interface UsernameSearchToken {
+  start: number
+  end: number
+  fragment: string
+}
+
+export type UserSuggestion = Pick<
+  DirectoryUser,
+  | 'directory_id'
+  | 'username'
+  | 'account_display_name'
+  | 'avatar_media_url'
+  | 'num_followers'
+>
+
+export function getUsernameSearchToken(
+  value: string,
+  caretPosition: number | null,
+): UsernameSearchToken | null {
+  const caret = Math.max(
+    0,
+    Math.min(caretPosition ?? value.length, value.length),
+  )
+  let start = caret
+  let end = caret
+
+  while (start > 0 && !/\s/.test(value[start - 1])) start -= 1
+  while (end < value.length && !/\s/.test(value[end])) end += 1
+
+  const token = value.slice(start, end)
+  const match = token.match(/^(?:from:)?@?([a-z0-9_]{2,15})$/i)
+
+  return match ? { start, end, fragment: match[1].toLocaleLowerCase() } : null
+}
+
+export function replaceUsernameTokenWithFromFilter(
+  value: string,
+  token: UsernameSearchToken,
+  username: string,
+) {
+  const filter = `from:${username}`
+
+  return {
+    value: `${value.slice(0, token.start)}${filter}${value.slice(token.end)}`,
+    caretPosition: token.start + filter.length,
+  }
+}
+
+export function rankUserSuggestions(
+  users: UserSuggestion[],
+  fragment: string,
+  limit: number,
+) {
+  const normalizedFragment = fragment.toLocaleLowerCase()
+
+  return [...users]
+    .sort((left, right) => {
+      const leftUsername = left.username.toLocaleLowerCase()
+      const rightUsername = right.username.toLocaleLowerCase()
+      const leftExact = leftUsername === normalizedFragment
+      const rightExact = rightUsername === normalizedFragment
+      if (leftExact !== rightExact) return leftExact ? -1 : 1
+
+      const leftPrefix = leftUsername.startsWith(normalizedFragment)
+      const rightPrefix = rightUsername.startsWith(normalizedFragment)
+      if (leftPrefix !== rightPrefix) return leftPrefix ? -1 : 1
+
+      const positionDifference =
+        leftUsername.indexOf(normalizedFragment) -
+        rightUsername.indexOf(normalizedFragment)
+      if (positionDifference !== 0) return positionDifference
+
+      const followerDifference =
+        (right.num_followers ?? -1) - (left.num_followers ?? -1)
+      if (followerDifference !== 0) return followerDifference
+
+      return leftUsername.localeCompare(rightUsername)
+    })
+    .slice(0, limit)
+}


### PR DESCRIPTION
## What changed

- adds a reusable account-suggestion combobox backed by the public `user_directory` view
- shows member avatars, display names, handles, and the resulting `from:username` operator
- replaces only the active username token when a suggestion is clicked or selected with the keyboard
- uses the same behavior in homepage, member landing, header, and advanced search fields
- adds focused parsing, ranking, pointer, and keyboard interaction tests

## Why

The archive already supports `from:username`, but people have to know and type the operator manually. Searching a full or partial username should surface the matching member as an entity, like Slack or Twitter search.

## User impact

Typing at least two username characters now opens suggestions. Selecting a member inserts `from:username` while preserving the rest of the search expression. Existing search URLs and backend parsing are unchanged.

## Root cause

The search controls were plain inputs with no account lookup or operator-insertion UI, even though the backend already understood author filters.

## Validation

- 19 focused tests passed, including pointer and arrow-key/Enter selection
- TypeScript check passed
- ESLint passed with no warnings
- Next.js production build completed successfully
- `git diff --check` passed
