### PR TITLE
Add PostHog monitoring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,11 @@ NEXT_PUBLIC_LOCAL_SERVICE_ROLE=<your-service-role-key(from pnpm supabase start)>
 SUPABASE_SERVICE_ROLE=<> #same as above, is needed for vercel in the server
 NODE_ENV=development
 
+# Optional PostHog browser monitoring. Leave the token unset to disable it.
+# Use https://eu.i.posthog.com instead if the PostHog project is in the EU region.
+NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=
+NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+
 # Staging-only login bypass.
 # Use this with a separate Supabase project loaded with mock data, never with prod data.
 NEXT_PUBLIC_ENABLE_STAGING_DEV_LOGIN=false

--- a/docs/local-setup.md
+++ b/docs/local-setup.md
@@ -23,6 +23,11 @@ ARCHIVE_PATH=<path_to_archive_folder>
 
 Both `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` can be found in [your Supabase project's API settings](https://app.supabase.com/project/_/settings/api)
 
+PostHog monitoring is optional. To enable page views, client error tracking,
+session replay, and Web Vitals, set `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN` to the
+project token from PostHog and set `NEXT_PUBLIC_POSTHOG_HOST` to the matching US
+or EU ingestion host. Leave the token unset to disable monitoring locally.
+
 1. Install [node](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) and optionally [pnpm](https://pnpm.io/installation#using-npm)
 
 2. Install dependencies

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "nextjs-toploader": "^1.6.12",
     "node-fetch": "^3.3.2",
     "postgres": "^3.4.7",
+    "posthog-js": "^1.413.3",
     "react": "18.2.0",
     "react-day-picker": "8.10.1",
     "react-dom": "18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ importers:
       postgres:
         specifier: ^3.4.7
         version: 3.4.7
+      posthog-js:
+        specifier: ^1.413.3
+        version: 1.413.3
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -903,6 +906,15 @@ packages:
 
   '@polka/url@1.0.0-next.28':
     resolution: {integrity: sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==}
+
+  '@posthog/browser-common@0.4.0':
+    resolution: {integrity: sha512-W9DCGVks15docUMPvJ2nd8NS16Gn74bsGWuaeg31beEKFSjdW8wvnQ1ETY6WSql5pYxZb3GdJmEUZVVstKSrBQ==}
+
+  '@posthog/core@1.46.9':
+    resolution: {integrity: sha512-EXO6y5ih+jBkTCpUCuYgQmajuDZuvy6vMvflkub6pLQyi0GPlCPWVSvZZkOeQw9e2MxoD5GteeGCt9R8+UJ/yQ==}
+
+  '@posthog/types@1.402.2':
+    resolution: {integrity: sha512-ZZTiS4dLwF4/D0YTzS3gGSLFnhuNOY5yu4d9VGS9trGe5GW6FjIXo20p18K5BPW2RZSYSld8sdnSAY3AUXleUQ==}
 
   '@radix-ui/number@1.1.0':
     resolution: {integrity: sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ==}
@@ -1712,6 +1724,9 @@ packages:
   '@types/triple-beam@1.3.5':
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/ws@8.5.14':
     resolution: {integrity: sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw==}
 
@@ -2168,6 +2183,9 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  core-js@3.50.0:
+    resolution: {integrity: sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==}
+
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
@@ -2373,6 +2391,9 @@ packages:
     resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
     engines: {node: '>=12'}
     deprecated: Use your platform's native DOMException instead
+
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   dotenv@16.4.7:
     resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
@@ -2661,6 +2682,9 @@ packages:
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
+
+  fflate@0.4.9:
+    resolution: {integrity: sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==}
 
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
@@ -3818,6 +3842,17 @@ packages:
     resolution: {integrity: sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==}
     engines: {node: '>=12'}
 
+  posthog-js@1.413.3:
+    resolution: {integrity: sha512-UoAymtZYVr84Ldp0ITXmlK4Q3GE8vU7GW8wC+aCput5RrKVJ8wkAPc12n3ElmKRlvLL+oD+Fotjc7n3wYG0RGQ==}
+
+  preact@10.29.8:
+    resolution: {integrity: sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==}
+    peerDependencies:
+      preact-render-to-string: '>=5'
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -3913,6 +3948,9 @@ packages:
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
@@ -4565,6 +4603,12 @@ packages:
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
+
+  web-vitals@6.0.0:
+    resolution: {integrity: sha512-Guaibvy/+uNtL6Bsu4jmMJGzuSl91oeRH5iO9pPRbYftnFUr3yqT1TUNX/OE4o9HexuEMU3Kb/Wg7iKhlffZUA==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -5409,6 +5453,17 @@ snapshots:
     optional: true
 
   '@polka/url@1.0.0-next.28': {}
+
+  '@posthog/browser-common@0.4.0':
+    dependencies:
+      '@posthog/core': 1.46.9
+      '@posthog/types': 1.402.2
+
+  '@posthog/core@1.46.9':
+    dependencies:
+      '@posthog/types': 1.402.2
+
+  '@posthog/types@1.402.2': {}
 
   '@radix-ui/number@1.1.0': {}
 
@@ -6275,6 +6330,9 @@ snapshots:
 
   '@types/triple-beam@1.3.5': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/ws@8.5.14':
     dependencies:
       '@types/node': 20.3.1
@@ -6757,6 +6815,8 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  core-js@3.50.0: {}
+
   core-util-is@1.0.3: {}
 
   create-jest@29.7.0(@types/node@20.3.1):
@@ -6953,6 +7013,10 @@ snapshots:
   domexception@4.0.0:
     dependencies:
       webidl-conversions: 7.0.0
+
+  dompurify@3.4.13:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dotenv@16.4.7: {}
 
@@ -7169,8 +7233,8 @@ snapshots:
       '@typescript-eslint/parser': 6.21.0(eslint@8.56.0)(typescript@5.1.3)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.1.3))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@8.56.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.1.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.56.0)
       eslint-plugin-react: 7.37.4(eslint@8.56.0)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.56.0)
@@ -7189,7 +7253,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(eslint@8.56.0))(eslint@8.56.0):
+  eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.56.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0
@@ -7201,22 +7265,22 @@ snapshots:
       is-glob: 4.0.3
       stable-hash: 0.0.4
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.1.3))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.1.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.1.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.1.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.56.0))(eslint@8.56.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.21.0(eslint@8.56.0)(typescript@5.1.3)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0(eslint@8.56.0))(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.1.3))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.1.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.56.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -7227,7 +7291,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.1.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.1.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.56.0))(eslint@8.56.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -7428,6 +7492,8 @@ snapshots:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
+
+  fflate@0.4.9: {}
 
   file-entry-cache@6.0.1:
     dependencies:
@@ -8799,6 +8865,23 @@ snapshots:
 
   postgres@3.4.7: {}
 
+  posthog-js@1.413.3:
+    dependencies:
+      '@posthog/browser-common': 0.4.0
+      '@posthog/core': 1.46.9
+      '@posthog/types': 1.402.2
+      core-js: 3.50.0
+      dompurify: 3.4.13
+      fflate: 0.4.9
+      preact: 10.29.8
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.3.0
+      web-vitals-soft-navs: web-vitals@6.0.0
+    transitivePeerDependencies:
+      - preact-render-to-string
+
+  preact@10.29.8: {}
+
   prelude-ls@1.2.1: {}
 
   prettier-plugin-tailwindcss@0.5.14(prettier@3.4.2):
@@ -8843,6 +8926,8 @@ snapshots:
   punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
+
+  query-selector-shadow-dom@1.0.1: {}
 
   querystringify@2.2.0: {}
 
@@ -9584,6 +9669,10 @@ snapshots:
       makeerror: 1.0.12
 
   web-streams-polyfill@3.3.3: {}
+
+  web-vitals@5.3.0: {}
+
+  web-vitals@6.0.0: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,6 +18,7 @@ import HashScrollHandler from '@/components/HashScrollHandler'
 import { checkIsAdmin } from '@/app/admin/data'
 import { DatabaseZap, Shield } from 'lucide-react'
 import { isClickHouseLabEnvironmentEnabled } from '@/lib/clickhouseLab'
+import PostHogMonitoring from '@/providers/PostHogMonitoring'
 
 const DynamicSignIn = dynamic(() => import('@/components/SignIn'), {
   ssr: false,
@@ -59,6 +60,7 @@ export default async function RootLayout({
       suppressHydrationWarning={true}
     >
       <body className="bg-background text-foreground transition-colors duration-300">
+        <PostHogMonitoring />
         <NextTopLoader showSpinner={false} height={3} color="#2acf80" />
         <ThemeProvider
           attribute="class"

--- a/src/providers/PostHogMonitoring.test.tsx
+++ b/src/providers/PostHogMonitoring.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react'
+import { act, render, waitFor } from '@testing-library/react'
+import PostHogMonitoring from './PostHogMonitoring'
+
+const mockPostHog = {
+  __loaded: false,
+  get_distinct_id: jest.fn(() => 'anonymous-id'),
+  identify: jest.fn(),
+  init: jest.fn(),
+  reset: jest.fn(),
+}
+
+const mockGetSession = jest.fn()
+const mockUnsubscribe = jest.fn()
+let mockAuthStateChangeCallback: (event: string, session: any) => void
+
+const mockOnAuthStateChange = jest.fn((callback) => {
+  mockAuthStateChangeCallback = callback
+  return {
+    data: {
+      subscription: {
+        unsubscribe: mockUnsubscribe,
+      },
+    },
+  }
+})
+
+const mockCreateBrowserClient = jest.fn(() => ({
+  auth: {
+    getSession: mockGetSession,
+    onAuthStateChange: mockOnAuthStateChange,
+  },
+}))
+
+jest.mock('posthog-js', () => ({
+  __esModule: true,
+  default: mockPostHog,
+}))
+
+jest.mock('@/utils/supabase', () => ({
+  createBrowserClient: mockCreateBrowserClient,
+}))
+
+describe('PostHogMonitoring', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockPostHog.__loaded = false
+    mockGetSession.mockResolvedValue({
+      data: {
+        session: {
+          user: { id: 'user-123' },
+        },
+      },
+    })
+  })
+
+  it('does not load monitoring without a project token', async () => {
+    render(<PostHogMonitoring projectToken="" />)
+
+    await act(async () => {})
+
+    expect(mockCreateBrowserClient).not.toHaveBeenCalled()
+    expect(mockPostHog.init).not.toHaveBeenCalled()
+  })
+
+  it('initializes monitoring and follows the authenticated user lifecycle', async () => {
+    const { unmount } = render(
+      <PostHogMonitoring
+        host="https://eu.i.posthog.com"
+        projectToken="phc_test"
+      />,
+    )
+
+    await waitFor(() => {
+      expect(mockPostHog.init).toHaveBeenCalledWith(
+        'phc_test',
+        expect.objectContaining({
+          api_host: 'https://eu.i.posthog.com',
+          capture_exceptions: true,
+          capture_pageview: 'history_change',
+          capture_performance: { web_vitals: true },
+          mask_personal_data_properties: true,
+          session_recording: { maskAllInputs: true },
+        }),
+      )
+    })
+
+    await waitFor(() => {
+      expect(mockPostHog.identify).toHaveBeenCalledWith('user-123')
+    })
+
+    act(() => {
+      mockAuthStateChangeCallback('SIGNED_OUT', null)
+    })
+
+    expect(mockPostHog.reset).toHaveBeenCalledTimes(1)
+
+    unmount()
+    expect(mockUnsubscribe).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/providers/PostHogMonitoring.tsx
+++ b/src/providers/PostHogMonitoring.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import { useEffect } from 'react'
+
+const posthogProjectToken = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN
+const posthogHost =
+  process.env.NEXT_PUBLIC_POSTHOG_HOST ?? 'https://us.i.posthog.com'
+
+type PostHogMonitoringProps = {
+  host?: string
+  projectToken?: string
+}
+
+export default function PostHogMonitoring({
+  host = posthogHost,
+  projectToken = posthogProjectToken,
+}: PostHogMonitoringProps = {}) {
+  useEffect(() => {
+    if (!projectToken) return
+
+    let isActive = true
+    let unsubscribeFromAuth: (() => void) | undefined
+
+    const initializePostHog = async () => {
+      const [{ default: posthog }, { createBrowserClient }] = await Promise.all(
+        [import('posthog-js'), import('@/utils/supabase')],
+      )
+
+      if (!isActive) return
+
+      if (!posthog.__loaded) {
+        posthog.init(projectToken, {
+          api_host: host,
+          defaults: '2026-05-30',
+          autocapture: true,
+          capture_pageview: 'history_change',
+          capture_pageleave: true,
+          capture_exceptions: true,
+          capture_performance: {
+            web_vitals: true,
+          },
+          person_profiles: 'identified_only',
+          mask_personal_data_properties: true,
+          custom_personal_data_properties: [
+            'access_token',
+            'code',
+            'email',
+            'refresh_token',
+            'token',
+          ],
+          session_recording: {
+            maskAllInputs: true,
+          },
+        })
+      }
+
+      const identifyUser = (userId: string) => {
+        if (posthog.get_distinct_id() !== userId) {
+          posthog.identify(userId)
+        }
+      }
+
+      const supabase = createBrowserClient()
+
+      void supabase.auth.getSession().then(({ data: { session } }) => {
+        if (isActive && session?.user.id) {
+          identifyUser(session.user.id)
+        }
+      })
+
+      const {
+        data: { subscription },
+      } = supabase.auth.onAuthStateChange((event, session) => {
+        if (event === 'SIGNED_OUT') {
+          posthog.reset()
+        } else if (session?.user.id) {
+          identifyUser(session.user.id)
+        }
+      })
+
+      unsubscribeFromAuth = () => subscription.unsubscribe()
+    }
+
+    void initializePostHog().catch((error) => {
+      console.error('Failed to initialize PostHog monitoring:', error)
+    })
+
+    return () => {
+      isActive = false
+      unsubscribeFromAuth?.()
+    }
+  }, [host, projectToken])
+
+  return null
+}


### PR DESCRIPTION
## Summary

- add lazy-loaded PostHog browser monitoring to the Next.js root layout
- capture route changes, client exceptions, Core Web Vitals, autocaptured interactions, and session replay with input masking
- identify authenticated Supabase users and reset identity on sign-out
- keep monitoring disabled when no PostHog project token is configured
- document the US/EU host and project-token environment variables
- add focused lifecycle coverage for initialization, identification, and sign-out

## Why

Community Archive currently has Vercel page analytics but no PostHog product telemetry, client error tracking, Web Vitals, or replay support. This adds those signals without adding startup cost to deployments where PostHog is not configured.

## Deployment impact

Set `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN` and the region-appropriate `NEXT_PUBLIC_POSTHOG_HOST` in the deployment environment, then redeploy. Without a token, behavior is unchanged.

## Validation

- `pnpm exec eslint src/providers/PostHogMonitoring.tsx src/providers/PostHogMonitoring.test.tsx src/app/layout.tsx`
- `pnpm type-check`
- focused Jest tests: 2 passed
- `pnpm build`
