### PR TITLE
Show recent privacy activity in admin dashboard

### DIFF
--- a/src/app/admin/RecentPrivacyActivity.test.tsx
+++ b/src/app/admin/RecentPrivacyActivity.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react'
+import { RecentPrivacyActivity } from './RecentPrivacyActivity'
+import type { RecentPrivacyActivity as RecentPrivacyActivityData } from './activity'
+
+const activity: RecentPrivacyActivityData = {
+  archiveDeletes: [
+    {
+      id: 'job:123',
+      accountId: '42',
+      username: 'alice',
+      source: 'Admin worker',
+      status: 'queued',
+      activityAt: '2026-07-18T14:00:00Z',
+      requestedAt: '2026-07-18T14:00:00Z',
+      detail: 'Delete job 12345678',
+      reason: 'Requested by account owner',
+      error: null,
+    },
+    {
+      id: 'action:9',
+      accountId: '84',
+      username: null,
+      source: 'Self-service log',
+      status: 'recorded',
+      activityAt: '2026-07-18T13:00:00Z',
+      requestedAt: '2026-07-18T13:00:00Z',
+      detail: 'Deleted all archive data',
+      reason: null,
+      error: null,
+    },
+  ],
+  optOuts: [
+    {
+      id: 'optout:1',
+      accountId: '42',
+      username: 'alice',
+      occurredAt: '2026-07-18T12:00:00Z',
+      reason: 'Privacy request',
+    },
+  ],
+  warning: null,
+}
+
+describe('RecentPrivacyActivity', () => {
+  it('shows recent delete states and explicit opt-outs', () => {
+    render(<RecentPrivacyActivity activity={activity} />)
+
+    expect(screen.getByText('Archive deletes')).toBeInTheDocument()
+    expect(screen.getByText('Queued')).toBeInTheDocument()
+    expect(screen.getByText('Logged')).toBeInTheDocument()
+    expect(screen.getAllByText('@alice')).toHaveLength(2)
+    expect(screen.getByText('Privacy request')).toBeInTheDocument()
+  })
+})

--- a/src/app/admin/RecentPrivacyActivity.tsx
+++ b/src/app/admin/RecentPrivacyActivity.tsx
@@ -1,0 +1,219 @@
+import { Badge } from '@/components/ui/badge'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import type {
+  ArchiveDeleteStatus,
+  RecentPrivacyActivity as RecentPrivacyActivityData,
+} from './activity'
+
+const formatDate = (value: string) => {
+  if (!value) return 'Unknown'
+  return (
+    new Intl.DateTimeFormat('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+      timeZone: 'UTC',
+    }).format(new Date(value)) + ' UTC'
+  )
+}
+
+function DeleteStatusBadge({ status }: { status: ArchiveDeleteStatus }) {
+  if (status === 'succeeded') return <Badge>Deleted</Badge>
+  if (status === 'failed') {
+    return <Badge variant="destructive">Failed</Badge>
+  }
+  if (status === 'processing') {
+    return <Badge variant="secondary">Processing</Badge>
+  }
+  if (status === 'queued') return <Badge variant="outline">Queued</Badge>
+  if (status === 'recorded') return <Badge variant="outline">Logged</Badge>
+  return <Badge variant="outline">Unknown</Badge>
+}
+
+function AccountLabel({
+  username,
+  accountId,
+}: {
+  username: string | null
+  accountId: string | null
+}) {
+  return (
+    <div>
+      <div className="font-medium">
+        {username ? `@${username}` : 'Unknown account'}
+      </div>
+      {accountId ? (
+        <div className="text-xs text-muted-foreground">{accountId}</div>
+      ) : null}
+    </div>
+  )
+}
+
+export function RecentPrivacyActivity({
+  activity,
+}: {
+  activity: RecentPrivacyActivityData
+}) {
+  return (
+    <section
+      className="flex flex-col gap-4"
+      aria-labelledby="privacy-activity-heading"
+    >
+      <div>
+        <h2
+          id="privacy-activity-heading"
+          className="text-xl font-semibold tracking-tight"
+        >
+          Recent privacy activity
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Latest archive deletion activity and current explicit opt-outs.
+        </p>
+      </div>
+
+      {activity.warning ? (
+        <div className="rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm text-amber-950 dark:border-amber-700 dark:bg-amber-950/30 dark:text-amber-100">
+          {activity.warning}
+        </div>
+      ) : null}
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Archive deletes</CardTitle>
+            <CardDescription>
+              Admin worker jobs plus client-recorded self-service deletes,
+              including queued or failed work.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Account</TableHead>
+                  <TableHead>Delete</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Updated</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {activity.archiveDeletes.map((event) => (
+                  <TableRow key={event.id}>
+                    <TableCell>
+                      <AccountLabel
+                        username={event.username}
+                        accountId={event.accountId}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <div className="text-sm">{event.detail}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {event.source}
+                      </div>
+                      {event.reason ? (
+                        <div className="mt-1 max-w-xs text-xs text-muted-foreground">
+                          {event.reason}
+                        </div>
+                      ) : null}
+                      {event.error ? (
+                        <div className="mt-1 max-w-xs text-xs text-red-700 dark:text-red-300">
+                          {event.error}
+                        </div>
+                      ) : null}
+                    </TableCell>
+                    <TableCell>
+                      <DeleteStatusBadge status={event.status} />
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap text-xs text-muted-foreground">
+                      {formatDate(event.activityAt)}
+                      {event.activityAt !== event.requestedAt ? (
+                        <div className="mt-1">
+                          Requested {formatDate(event.requestedAt)}
+                        </div>
+                      ) : null}
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {!activity.archiveDeletes.length ? (
+                  <TableRow>
+                    <TableCell
+                      colSpan={4}
+                      className="text-center text-sm text-muted-foreground"
+                    >
+                      No archive deletes recorded yet.
+                    </TableCell>
+                  </TableRow>
+                ) : null}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Explicit opt-outs</CardTitle>
+            <CardDescription>
+              Accounts currently marked as explicitly opted out, newest first.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Account</TableHead>
+                  <TableHead>Reason</TableHead>
+                  <TableHead>Opted out</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {activity.optOuts.map((optOut) => (
+                  <TableRow key={optOut.id}>
+                    <TableCell>
+                      <AccountLabel
+                        username={optOut.username}
+                        accountId={optOut.accountId}
+                      />
+                    </TableCell>
+                    <TableCell className="max-w-xs text-sm text-muted-foreground">
+                      {optOut.reason || 'No reason recorded'}
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap text-xs text-muted-foreground">
+                      {formatDate(optOut.occurredAt)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {!activity.optOuts.length ? (
+                  <TableRow>
+                    <TableCell
+                      colSpan={3}
+                      className="text-center text-sm text-muted-foreground"
+                    >
+                      No explicit opt-outs recorded yet.
+                    </TableCell>
+                  </TableRow>
+                ) : null}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    </section>
+  )
+}

--- a/src/app/admin/activity.ts
+++ b/src/app/admin/activity.ts
@@ -1,0 +1,199 @@
+import type { Json } from '@/database-types'
+import { getAdminClient } from './data'
+
+const RECENT_ACTIVITY_LIMIT = 10
+const RECENT_OPT_OUT_CANDIDATE_LIMIT = 100
+
+const SELF_SERVICE_DELETE_ACTIONS = [
+  'delete_archive',
+  'delete_all_archives',
+  'opt_out_and_delete',
+] as const
+
+export type ArchiveDeleteStatus =
+  | 'queued'
+  | 'processing'
+  | 'succeeded'
+  | 'failed'
+  | 'recorded'
+  | 'unknown'
+
+export type RecentArchiveDelete = {
+  id: string
+  accountId: string | null
+  username: string | null
+  source: 'Admin worker' | 'Self-service log'
+  status: ArchiveDeleteStatus
+  activityAt: string
+  requestedAt: string
+  detail: string
+  reason: string | null
+  error: string | null
+}
+
+export type RecentOptOut = {
+  id: string
+  accountId: string | null
+  username: string
+  occurredAt: string
+  reason: string | null
+}
+
+export type RecentPrivacyActivity = {
+  archiveDeletes: RecentArchiveDelete[]
+  optOuts: RecentOptOut[]
+  warning: string | null
+}
+
+function metadataValue(metadata: Json | null, key: string): string | null {
+  if (!metadata || Array.isArray(metadata) || typeof metadata !== 'object') {
+    return null
+  }
+  const value = metadata[key]
+  if (typeof value === 'string' || typeof value === 'number') {
+    return String(value)
+  }
+  return null
+}
+
+function normalizeJobStatus(value: string): ArchiveDeleteStatus {
+  switch (value.toUpperCase()) {
+    case 'QUEUED':
+      return 'queued'
+    case 'PROCESSING':
+      return 'processing'
+    case 'DONE':
+      return 'succeeded'
+    case 'FAILED':
+      return 'failed'
+    default:
+      return 'unknown'
+  }
+}
+
+function selfServiceDeleteDetail(
+  actionType: string,
+  metadata: Json | null,
+): string {
+  if (actionType === 'delete_archive') {
+    const archiveId = metadataValue(metadata, 'archive_upload_id')
+    return archiveId
+      ? `Deleted archive upload #${archiveId}`
+      : 'Deleted one archive upload'
+  }
+  if (actionType === 'opt_out_and_delete') {
+    return 'Deleted all archive data and explicitly opted out'
+  }
+  return 'Deleted all archive data'
+}
+
+const timeValue = (value: string) => {
+  const parsed = Date.parse(value)
+  return Number.isNaN(parsed) ? 0 : parsed
+}
+
+export async function loadRecentPrivacyActivity(): Promise<RecentPrivacyActivity> {
+  const admin = await getAdminClient()
+
+  const [jobsResponse, actionLogResponse, optOutResponse] = await Promise.all([
+    admin.rpc('admin_list_recent_delete_jobs', {
+      p_limit: RECENT_ACTIVITY_LIMIT,
+    }),
+    admin
+      .from('user_action_log')
+      .select('id, account_id, action_type, metadata, created_at')
+      .in('action_type', [...SELF_SERVICE_DELETE_ACTIONS])
+      .order('created_at', { ascending: false })
+      .limit(RECENT_ACTIVITY_LIMIT),
+    admin
+      .from('optin')
+      .select(
+        'id, username, twitter_user_id, opt_out_reason, opted_out_at, updated_at, created_at',
+      )
+      .eq('explicit_optout', true)
+      .order('updated_at', { ascending: false, nullsFirst: false })
+      .limit(RECENT_OPT_OUT_CANDIDATE_LIMIT),
+  ])
+
+  const warnings: string[] = []
+  if (jobsResponse.error) {
+    warnings.push(
+      `Could not read admin delete jobs: ${jobsResponse.error.message}`,
+    )
+  }
+  if (actionLogResponse.error) {
+    warnings.push(
+      `Could not read self-service delete history: ${actionLogResponse.error.message}`,
+    )
+  }
+  if (optOutResponse.error) {
+    warnings.push(
+      `Could not read explicit opt-outs: ${optOutResponse.error.message}`,
+    )
+  }
+
+  // Some admin-created opt-out rows predate opted_out_at being populated on
+  // INSERT, so sort by the best available timestamp after fetching recent
+  // updated candidates instead of putting all NULL opted_out_at rows last.
+  const optOutCandidates: RecentOptOut[] = (optOutResponse.data ?? []).map(
+    (row) => ({
+      id: row.id,
+      accountId: row.twitter_user_id,
+      username: row.username,
+      occurredAt: row.opted_out_at ?? row.updated_at ?? row.created_at ?? '',
+      reason: row.opt_out_reason,
+    }),
+  )
+  const optOuts = [...optOutCandidates]
+    .sort((a, b) => timeValue(b.occurredAt) - timeValue(a.occurredAt))
+    .slice(0, RECENT_ACTIVITY_LIMIT)
+
+  const usernamesByAccountId = new Map(
+    optOutCandidates
+      .filter((row) => row.accountId)
+      .map((row) => [row.accountId as string, row.username]),
+  )
+
+  const adminDeletes: RecentArchiveDelete[] = (jobsResponse.data ?? []).map(
+    (row) => ({
+      id: `job:${row.job_key}`,
+      accountId: row.account_id,
+      username: row.username,
+      source: 'Admin worker',
+      status: normalizeJobStatus(row.status),
+      activityAt: row.updated_at,
+      requestedAt: row.created_at,
+      detail: `Delete job ${row.job_key.slice(0, 8)}`,
+      reason: row.reason,
+      error: row.error,
+    }),
+  )
+
+  const selfServiceDeletes: RecentArchiveDelete[] = (
+    actionLogResponse.data ?? []
+  ).map((row) => ({
+    id: `action:${row.id}`,
+    accountId: row.account_id,
+    username: row.account_id
+      ? (usernamesByAccountId.get(row.account_id) ?? null)
+      : null,
+    source: 'Self-service log',
+    // user_action_log is written by the browser after a successful RPC, but
+    // it is not a server-side deletion receipt. Label it as recorded rather
+    // than claiming the database independently verified completion.
+    status: 'recorded',
+    activityAt: row.created_at,
+    requestedAt: row.created_at,
+    detail: selfServiceDeleteDetail(row.action_type, row.metadata),
+    reason: null,
+    error: null,
+  }))
+
+  return {
+    archiveDeletes: [...adminDeletes, ...selfServiceDeletes]
+      .sort((a, b) => timeValue(b.activityAt) - timeValue(a.activityAt))
+      .slice(0, RECENT_ACTIVITY_LIMIT),
+    optOuts,
+    warning: warnings.length ? warnings.join(' ') : null,
+  }
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -7,6 +7,8 @@ import {
   CardTitle,
 } from '@/components/ui/card'
 import { AdminTable } from './AdminTable'
+import { RecentPrivacyActivity } from './RecentPrivacyActivity'
+import { loadRecentPrivacyActivity } from './activity'
 import {
   ADMIN_USERNAME,
   getDisplayUsername,
@@ -31,7 +33,10 @@ export default async function AdminPage({
 }) {
   const { user } = await requireAdmin()
   const search = normalizeUsername(searchParams?.q)
-  const data = await loadInitialAccounts(search)
+  const [data, recentPrivacyActivity] = await Promise.all([
+    loadInitialAccounts(search),
+    loadRecentPrivacyActivity(),
+  ])
   const twitterUsername = getDisplayUsername(user)
 
   return (
@@ -60,6 +65,8 @@ export default async function AdminPage({
             </div>
           ) : null}
         </section>
+
+        <RecentPrivacyActivity activity={recentPrivacyActivity} />
 
         <Card>
           <CardHeader>

--- a/src/database-types.ts
+++ b/src/database-types.ts
@@ -1268,14 +1268,14 @@ export type Database = {
           p_limit?: number
         }
         Returns: {
-          account_id: string
-          created_at: string
-          error: string
           job_key: string
-          reason: string
           status: string
-          updated_at: string
+          account_id: string
           username: string
+          reason: string
+          created_at: string
+          updated_at: string
+          error: string
         }[]
       }
       admin_set_scrape_block: {
@@ -2139,3 +2139,4 @@ export type CompositeTypes<
   : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
     ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never
+

--- a/src/database-types.ts
+++ b/src/database-types.ts
@@ -1263,6 +1263,21 @@ export type Database = {
         }
         Returns: string[]
       }
+      admin_list_recent_delete_jobs: {
+        Args: {
+          p_limit?: number
+        }
+        Returns: {
+          account_id: string
+          created_at: string
+          error: string
+          job_key: string
+          reason: string
+          status: string
+          updated_at: string
+          username: string
+        }[]
+      }
       admin_set_scrape_block: {
         Args: {
           p_account_id: string
@@ -2124,4 +2139,3 @@ export type CompositeTypes<
   : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
     ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never
-

--- a/supabase/migrations/20260718105500_add_admin_recent_delete_jobs.sql
+++ b/supabase/migrations/20260718105500_add_admin_recent_delete_jobs.sql
@@ -1,0 +1,46 @@
+-- Service-role-only read bridge for the admin dashboard's recent archive
+-- delete list. private.admin_jobs is intentionally not exposed through
+-- PostgREST, so the server-rendered dashboard needs a narrow SECURITY DEFINER
+-- function rather than direct table access.
+
+CREATE OR REPLACE FUNCTION public.admin_list_recent_delete_jobs(
+  p_limit integer DEFAULT 20
+) RETURNS TABLE (
+  job_key uuid,
+  status text,
+  account_id text,
+  username text,
+  reason text,
+  created_at timestamptz,
+  updated_at timestamptz,
+  error text
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT
+    j.key AS job_key,
+    j.status,
+    j.args->>'account_id' AS account_id,
+    j.args->>'username' AS username,
+    j.args->>'reason' AS reason,
+    j.created_at,
+    j.updated_at,
+    j.args->>'error' AS error
+  FROM private.admin_jobs AS j
+  WHERE j.job_name = 'admin_delete_with_export'
+  ORDER BY j.updated_at DESC, j.created_at DESC
+  LIMIT LEAST(GREATEST(COALESCE(p_limit, 20), 1), 100);
+$$;
+
+ALTER FUNCTION public.admin_list_recent_delete_jobs(integer) OWNER TO postgres;
+
+REVOKE ALL ON FUNCTION public.admin_list_recent_delete_jobs(integer)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.admin_list_recent_delete_jobs(integer)
+  TO service_role;
+
+COMMENT ON FUNCTION public.admin_list_recent_delete_jobs(integer) IS
+  'Returns recent admin archive-delete jobs for the service-role-gated admin dashboard.';

--- a/supabase/schemas/070_functions.sql
+++ b/supabase/schemas/070_functions.sql
@@ -2909,3 +2909,43 @@ BEGIN
 END;
 $$;
 ALTER FUNCTION public.admin_enqueue_delete_with_export(text, text, text, uuid) OWNER TO postgres;
+
+-- admin_list_recent_delete_jobs: service-role-only read bridge for the
+-- dashboard. private.admin_jobs remains outside PostgREST's exposed schemas.
+CREATE OR REPLACE FUNCTION public.admin_list_recent_delete_jobs(
+  p_limit integer DEFAULT 20
+) RETURNS TABLE (
+  job_key uuid,
+  status text,
+  account_id text,
+  username text,
+  reason text,
+  created_at timestamptz,
+  updated_at timestamptz,
+  error text
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT
+    j.key AS job_key,
+    j.status,
+    j.args->>'account_id' AS account_id,
+    j.args->>'username' AS username,
+    j.args->>'reason' AS reason,
+    j.created_at,
+    j.updated_at,
+    j.args->>'error' AS error
+  FROM private.admin_jobs AS j
+  WHERE j.job_name = 'admin_delete_with_export'
+  ORDER BY j.updated_at DESC, j.created_at DESC
+  LIMIT LEAST(GREATEST(COALESCE(p_limit, 20), 1), 100);
+$$;
+ALTER FUNCTION public.admin_list_recent_delete_jobs(integer) OWNER TO postgres;
+
+REVOKE ALL ON FUNCTION public.admin_list_recent_delete_jobs(integer)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.admin_list_recent_delete_jobs(integer)
+  TO service_role;


### PR DESCRIPTION
## Summary

- add recent privacy activity cards above the existing admin account controls
- show admin archive-delete jobs with queued, processing, completed, and failed states
- show client-recorded self-service delete logs without presenting them as server-verified receipts
- show current explicit opt-outs newest-first with account IDs, reasons, and timestamps
- add a service-role-only RPC so `private.admin_jobs` stays outside PostgREST

## Why

Operators could manage opt-outs and queue deletes from `/admin`, but they could not see recent delete history or worker state without querying private tables directly. This puts the latest privacy activity in the gated dashboard while preserving the private-schema boundary.

## Impact

Trusted admins get a quick operational view of recent archive deletions and opt-outs. The new delete-job section requires the included Supabase migration to be applied during deployment.

## Validation

- `tsc --noEmit`
- focused `RecentPrivacyActivity` render test
- `next lint`
- `next build` (passes; existing dynamic-route prerender notices remain)
