### PR TITLE
Add staging ClickHouse analytics lab

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,16 @@ STAGING_DEV_LOGIN_DISPLAY_NAME=Alice Staging
 ALLOW_STAGING_DEV_LOGIN_ON_PROD_SUPABASE=false
 ALLOW_STAGING_ADMIN_ON_PROD_SUPABASE=false
 
+# Server-side ClickHouse analytics gateway.
+# Keep both read flags false until the matching gateway endpoint is deployed.
+CLICKHOUSE_ANALYTICS_API_URL=https://stream.community-archive.org:3000/analytics
+CLICKHOUSE_ANALYTICS_API_TOKEN=<shared-gateway-token>
+ENABLE_CLICKHOUSE_READS=false
+NEXT_PUBLIC_ENABLE_CLICKHOUSE_SEARCH=false
+
+# Staging-only admin analytics lab.
+ENABLE_CLICKHOUSE_LAB=false
+
 ARCHIVE_PATH=<path_to_archive_folder>
 
 NEXT_PUBLIC_USER_ID=<>

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -28,6 +28,11 @@ STAGING_DEV_LOGIN_USERNAME=alice_dev
 STAGING_DEV_LOGIN_PROVIDER_ID=mock_alice
 STAGING_DEV_LOGIN_DISPLAY_NAME=Alice Staging
 ALLOW_STAGING_ADMIN_ON_PROD_SUPABASE=false
+
+# Staging-only ClickHouse analytics lab (server-side secrets)
+ENABLE_CLICKHOUSE_LAB=true
+CLICKHOUSE_ANALYTICS_API_URL=https://stream.community-archive.org:3000/analytics
+CLICKHOUSE_ANALYTICS_API_TOKEN=<shared-staging-gateway-token>
 ```
 
 The default staging login identity is configured via env:
@@ -43,6 +48,12 @@ Do not commit the real password. The bootstrap script below writes it to an igno
 
 The server route always refuses staging dev login against the known production
 Supabase project. No environment flag can override that production guard.
+
+The same production-project refusal applies to `/clickhouse` and its API proxy:
+even if `ENABLE_CLICKHOUSE_LAB=true` is accidentally added to Production, the
+lab returns 404 when `NEXT_PUBLIC_SUPABASE_URL` points at the production
+Supabase project. The browser only talks to `/api/clickhouse/*`; the bearer
+token and upstream analytics URL remain server-side Vercel variables.
 
 When `ENABLE_STAGING_DEV_LOGIN=true` and the deployment is not pointed at the known production Supabase host, `/admin` is available to signed-in staging mock users. Production remains restricted to the Twitter username `exgenesis`.
 
@@ -112,6 +123,9 @@ For PR-created Vercel Preview deployments, add the values from `.env.staging.gen
 - `STAGING_DEV_LOGIN_USERNAME`
 - `STAGING_DEV_LOGIN_PROVIDER_ID`
 - `STAGING_DEV_LOGIN_DISPLAY_NAME`
+- `ENABLE_CLICKHOUSE_LAB=true`
+- `CLICKHOUSE_ANALYTICS_API_URL`
+- `CLICKHOUSE_ANALYTICS_API_TOKEN`
 
 After updating Preview env vars, redeploy the PR preview so the new values are picked up.
 

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -33,6 +33,10 @@ ALLOW_STAGING_ADMIN_ON_PROD_SUPABASE=false
 ENABLE_CLICKHOUSE_LAB=true
 CLICKHOUSE_ANALYTICS_API_URL=https://stream.community-archive.org:3000/analytics
 CLICKHOUSE_ANALYTICS_API_TOKEN=<shared-staging-gateway-token>
+
+# Opt-in application reads. Leave false until /analytics/search is deployed.
+ENABLE_CLICKHOUSE_READS=false
+NEXT_PUBLIC_ENABLE_CLICKHOUSE_SEARCH=false
 ```
 
 The default staging login identity is configured via env:
@@ -126,6 +130,9 @@ For PR-created Vercel Preview deployments, add the values from `.env.staging.gen
 - `ENABLE_CLICKHOUSE_LAB=true`
 - `CLICKHOUSE_ANALYTICS_API_URL`
 - `CLICKHOUSE_ANALYTICS_API_TOKEN`
+- `ENABLE_CLICKHOUSE_READS=false` (set true when testing homepage/search reads)
+- `NEXT_PUBLIC_ENABLE_CLICKHOUSE_SEARCH=false` (set true in the same build that
+  should try ClickHouse text search)
 
 After updating Preview env vars, redeploy the PR preview so the new values are picked up.
 

--- a/src/app/api/clickhouse/[...path]/route.ts
+++ b/src/app/api/clickhouse/[...path]/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  analyticsGatewayRequestUrl,
+  canAccessClickHouseLab,
+} from '@/lib/clickhouseLab'
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 60
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { path: string[] } },
+) {
+  if (!(await canAccessClickHouseLab())) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  const token = process.env.CLICKHOUSE_ANALYTICS_API_TOKEN
+  if (!token) {
+    console.error('CLICKHOUSE_ANALYTICS_API_TOKEN is not configured')
+    return NextResponse.json(
+      { error: 'ClickHouse analytics is not configured' },
+      { status: 503 },
+    )
+  }
+
+  let target: URL
+  try {
+    target = analyticsGatewayRequestUrl(
+      params.path,
+      new URL(request.url).searchParams,
+    )
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Invalid request'
+    return NextResponse.json({ error: message }, { status: 400 })
+  }
+
+  try {
+    const response = await fetch(target, {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: 'no-store',
+      signal: AbortSignal.timeout(55_000),
+    })
+    const body = await response.text()
+    return new NextResponse(body, {
+      status: response.status,
+      headers: {
+        'Content-Type':
+          response.headers.get('content-type') || 'application/json',
+        'Cache-Control': 'private, no-store',
+      },
+    })
+  } catch (error) {
+    console.error('ClickHouse analytics gateway request failed:', error)
+    return NextResponse.json(
+      { error: 'ClickHouse analytics gateway is unavailable' },
+      { status: 502 },
+    )
+  }
+}

--- a/src/app/api/tweet-search/route.ts
+++ b/src/app/api/tweet-search/route.ts
@@ -1,15 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { canAccessClickHouseLab } from '@/lib/clickhouseLab'
-import { analyticsGatewayRequestUrl } from '@/lib/clickhouseGateway'
+import {
+  analyticsGatewayRequestUrl,
+  isClickHouseReadsEnabled,
+} from '@/lib/clickhouseGateway'
 
 export const dynamic = 'force-dynamic'
-export const maxDuration = 60
+export const maxDuration = 30
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: { path: string[] } },
-) {
-  if (!(await canAccessClickHouseLab())) {
+export async function GET(request: NextRequest) {
+  if (!isClickHouseReadsEnabled()) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 })
   }
 
@@ -17,7 +16,7 @@ export async function GET(
   if (!token) {
     console.error('CLICKHOUSE_ANALYTICS_API_TOKEN is not configured')
     return NextResponse.json(
-      { error: 'ClickHouse analytics is not configured' },
+      { error: 'Tweet search is not configured' },
       { status: 503 },
     )
   }
@@ -25,7 +24,7 @@ export async function GET(
   let target: URL
   try {
     target = analyticsGatewayRequestUrl(
-      params.path,
+      ['search'],
       new URL(request.url).searchParams,
     )
   } catch (error) {
@@ -37,7 +36,7 @@ export async function GET(
     const response = await fetch(target, {
       headers: { Authorization: `Bearer ${token}` },
       cache: 'no-store',
-      signal: AbortSignal.timeout(55_000),
+      signal: AbortSignal.timeout(25_000),
     })
     const body = await response.text()
     return new NextResponse(body, {
@@ -49,9 +48,9 @@ export async function GET(
       },
     })
   } catch (error) {
-    console.error('ClickHouse analytics gateway request failed:', error)
+    console.error('ClickHouse tweet search request failed:', error)
     return NextResponse.json(
-      { error: 'ClickHouse analytics gateway is unavailable' },
+      { error: 'Tweet search is temporarily unavailable' },
       { status: 502 },
     )
   }

--- a/src/app/clickhouse/ClickHouseLabClient.tsx
+++ b/src/app/clickhouse/ClickHouseLabClient.tsx
@@ -1,0 +1,631 @@
+'use client'
+
+import { FormEvent, useEffect, useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import {
+  Activity,
+  ArrowUpRight,
+  AtSign,
+  Database,
+  Heart,
+  Quote,
+  Search,
+  Sparkles,
+  Timer,
+  Users,
+} from 'lucide-react'
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+
+type Timing = {
+  wallMs: number
+  clickhouseMs: number
+  rowsRead: number
+  bytesRead: number
+  roundTrips?: number
+}
+
+type SummaryResponse = {
+  data: {
+    totalAccounts: string
+    memberAccounts: string
+    totalTweets: string
+    totalLikes: string
+    totalUserMentions: string
+    topMentionedUsers: Array<{
+      account_id: string
+      username: string
+      display_name: string
+      mention_count: string
+    }>
+    topAccountsByFollowers: Array<{
+      account_id: string
+      username: string
+      display_name: string
+      follower_count: string
+    }>
+    sourceUpdatedAt: string
+    collectedAt: string
+  }
+  timing: Timing
+}
+
+type QuoteRow = {
+  tweetId: string
+  quoteCount: string
+  accountId: string | null
+  username: string | null
+  displayName: string | null
+  createdAt: string | null
+  fullText: string | null
+  favoriteCount: string
+  retweetCount: string
+}
+
+type QuotesResponse = { data: QuoteRow[]; timing: Timing }
+
+type TrendRow = {
+  bucket: string
+  tweets: string
+  accounts: string
+  totalTweets: string
+  ratePerThousand: number
+}
+
+type TrendResponse = {
+  data: TrendRow[]
+  query: { tokens: string[]; bucket: string; match: string }
+  timing: Timing
+}
+
+const compactNumber = new Intl.NumberFormat('en-US', {
+  notation: 'compact',
+  maximumFractionDigits: 1,
+})
+const exactNumber = new Intl.NumberFormat('en-US')
+const dateTime = new Intl.DateTimeFormat('en-US', {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+})
+
+function number(value: string | number | null | undefined, compact = false) {
+  const parsed = Number(value || 0)
+  return (compact ? compactNumber : exactNumber).format(parsed)
+}
+
+function date(value: string | null | undefined) {
+  if (!value) return 'Unknown'
+  const parsed = new Date(
+    value.includes('T') ? value : `${value.replace(' ', 'T')}Z`,
+  )
+  return Number.isNaN(parsed.valueOf()) ? value : dateTime.format(parsed)
+}
+
+function bytes(value: number) {
+  if (value < 1024) return `${value} B`
+  if (value < 1024 ** 2) return `${(value / 1024).toFixed(1)} KB`
+  if (value < 1024 ** 3) return `${(value / 1024 ** 2).toFixed(1)} MB`
+  return `${(value / 1024 ** 3).toFixed(1)} GB`
+}
+
+async function request<T>(path: string): Promise<T> {
+  const response = await fetch(`/api/clickhouse/${path}`, { cache: 'no-store' })
+  const payload = await response.json().catch(() => ({}))
+  if (!response.ok) {
+    throw new Error(payload.error || `Request failed (${response.status})`)
+  }
+  return payload as T
+}
+
+function TimingBadge({ timing }: { timing?: Timing }) {
+  if (!timing) return null
+  return (
+    <Badge
+      variant="outline"
+      className="gap-1.5 font-normal text-muted-foreground"
+    >
+      <Timer className="h-3.5 w-3.5" />
+      {number(timing.clickhouseMs)} ms CH · {number(timing.rowsRead, true)} rows
+      · {bytes(timing.bytesRead)}
+    </Badge>
+  )
+}
+
+function LoadingPanel({ label }: { label: string }) {
+  return (
+    <div className="min-h-40 flex items-center justify-center rounded-lg border border-dashed text-sm text-muted-foreground">
+      <Activity className="mr-2 h-4 w-4 animate-pulse" /> {label}
+    </div>
+  )
+}
+
+export default function ClickHouseLabClient() {
+  const router = useRouter()
+  const [summary, setSummary] = useState<SummaryResponse | null>(null)
+  const [quotes, setQuotes] = useState<QuotesResponse | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [identifier, setIdentifier] = useState('')
+  const [wordQuery, setWordQuery] = useState('')
+  const [bucket, setBucket] = useState('month')
+  const [match, setMatch] = useState('all')
+  const [from, setFrom] = useState('')
+  const [to, setTo] = useState('')
+  const [trend, setTrend] = useState<TrendResponse | null>(null)
+  const [trendScale, setTrendScale] = useState<'raw' | 'normalized'>(
+    'normalized',
+  )
+  const [trendLoading, setTrendLoading] = useState(false)
+  const [trendError, setTrendError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    Promise.all([
+      request<SummaryResponse>('summary'),
+      request<QuotesResponse>('top-quotes?limit=25'),
+    ])
+      .then(([summaryResponse, quotesResponse]) => {
+        if (cancelled) return
+        setSummary(summaryResponse)
+        setQuotes(quotesResponse)
+      })
+      .catch((error) => {
+        if (!cancelled)
+          setLoadError(
+            error instanceof Error ? error.message : 'Unable to load analytics',
+          )
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const chartData = useMemo(
+    () =>
+      (trend?.data || []).map((row) => ({
+        ...row,
+        label: row.bucket.slice(0, 10),
+        value: trendScale === 'raw' ? Number(row.tweets) : row.ratePerThousand,
+      })),
+    [trend, trendScale],
+  )
+
+  function openUser(event: FormEvent) {
+    event.preventDefault()
+    const clean = identifier.trim().replace(/^@/, '')
+    if (clean) router.push(`/clickhouse/user/${encodeURIComponent(clean)}`)
+  }
+
+  async function runTrend(event: FormEvent) {
+    event.preventDefault()
+    setTrendLoading(true)
+    setTrendError(null)
+    const params = new URLSearchParams({ q: wordQuery, bucket, match })
+    if (from) params.set('from', from)
+    if (to) params.set('to', to)
+    try {
+      setTrend(await request<TrendResponse>(`word-trend?${params}`))
+    } catch (error) {
+      setTrendError(
+        error instanceof Error ? error.message : 'Unable to run trend',
+      )
+    } finally {
+      setTrendLoading(false)
+    }
+  }
+
+  return (
+    <main className="flex-1 bg-card dark:bg-background">
+      <div className="mx-auto w-full max-w-7xl px-4 py-10 sm:px-6 lg:px-8">
+        <section className="relative overflow-hidden rounded-2xl border bg-background p-7 sm:p-10">
+          <div className="absolute -right-24 -top-28 h-72 w-72 rounded-full bg-brand/10 blur-3xl" />
+          <div className="relative flex flex-col justify-between gap-8 lg:flex-row lg:items-end">
+            <div className="max-w-3xl">
+              <div className="mb-4 flex flex-wrap items-center gap-2">
+                <Badge className="gap-1.5 bg-brand text-brand-foreground">
+                  <Database className="h-3.5 w-3.5" /> ClickHouse staging lab
+                </Badge>
+                {summary ? <TimingBadge timing={summary.timing} /> : null}
+              </div>
+              <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl">
+                Ask the archive at analytical speed.
+              </h1>
+              <p className="mt-4 max-w-2xl text-base leading-7 text-muted-foreground">
+                A staging-only surface over the canonical ClickHouse projection.
+                PostgreSQL remains the app and policy database; this lab tests
+                analytical reads before any public cutover.
+              </p>
+            </div>
+            <form onSubmit={openUser} className="flex w-full max-w-md gap-2">
+              <div className="relative flex-1">
+                <AtSign className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+                <Input
+                  value={identifier}
+                  onChange={(event) => setIdentifier(event.target.value)}
+                  placeholder="username or account ID"
+                  className="pl-9"
+                  aria-label="Username or account ID"
+                />
+              </div>
+              <Button type="submit" disabled={!identifier.trim()}>
+                User page <ArrowUpRight className="ml-2 h-4 w-4" />
+              </Button>
+            </form>
+          </div>
+        </section>
+
+        {loadError ? (
+          <div className="mt-6 rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-950 dark:border-red-800 dark:bg-red-950/30 dark:text-red-100">
+            {loadError}
+          </div>
+        ) : null}
+
+        <section className="mt-8">
+          <div className="mb-4 flex items-end justify-between gap-4">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-brand">
+                Global summary
+              </p>
+              <h2 className="mt-1 text-2xl font-semibold">
+                Canonical corpus now
+              </h2>
+            </div>
+            {summary ? (
+              <p className="text-right text-xs text-muted-foreground">
+                snapshot {date(summary.data.collectedAt)}
+                <br />
+                newest observation {date(summary.data.sourceUpdatedAt)}
+              </p>
+            ) : null}
+          </div>
+          {summary ? (
+            <>
+              <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-5">
+                {[
+                  ['Tweets', summary.data.totalTweets, Database],
+                  ['Authors', summary.data.totalAccounts, Users],
+                  ['Observed likes', summary.data.totalLikes, Heart],
+                  ['Mention edges', summary.data.totalUserMentions, AtSign],
+                  ['Opted-in members', summary.data.memberAccounts, Sparkles],
+                ].map(([label, value, Icon]) => (
+                  <Card key={String(label)}>
+                    <CardContent className="p-5">
+                      <div className="flex items-center justify-between text-sm text-muted-foreground">
+                        <span>{String(label)}</span>
+                        <Icon className="h-4 w-4" />
+                      </div>
+                      <strong className="mt-3 block text-3xl font-semibold tracking-tight">
+                        {number(String(value), true)}
+                      </strong>
+                      <span className="text-xs text-muted-foreground">
+                        {number(String(value))} exact-ish
+                      </span>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+              <div className="mt-4 grid gap-4 lg:grid-cols-2">
+                <Card>
+                  <CardHeader className="pb-3">
+                    <CardTitle className="text-base">
+                      Most mentioned across the corpus
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-1">
+                    {summary.data.topMentionedUsers
+                      .slice(0, 8)
+                      .map((row, index) => (
+                        <Link
+                          key={row.account_id}
+                          href={`/clickhouse/user/${row.account_id}`}
+                          className="flex items-center gap-3 rounded-md px-2 py-2 text-sm hover:bg-muted"
+                        >
+                          <span className="w-5 text-xs tabular-nums text-muted-foreground">
+                            {index + 1}
+                          </span>
+                          <span className="min-w-0 flex-1 truncate">
+                            <strong>@{row.username || 'unknown'}</strong>
+                            <span className="ml-2 text-muted-foreground">
+                              {row.display_name}
+                            </span>
+                          </span>
+                          <span className="tabular-nums text-muted-foreground">
+                            {number(row.mention_count, true)}
+                          </span>
+                        </Link>
+                      ))}
+                  </CardContent>
+                </Card>
+                <Card>
+                  <CardHeader className="pb-3">
+                    <CardTitle className="text-base">
+                      Largest observed audiences
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-1">
+                    {summary.data.topAccountsByFollowers
+                      .slice(0, 8)
+                      .map((row, index) => (
+                        <Link
+                          key={row.account_id}
+                          href={`/clickhouse/user/${row.account_id}`}
+                          className="flex items-center gap-3 rounded-md px-2 py-2 text-sm hover:bg-muted"
+                        >
+                          <span className="w-5 text-xs tabular-nums text-muted-foreground">
+                            {index + 1}
+                          </span>
+                          <span className="min-w-0 flex-1 truncate">
+                            <strong>@{row.username || 'unknown'}</strong>
+                            <span className="ml-2 text-muted-foreground">
+                              {row.display_name}
+                            </span>
+                          </span>
+                          <span className="tabular-nums text-muted-foreground">
+                            {number(row.follower_count, true)}
+                          </span>
+                        </Link>
+                      ))}
+                  </CardContent>
+                </Card>
+              </div>
+            </>
+          ) : (
+            <LoadingPanel label="Loading canonical summary" />
+          )}
+        </section>
+
+        <section className="mt-12">
+          <div className="mb-4 flex flex-wrap items-end justify-between gap-4">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-brand">
+                Word trends
+              </p>
+              <h2 className="mt-1 text-2xl font-semibold">
+                Language over time
+              </h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Compare raw matches or normalize them per 1,000 archived tweets
+                in each period.
+              </p>
+            </div>
+            <TimingBadge timing={trend?.timing} />
+          </div>
+          <Card>
+            <CardContent className="p-5 sm:p-6">
+              <form
+                onSubmit={runTrend}
+                className="grid gap-3 lg:grid-cols-[minmax(220px,1fr)_130px_130px_150px_150px_auto]"
+              >
+                <div className="relative">
+                  <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+                  <Input
+                    value={wordQuery}
+                    onChange={(event) => setWordQuery(event.target.value)}
+                    placeholder="e.g. AI, community archive"
+                    className="pl-9"
+                    required
+                  />
+                </div>
+                <select
+                  value={match}
+                  onChange={(event) => setMatch(event.target.value)}
+                  className="h-10 rounded-md border bg-background px-3 text-sm"
+                >
+                  <option value="all">All words</option>
+                  <option value="any">Any word</option>
+                </select>
+                <select
+                  value={bucket}
+                  onChange={(event) => setBucket(event.target.value)}
+                  className="h-10 rounded-md border bg-background px-3 text-sm"
+                >
+                  <option value="day">Daily</option>
+                  <option value="week">Weekly</option>
+                  <option value="month">Monthly</option>
+                  <option value="year">Yearly</option>
+                </select>
+                <Input
+                  type="date"
+                  value={from}
+                  onChange={(event) => setFrom(event.target.value)}
+                  aria-label="From date"
+                />
+                <Input
+                  type="date"
+                  value={to}
+                  onChange={(event) => setTo(event.target.value)}
+                  aria-label="To date"
+                />
+                <Button
+                  type="submit"
+                  disabled={trendLoading || !wordQuery.trim()}
+                >
+                  {trendLoading ? 'Aggregating…' : 'Run trend'}
+                </Button>
+              </form>
+              {trendError ? (
+                <p className="mt-4 text-sm text-red-500">{trendError}</p>
+              ) : null}
+              {trend ? (
+                <div className="mt-6">
+                  <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+                    <p className="text-sm text-muted-foreground">
+                      {trend.query.tokens
+                        .map((token) => `“${token}”`)
+                        .join(trend.query.match === 'all' ? ' + ' : ' / ')}{' '}
+                      · {trend.data.length} buckets
+                    </p>
+                    <div className="flex rounded-md border p-0.5 text-xs">
+                      <button
+                        type="button"
+                        onClick={() => setTrendScale('normalized')}
+                        className={`rounded px-2.5 py-1 ${trendScale === 'normalized' ? 'bg-muted font-medium' : 'text-muted-foreground'}`}
+                      >
+                        Per 1K tweets
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setTrendScale('raw')}
+                        className={`rounded px-2.5 py-1 ${trendScale === 'raw' ? 'bg-muted font-medium' : 'text-muted-foreground'}`}
+                      >
+                        Raw matches
+                      </button>
+                    </div>
+                  </div>
+                  <div className="h-80 w-full">
+                    <ResponsiveContainer width="100%" height="100%">
+                      <AreaChart
+                        data={chartData}
+                        margin={{ top: 10, right: 12, bottom: 4, left: 0 }}
+                      >
+                        <defs>
+                          <linearGradient
+                            id="wordTrendFill"
+                            x1="0"
+                            y1="0"
+                            x2="0"
+                            y2="1"
+                          >
+                            <stop
+                              offset="5%"
+                              stopColor="hsl(var(--brand))"
+                              stopOpacity={0.35}
+                            />
+                            <stop
+                              offset="95%"
+                              stopColor="hsl(var(--brand))"
+                              stopOpacity={0.02}
+                            />
+                          </linearGradient>
+                        </defs>
+                        <CartesianGrid
+                          strokeDasharray="3 3"
+                          stroke="hsl(var(--border))"
+                          vertical={false}
+                        />
+                        <XAxis
+                          dataKey="label"
+                          tick={{ fontSize: 11 }}
+                          minTickGap={36}
+                          stroke="hsl(var(--muted-foreground))"
+                        />
+                        <YAxis
+                          tick={{ fontSize: 11 }}
+                          width={54}
+                          tickFormatter={(value) => number(value, true)}
+                          stroke="hsl(var(--muted-foreground))"
+                        />
+                        <Tooltip
+                          formatter={(value: number) => [
+                            trendScale === 'raw'
+                              ? number(value)
+                              : `${Number(value).toFixed(2)} / 1K`,
+                            trendScale === 'raw' ? 'Tweets' : 'Rate',
+                          ]}
+                          labelFormatter={(label) => String(label)}
+                          contentStyle={{
+                            background: 'hsl(var(--popover))',
+                            border: '1px solid hsl(var(--border))',
+                            borderRadius: '8px',
+                          }}
+                        />
+                        <Area
+                          type="monotone"
+                          dataKey="value"
+                          stroke="hsl(var(--brand))"
+                          strokeWidth={2}
+                          fill="url(#wordTrendFill)"
+                        />
+                      </AreaChart>
+                    </ResponsiveContainer>
+                  </div>
+                </div>
+              ) : (
+                <div className="mt-6 flex h-64 items-center justify-center rounded-lg border border-dashed text-center text-sm text-muted-foreground">
+                  Enter up to four words to aggregate the full corpus by day,
+                  week, month, or year.
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </section>
+
+        <section className="mt-12">
+          <div className="mb-4 flex items-end justify-between gap-4">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-brand">
+                Quote graph
+              </p>
+              <h2 className="mt-1 text-2xl font-semibold">Most quoted posts</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Unique archived quote posts grouped by their target tweet.
+              </p>
+            </div>
+            <TimingBadge timing={quotes?.timing} />
+          </div>
+          {quotes ? (
+            <Card>
+              <CardContent className="divide-y p-0">
+                {quotes.data.map((row, index) => (
+                  <article
+                    key={row.tweetId}
+                    className="grid gap-3 p-5 sm:grid-cols-[42px_90px_minmax(0,1fr)_auto] sm:items-start"
+                  >
+                    <span className="text-sm tabular-nums text-muted-foreground">
+                      {String(index + 1).padStart(2, '0')}
+                    </span>
+                    <div>
+                      <strong className="block text-xl tabular-nums">
+                        {number(row.quoteCount)}
+                      </strong>
+                      <span className="text-xs text-muted-foreground">
+                        quote posts
+                      </span>
+                    </div>
+                    <div className="min-w-0">
+                      <p className="line-clamp-3 text-sm leading-6">
+                        {row.fullText ||
+                          'Target tweet is not present in the current corpus.'}
+                      </p>
+                      <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                        <span>@{row.username || 'unknown'}</span>
+                        <span>{date(row.createdAt)}</span>
+                        <span>♥ {number(row.favoriteCount, true)}</span>
+                        <span>↻ {number(row.retweetCount, true)}</span>
+                      </div>
+                    </div>
+                    <a
+                      href={
+                        row.username
+                          ? `https://x.com/${encodeURIComponent(row.username)}/status/${row.tweetId}`
+                          : `https://x.com/i/status/${row.tweetId}`
+                      }
+                      target="_blank"
+                      rel="noreferrer"
+                      className="inline-flex items-center text-xs font-medium text-brand hover:underline"
+                    >
+                      Open <ArrowUpRight className="ml-1 h-3.5 w-3.5" />
+                    </a>
+                  </article>
+                ))}
+              </CardContent>
+            </Card>
+          ) : (
+            <LoadingPanel label="Counting quote targets" />
+          )}
+        </section>
+      </div>
+    </main>
+  )
+}

--- a/src/app/clickhouse/ClickHouseLabClient.tsx
+++ b/src/app/clickhouse/ClickHouseLabClient.tsx
@@ -309,7 +309,7 @@ export default function ClickHouseLabClient() {
                         {number(String(value), true)}
                       </strong>
                       <span className="text-xs text-muted-foreground">
-                        {number(String(value))} exact-ish
+                        {number(String(value))} computed snapshot
                       </span>
                     </CardContent>
                   </Card>

--- a/src/app/clickhouse/page.tsx
+++ b/src/app/clickhouse/page.tsx
@@ -1,0 +1,14 @@
+import { requireClickHouseLab } from '@/lib/clickhouseLab'
+import ClickHouseLabClient from './ClickHouseLabClient'
+
+export const dynamic = 'force-dynamic'
+
+export const metadata = {
+  title: 'ClickHouse lab | Community Archive',
+  description: 'Staging-only analytical views powered by ClickHouse.',
+}
+
+export default async function ClickHouseLabPage() {
+  await requireClickHouseLab()
+  return <ClickHouseLabClient />
+}

--- a/src/app/clickhouse/user/[identifier]/ClickHouseUserClient.tsx
+++ b/src/app/clickhouse/user/[identifier]/ClickHouseUserClient.tsx
@@ -1,0 +1,401 @@
+'use client'
+
+import { FormEvent, useEffect, useState } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import {
+  ArrowLeft,
+  ArrowUpRight,
+  AtSign,
+  Database,
+  Heart,
+  MessageCircle,
+  Quote,
+  Repeat2,
+  Search,
+  Timer,
+  Users,
+} from 'lucide-react'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+
+type Timing = {
+  wallMs: number
+  clickhouseMs: number
+  rowsRead: number
+  bytesRead: number
+}
+
+type UserResponse = {
+  data: {
+    account: {
+      accountId: string
+      username: string
+      displayName: string
+      bio: string | null
+      avatarUrl: string | null
+      headerUrl: string | null
+      followers: string
+      following: string
+      statusCount: string
+      latestObservedAt: string
+    }
+    topTweets: Array<{
+      tweetId: string
+      createdAt: string
+      fullText: string
+      replyToUsername: string | null
+      favoriteCount: string
+      retweetCount: string
+    }>
+    topInteractedAccounts: Array<{
+      accountId: string
+      username: string | null
+      displayName: string | null
+      avatarUrl: string | null
+      interactionCount: string
+      mentionCount: string
+      replyCount: string
+      quoteCount: string
+      repostCount: string
+    }>
+  }
+  timing: Timing
+}
+
+const compactNumber = new Intl.NumberFormat('en-US', {
+  notation: 'compact',
+  maximumFractionDigits: 1,
+})
+const exactNumber = new Intl.NumberFormat('en-US')
+const dateFormat = new Intl.DateTimeFormat('en-US', { dateStyle: 'medium' })
+
+function number(value: string | number | null | undefined, compact = false) {
+  return (compact ? compactNumber : exactNumber).format(Number(value || 0))
+}
+
+function date(value: string | null | undefined) {
+  if (!value) return 'Unknown date'
+  const parsed = new Date(
+    value.includes('T') ? value : `${value.replace(' ', 'T')}Z`,
+  )
+  return Number.isNaN(parsed.valueOf()) ? value : dateFormat.format(parsed)
+}
+
+async function loadUser(identifier: string): Promise<UserResponse> {
+  const response = await fetch(
+    `/api/clickhouse/user/${encodeURIComponent(identifier)}?limit=25`,
+    { cache: 'no-store' },
+  )
+  const payload = await response.json().catch(() => ({}))
+  if (!response.ok)
+    throw new Error(payload.error || `Request failed (${response.status})`)
+  return payload as UserResponse
+}
+
+function CountBadge({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: typeof AtSign
+  label: string
+  value: string
+}) {
+  if (!Number(value)) return null
+  return (
+    <Badge variant="secondary" className="gap-1 font-normal">
+      <Icon className="h-3 w-3" /> {number(value, true)} {label}
+    </Badge>
+  )
+}
+
+export default function ClickHouseUserClient({
+  identifier,
+}: {
+  identifier: string
+}) {
+  const router = useRouter()
+  const [data, setData] = useState<UserResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [search, setSearch] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+    setData(null)
+    setError(null)
+    loadUser(identifier)
+      .then((response) => {
+        if (!cancelled) setData(response)
+      })
+      .catch((requestError) => {
+        if (!cancelled)
+          setError(
+            requestError instanceof Error
+              ? requestError.message
+              : 'Unable to load user',
+          )
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [identifier])
+
+  function openUser(event: FormEvent) {
+    event.preventDefault()
+    const clean = search.trim().replace(/^@/, '')
+    if (clean) router.push(`/clickhouse/user/${encodeURIComponent(clean)}`)
+  }
+
+  if (error) {
+    return (
+      <main className="flex flex-1 items-center justify-center px-4 py-20">
+        <Card className="w-full max-w-xl">
+          <CardContent className="p-8 text-center">
+            <Database className="mx-auto h-8 w-8 text-muted-foreground" />
+            <h1 className="mt-4 text-2xl font-semibold">Account unavailable</h1>
+            <p className="mt-2 text-sm text-muted-foreground">{error}</p>
+            <Button asChild className="mt-6">
+              <Link href="/clickhouse">
+                <ArrowLeft className="mr-2 h-4 w-4" />
+                Back to the lab
+              </Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </main>
+    )
+  }
+
+  if (!data) {
+    return (
+      <main className="flex flex-1 items-center justify-center py-24 text-sm text-muted-foreground">
+        <Database className="mr-2 h-5 w-5 animate-pulse" />
+        Building the ClickHouse user view…
+      </main>
+    )
+  }
+
+  const { account, topTweets, topInteractedAccounts } = data.data
+  return (
+    <main className="flex-1 bg-card dark:bg-background">
+      <div className="mx-auto w-full max-w-6xl px-4 py-10 sm:px-6 lg:px-8">
+        <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
+          <Button asChild variant="ghost" size="sm">
+            <Link href="/clickhouse">
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              ClickHouse lab
+            </Link>
+          </Button>
+          <form onSubmit={openUser} className="flex w-full max-w-sm gap-2">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+              <Input
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                placeholder="another username"
+                className="pl-9"
+              />
+            </div>
+            <Button type="submit" variant="secondary" disabled={!search.trim()}>
+              Open
+            </Button>
+          </form>
+        </div>
+
+        <section className="relative overflow-hidden rounded-2xl border bg-background">
+          {account.headerUrl ? (
+            <div
+              className="h-36 bg-cover bg-center sm:h-48"
+              style={{
+                backgroundImage: `url(${JSON.stringify(account.headerUrl).slice(1, -1)})`,
+              }}
+            />
+          ) : (
+            <div className="h-24 bg-gradient-to-r from-brand/20 via-brand/5 to-transparent" />
+          )}
+          <div className="p-6 sm:p-8">
+            <div className="flex flex-col gap-5 sm:flex-row sm:items-start">
+              <Avatar className="-mt-16 h-24 w-24 border-4 border-background bg-muted sm:h-28 sm:w-28">
+                <AvatarImage
+                  src={account.avatarUrl || undefined}
+                  alt={`@${account.username}`}
+                />
+                <AvatarFallback className="text-3xl">
+                  {(account.displayName || account.username || '?')
+                    .slice(0, 1)
+                    .toUpperCase()}
+                </AvatarFallback>
+              </Avatar>
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <h1 className="truncate text-3xl font-semibold">
+                      {account.displayName || account.username}
+                    </h1>
+                    <p className="text-muted-foreground">@{account.username}</p>
+                  </div>
+                  <Badge variant="outline" className="gap-1.5">
+                    <Timer className="h-3.5 w-3.5" />
+                    {number(data.timing.clickhouseMs)} ms CH
+                  </Badge>
+                </div>
+                {account.bio ? (
+                  <p className="mt-4 max-w-3xl text-sm leading-6 text-muted-foreground">
+                    {account.bio}
+                  </p>
+                ) : null}
+                <div className="mt-5 flex flex-wrap gap-x-6 gap-y-2 text-sm">
+                  <span>
+                    <strong>{number(account.statusCount, true)}</strong>{' '}
+                    statuses
+                  </span>
+                  <span>
+                    <strong>{number(account.followers, true)}</strong> followers
+                  </span>
+                  <span>
+                    <strong>{number(account.following, true)}</strong> following
+                  </span>
+                  <span className="text-muted-foreground">
+                    observed {date(account.latestObservedAt)}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div className="mt-8 grid gap-8 lg:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.65fr)]">
+          <section>
+            <div className="mb-4">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-brand">
+                Top tweets
+              </p>
+              <h2 className="mt-1 text-2xl font-semibold">
+                Highest observed engagement
+              </h2>
+            </div>
+            <Card>
+              <CardContent className="divide-y p-0">
+                {topTweets.map((tweet, index) => (
+                  <article key={tweet.tweetId} className="p-5 sm:p-6">
+                    <div className="flex gap-4">
+                      <span className="w-7 flex-none text-xs tabular-nums text-muted-foreground">
+                        {String(index + 1).padStart(2, '0')}
+                      </span>
+                      <div className="min-w-0 flex-1">
+                        <p className="whitespace-pre-wrap text-sm leading-6">
+                          {tweet.fullText}
+                        </p>
+                        <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-muted-foreground">
+                          {tweet.replyToUsername ? (
+                            <span>reply to @{tweet.replyToUsername}</span>
+                          ) : null}
+                          <span>{date(tweet.createdAt)}</span>
+                          <span className="inline-flex items-center gap-1">
+                            <Heart className="h-3.5 w-3.5" />
+                            {number(tweet.favoriteCount, true)}
+                          </span>
+                          <span className="inline-flex items-center gap-1">
+                            <Repeat2 className="h-3.5 w-3.5" />
+                            {number(tweet.retweetCount, true)}
+                          </span>
+                          <a
+                            href={`https://x.com/${encodeURIComponent(account.username)}/status/${tweet.tweetId}`}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="ml-auto inline-flex items-center font-medium text-brand hover:underline"
+                          >
+                            Open <ArrowUpRight className="ml-1 h-3 w-3" />
+                          </a>
+                        </div>
+                      </div>
+                    </div>
+                  </article>
+                ))}
+              </CardContent>
+            </Card>
+          </section>
+
+          <section>
+            <div className="mb-4">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-brand">
+                Interaction graph
+              </p>
+              <h2 className="mt-1 text-2xl font-semibold">
+                Top interacted accounts
+              </h2>
+            </div>
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="flex items-center gap-2 text-sm font-normal text-muted-foreground">
+                  <Users className="h-4 w-4" />
+                  Mentions, replies, quotes, and repost targets
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-1 px-3 pb-4">
+                {topInteractedAccounts.map((row, index) => (
+                  <Link
+                    href={`/clickhouse/user/${row.accountId}`}
+                    key={row.accountId}
+                    className="block rounded-lg p-3 hover:bg-muted"
+                  >
+                    <div className="flex items-center gap-3">
+                      <span className="w-5 text-xs tabular-nums text-muted-foreground">
+                        {index + 1}
+                      </span>
+                      <Avatar className="h-9 w-9">
+                        <AvatarImage src={row.avatarUrl || undefined} />
+                        <AvatarFallback>
+                          {(row.displayName || row.username || '?')
+                            .slice(0, 1)
+                            .toUpperCase()}
+                        </AvatarFallback>
+                      </Avatar>
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-semibold">
+                          {row.displayName || row.username || row.accountId}
+                        </p>
+                        <p className="truncate text-xs text-muted-foreground">
+                          @{row.username || row.accountId}
+                        </p>
+                      </div>
+                      <strong className="text-sm tabular-nums">
+                        {number(row.interactionCount, true)}
+                      </strong>
+                    </div>
+                    <div className="ml-8 mt-2 flex flex-wrap gap-1.5">
+                      <CountBadge
+                        icon={AtSign}
+                        label="mentions"
+                        value={row.mentionCount}
+                      />
+                      <CountBadge
+                        icon={MessageCircle}
+                        label="replies"
+                        value={row.replyCount}
+                      />
+                      <CountBadge
+                        icon={Quote}
+                        label="quotes"
+                        value={row.quoteCount}
+                      />
+                      <CountBadge
+                        icon={Repeat2}
+                        label="reposts"
+                        value={row.repostCount}
+                      />
+                    </div>
+                  </Link>
+                ))}
+              </CardContent>
+            </Card>
+          </section>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/app/clickhouse/user/[identifier]/page.tsx
+++ b/src/app/clickhouse/user/[identifier]/page.tsx
@@ -1,0 +1,13 @@
+import { requireClickHouseLab } from '@/lib/clickhouseLab'
+import ClickHouseUserClient from './ClickHouseUserClient'
+
+export const dynamic = 'force-dynamic'
+
+export default async function ClickHouseUserPage({
+  params,
+}: {
+  params: { identifier: string }
+}) {
+  await requireClickHouseLab()
+  return <ClickHouseUserClient identifier={params.identifier} />
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,7 +16,8 @@ import MobileNavigation from '@/components/MobileNavigation'
 import Footer from '@/components/Footer'
 import HashScrollHandler from '@/components/HashScrollHandler'
 import { checkIsAdmin } from '@/app/admin/data'
-import { Shield } from 'lucide-react'
+import { DatabaseZap, Shield } from 'lucide-react'
+import { isClickHouseLabEnvironmentEnabled } from '@/lib/clickhouseLab'
 
 const DynamicSignIn = dynamic(() => import('@/components/SignIn'), {
   ssr: false,
@@ -50,6 +51,7 @@ export default async function RootLayout({
   children: React.ReactNode
 }) {
   const isAdmin = await checkIsAdmin()
+  const showClickHouseLab = isAdmin && isClickHouseLabEnvironmentEnabled()
   return (
     <html
       lang="en"
@@ -108,6 +110,16 @@ export default async function RootLayout({
                       className="inline-flex h-10 w-10 items-center justify-center rounded-md border border-input bg-background transition-colors hover:bg-accent hover:text-accent-foreground"
                     >
                       <Shield className="h-5 w-5" />
+                    </Link>
+                  ) : null}
+                  {showClickHouseLab ? (
+                    <Link
+                      href="/clickhouse"
+                      aria-label="ClickHouse staging lab"
+                      title="ClickHouse staging lab"
+                      className="inline-flex h-10 w-10 items-center justify-center rounded-md border border-input bg-background text-brand transition-colors hover:bg-accent"
+                    >
+                      <DatabaseZap className="h-5 w-5" />
                     </Link>
                   ) : null}
                   <MobileMenu />

--- a/src/lib/clickhouseGateway.ts
+++ b/src/lib/clickhouseGateway.ts
@@ -1,0 +1,105 @@
+const ALLOWED_ENDPOINTS: Record<string, ReadonlySet<string>> = {
+  summary: new Set(),
+  search: new Set([
+    'q',
+    'mode',
+    'from_user',
+    'reply_to_user',
+    'since',
+    'until',
+    'limit',
+    'offset',
+  ]),
+  'word-trend': new Set(['q', 'bucket', 'match', 'from', 'to']),
+  'top-quotes': new Set(['limit']),
+}
+
+export function isClickHouseReadsEnabled(
+  enabled = process.env.ENABLE_CLICKHOUSE_READS,
+): boolean {
+  return enabled === 'true'
+}
+
+export function analyticsGatewayRequestUrl(
+  path: string[],
+  incomingSearchParams: URLSearchParams,
+  baseUrl = process.env.CLICKHOUSE_ANALYTICS_API_URL,
+): URL {
+  if (!baseUrl)
+    throw new Error('CLICKHOUSE_ANALYTICS_API_URL is not configured')
+
+  const cleanPath = path.map((segment) => decodeURIComponent(segment))
+  let allowedParams: ReadonlySet<string> | undefined
+  if (cleanPath.length === 1) {
+    allowedParams = ALLOWED_ENDPOINTS[cleanPath[0]]
+  } else if (
+    cleanPath.length === 2 &&
+    cleanPath[0] === 'user' &&
+    /^[A-Za-z0-9_@]{1,80}$/.test(cleanPath[1])
+  ) {
+    allowedParams = new Set(['limit'])
+  }
+
+  if (!allowedParams)
+    throw new Error('Unsupported ClickHouse analytics endpoint')
+
+  const base = new URL(baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`)
+  const relativePath = cleanPath.map(encodeURIComponent).join('/')
+  const target = new URL(relativePath, base)
+  for (const key of Array.from(allowedParams)) {
+    const value = incomingSearchParams.get(key)
+    if (value !== null) target.searchParams.set(key, value)
+  }
+  return target
+}
+
+type NextFetchInit = RequestInit & {
+  next?: {
+    revalidate?: number
+  }
+}
+
+interface AnalyticsGatewayJsonOptions {
+  fetchImpl?: typeof fetch
+  revalidate?: number
+  timeoutMs?: number
+  baseUrl?: string
+  token?: string
+}
+
+export async function fetchAnalyticsGatewayJson<T>(
+  path: string[],
+  searchParams = new URLSearchParams(),
+  options: AnalyticsGatewayJsonOptions = {},
+): Promise<T> {
+  const token = options.token ?? process.env.CLICKHOUSE_ANALYTICS_API_TOKEN
+  if (!token)
+    throw new Error('CLICKHOUSE_ANALYTICS_API_TOKEN is not configured')
+
+  const target = analyticsGatewayRequestUrl(path, searchParams, options.baseUrl)
+  const fetchImpl = options.fetchImpl ?? fetch
+  const init: NextFetchInit = {
+    headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(options.timeoutMs ?? 15_000),
+  }
+
+  if (options.revalidate !== undefined) {
+    init.next = { revalidate: options.revalidate }
+  } else {
+    init.cache = 'no-store'
+  }
+
+  const response = await fetchImpl(target, init)
+  const body = await response.text()
+  if (!response.ok) {
+    throw new Error(
+      `ClickHouse analytics request failed (${response.status}): ${body.slice(0, 300)}`,
+    )
+  }
+
+  try {
+    return JSON.parse(body) as T
+  } catch {
+    throw new Error('ClickHouse analytics returned invalid JSON')
+  }
+}

--- a/src/lib/clickhouseLab.test.ts
+++ b/src/lib/clickhouseLab.test.ts
@@ -1,0 +1,39 @@
+import {
+  analyticsGatewayRequestUrl,
+  isClickHouseLabEnvironmentEnabled,
+} from './clickhouseLab'
+
+describe('ClickHouse staging lab guard', () => {
+  test('requires the flag and refuses the production Supabase project', () => {
+    expect(
+      isClickHouseLabEnvironmentEnabled('true', 'https://staging.supabase.co'),
+    ).toBe(true)
+    expect(
+      isClickHouseLabEnvironmentEnabled('false', 'https://staging.supabase.co'),
+    ).toBe(false)
+    expect(
+      isClickHouseLabEnvironmentEnabled(
+        'true',
+        'https://fabxmporizzqflnftavs.supabase.co',
+      ),
+    ).toBe(false)
+  })
+
+  test('builds only allowlisted gateway paths and parameters', () => {
+    const target = analyticsGatewayRequestUrl(
+      ['word-trend'],
+      new URLSearchParams('q=clickhouse&bucket=month&raw_sql=DROP'),
+      'https://stream.example/analytics',
+    )
+    expect(target.toString()).toBe(
+      'https://stream.example/analytics/word-trend?q=clickhouse&bucket=month',
+    )
+    expect(() =>
+      analyticsGatewayRequestUrl(
+        ['query'],
+        new URLSearchParams(),
+        'https://stream.example/analytics',
+      ),
+    ).toThrow('Unsupported ClickHouse analytics endpoint')
+  })
+})

--- a/src/lib/clickhouseLab.test.ts
+++ b/src/lib/clickhouseLab.test.ts
@@ -36,4 +36,17 @@ describe('ClickHouse staging lab guard', () => {
       ),
     ).toThrow('Unsupported ClickHouse analytics endpoint')
   })
+
+  test('allows only bounded tweet-search parameters', () => {
+    const target = analyticsGatewayRequestUrl(
+      ['search'],
+      new URLSearchParams(
+        'q=open+source&mode=phrase&from_user=alice&limit=20&offset=40&raw_sql=DROP',
+      ),
+      'https://stream.example/analytics',
+    )
+    expect(target.toString()).toBe(
+      'https://stream.example/analytics/search?q=open+source&mode=phrase&from_user=alice&limit=20&offset=40',
+    )
+  })
 })

--- a/src/lib/clickhouseLab.ts
+++ b/src/lib/clickhouseLab.ts
@@ -1,0 +1,84 @@
+import { isAdminUser } from '@/app/admin/data'
+import { createServerClient } from '@/utils/supabase'
+import { cookies } from 'next/headers'
+import { notFound, redirect } from 'next/navigation'
+
+const PRODUCTION_SUPABASE_HOST = 'fabxmporizzqflnftavs.supabase.co'
+
+export function isClickHouseLabEnvironmentEnabled(
+  enabled = process.env.ENABLE_CLICKHOUSE_LAB,
+  supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL,
+): boolean {
+  return (
+    enabled === 'true' &&
+    Boolean(supabaseUrl) &&
+    !supabaseUrl?.includes(PRODUCTION_SUPABASE_HOST)
+  )
+}
+
+export async function requireClickHouseLab() {
+  if (!isClickHouseLabEnvironmentEnabled()) notFound()
+
+  const cookieStore = await cookies()
+  const supabase = createServerClient(cookieStore)
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser()
+
+  if (error || !user) {
+    redirect('/login?redirect=/clickhouse')
+  }
+  if (!isAdminUser(user)) notFound()
+  return user
+}
+
+export async function canAccessClickHouseLab(): Promise<boolean> {
+  if (!isClickHouseLabEnvironmentEnabled()) return false
+  const cookieStore = await cookies()
+  const supabase = createServerClient(cookieStore)
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser()
+  return !error && Boolean(user && isAdminUser(user))
+}
+
+const ALLOWED_ENDPOINTS: Record<string, ReadonlySet<string>> = {
+  summary: new Set(),
+  'word-trend': new Set(['q', 'bucket', 'match', 'from', 'to']),
+  'top-quotes': new Set(['limit']),
+}
+
+export function analyticsGatewayRequestUrl(
+  path: string[],
+  incomingSearchParams: URLSearchParams,
+  baseUrl = process.env.CLICKHOUSE_ANALYTICS_API_URL,
+): URL {
+  if (!baseUrl)
+    throw new Error('CLICKHOUSE_ANALYTICS_API_URL is not configured')
+
+  const cleanPath = path.map((segment) => decodeURIComponent(segment))
+  let allowedParams: ReadonlySet<string> | undefined
+  if (cleanPath.length === 1) {
+    allowedParams = ALLOWED_ENDPOINTS[cleanPath[0]]
+  } else if (
+    cleanPath.length === 2 &&
+    cleanPath[0] === 'user' &&
+    /^[A-Za-z0-9_@]{1,80}$/.test(cleanPath[1])
+  ) {
+    allowedParams = new Set(['limit'])
+  }
+
+  if (!allowedParams)
+    throw new Error('Unsupported ClickHouse analytics endpoint')
+
+  const base = new URL(baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`)
+  const relativePath = cleanPath.map(encodeURIComponent).join('/')
+  const target = new URL(relativePath, base)
+  for (const key of Array.from(allowedParams)) {
+    const value = incomingSearchParams.get(key)
+    if (value !== null) target.searchParams.set(key, value)
+  }
+  return target
+}

--- a/src/lib/clickhouseLab.ts
+++ b/src/lib/clickhouseLab.ts
@@ -5,6 +5,8 @@ import { notFound, redirect } from 'next/navigation'
 
 const PRODUCTION_SUPABASE_HOST = 'fabxmporizzqflnftavs.supabase.co'
 
+export { analyticsGatewayRequestUrl } from './clickhouseGateway'
+
 export function isClickHouseLabEnvironmentEnabled(
   enabled = process.env.ENABLE_CLICKHOUSE_LAB,
   supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL,
@@ -42,43 +44,4 @@ export async function canAccessClickHouseLab(): Promise<boolean> {
     error,
   } = await supabase.auth.getUser()
   return !error && Boolean(user && isAdminUser(user))
-}
-
-const ALLOWED_ENDPOINTS: Record<string, ReadonlySet<string>> = {
-  summary: new Set(),
-  'word-trend': new Set(['q', 'bucket', 'match', 'from', 'to']),
-  'top-quotes': new Set(['limit']),
-}
-
-export function analyticsGatewayRequestUrl(
-  path: string[],
-  incomingSearchParams: URLSearchParams,
-  baseUrl = process.env.CLICKHOUSE_ANALYTICS_API_URL,
-): URL {
-  if (!baseUrl)
-    throw new Error('CLICKHOUSE_ANALYTICS_API_URL is not configured')
-
-  const cleanPath = path.map((segment) => decodeURIComponent(segment))
-  let allowedParams: ReadonlySet<string> | undefined
-  if (cleanPath.length === 1) {
-    allowedParams = ALLOWED_ENDPOINTS[cleanPath[0]]
-  } else if (
-    cleanPath.length === 2 &&
-    cleanPath[0] === 'user' &&
-    /^[A-Za-z0-9_@]{1,80}$/.test(cleanPath[1])
-  ) {
-    allowedParams = new Set(['limit'])
-  }
-
-  if (!allowedParams)
-    throw new Error('Unsupported ClickHouse analytics endpoint')
-
-  const base = new URL(baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`)
-  const relativePath = cleanPath.map(encodeURIComponent).join('/')
-  const target = new URL(relativePath, base)
-  for (const key of Array.from(allowedParams)) {
-    const value = incomingSearchParams.get(key)
-    if (value !== null) target.searchParams.set(key, value)
-  }
-  return target
 }

--- a/src/lib/clickhouseSearch.test.ts
+++ b/src/lib/clickhouseSearch.test.ts
@@ -1,0 +1,79 @@
+import { searchTweetsWithClickHouse } from './clickhouseSearch'
+
+describe('searchTweetsWithClickHouse', () => {
+  test('maps filters, pagination, accounts, and media to timeline tweets', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: jest.fn().mockResolvedValue(
+        JSON.stringify({
+          data: {
+            tweets: [
+              {
+                tweetId: '123',
+                createdAt: '2025-01-01 00:00:00.000',
+                fullText: 'Open source matters',
+                replyToTweetId: null,
+                favoriteCount: '4',
+                retweetCount: '2',
+                username: 'alice',
+                accountDisplayName: 'Alice',
+                avatarMediaUrl: 'https://example.com/avatar.jpg',
+                media: [
+                  {
+                    mediaUrl: 'https://example.com/photo.jpg',
+                    mediaType: 'photo',
+                    width: 800,
+                    height: 600,
+                  },
+                ],
+              },
+            ],
+            nextOffset: 40,
+          },
+        }),
+      ),
+    })
+
+    const tweets = await searchTweetsWithClickHouse(
+      {
+        searchQuery: 'Open & source',
+        rawSearchQuery: 'Open source',
+        fromUsername: 'alice',
+        replyToUsername: 'bob',
+        startDate: '2024-01-01',
+        endDate: '2025-01-01',
+      },
+      2,
+      20,
+      fetchImpl as any,
+    )
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      '/api/tweet-search?q=Open+source&mode=phrase&limit=20&offset=20&from_user=alice&reply_to_user=bob&since=2024-01-01&until=2025-01-01',
+      { cache: 'no-store' },
+    )
+    expect(tweets).toEqual([
+      expect.objectContaining({
+        tweet_id: '123',
+        favorite_count: 4,
+        retweet_count: 2,
+        account: {
+          username: 'alice',
+          account_display_name: 'Alice',
+          profile: {
+            avatar_media_url: 'https://example.com/avatar.jpg',
+          },
+        },
+        media: [
+          {
+            media_url: 'https://example.com/photo.jpg',
+            media_type: 'photo',
+            width: 800,
+            height: 600,
+          },
+        ],
+      }),
+    ])
+  })
+})

--- a/src/lib/clickhouseSearch.ts
+++ b/src/lib/clickhouseSearch.ts
@@ -1,0 +1,96 @@
+import { TimelineTweet } from './types'
+import type { FilterCriteria } from './queries/tweetQueries'
+
+interface ClickHouseSearchTweet {
+  tweetId: string
+  createdAt: string
+  fullText: string
+  replyToTweetId: string | null
+  favoriteCount: string | number
+  retweetCount: string | number | null
+  username: string | null
+  accountDisplayName: string | null
+  avatarMediaUrl: string | null
+  media: Array<{
+    mediaUrl: string
+    mediaType: string
+    width: number | null
+    height: number | null
+  }>
+}
+
+interface ClickHouseSearchResponse {
+  data: {
+    tweets: ClickHouseSearchTweet[]
+    nextOffset: number | null
+  }
+}
+
+export async function searchTweetsWithClickHouse(
+  criteria: FilterCriteria,
+  page: number,
+  pageSize: number,
+  fetchImpl: typeof fetch = fetch,
+): Promise<TimelineTweet[]> {
+  const query = criteria.rawSearchQuery?.trim()
+  if (!query) {
+    throw new Error('ClickHouse text search requires the raw search query')
+  }
+
+  const params = new URLSearchParams({
+    q: query,
+    mode: query.split(/\s+/).length > 1 ? 'phrase' : 'all',
+    limit: String(pageSize),
+    offset: String((page - 1) * pageSize),
+  })
+  if (criteria.fromUsername) params.set('from_user', criteria.fromUsername)
+  if (criteria.replyToUsername)
+    params.set('reply_to_user', criteria.replyToUsername)
+  if (criteria.startDate) params.set('since', criteria.startDate)
+  if (criteria.endDate) params.set('until', criteria.endDate)
+
+  const response = await fetchImpl(`/api/tweet-search?${params.toString()}`, {
+    cache: 'no-store',
+  })
+  const body = await response.text()
+  if (!response.ok) {
+    throw new Error(
+      `ClickHouse tweet search failed (${response.status}): ${body.slice(0, 300)}`,
+    )
+  }
+
+  let result: ClickHouseSearchResponse
+  try {
+    result = JSON.parse(body) as ClickHouseSearchResponse
+  } catch {
+    throw new Error('ClickHouse tweet search returned invalid JSON')
+  }
+
+  if (!Array.isArray(result.data?.tweets)) {
+    throw new Error('ClickHouse tweet search returned an invalid response')
+  }
+
+  return result.data.tweets.map((tweet) => ({
+    tweet_id: tweet.tweetId,
+    created_at: tweet.createdAt,
+    full_text: tweet.fullText,
+    favorite_count: Number(tweet.favoriteCount || 0),
+    retweet_count:
+      tweet.retweetCount === null ? null : Number(tweet.retweetCount || 0),
+    reply_to_tweet_id: tweet.replyToTweetId,
+    account: {
+      username: tweet.username || 'unknown_user',
+      account_display_name:
+        tweet.accountDisplayName || tweet.username || 'Unknown User',
+      profile: tweet.avatarMediaUrl
+        ? { avatar_media_url: tweet.avatarMediaUrl }
+        : undefined,
+    },
+    media: (tweet.media || []).map((item) => ({
+      media_url: item.mediaUrl,
+      media_type: item.mediaType,
+      width: item.width ?? undefined,
+      height: item.height ?? undefined,
+    })),
+  }))
+}

--- a/src/lib/queries/tweetQueries.test.ts
+++ b/src/lib/queries/tweetQueries.test.ts
@@ -3,9 +3,13 @@ import { buildAndTsQuery, fetchTweets, FilterCriteria } from './tweetQueries'
 // Mock both RPC search functions
 const mockRpcSearch = jest.fn()
 const mockRpcExactPhrase = jest.fn()
+const mockClickHouseSearch = jest.fn()
 jest.mock('../pgSearch', () => ({
   searchTweets: (...args: any[]) => mockRpcSearch(...args),
   searchTweetsExactPhrase: (...args: any[]) => mockRpcExactPhrase(...args),
+}))
+jest.mock('../clickhouseSearch', () => ({
+  searchTweetsWithClickHouse: (...args: any[]) => mockClickHouseSearch(...args),
 }))
 
 // Helper to create a fake RPC result row (flat shape from RPC)
@@ -71,6 +75,62 @@ describe('fetchTweets — exact phrase search via FTS simple', () => {
   beforeEach(() => {
     mockRpcSearch.mockReset()
     mockRpcExactPhrase.mockReset()
+    mockClickHouseSearch.mockReset()
+    delete process.env.NEXT_PUBLIC_ENABLE_CLICKHOUSE_SEARCH
+  })
+
+  it('uses ClickHouse when text-search reads are enabled', async () => {
+    process.env.NEXT_PUBLIC_ENABLE_CLICKHOUSE_SEARCH = 'true'
+    mockClickHouseSearch.mockResolvedValueOnce([
+      {
+        tweet_id: 'ch-1',
+        created_at: '2025-01-01T00:00:00Z',
+        full_text: 'open source',
+        favorite_count: 1,
+        retweet_count: 0,
+        reply_to_tweet_id: null,
+        account: {
+          username: 'alice',
+          account_display_name: 'Alice',
+        },
+        media: [],
+      },
+    ])
+
+    const result = await fetchTweets(
+      buildMockSupabase(),
+      {
+        searchQuery: 'open & source',
+        rawSearchQuery: 'open source',
+      },
+      1,
+      20,
+    )
+
+    expect(mockClickHouseSearch).toHaveBeenCalledTimes(1)
+    expect(mockRpcSearch).not.toHaveBeenCalled()
+    expect(mockRpcExactPhrase).not.toHaveBeenCalled()
+    expect(result.tweets[0].tweet_id).toBe('ch-1')
+  })
+
+  it('falls back to the existing RPC when ClickHouse is unavailable', async () => {
+    process.env.NEXT_PUBLIC_ENABLE_CLICKHOUSE_SEARCH = 'true'
+    mockClickHouseSearch.mockRejectedValueOnce(new Error('gateway down'))
+    mockRpcSearch.mockResolvedValueOnce([makeRpcTweet('pg-1')])
+
+    const result = await fetchTweets(
+      buildMockSupabase(),
+      {
+        searchQuery: 'hello',
+        rawSearchQuery: 'hello',
+      },
+      1,
+      20,
+    )
+
+    expect(mockClickHouseSearch).toHaveBeenCalledTimes(1)
+    expect(mockRpcSearch).toHaveBeenCalledTimes(1)
+    expect(result.tweets[0].tweet_id).toBe('pg-1')
   })
 
   it('returns exact phrase matches for multi-word queries', async () => {

--- a/src/lib/queries/tweetQueries.ts
+++ b/src/lib/queries/tweetQueries.ts
@@ -3,6 +3,7 @@ import { TimelineTweet, RawSupabaseTweet, RawSupabaseAccount, RawSupabaseProfile
 import { searchTweets as rpcSearchTweets, searchTweetsExactPhrase as rpcSearchExactPhrase } from '../pgSearch';
 import { type SearchParams } from '../types';
 import { getLatestAvatarMediaUrl } from '@/lib/avatar';
+import { searchTweetsWithClickHouse } from '../clickhouseSearch';
 
 export interface FilterCriteria {
   userId?: string; // For fetching tweets by a specific user
@@ -134,6 +135,29 @@ export async function fetchTweets(
     try {
       const offset = (page - 1) * pageSize;
       const rawText = criteria.rawSearchQuery;
+
+      if (
+        rawText &&
+        process.env.NEXT_PUBLIC_ENABLE_CLICKHOUSE_SEARCH === 'true'
+      ) {
+        try {
+          const clickHouseTweets = await searchTweetsWithClickHouse(
+            criteria,
+            page,
+            pageSize,
+          );
+          return {
+            tweets: clickHouseTweets,
+            totalCount: clickHouseTweets.length === 0 ? 0 : null,
+            error: null,
+          };
+        } catch (error) {
+          console.warn(
+            'ClickHouse tweet search failed; falling back to Supabase:',
+            error,
+          );
+        }
+      }
 
       // Multi-word phrase search: use FTS 'simple' config via RPC.
       // The 'simple' config doesn't drop stop words, so phraseto_tsquery

--- a/src/lib/stats.test.ts
+++ b/src/lib/stats.test.ts
@@ -1,6 +1,46 @@
 import { getStats } from './stats'
 
 describe('getStats', () => {
+  it('uses the canonical ClickHouse summary when reads are enabled', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: jest.fn().mockResolvedValue(
+        JSON.stringify({
+          data: {
+            memberAccounts: '500',
+            totalTweets: '14345564',
+            totalUserMentions: '4200000',
+          },
+        }),
+      ),
+    })
+    const supabase = {
+      schema: jest.fn(),
+    }
+
+    await expect(
+      getStats(supabase as any, {
+        clickHouseEnabled: true,
+        fetchImpl: fetchImpl as any,
+        clickHouseBaseUrl: 'https://stream.example/analytics',
+        clickHouseToken: 'secret',
+      }),
+    ).resolves.toEqual({
+      userCount: 500,
+      tweetCount: 14_345_564,
+      userMentionsCount: 4_200_000,
+    })
+    expect(supabase.schema).not.toHaveBeenCalled()
+    expect(fetchImpl).toHaveBeenCalledWith(
+      new URL('https://stream.example/analytics/summary'),
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer secret' },
+        next: { revalidate: 60 },
+      }),
+    )
+  })
+
   it('fetches the tweet summary and deduplicated participating-user count', async () => {
     const summarySingle = jest.fn().mockResolvedValue({
       data: {
@@ -22,7 +62,9 @@ describe('getStats', () => {
       schema: jest.fn().mockReturnValue({ from }),
     }
 
-    await expect(getStats(supabase as any)).resolves.toEqual({
+    await expect(
+      getStats(supabase as any, { clickHouseEnabled: false }),
+    ).resolves.toEqual({
       userCount: 500,
       tweetCount: 13_600_000,
       userMentionsCount: 4_200_000,

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -1,8 +1,70 @@
 import { createServerClient } from '@/utils/supabase'
 import { cookies } from 'next/headers'
 import { SupabaseClient } from '@supabase/supabase-js'
+import {
+  fetchAnalyticsGatewayJson,
+  isClickHouseReadsEnabled,
+} from './clickhouseGateway'
 
-export const getStats = async (supabase: SupabaseClient) => {
+interface ClickHouseSummaryResponse {
+  data: {
+    memberAccounts: string | number
+    totalTweets: string | number
+    totalUserMentions: string | number
+  }
+}
+
+interface GetStatsOptions {
+  clickHouseEnabled?: boolean
+  fetchImpl?: typeof fetch
+  clickHouseBaseUrl?: string
+  clickHouseToken?: string
+}
+
+function safeCount(value: string | number, field: string): number {
+  const count = Number(value)
+  if (!Number.isSafeInteger(count) || count < 0) {
+    throw new Error(`ClickHouse summary returned an invalid ${field}`)
+  }
+  return count
+}
+
+export const getStats = async (
+  supabase: SupabaseClient,
+  options: GetStatsOptions = {},
+) => {
+  const clickHouseEnabled =
+    options.clickHouseEnabled ?? isClickHouseReadsEnabled()
+
+  if (clickHouseEnabled) {
+    try {
+      const summary =
+        await fetchAnalyticsGatewayJson<ClickHouseSummaryResponse>(
+          ['summary'],
+          new URLSearchParams(),
+          {
+            fetchImpl: options.fetchImpl,
+            revalidate: 60,
+            baseUrl: options.clickHouseBaseUrl,
+            token: options.clickHouseToken,
+          },
+        )
+      return {
+        userCount: safeCount(summary.data.memberAccounts, 'member count'),
+        tweetCount: safeCount(summary.data.totalTweets, 'tweet count'),
+        userMentionsCount: safeCount(
+          summary.data.totalUserMentions,
+          'mention count',
+        ),
+      }
+    } catch (error) {
+      console.error(
+        'Failed to fetch homepage stats from ClickHouse; falling back to Supabase:',
+        error,
+      )
+    }
+  }
+
   const publicSchema = supabase.schema('public')
   const [summaryResult, memberResult] = await Promise.all([
     publicSchema


### PR DESCRIPTION
## Summary
- keep the staging-only, admin-gated ClickHouse analytics lab
- read homepage tweet/member stats from the canonical ClickHouse summary with automatic Supabase fallback
- add a bounded, rate-limited server proxy at `/api/tweet-search`; the gateway token remains server-only
- make text search try ClickHouse first and fall back to the existing Supabase RPC on any gateway/query error
- restrict public ClickHouse search to the policy-safe public Parquet projection until deletion/opt-out tombstones propagate to the broader canonical sink

## Root cause
The reported blank homepage was caused by the exact Supabase `user_directory` count timing out. The page treated the paired stats request as all-or-nothing, even though ClickHouse was healthy.

## Verification
- TypeScript typecheck
- focused server Jest suite: 21 tests passed
- targeted Next lint: no warnings or errors
- Next.js production build
- live read-only ClickHouse search verification: common two-word phrase about 1.0 second over the 8,277,358-row public projection

## Staging configuration
The firehose PR must be deployed first so `/analytics/search` exists.

Set these in Vercel Preview, then redeploy:
- `ENABLE_CLICKHOUSE_LAB=true`
- `CLICKHOUSE_ANALYTICS_API_URL=https://stream.community-archive.org:3000/analytics`
- `CLICKHOUSE_ANALYTICS_API_TOKEN=<matching gateway token>`
- `ENABLE_CLICKHOUSE_READS=true`
- `NEXT_PUBLIC_ENABLE_CLICKHOUSE_SEARCH=true`

For a stats-only canary, enable `ENABLE_CLICKHOUSE_READS` first and leave `NEXT_PUBLIC_ENABLE_CLICKHOUSE_SEARCH=false`.
