### PR TITLE
Read stream monitor activity from ClickHouse

### DIFF
--- a/src/app/api/scraping-stats/route.ts
+++ b/src/app/api/scraping-stats/route.ts
@@ -1,12 +1,43 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
 import {
   DateRangeValidation,
   getStatsRangeLimitMs,
   validateDateRange,
 } from '@/lib/apiInputValidation'
+import { fetchAnalyticsGatewayJson } from '@/lib/clickhouseGateway'
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 30
 
 const MAX_HOURS_BACK = 720
+const SUPPORTED_GRANULARITIES = new Set(['hour', 'day', 'week'])
+
+type StreamStatsResponse = {
+  data: Array<{
+    period_start: string
+    period_end: string
+    tweet_count: number
+    source_messages: number
+    source_count: number
+    latest_observed_at: string | null
+  }>
+  summary: {
+    totalTweets: number
+    sourceMessages: number
+    sourceCount: number
+    avgTweetsPerPeriod: number
+    periodsIncluded: number
+    latestObservedAt: string | null
+    scope: 'firehose' | 'all'
+    countMode: 'unique_tweets_observed'
+  }
+  timing: {
+    wallMs: number
+    clickhouseMs: number
+    rowsRead: number
+    bytesRead: number
+  }
+}
 
 export async function GET(request: NextRequest) {
   try {
@@ -15,172 +46,93 @@ export async function GET(request: NextRequest) {
     const granularity = searchParams.get('granularity') || 'hour'
     const startDate = searchParams.get('startDate')
     const endDate = searchParams.get('endDate')
-    const streamedOnly = searchParams.get('streamedOnly') !== 'false' // Default to true
+    const streamedOnly = searchParams.get('streamedOnly') !== 'false'
 
-    // Validate input
-    if (!Number.isInteger(hoursBack) || hoursBack < 1 || hoursBack > MAX_HOURS_BACK) { // Max 30 days
+    if (
+      !Number.isInteger(hoursBack) ||
+      hoursBack < 1 ||
+      hoursBack > MAX_HOURS_BACK
+    ) {
       return NextResponse.json(
         { error: 'Invalid hoursBack parameter. Must be between 1 and 720.' },
-        { status: 400 }
+        { status: 400 },
+      )
+    }
+    if (!SUPPORTED_GRANULARITIES.has(granularity)) {
+      return NextResponse.json(
+        { error: 'Invalid granularity. Must be one of: hour, day, week.' },
+        { status: 400 },
       )
     }
 
     const maxRangeMs = getStatsRangeLimitMs(granularity)
     if (maxRangeMs === null) {
       return NextResponse.json(
-        { error: 'Invalid granularity. Must be one of: minute, hour, day, week, month.' },
-        { status: 400 }
+        { error: 'Invalid granularity.' },
+        { status: 400 },
       )
     }
 
-    if (hoursBack * 60 * 60 * 1000 > maxRangeMs) {
-      return NextResponse.json(
-        { error: `Date range too large for ${granularity} granularity.` },
-        { status: 400 }
-      )
-    }
-
-    // Validate custom date range up front so we can reject before we waste
-    // a service-role RPC call. An attacker could otherwise request a 10-year
-    // minute-granularity report and exhaust DB resources.
-    let customRange: Extract<DateRangeValidation, { ok: true }> | null = null
+    let range: Extract<DateRangeValidation, { ok: true }>
     if (startDate || endDate) {
       if (!startDate || !endDate) {
         return NextResponse.json(
           { error: 'Both startDate and endDate are required for custom range.' },
-          { status: 400 }
+          { status: 400 },
         )
       }
-      const range = validateDateRange(startDate, endDate, maxRangeMs)
-      if (!range.ok && range.error === 'invalid') {
+      const customRange = validateDateRange(startDate, endDate, maxRangeMs)
+      if (!customRange.ok && customRange.error === 'invalid') {
         return NextResponse.json(
           { error: 'Invalid date format. Use ISO 8601 timestamps.' },
-          { status: 400 }
+          { status: 400 },
         )
       }
-      if (!range.ok && range.error === 'order') {
+      if (!customRange.ok && customRange.error === 'order') {
         return NextResponse.json(
           { error: 'startDate must be before endDate' },
-          { status: 400 }
+          { status: 400 },
         )
       }
-      if (!range.ok) {
+      if (!customRange.ok) {
         return NextResponse.json(
           { error: `Date range too large for ${granularity} granularity.` },
-          { status: 400 }
+          { status: 400 },
         )
       }
-      customRange = range
+      range = customRange
+    } else {
+      const end = new Date()
+      const start = new Date(end.getTime() - hoursBack * 60 * 60 * 1000)
+      range = { ok: true, start, end }
     }
 
-    // Create service role client to access private schema functions
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
-    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE || process.env.SUPABASE_SERVICE_ROLE_KEY!
-    
-    const supabase = createClient(supabaseUrl, serviceRoleKey, {
-      auth: {
-        autoRefreshToken: false,
-        persistSession: false
-      }
+    const upstreamParams = new URLSearchParams({
+      start: range.start.toISOString(),
+      end: range.end.toISOString(),
+      granularity,
+      scope: streamedOnly ? 'firehose' : 'all',
     })
-    
-    // Handle different time ranges
-    if (!customRange) {
-      // Simple hour-based query
-      const now = new Date()
-      const start = new Date(now.getTime() - hoursBack * 60 * 60 * 1000)
-      
-      const { data, error } = await supabase
-        .rpc('get_streaming_stats', {
-          p_start_date: start.toISOString(),
-          p_end_date: now.toISOString(),
-          p_granularity: granularity,
-          p_streamed_only: streamedOnly
-        })
-
-      if (error) {
-        console.error('Error fetching streaming stats:', error)
-        throw new Error('Failed to fetch streaming stats: ' + error.message)
-      }
-
-      // Calculate totals
-      const totalTweets = data?.reduce((sum: number, item: any) => sum + (item.tweet_count || 0), 0) || 0
-      const maxUniqueScrapers = data?.reduce((max: number, item: any) => Math.max(max, item.unique_scrapers || 0), 0) || 0
-      const avgTweetsPerPeriod = data?.length ? Math.round(totalTweets / data.length) : 0
-
-      const response = {
-        data,
-        summary: {
-          totalTweets,
-          uniqueScrapers: maxUniqueScrapers,
-          avgTweetsPerPeriod,
-          periodsIncluded: data?.length || 0
-        }
-      }
-
-      const headers: Record<string, string> = {
-        'Content-Type': 'application/json',
-        // Cache for 5 minutes for current data
-        'Cache-Control': 's-maxage=300, stale-while-revalidate=600'
-      }
-
-      return NextResponse.json(response, { headers })
-    }
-    
-    // Handle custom date ranges
-    if (customRange) {
-      const { data, error } = await supabase
-        .rpc('get_streaming_stats', {
-          p_start_date: customRange.start.toISOString(),
-          p_end_date: customRange.end.toISOString(),
-          p_granularity: granularity,
-          p_streamed_only: streamedOnly
-        })
-
-      if (error) {
-        console.error('Error fetching streaming stats:', error)
-        throw new Error('Failed to fetch streaming stats: ' + error.message)
-      }
-
-      // Calculate totals
-      const totalTweets = data?.reduce((sum: number, item: any) => sum + (item.tweet_count || 0), 0) || 0
-      const maxUniqueScrapers = data?.reduce((max: number, item: any) => Math.max(max, item.unique_scrapers || 0), 0) || 0
-      const avgTweetsPerPeriod = data?.length ? Math.round(totalTweets / data.length) : 0
-
-      const response = {
-        data,
-        summary: {
-          totalTweets,
-          uniqueScrapers: maxUniqueScrapers,
-          avgTweetsPerPeriod,
-          periodsIncluded: data?.length || 0
-        }
-      }
-
-      // Cache headers
-      const now = new Date()
-      const end = customRange.end
-      const isCurrentPeriod = end > new Date(now.getTime() - 60 * 60 * 1000) // Within last hour
-      
-      const headers: Record<string, string> = {
-        'Content-Type': 'application/json',
-        'Cache-Control': isCurrentPeriod ? 
-          's-maxage=300, stale-while-revalidate=600' : // 5 min for current
-          's-maxage=3600, stale-while-revalidate=7200'  // 1 hour for historical
-      }
-
-      return NextResponse.json(response, { headers })
-    }
-    
-    return NextResponse.json(
-      { error: 'Please provide either hoursBack parameter or both startDate and endDate' },
-      { status: 400 }
+    const response = await fetchAnalyticsGatewayJson<StreamStatsResponse>(
+      ['stream-stats'],
+      upstreamParams,
+      { timeoutMs: 25_000 },
     )
+
+    const currentPeriod =
+      range.end > new Date(Date.now() - 60 * 60 * 1000)
+    return NextResponse.json(response, {
+      headers: {
+        'Cache-Control': currentPeriod
+          ? 's-maxage=300, stale-while-revalidate=600'
+          : 's-maxage=3600, stale-while-revalidate=7200',
+      },
+    })
   } catch (error) {
-    console.error('Error in scraping-stats API:', error)
+    console.error('ClickHouse stream-stats request failed:', error)
     return NextResponse.json(
-      { error: 'Failed to fetch scraping stats' },
-      { status: 500 }
+      { error: 'Streaming statistics are temporarily unavailable' },
+      { status: 502 },
     )
   }
 }

--- a/src/app/stream-monitor/page.tsx
+++ b/src/app/stream-monitor/page.tsx
@@ -129,8 +129,10 @@ const StreamMonitor = () => {
   const chartData = scrapingStats?.data
   const chartLoading = statsLoading
   const chartError = statsError
-  const scraperCount = scrapingStats?.summary?.uniqueScrapers || 0
-  const scraperLoading = statsLoading
+  const sourceMetric = showStreamedOnly
+    ? scrapingStats?.summary?.sourceMessages || 0
+    : scrapingStats?.summary?.sourceCount || 0
+  const sourceMetricLoading = statsLoading
 
   // Query for latest tweets with pagination
   const {
@@ -169,7 +171,9 @@ const StreamMonitor = () => {
 
   const chartConfig = {
     tweet_count: {
-      label: showStreamedOnly ? 'Tweets Streamed' : 'Total Tweets',
+      label: showStreamedOnly
+        ? 'Unique Tweets Streamed'
+        : 'Unique Tweets Observed',
       color: 'hsl(var(--chart-1))',
     },
   }
@@ -328,12 +332,14 @@ const StreamMonitor = () => {
         <Card>
           <CardHeader className="pb-2">
             <CardTitle className="text-base">
-              {showStreamedOnly ? 'Total Streamed' : 'Total Tweets'}
+              {showStreamedOnly
+                ? 'Unique Tweets Streamed'
+                : 'Unique Tweets Observed'}
             </CardTitle>
             <CardDescription>
               {showStreamedOnly
-                ? 'Streamed in time range'
-                : 'All tweets in time range'}
+                ? 'Persisted to ClickHouse in time range'
+                : 'Across all ClickHouse producers'}
             </CardDescription>
           </CardHeader>
           <CardContent>
@@ -359,16 +365,18 @@ const StreamMonitor = () => {
 
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-base">Unique Sources</CardTitle>
+            <CardTitle className="text-base">
+              {showStreamedOnly ? 'Firehose Batches' : 'Data Producers'}
+            </CardTitle>
             <CardDescription>
               {showStreamedOnly
-                ? 'Active streaming scrapers'
-                : 'All data sources'}
+                ? 'Accepted source messages represented'
+                : 'Distinct ClickHouse source labels'}
             </CardDescription>
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold text-purple-600 dark:text-purple-400">
-              {scraperLoading ? '...' : scraperCount || 0}
+              {sourceMetricLoading ? '...' : sourceMetric}
             </div>
           </CardContent>
         </Card>

--- a/src/lib/clickhouseGateway.ts
+++ b/src/lib/clickhouseGateway.ts
@@ -11,6 +11,12 @@ const ALLOWED_ENDPOINTS: Record<string, ReadonlySet<string>> = {
     'offset',
   ]),
   'word-trend': new Set(['q', 'bucket', 'match', 'from', 'to']),
+  'stream-stats': new Set([
+    'start',
+    'end',
+    'granularity',
+    'scope',
+  ]),
   'top-quotes': new Set([
     'limit',
     'exclude_self',

--- a/src/lib/clickhouseLab.test.ts
+++ b/src/lib/clickhouseLab.test.ts
@@ -62,4 +62,17 @@ describe('ClickHouse staging lab guard', () => {
       'https://stream.example/analytics/top-quotes?limit=25&exclude_self=true&include_usernames=alice%2C+bob&exclude_usernames=bot',
     )
   })
+
+  test('allows bounded stream-stat parameters without forwarding raw SQL', () => {
+    const target = analyticsGatewayRequestUrl(
+      ['stream-stats'],
+      new URLSearchParams(
+        'start=2026-07-20T00%3A00%3A00.000Z&end=2026-07-27T00%3A00%3A00.000Z&granularity=day&scope=firehose&raw_sql=DROP',
+      ),
+      'https://stream.example/analytics',
+    )
+    expect(target.toString()).toBe(
+      'https://stream.example/analytics/stream-stats?start=2026-07-20T00%3A00%3A00.000Z&end=2026-07-27T00%3A00%3A00.000Z&granularity=day&scope=firehose',
+    )
+  })
 })

--- a/src/lib/scrapingStatsRoute.test.ts
+++ b/src/lib/scrapingStatsRoute.test.ts
@@ -1,0 +1,63 @@
+import { NextRequest } from 'next/server'
+import { GET } from '@/app/api/scraping-stats/route'
+import { fetchAnalyticsGatewayJson } from './clickhouseGateway'
+
+jest.mock('./clickhouseGateway', () => ({
+  fetchAnalyticsGatewayJson: jest.fn(),
+}))
+
+const fetchAnalyticsGatewayJsonMock =
+  fetchAnalyticsGatewayJson as jest.MockedFunction<
+    typeof fetchAnalyticsGatewayJson
+  >
+
+describe('ClickHouse-backed scraping stats route', () => {
+  beforeEach(() => {
+    fetchAnalyticsGatewayJsonMock.mockReset()
+  })
+
+  test('forwards a validated firehose range to the analytics gateway', async () => {
+    fetchAnalyticsGatewayJsonMock.mockResolvedValue({
+      data: [],
+      summary: {
+        totalTweets: 0,
+        sourceMessages: 0,
+        sourceCount: 0,
+        avgTweetsPerPeriod: 0,
+        periodsIncluded: 0,
+        latestObservedAt: null,
+        scope: 'firehose',
+        countMode: 'unique_tweets_observed',
+      },
+      timing: {
+        wallMs: 1,
+        clickhouseMs: 1,
+        rowsRead: 0,
+        bytesRead: 0,
+      },
+    })
+
+    const response = await GET(new NextRequest(
+      'https://community-archive.org/api/scraping-stats?startDate=2026-07-20T00%3A00%3A00.000Z&endDate=2026-07-27T00%3A00%3A00.000Z&granularity=day&streamedOnly=true',
+    ))
+
+    expect(response.status).toBe(200)
+    expect(fetchAnalyticsGatewayJsonMock).toHaveBeenCalledTimes(1)
+    const [path, params, options] =
+      fetchAnalyticsGatewayJsonMock.mock.calls[0]!
+    expect(path).toEqual(['stream-stats'])
+    expect(params!.toString()).toBe(
+      'start=2026-07-20T00%3A00%3A00.000Z&end=2026-07-27T00%3A00%3A00.000Z&granularity=day&scope=firehose',
+    )
+    expect(options).toEqual({ timeoutMs: 25_000 })
+  })
+
+  test('rejects unsupported granularities before calling ClickHouse', async () => {
+    const response = await GET(new NextRequest(
+      'https://community-archive.org/api/scraping-stats?granularity=minute',
+    ))
+
+    expect(response.status).toBe(400)
+    expect(fetchAnalyticsGatewayJsonMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- route Stream Monitor activity stats through the authenticated ClickHouse analytics gateway
- remove the Supabase `get_streaming_stats` RPC from this stats path
- label the chart as unique tweet IDs observed per bucket
- show represented firehose source-message batches and ClickHouse producer counts
- keep bounded inputs and public edge caching

The latest-tweets list remains on Supabase; this PR only moves the Stream Monitor activity statistics requested here. Supabase remains the backward-compatible serving store.

## Validation

- 7 focused server tests
- 69 tests across the full server-side lib suite
- TypeScript type-check
- focused Next lint
- production Next build
- gateway allowlist test confirms raw SQL parameters are discarded
- live upstream ClickHouse endpoint returned 646 unique tweets from 721 firehose messages over two hours in 62.3ms, with a current `latestObservedAt`
- GitHub workflow and Vercel preview deployment are green

The Vercel preview page is protected by team SSO, so the automated browser could verify deployment health but could not perform an authenticated visual smoke test.
