### PR TITLE
Fix admin export retention marker update

### DIFF
--- a/services/admin-delete-worker/src/retention.ts
+++ b/services/admin-delete-worker/src/retention.ts
@@ -52,7 +52,7 @@ export async function purgeExpiredExports(
         SET args = COALESCE(args, '{}'::jsonb)
           || jsonb_build_object(
             'export_deleted_at', now(),
-            'export_retention_hours', ${RETENTION_HOURS}
+            'export_retention_hours', ${RETENTION_HOURS}::integer
           ),
           updated_at = now()
         WHERE key = ${job.key}


### PR DESCRIPTION
## What

Cast the configured export retention hours to `integer` when recording deletion metadata.

## Why

The production worker successfully removed expired objects from storage, but PostgreSQL rejected the subsequent `jsonb_build_object` update with error 42P18 because it could not infer the bound parameter type. That left jobs unmarked and caused repeated retention attempts.

## Impact

The 24-hour admin-export retention sweep can complete atomically from the application's perspective: storage is cleared and matching jobs are marked with `export_deleted_at`.

## Checks

- admin-delete-worker TypeScript typecheck
- `git diff --check`
