### PR TITLE
Route ClickHouse reads through analytics gateway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ ALLOW_STAGING_ADMIN_ON_PROD_SUPABASE=false
 
 # Server-side ClickHouse analytics gateway.
 # Keep both read flags false until the matching gateway endpoint is deployed.
-CLICKHOUSE_ANALYTICS_API_URL=https://stream.community-archive.org:3000/analytics
+CLICKHOUSE_ANALYTICS_API_URL=https://analytics.community-archive.org/analytics
 CLICKHOUSE_SEARCH_API_URL=https://analytics.community-archive.org
 CLICKHOUSE_ANALYTICS_API_TOKEN=<shared-gateway-token>
 ENABLE_CLICKHOUSE_READS=false

--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,7 @@ ALLOW_STAGING_ADMIN_ON_PROD_SUPABASE=false
 # Server-side ClickHouse analytics gateway.
 # Keep both read flags false until the matching gateway endpoint is deployed.
 CLICKHOUSE_ANALYTICS_API_URL=https://stream.community-archive.org:3000/analytics
+CLICKHOUSE_SEARCH_API_URL=https://stream.community-archive.org:3001/analytics
 CLICKHOUSE_ANALYTICS_API_TOKEN=<shared-gateway-token>
 ENABLE_CLICKHOUSE_READS=false
 NEXT_PUBLIC_ENABLE_CLICKHOUSE_SEARCH=false

--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,7 @@ ALLOW_STAGING_ADMIN_ON_PROD_SUPABASE=false
 # Server-side ClickHouse analytics gateway.
 # Keep both read flags false until the matching gateway endpoint is deployed.
 CLICKHOUSE_ANALYTICS_API_URL=https://stream.community-archive.org:3000/analytics
-CLICKHOUSE_SEARCH_API_URL=https://stream.community-archive.org:3001/analytics
+CLICKHOUSE_SEARCH_API_URL=https://analytics.community-archive.org
 CLICKHOUSE_ANALYTICS_API_TOKEN=<shared-gateway-token>
 ENABLE_CLICKHOUSE_READS=false
 NEXT_PUBLIC_ENABLE_CLICKHOUSE_SEARCH=false

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -32,6 +32,7 @@ ALLOW_STAGING_ADMIN_ON_PROD_SUPABASE=false
 # Staging-only ClickHouse analytics lab (server-side secrets)
 ENABLE_CLICKHOUSE_LAB=true
 CLICKHOUSE_ANALYTICS_API_URL=https://stream.community-archive.org:3000/analytics
+CLICKHOUSE_SEARCH_API_URL=https://stream.community-archive.org:3001/analytics
 CLICKHOUSE_ANALYTICS_API_TOKEN=<shared-staging-gateway-token>
 
 # Opt-in application reads. Leave false until /analytics/search is deployed.
@@ -129,6 +130,8 @@ For PR-created Vercel Preview deployments, add the values from `.env.staging.gen
 - `STAGING_DEV_LOGIN_DISPLAY_NAME`
 - `ENABLE_CLICKHOUSE_LAB=true`
 - `CLICKHOUSE_ANALYTICS_API_URL`
+- `CLICKHOUSE_SEARCH_API_URL` (the standalone mirror-search gateway; falls
+  back to `CLICKHOUSE_ANALYTICS_API_URL` only when omitted)
 - `CLICKHOUSE_ANALYTICS_API_TOKEN`
 - `ENABLE_CLICKHOUSE_READS=false` (set true when testing homepage/search reads)
 - `NEXT_PUBLIC_ENABLE_CLICKHOUSE_SEARCH=false` (set true in the same build that

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -31,7 +31,7 @@ ALLOW_STAGING_ADMIN_ON_PROD_SUPABASE=false
 
 # Staging-only ClickHouse analytics lab (server-side secrets)
 ENABLE_CLICKHOUSE_LAB=true
-CLICKHOUSE_ANALYTICS_API_URL=https://stream.community-archive.org:3000/analytics
+CLICKHOUSE_ANALYTICS_API_URL=https://analytics.community-archive.org/analytics
 CLICKHOUSE_SEARCH_API_URL=https://analytics.community-archive.org
 CLICKHOUSE_ANALYTICS_API_TOKEN=<shared-staging-gateway-token>
 

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -32,10 +32,10 @@ ALLOW_STAGING_ADMIN_ON_PROD_SUPABASE=false
 # Staging-only ClickHouse analytics lab (server-side secrets)
 ENABLE_CLICKHOUSE_LAB=true
 CLICKHOUSE_ANALYTICS_API_URL=https://stream.community-archive.org:3000/analytics
-CLICKHOUSE_SEARCH_API_URL=https://stream.community-archive.org:3001/analytics
+CLICKHOUSE_SEARCH_API_URL=https://analytics.community-archive.org
 CLICKHOUSE_ANALYTICS_API_TOKEN=<shared-staging-gateway-token>
 
-# Opt-in application reads. Leave false until /analytics/search is deployed.
+# Opt-in application reads. Leave false until the dedicated /search endpoint is deployed.
 ENABLE_CLICKHOUSE_READS=false
 NEXT_PUBLIC_ENABLE_CLICKHOUSE_SEARCH=false
 ```

--- a/src/app/api/tweet-search/route.ts
+++ b/src/app/api/tweet-search/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import {
   analyticsGatewayRequestUrl,
+  clickHouseSearchGatewayBaseUrl,
   isClickHouseReadsEnabled,
 } from '@/lib/clickhouseGateway'
 
@@ -26,6 +27,7 @@ export async function GET(request: NextRequest) {
     target = analyticsGatewayRequestUrl(
       ['search'],
       new URL(request.url).searchParams,
+      clickHouseSearchGatewayBaseUrl(),
     )
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Invalid request'

--- a/src/lib/clickhouseGateway.ts
+++ b/src/lib/clickhouseGateway.ts
@@ -31,6 +31,13 @@ export function isClickHouseReadsEnabled(
   return enabled === 'true'
 }
 
+export function clickHouseSearchGatewayBaseUrl(
+  searchUrl = process.env.CLICKHOUSE_SEARCH_API_URL,
+  analyticsUrl = process.env.CLICKHOUSE_ANALYTICS_API_URL,
+): string | undefined {
+  return searchUrl || analyticsUrl
+}
+
 export function analyticsGatewayRequestUrl(
   path: string[],
   incomingSearchParams: URLSearchParams,

--- a/src/lib/clickhouseLab.test.ts
+++ b/src/lib/clickhouseLab.test.ts
@@ -2,6 +2,7 @@ import {
   analyticsGatewayRequestUrl,
   isClickHouseLabEnvironmentEnabled,
 } from './clickhouseLab'
+import { clickHouseSearchGatewayBaseUrl } from './clickhouseGateway'
 
 describe('ClickHouse staging lab guard', () => {
   test('requires the flag and refuses the production Supabase project', () => {
@@ -48,6 +49,21 @@ describe('ClickHouse staging lab guard', () => {
     expect(target.toString()).toBe(
       'https://stream.example/analytics/search?q=open+source&mode=phrase&from_user=alice&limit=20&offset=40',
     )
+  })
+
+  test('routes public search to its dedicated ClickHouse gateway', () => {
+    expect(
+      clickHouseSearchGatewayBaseUrl(
+        'https://stream.example:3001/analytics',
+        'https://stream.example:3000/analytics',
+      ),
+    ).toBe('https://stream.example:3001/analytics')
+    expect(
+      clickHouseSearchGatewayBaseUrl(
+        undefined,
+        'https://stream.example:3000/analytics',
+      ),
+    ).toBe('https://stream.example:3000/analytics')
   })
 
   test('allows quote filters without forwarding unknown parameters', () => {

--- a/src/lib/clickhouseLab.test.ts
+++ b/src/lib/clickhouseLab.test.ts
@@ -44,20 +44,20 @@ describe('ClickHouse staging lab guard', () => {
       new URLSearchParams(
         'q=open+source&mode=phrase&from_user=alice&limit=20&offset=40&raw_sql=DROP',
       ),
-      'https://stream.example/analytics',
+      'https://analytics.example',
     )
     expect(target.toString()).toBe(
-      'https://stream.example/analytics/search?q=open+source&mode=phrase&from_user=alice&limit=20&offset=40',
+      'https://analytics.example/search?q=open+source&mode=phrase&from_user=alice&limit=20&offset=40',
     )
   })
 
   test('routes public search to its dedicated ClickHouse gateway', () => {
     expect(
       clickHouseSearchGatewayBaseUrl(
-        'https://stream.example:3001/analytics',
+        'https://analytics.example',
         'https://stream.example:3000/analytics',
       ),
-    ).toBe('https://stream.example:3001/analytics')
+    ).toBe('https://analytics.example')
     expect(
       clickHouseSearchGatewayBaseUrl(
         undefined,


### PR DESCRIPTION
## What

- route all website ClickHouse reads through the standalone control-plane gateway
- set `CLICKHOUSE_ANALYTICS_API_URL=https://analytics.community-archive.org/analytics`
- add a dedicated `CLICKHOUSE_SEARCH_API_URL=https://analytics.community-archive.org` for the shorter `/search` alias
- retain the analytics base as the search compatibility fallback

## Why

ClickHouse analytics and mirror search are not browser-extension firehose responsibilities. The website now uses the neutral analytics hostname for homepage stats, analytics lab reads, and tweet search.

## Deployment

1. Add the Namecheap `analytics` A record pointing to `46.62.143.147`.
2. Verify `https://analytics.community-archive.org/health` has a valid certificate.
3. Set both URLs above in Preview and Production.
4. Keep the existing `CLICKHOUSE_ANALYTICS_API_TOKEN`, then redeploy.

## Checks

- focused server Jest suite: 6 tests passed
- TypeScript type-check passed
- branch includes current `main`
- Next lint and full production build passed on the parent change
- `git diff --check`
