### PR TITLE
Block scraping on self-service opt-out

### DIFF
--- a/docs/admin-delete-worker.md
+++ b/docs/admin-delete-worker.md
@@ -173,8 +173,8 @@ into the worker host.
 | Where | What | Retention |
 |-------|------|-----------|
 | **stdout (Docker logs)** | Structured JSON, one line per event. Goes to journald or Docker log driver on Hetzner. | Whatever the host's log rotation does (~30d default). |
-| **`admin-deleted-user-data/<prefix>/worker.log`** | The same structured log, but specific to that job, uploaded at the end of processing (success OR failure). | Forever (until admin manually clears the bucket). |
-| **`manifest.json`** | Summary: who/when/what counts, phase timings, final status. Per-job, alongside `worker.log`. | Forever. |
+| **`admin-deleted-user-data/<prefix>/worker.log`** | The same structured log, but specific to that job, uploaded at the end of processing (success OR failure). | 24 hours. |
+| **`manifest.json`** | Summary: who/when/what counts, phase timings, final status. Per-job, alongside `worker.log`. | 24 hours. |
 | **`private.admin_jobs.args`** | Status transitions + final error message (truncated to ~1KB) for `gh / SQL editor` triage. | Until the row is purged. |
 | **Sentry (optional)** | Worker crashes + per-job exceptions, with the job's `key` as the tag for grouping. | Whatever Sentry retention is. |
 
@@ -344,5 +344,5 @@ delete the inline path.
 4. **Retry policy?** v1: no automatic retry, admin re-clicks. v2:
    maybe exponential backoff for transient failures (timeouts,
    network blips) but not for logical errors (account not found).
-5. **`admin-deleted-user-data` bucket lifecycle?** Currently no
-   auto-deletion. Decide later (audit retention vs storage cost).
+5. **`admin-deleted-user-data` retention:** 24 hours. The worker sweeps
+   successful and partial failed exports every 15 minutes.

--- a/services/admin-delete-worker/README.md
+++ b/services/admin-delete-worker/README.md
@@ -170,9 +170,14 @@ structured fields above are queryable — no parsing needed.
 
 Every successful job writes
 `admin-deleted-user-data/<timestamp>-<account_id>/manifest.json` last.
-Its presence means the entire export succeeded; its absence means
-the export aborted partway. Open the bucket in Supabase Studio →
-Storage to browse.
+
+The worker sweeps completed and failed exports every 15 minutes. Export
+objects are deleted after 24 hours, including partial exports from failed
+jobs; the job row retains only the deletion timestamp and row-count metadata.
+During the 24-hour recovery window, its presence means the entire export
+succeeded; its absence can mean either the export aborted partway or its
+retention window expired. Open the bucket in Supabase Studio → Storage to
+browse.
 
 ## Local development
 

--- a/services/admin-delete-worker/src/index.ts
+++ b/services/admin-delete-worker/src/index.ts
@@ -4,9 +4,11 @@ import postgres from 'postgres'
 import { logger } from './logger.ts'
 import { exportAndDelete } from './exporter.ts'
 import { makeRunRecorder } from './runRecorder.ts'
+import { purgeExpiredExports } from './retention.ts'
 
 const WORKER_NAME = 'admin_delete_with_export'
 const POLL_INTERVAL_MS = Number(process.env.POLL_INTERVAL_MS ?? 10_000)
+const RETENTION_SWEEP_INTERVAL_MS = 15 * 60_000
 
 function requireEnv(name: string): string {
   const v = process.env[name]
@@ -37,7 +39,10 @@ async function main() {
   let stopping = false
   for (const sig of ['SIGTERM', 'SIGINT'] as const) {
     process.on(sig, () => {
-      logger.info({ sig }, 'shutdown signal received; finishing current loop then exiting')
+      logger.info(
+        { sig },
+        'shutdown signal received; finishing current loop then exiting',
+      )
       stopping = true
     })
   }
@@ -47,8 +52,13 @@ async function main() {
     'worker started; polling private.admin_jobs',
   )
 
+  let nextRetentionSweepAt = 0
   while (!stopping) {
     try {
+      if (Date.now() >= nextRetentionSweepAt) {
+        await purgeExpiredExports(storage, sql)
+        nextRetentionSweepAt = Date.now() + RETENTION_SWEEP_INTERVAL_MS
+      }
       const did = await drainOnce(sql, storage, recorder)
       if (!did) {
         // Nothing to do — sleep until next poll. (If we DID do something
@@ -59,7 +69,10 @@ async function main() {
       // Top-level catch is for *infrastructure* errors (DB went away,
       // etc.) — per-job errors are handled inside drainOnce. Log loudly,
       // back off, and keep polling.
-      logger.error({ err: serializeError(e) }, 'top-level loop error; backing off')
+      logger.error(
+        { err: serializeError(e) },
+        'top-level loop error; backing off',
+      )
       await sleep(POLL_INTERVAL_MS * 3, () => stopping)
     }
   }
@@ -125,7 +138,10 @@ async function drainOnce(
   if (claimed.length === 0) return false
 
   const job = claimed[0]
-  const jobLogger = logger.child({ job_key: job.key, account_id: job.args.account_id })
+  const jobLogger = logger.child({
+    job_key: job.key,
+    account_id: job.args.account_id,
+  })
   jobLogger.info({ args: job.args }, 'claimed job')
 
   const runId = await recorder.start({

--- a/services/admin-delete-worker/src/retention.ts
+++ b/services/admin-delete-worker/src/retention.ts
@@ -1,0 +1,110 @@
+import type postgres from 'postgres'
+import { logger } from './logger.ts'
+
+type SupabaseClient = any
+
+const EXPORT_BUCKET = 'admin-deleted-user-data'
+const RETENTION_HOURS = 24
+const PAGE_SIZE = 1000
+
+type ExpiredJob = {
+  key: string
+  args: {
+    account_id?: string
+    enqueued_at?: string
+    export_prefix?: string
+  } | null
+}
+
+export async function purgeExpiredExports(
+  storage: SupabaseClient,
+  sql: postgres.Sql,
+): Promise<void> {
+  const jobs = await sql<ExpiredJob[]>`
+    SELECT key, args
+    FROM private.admin_jobs
+    WHERE job_name = 'admin_delete_with_export'
+      AND status IN ('DONE', 'FAILED')
+      AND updated_at < now() - (${RETENTION_HOURS} * interval '1 hour')
+      AND COALESCE(args->>'export_deleted_at', '') = ''
+    ORDER BY updated_at ASC
+    LIMIT 20
+  `
+
+  for (const job of jobs) {
+    const prefix = exportPrefix(job.args)
+    if (!prefix) {
+      logger.warn({ job_key: job.key }, 'cannot derive expired export prefix')
+      continue
+    }
+
+    try {
+      const paths = await listFilesRecursively(storage, prefix)
+      for (let offset = 0; offset < paths.length; offset += 100) {
+        const { error } = await storage.storage
+          .from(EXPORT_BUCKET)
+          .remove(paths.slice(offset, offset + 100))
+        if (error) throw new Error(error.message)
+      }
+
+      await sql`
+        UPDATE private.admin_jobs
+        SET args = COALESCE(args, '{}'::jsonb)
+          || jsonb_build_object(
+            'export_deleted_at', now(),
+            'export_retention_hours', ${RETENTION_HOURS}
+          ),
+          updated_at = now()
+        WHERE key = ${job.key}
+      `
+      logger.info(
+        { job_key: job.key, prefix, objects_deleted: paths.length },
+        'expired admin deletion export removed',
+      )
+    } catch (error) {
+      logger.error(
+        { job_key: job.key, prefix, error },
+        'failed to remove expired admin deletion export',
+      )
+    }
+  }
+}
+
+function exportPrefix(args: ExpiredJob['args']): string | null {
+  if (args?.export_prefix) return args.export_prefix
+  if (!args?.enqueued_at || !args.account_id) return null
+  return `${args.enqueued_at.replace(/[:.]/g, '-')}-${args.account_id}`
+}
+
+async function listFilesRecursively(
+  storage: SupabaseClient,
+  prefix: string,
+): Promise<string[]> {
+  const paths: string[] = []
+  let offset = 0
+
+  while (true) {
+    const { data, error } = await storage.storage
+      .from(EXPORT_BUCKET)
+      .list(prefix, {
+        limit: PAGE_SIZE,
+        offset,
+        sortBy: { column: 'name', order: 'asc' },
+      })
+    if (error) throw new Error(error.message)
+
+    const entries = (data ?? []) as Array<{ id?: string | null; name: string }>
+    for (const entry of entries) {
+      const path = `${prefix}/${entry.name}`
+      if (entry.id) {
+        paths.push(path)
+      } else {
+        paths.push(...(await listFilesRecursively(storage, path)))
+      }
+    }
+    if (entries.length < PAGE_SIZE) break
+    offset += PAGE_SIZE
+  }
+
+  return paths
+}

--- a/src/app/profile/ProfileContent.tsx
+++ b/src/app/profile/ProfileContent.tsx
@@ -191,7 +191,8 @@ export default function ProfileContent({
     })
   }
 
-  // Confirmed from the opt-out modal: delete all data first, then add to opt-out list.
+  // Confirmed from the opt-out modal: persist the hard opt-out before deletion
+  // so a partial deletion failure can never leave scraping enabled.
   const confirmOptOutAndDelete = async () => {
     if (!userMetadata?.provider_id) {
       setError('Unable to identify user account')
@@ -202,19 +203,26 @@ export default function ProfileContent({
     setError(null)
     setSuccess(null)
 
+    let optOutSaved = false
     try {
-      await deleteArchive(supabase, userMetadata.provider_id)
-      await deleteStorageFiles(userMetadata.provider_id)
       await persistOptOut(true)
-
+      optOutSaved = true
       setExplicitOptOut(true)
       setOptInStatus(false)
+
+      await deleteArchive(supabase, userMetadata.provider_id)
+      await deleteStorageFiles(userMetadata.provider_id)
+
       setShowOptOutDialog(false)
       setSuccess('Data deleted and added to explicit opt-out list')
       await logUserAction('opt_out_and_delete')
       router.refresh()
     } catch (err: any) {
-      setError(err.message || 'Failed to opt out and delete data')
+      setError(
+        optOutSaved
+          ? `Opt-out saved and scraping blocked, but data deletion failed: ${err.message || 'unknown error'}`
+          : err.message || 'Failed to opt out and delete data',
+      )
     } finally {
       setDeletingArchive(null)
     }
@@ -449,7 +457,7 @@ export default function ProfileContent({
                               })}
                             </p>
                             <p className="text-xs text-muted-foreground">
-                              {archive.keep_private ? '🔒 Private' : '🌐 Public'}
+                              🌐 Public
                             </p>
                           </div>
                         </div>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -52,7 +52,6 @@ export default async function ProfilePage() {
             upload_phase,
             created_at,
             archive_at,
-            keep_private,
             accounts:all_account!left(
               account_id,
               username,

--- a/src/components/file-upload-dialog.tsx
+++ b/src/components/file-upload-dialog.tsx
@@ -28,7 +28,6 @@ import { calculateArchiveStats } from '@/lib/upload-archive/calculateArchiveStat
 import { applyOptionsToArchive } from '@/lib/upload-archive/applyOptionsToArchive'
 
 interface FileUploadDialogState {
-  keepPrivate: boolean
   showAdvancedOptions: boolean
   uploadLikes: boolean
   uploadStatus: 'not_started' | 'uploading' | 'completed'
@@ -42,7 +41,6 @@ interface FileUploadDialogState {
 }
 
 const initialState: FileUploadDialogState = {
-  keepPrivate: false,
   showAdvancedOptions: false,
   uploadLikes: true,
   uploadStatus: 'not_started',
@@ -96,7 +94,7 @@ export function FileUploadDialog({
   const handleUpload = async () => {
     setState((prev) => ({ ...prev, uploadStatus: 'uploading', error: null }))
     const options: UploadOptions = {
-      keepPrivate: state.keepPrivate,
+      keepPrivate: false,
       uploadLikes: state.uploadLikes,
       startDate: dateRange.start,
       endDate: dateRange.end,

--- a/src/lib/db_insert.ts
+++ b/src/lib/db_insert.ts
@@ -118,7 +118,7 @@ const insertAccountAndUploadRow = async (
       .update({ 
         username: username,
         archive_at: latestTweetDate,
-        keep_private: uploadOptions.keepPrivate,
+        keep_private: false,
         upload_likes: uploadOptions.uploadLikes,
         start_date: uploadOptions.startDate,
         end_date: uploadOptions.endDate,
@@ -136,7 +136,7 @@ const insertAccountAndUploadRow = async (
           account_id: accountId,
           username: username,
           archive_at: latestTweetDate,
-          keep_private: uploadOptions.keepPrivate,
+          keep_private: false,
           upload_likes: uploadOptions.uploadLikes,
           start_date: uploadOptions.startDate,
           end_date: uploadOptions.endDate,

--- a/src/lib/upload-archive/applyOptionsToArchive.ts
+++ b/src/lib/upload-archive/applyOptionsToArchive.ts
@@ -38,12 +38,12 @@ export const applyOptionsToArchive = (
       options.endDate.toISOString(),
     )
   }
-  if (options.keepPrivate) {
-    console.log('Keeping tweets private')
-  }
   if (!options.uploadLikes) {
     console.log('Emptying likes list')
     archive = emptyLikesList(archive)
   }
-  return { 'upload-options': options, ...archive }
+  return {
+    'upload-options': { ...options, keepPrivate: false },
+    ...archive,
+  }
 }

--- a/supabase/migrations/20260727190000_propagate_explicit_optouts_to_scrape_block.sql
+++ b/supabase/migrations/20260727190000_propagate_explicit_optouts_to_scrape_block.sql
@@ -1,0 +1,68 @@
+-- Treat every uploaded archive as public and make explicit opt-outs a hard,
+-- persistent scrape deny. Blocks are never removed automatically because
+-- tes.blocked_scraping_users also contains administrator-managed entries.
+
+UPDATE public.archive_upload
+SET keep_private = false
+WHERE keep_private IS TRUE;
+
+ALTER TABLE public.archive_upload
+  DROP CONSTRAINT IF EXISTS archive_upload_public_only;
+
+ALTER TABLE public.archive_upload
+  ADD CONSTRAINT archive_upload_public_only
+  CHECK (keep_private IS NOT TRUE);
+
+CREATE OR REPLACE FUNCTION public.propagate_explicit_optout_scrape_block()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_account_id text;
+BEGIN
+    IF NEW.explicit_optout IS NOT TRUE THEN
+        RETURN NEW;
+    END IF;
+
+    v_account_id := NULLIF(BTRIM(NEW.twitter_user_id), '');
+
+    IF v_account_id IS NULL AND NULLIF(BTRIM(NEW.username), '') IS NOT NULL THEN
+        SELECT a.account_id
+        INTO v_account_id
+        FROM public.all_account AS a
+        WHERE LOWER(a.username) = LOWER(BTRIM(NEW.username))
+        ORDER BY a.updated_at DESC NULLS LAST
+        LIMIT 1;
+    END IF;
+
+    IF v_account_id IS NOT NULL THEN
+        INSERT INTO tes.blocked_scraping_users (account_id)
+        VALUES (v_account_id)
+        ON CONFLICT (account_id) DO NOTHING;
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION public.propagate_explicit_optout_scrape_block() OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.propagate_explicit_optout_scrape_block()
+  FROM PUBLIC, anon, authenticated;
+
+DROP TRIGGER IF EXISTS propagate_explicit_optout_scrape_block ON public.optin;
+CREATE TRIGGER propagate_explicit_optout_scrape_block
+AFTER INSERT OR UPDATE OF explicit_optout, twitter_user_id, username
+ON public.optin
+FOR EACH ROW
+EXECUTE FUNCTION public.propagate_explicit_optout_scrape_block();
+
+INSERT INTO tes.blocked_scraping_users (account_id)
+SELECT DISTINCT COALESCE(NULLIF(BTRIM(o.twitter_user_id), ''), a.account_id)
+FROM public.optin AS o
+LEFT JOIN public.all_account AS a
+  ON LOWER(a.username) = LOWER(BTRIM(o.username))
+WHERE o.explicit_optout IS TRUE
+  AND COALESCE(NULLIF(BTRIM(o.twitter_user_id), ''), a.account_id) IS NOT NULL
+ON CONFLICT (account_id) DO NOTHING;

--- a/supabase/schemas/050_constraints.sql
+++ b/supabase/schemas/050_constraints.sql
@@ -76,6 +76,8 @@ ALTER TABLE ONLY "public"."all_profile"
 ALTER TABLE ONLY "public"."archive_upload"
     ADD CONSTRAINT "archive_upload_account_id_archive_at_key" UNIQUE ("account_id", "archive_at");
 ALTER TABLE ONLY "public"."archive_upload"
+    ADD CONSTRAINT "archive_upload_public_only" CHECK ("keep_private" IS NOT TRUE);
+ALTER TABLE ONLY "public"."archive_upload"
     ADD CONSTRAINT "archive_upload_pkey" PRIMARY KEY ("id");
 
 ALTER TABLE ONLY "public"."conversations"

--- a/supabase/schemas/070_functions.sql
+++ b/supabase/schemas/070_functions.sql
@@ -81,6 +81,44 @@ $$;
 ALTER FUNCTION "public"."update_optin_updated_at"() OWNER TO "postgres";
 
 
+-- Explicit opt-outs are a hard scrape deny. Resolve username-only legacy rows
+-- when possible, and never remove a block automatically because the same table
+-- also contains administrator-managed blocks.
+CREATE OR REPLACE FUNCTION "public"."propagate_explicit_optout_scrape_block"() RETURNS "trigger"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+    v_account_id text;
+BEGIN
+    IF NEW.explicit_optout IS NOT TRUE THEN
+        RETURN NEW;
+    END IF;
+
+    v_account_id := NULLIF(BTRIM(NEW.twitter_user_id), '');
+
+    IF v_account_id IS NULL AND NULLIF(BTRIM(NEW.username), '') IS NOT NULL THEN
+        SELECT a.account_id
+        INTO v_account_id
+        FROM public.all_account AS a
+        WHERE LOWER(a.username) = LOWER(BTRIM(NEW.username))
+        ORDER BY a.updated_at DESC NULLS LAST
+        LIMIT 1;
+    END IF;
+
+    IF v_account_id IS NOT NULL THEN
+        INSERT INTO tes.blocked_scraping_users (account_id)
+        VALUES (v_account_id)
+        ON CONFLICT (account_id) DO NOTHING;
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION "public"."propagate_explicit_optout_scrape_block"() OWNER TO "postgres";
+
+
 -- Generic updated_at column maintainer
 CREATE OR REPLACE FUNCTION "public"."update_updated_at_column"() RETURNS "trigger"
     LANGUAGE "plpgsql"

--- a/supabase/schemas/080_triggers.sql
+++ b/supabase/schemas/080_triggers.sql
@@ -16,6 +16,8 @@ CREATE OR REPLACE TRIGGER "update_likes_updated_at" BEFORE UPDATE ON "public"."l
 
 CREATE OR REPLACE TRIGGER "update_optin_timestamp" BEFORE UPDATE ON "public"."optin" FOR EACH ROW EXECUTE FUNCTION "public"."update_optin_updated_at"();
 
+CREATE OR REPLACE TRIGGER "propagate_explicit_optout_scrape_block" AFTER INSERT OR UPDATE OF "explicit_optout", "twitter_user_id", "username" ON "public"."optin" FOR EACH ROW EXECUTE FUNCTION "public"."propagate_explicit_optout_scrape_block"();
+
 CREATE OR REPLACE TRIGGER "update_tweet_media_updated_at" BEFORE UPDATE ON "public"."tweet_media" FOR EACH ROW EXECUTE FUNCTION "public"."update_updated_at_column"();
 
 CREATE OR REPLACE TRIGGER "update_tweet_urls_updated_at" BEFORE UPDATE ON "public"."tweet_urls" FOR EACH ROW EXECUTE FUNCTION "public"."update_updated_at_column"();


### PR DESCRIPTION
## Summary
- propagate every resolvable explicit opt-out into the scrape blocklist in the same database transaction
- keep manual/admin scrape blocks fail-closed when a profile opt-out flag is later cleared
- block before self-service delete so partial deletion failures cannot re-enable scraping
- normalize all archive uploads to public and reject the legacy `keep_private=true` state
- expire successful and partial admin deletion exports after 24 hours

## Migration behavior
- normalizes existing `archive_upload.keep_private=true` rows to false
- backfills all resolvable explicit opt-outs into `tes.blocked_scraping_users`
- installs the opt-out propagation trigger
- staging currently has exactly this one pending migration; the staging schema workflow should apply it for review

## Checks
- app TypeScript typecheck
- admin delete worker TypeScript build
- migration inventory check against staging (one expected pending migration)
- `git diff --check`
