### PR TITLE
Fix opt-in completion after OAuth

### DIFF
--- a/src/components/HeroCTAButtons.test.tsx
+++ b/src/components/HeroCTAButtons.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react'
+import { render, waitFor } from '@testing-library/react'
+import HeroCTAButtons from './HeroCTAButtons'
+
+const mockReplace = jest.fn()
+const mockRefresh = jest.fn()
+const mockUnsubscribe = jest.fn()
+const mockSingle = jest.fn()
+const mockFetch = jest.fn()
+const originalFetch = global.fetch
+
+const mockSupabase = {
+  auth: {
+    getSession: jest.fn(),
+    onAuthStateChange: jest.fn(() => ({
+      data: { subscription: { unsubscribe: mockUnsubscribe } },
+    })),
+    signInWithOAuth: jest.fn(),
+  },
+  from: jest.fn(() => ({
+    select: jest.fn(() => ({
+      eq: jest.fn(() => ({ single: mockSingle })),
+    })),
+  })),
+}
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mockReplace, refresh: mockRefresh }),
+  useSearchParams: () => new URLSearchParams(window.location.search),
+}))
+
+jest.mock('@/hooks/useAuthAndArchive', () => ({
+  useAuthAndArchive: () => ({
+    userMetadata: { user_name: 'ExampleUser', provider_id: 'twitter-123' },
+  }),
+}))
+
+jest.mock('@/utils/supabase', () => ({
+  createBrowserClient: () => mockSupabase,
+}))
+
+describe('HeroCTAButtons', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    window.history.replaceState({}, '', '/?action=optin')
+    mockSupabase.auth.getSession.mockResolvedValue({
+      data: { session: { user: { id: 'auth-user-123' } } },
+    })
+    mockSingle.mockResolvedValue({
+      data: null,
+      error: { code: 'PGRST116' },
+    })
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true }),
+    })
+    global.fetch = mockFetch
+  })
+
+  afterAll(() => {
+    global.fetch = originalFetch
+  })
+
+  it('completes a pending opt-in when the user returns from OAuth', async () => {
+    render(<HeroCTAButtons />)
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1))
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/opt-in', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        userId: 'auth-user-123',
+        username: 'exampleuser',
+        twitterUserId: 'twitter-123',
+        optedIn: true,
+        termsVersion: 'v1.0',
+      }),
+    })
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/')
+      expect(mockRefresh).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('does not opt in automatically without the OAuth return action', async () => {
+    window.history.replaceState({}, '', '/')
+
+    render(<HeroCTAButtons />)
+
+    await waitFor(() => {
+      expect(mockSupabase.auth.getSession).toHaveBeenCalledTimes(1)
+      expect(mockSingle).toHaveBeenCalledTimes(1)
+    })
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/HeroCTAButtons.tsx
+++ b/src/components/HeroCTAButtons.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useState, useEffect } from 'react'
-import { useRouter } from 'next/navigation'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import {
   Tooltip,
@@ -25,8 +25,10 @@ export default function HeroCTAButtons({
   initialIsOptedIn = false,
 }: HeroCTAButtonsProps) {
   const router = useRouter()
+  const searchParams = useSearchParams()
   const { userMetadata } = useAuthAndArchive()
-  const supabase = createBrowserClient()
+  const supabase = useMemo(() => createBrowserClient(), [])
+  const autoOptInStarted = useRef(false)
 
   const [user, setUser] = useState<any>(null)
   const [isOptedIn, setIsOptedIn] = useState(initialIsOptedIn)
@@ -34,6 +36,7 @@ export default function HeroCTAButtons({
 
   const twitterUsername = userMetadata?.user_name
   const twitterUserId = userMetadata?.provider_id
+  const shouldAutoOptIn = searchParams.get('action') === 'optin'
 
   // Get current user session
   useEffect(() => {
@@ -122,20 +125,8 @@ export default function HeroCTAButtons({
     }
   }
 
-  const handleOptIn = async () => {
-    if (!user) {
-      await signIn('optin')
-      return
-    }
-
-    if (!twitterUsername) {
-      console.error('No Twitter username found')
-      return
-    }
-
-    if (isOptedIn) {
-      return
-    }
+  const completeOptIn = useCallback(async () => {
+    if (!user?.id || !twitterUsername || isOptedIn) return false
 
     setIsOptInLoading(true)
 
@@ -161,11 +152,54 @@ export default function HeroCTAButtons({
       setIsOptedIn(true)
       router.replace('/')
       router.refresh()
+      return true
     } catch (err: any) {
       console.error('Opt-in error:', err.message)
+      return false
     } finally {
       setIsOptInLoading(false)
     }
+  }, [isOptedIn, router, twitterUserId, twitterUsername, user?.id])
+
+  // Clicking Opt in before authentication records the intent in the OAuth
+  // callback URL. Complete that intent as soon as the returning session and
+  // Twitter metadata are available, so the user does not have to click twice.
+  useEffect(() => {
+    if (!shouldAutoOptIn || autoOptInStarted.current) {
+      return
+    }
+
+    if (isOptedIn) {
+      autoOptInStarted.current = true
+      router.replace('/')
+      return
+    }
+
+    if (!user?.id || !twitterUsername) return
+
+    autoOptInStarted.current = true
+    void completeOptIn()
+  }, [
+    completeOptIn,
+    isOptedIn,
+    router,
+    shouldAutoOptIn,
+    twitterUsername,
+    user?.id,
+  ])
+
+  const handleOptIn = async () => {
+    if (!user) {
+      await signIn('optin')
+      return
+    }
+
+    if (!twitterUsername) {
+      console.error('No Twitter username found')
+      return
+    }
+
+    await completeOptIn()
   }
 
   const getOptInButtonText = () => {


### PR DESCRIPTION
## Summary

- complete a pending opt-in automatically when a user returns from Twitter OAuth
- wait for the restored session and Twitter metadata, and guard against duplicate submissions
- clear the `action=optin` URL after completion and refresh the homepage state
- add regression coverage for OAuth returns and ordinary homepage visits

## Root cause

The pre-login **Opt in** button already preserved the user's intent by returning them to `/?action=optin`, but `HeroCTAButtons` never read that action. After login, the user therefore landed back on the same button and had to click it again.

This change consumes the existing return action and calls the existing authenticated `/api/opt-in` endpoint. No Twitter OAuth configuration changes are required.

## User impact

A signed-out user can click **Opt in** once, finish Twitter authentication, and return with the opt-in completed automatically.

## Validation

- focused Jest regression tests: 2 passed
- TypeScript: `tsc --noEmit`
- ESLint: no warnings or errors in the changed component/test
- Next.js production build: passed

Closes #444
