### PR TITLE
Fix archive upload from profile settings

### DIFF
--- a/src/app/profile/ProfileContent.tsx
+++ b/src/app/profile/ProfileContent.tsx
@@ -8,7 +8,7 @@ import { Switch } from '@/components/ui/switch'
 import { Label } from '@/components/ui/label'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog'
-import { AlertCircle, Archive, Trash2, UserX, CheckCircle, Upload } from 'lucide-react'
+import { AlertCircle, Archive, Trash2, UserX, CheckCircle } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { createBrowserClient } from '@/utils/supabase'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -16,6 +16,7 @@ import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
 import { formatDistanceToNow } from 'date-fns'
 import { deleteArchive, deleteSingleArchive } from '@/lib/db_insert'
 import { useAuthAndArchive } from '@/hooks/useAuthAndArchive'
+import { ArchiveUploadButton } from '@/components/ArchiveUploadButton'
 
 interface ProfileContentProps {
   user: User
@@ -402,15 +403,13 @@ export default function ProfileContent({
                 </CardDescription>
               </div>
               {archives?.length > 0 && (
-                <Button
+                <ArchiveUploadButton
                   variant="outline"
                   size="sm"
-                  onClick={() => router.push('/#upload-archive')}
                   className="gap-2"
                 >
-                  <Upload className="h-4 w-4" />
                   New Upload
-                </Button>
+                </ArchiveUploadButton>
               )}
             </CardHeader>
             <CardContent>
@@ -418,13 +417,12 @@ export default function ProfileContent({
                 <div className="text-center py-8 text-muted-foreground">
                   <Archive className="h-12 w-12 mx-auto mb-3 opacity-50" />
                   <p>You haven&apos;t uploaded any archives yet</p>
-                  <Button
+                  <ArchiveUploadButton
                     variant="outline"
-                    className="mt-4"
-                    onClick={() => router.push('/#upload-archive')}
+                    className="mt-4 gap-2"
                   >
                     Upload Archive
-                  </Button>
+                  </ArchiveUploadButton>
                 </div>
               ) : (
                 <div className="space-y-4">

--- a/src/components/ArchiveUploadButton.test.tsx
+++ b/src/components/ArchiveUploadButton.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { handleFileUpload } from '@/lib/upload-archive/handleFileUpload'
+import type { Archive } from '@/lib/types'
+import { ArchiveUploadButton } from './ArchiveUploadButton'
+
+jest.mock('@/utils/supabase', () => ({
+  createBrowserClient: () => ({ auth: {} }),
+}))
+
+jest.mock('@/lib/upload-archive/handleFileUpload', () => ({
+  handleFileUpload: jest.fn(),
+}))
+
+jest.mock('./file-upload-dialog', () => ({
+  FileUploadDialog: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div role="dialog">Confirm archive upload</div> : null,
+}))
+
+const mockedHandleFileUpload = handleFileUpload as jest.MockedFunction<
+  typeof handleFileUpload
+>
+
+describe('ArchiveUploadButton', () => {
+  beforeEach(() => {
+    mockedHandleFileUpload.mockReset()
+  })
+
+  it('opens the file picker and starts the upload flow in place', async () => {
+    const user = userEvent.setup()
+    const archive = {} as Archive
+    mockedHandleFileUpload.mockResolvedValue(archive)
+
+    render(
+      <ArchiveUploadButton variant="outline">
+        Upload Archive
+      </ArchiveUploadButton>,
+    )
+
+    const fileInput = screen.getByLabelText(
+      'Choose Twitter archive zip',
+    ) as HTMLInputElement
+    const clickSpy = jest.spyOn(fileInput, 'click')
+
+    await user.click(screen.getByRole('button', { name: 'Upload Archive' }))
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+
+    const file = new File(['archive'], 'twitter-archive.zip', {
+      type: 'application/zip',
+    })
+    await user.upload(fileInput, file)
+
+    await waitFor(() => {
+      expect(mockedHandleFileUpload).toHaveBeenCalledTimes(1)
+    })
+    expect(screen.getByRole('dialog')).toHaveTextContent(
+      'Confirm archive upload',
+    )
+  })
+})

--- a/src/components/ArchiveUploadButton.test.tsx
+++ b/src/components/ArchiveUploadButton.test.tsx
@@ -46,6 +46,15 @@ describe('ArchiveUploadButton', () => {
     await user.click(screen.getByRole('button', { name: 'Upload Archive' }))
     expect(clickSpy).toHaveBeenCalledTimes(1)
 
+    const requestLink = screen.getByRole('link', {
+      name: 'Request your archive from X',
+    })
+    expect(requestLink).toHaveAttribute(
+      'href',
+      'https://x.com/settings/download_your_data',
+    )
+    expect(requestLink).toHaveAttribute('target', '_blank')
+
     const file = new File(['archive'], 'twitter-archive.zip', {
       type: 'application/zip',
     })

--- a/src/components/ArchiveUploadButton.tsx
+++ b/src/components/ArchiveUploadButton.tsx
@@ -41,14 +41,24 @@ export function ArchiveUploadButton({
 
   return (
     <>
-      <Button
-        {...buttonProps}
-        onClick={() => fileInputRef.current?.click()}
-        disabled={isProcessing}
-      >
-        <Upload className="h-4 w-4" />
-        {isProcessing ? 'Processing...' : children}
-      </Button>
+      <div className="inline-flex flex-col items-center gap-1">
+        <Button
+          {...buttonProps}
+          onClick={() => fileInputRef.current?.click()}
+          disabled={isProcessing}
+        >
+          <Upload className="h-4 w-4" />
+          {isProcessing ? 'Processing...' : children}
+        </Button>
+        <a
+          href="https://x.com/settings/download_your_data"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs text-muted-foreground hover:underline"
+        >
+          Request your archive from X
+        </a>
+      </div>
       <input
         ref={fileInputRef}
         type="file"

--- a/src/components/ArchiveUploadButton.tsx
+++ b/src/components/ArchiveUploadButton.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import React, { useRef, useState } from 'react'
+import { Upload } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { handleFileUpload } from '@/lib/upload-archive/handleFileUpload'
+import { Archive } from '@/lib/types'
+import { createBrowserClient } from '@/utils/supabase'
+import { FileUploadDialog } from './file-upload-dialog'
+
+type ArchiveUploadButtonProps = Omit<
+  React.ComponentProps<typeof Button>,
+  'disabled' | 'onClick'
+>
+
+export function ArchiveUploadButton({
+  children,
+  ...buttonProps
+}: ArchiveUploadButtonProps) {
+  const supabase = createBrowserClient()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [archive, setArchive] = useState<Archive | null>(null)
+  const [isProcessing, setIsProcessing] = useState(false)
+  const [isDialogOpen, setIsDialogOpen] = useState(false)
+
+  const onFileUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    setIsProcessing(true)
+
+    try {
+      const uploadedArchive = await handleFileUpload(event, setIsProcessing)
+      setArchive(uploadedArchive)
+      setIsDialogOpen(true)
+    } catch (error) {
+      console.error('Error processing archive:', error)
+      alert(`Error processing archive: ${(error as Error).message}`)
+    } finally {
+      setIsProcessing(false)
+      event.target.value = ''
+    }
+  }
+
+  return (
+    <>
+      <Button
+        {...buttonProps}
+        onClick={() => fileInputRef.current?.click()}
+        disabled={isProcessing}
+      >
+        <Upload className="h-4 w-4" />
+        {isProcessing ? 'Processing...' : children}
+      </Button>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".zip,application/zip"
+        onChange={onFileUpload}
+        disabled={isProcessing}
+        multiple
+        className="hidden"
+        aria-label="Choose Twitter archive zip"
+      />
+      {archive && (
+        <FileUploadDialog
+          supabase={supabase}
+          isOpen={isDialogOpen}
+          onClose={() => setIsDialogOpen(false)}
+          archive={archive}
+        />
+      )}
+    </>
+  )
+}


### PR DESCRIPTION
## Summary

- make both upload actions in Profile Settings open the archive zip picker in place
- reuse the existing archive parser and upload confirmation dialog without navigating back to the homepage
- show a small nearby link to request an archive from X when the user does not have one yet
- add a focused interaction test for file-picker and confirmation behavior

## Root cause

The `New Upload` and `Upload Archive` buttons both called `router.push('/#upload-archive')`, so clicking them always left Profile Settings instead of starting an upload there.

## Verification

- focused `ArchiveUploadButton` interaction test
- TypeScript type-check
- Next.js lint
- production build

Closes #439
