### PR TITLE
Add missing accounts ranking page

### DIFF
--- a/src/app/missing-accounts/loading.tsx
+++ b/src/app/missing-accounts/loading.tsx
@@ -1,0 +1,16 @@
+export default function MissingAccountsLoading() {
+  return (
+    <main className="min-h-screen bg-background py-12 md:py-16">
+      <div className="mx-auto w-full max-w-6xl animate-pulse px-4 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-3xl text-center">
+          <div className="mx-auto h-7 w-40 rounded-full bg-muted" />
+          <div className="mx-auto mt-5 h-12 max-w-lg rounded bg-muted" />
+          <div className="mx-auto mt-4 h-6 max-w-2xl rounded bg-muted" />
+        </div>
+        <div className="mx-auto mt-10 h-14 max-w-2xl rounded-lg bg-muted" />
+        <div className="mt-8 h-8 w-48 rounded bg-muted" />
+        <div className="mt-5 h-[34rem] rounded-lg border border-border bg-card" />
+      </div>
+    </main>
+  )
+}

--- a/src/app/missing-accounts/page.tsx
+++ b/src/app/missing-accounts/page.tsx
@@ -1,0 +1,336 @@
+import type { Metadata } from 'next'
+import Image from 'next/image'
+import Link from 'next/link'
+import {
+  Archive,
+  ArrowUpRight,
+  AtSign,
+  MessageCircle,
+  Radio,
+} from 'lucide-react'
+
+import type { MissingAccount } from '@/lib/missingAccounts'
+import { getMissingAccounts } from '@/lib/missingAccounts'
+
+export const dynamic = 'force-dynamic'
+
+export const metadata: Metadata = {
+  title: 'Missing accounts | Community Archive',
+  description:
+    'The most-mentioned accounts that still need to opt in or upload their Twitter archive.',
+}
+
+type View = 'opt-in' | 'archive'
+
+const supportedAvatarHosts = new Set([
+  'pbs.twimg.com',
+  'd1ts43dypk8bqh.cloudfront.net',
+  'www.gravatar.com',
+  'opencollective-production.s3.us-west-1.amazonaws.com',
+])
+const numberFormatter = new Intl.NumberFormat('en-US')
+
+function supportedAvatarUrl(value: string | null): string | null {
+  if (!value) return null
+  try {
+    const url = new URL(value)
+    return url.protocol === 'https:' && supportedAvatarHosts.has(url.hostname)
+      ? value
+      : null
+  } catch {
+    return null
+  }
+}
+
+function accountUrl(account: MissingAccount): string {
+  return account.username
+    ? `https://x.com/${account.username}`
+    : `https://x.com/i/user/${account.accountId}`
+}
+
+function AccountIdentity({ account }: { account: MissingAccount }) {
+  const avatarUrl = supportedAvatarUrl(account.avatarUrl)
+  const displayName =
+    account.displayName || account.username || 'Unknown account'
+  const fallback = (account.username || account.displayName || '?')
+    .slice(0, 1)
+    .toUpperCase()
+
+  return (
+    <a
+      href={accountUrl(account)}
+      target="_blank"
+      rel="noreferrer"
+      className="group flex min-w-0 items-center gap-3 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <span className="relative flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-full bg-muted text-sm font-semibold text-muted-foreground">
+        {avatarUrl ? (
+          <Image
+            src={avatarUrl}
+            alt=""
+            fill
+            sizes="40px"
+            className="object-cover"
+          />
+        ) : (
+          fallback
+        )}
+      </span>
+      <span className="min-w-0">
+        <span className="flex items-center gap-1 font-semibold text-foreground group-hover:underline">
+          <span className="truncate">{displayName}</span>
+          <ArrowUpRight
+            aria-hidden="true"
+            className="h-3.5 w-3.5 shrink-0 text-muted-foreground"
+          />
+        </span>
+        <span className="block truncate text-sm text-muted-foreground">
+          {account.username ? `@${account.username}` : account.accountId}
+        </span>
+      </span>
+    </a>
+  )
+}
+
+function AccountRanking({
+  accounts,
+  view,
+}: {
+  accounts: MissingAccount[]
+  view: View
+}) {
+  if (accounts.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-border bg-card px-6 py-14 text-center">
+        <p className="font-medium text-foreground">No accounts to show yet.</p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          The ranking will appear when the latest archive data is available.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-border bg-card">
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[680px] border-collapse text-left">
+          <caption className="sr-only">
+            Accounts ranked by unique archived tweets that mention or reply to
+            them
+          </caption>
+          <thead className="bg-muted text-xs uppercase tracking-wide text-muted-foreground">
+            <tr>
+              <th scope="col" className="w-16 px-4 py-3 text-right font-medium">
+                Rank
+              </th>
+              <th scope="col" className="px-4 py-3 font-medium">
+                Account
+              </th>
+              <th scope="col" className="px-4 py-3 text-right font-medium">
+                Referenced by
+              </th>
+              <th scope="col" className="px-4 py-3 text-right font-medium">
+                Mentions
+              </th>
+              <th scope="col" className="px-4 py-3 text-right font-medium">
+                Replies
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {accounts.map((account) => (
+              <tr
+                key={`${view}:${account.accountId}`}
+                className="border-t border-border transition-colors hover:bg-accent"
+              >
+                <td className="px-4 py-4 text-right text-sm font-semibold tabular-nums text-muted-foreground">
+                  {account.rank}
+                </td>
+                <td className="px-4 py-4">
+                  <AccountIdentity account={account} />
+                </td>
+                <td className="px-4 py-4 text-right font-semibold tabular-nums text-foreground">
+                  {numberFormatter.format(Number(account.referenceCount))}
+                  <span className="ml-1 text-xs font-normal text-muted-foreground">
+                    posts
+                  </span>
+                </td>
+                <td className="px-4 py-4 text-right text-sm tabular-nums text-muted-foreground">
+                  {numberFormatter.format(Number(account.mentionCount))}
+                </td>
+                <td className="px-4 py-4 text-right text-sm tabular-nums text-muted-foreground">
+                  {numberFormatter.format(Number(account.replyCount))}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+function ViewTab({
+  href,
+  active,
+  icon,
+  label,
+  count,
+}: {
+  href: string
+  active: boolean
+  icon: React.ReactNode
+  label: string
+  count: number
+}) {
+  return (
+    <Link
+      href={href}
+      aria-current={active ? 'page' : undefined}
+      className={`flex flex-1 items-center justify-center gap-2 rounded-md px-4 py-3 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:flex-none ${
+        active
+          ? 'bg-background text-foreground'
+          : 'text-muted-foreground hover:bg-background/60 hover:text-foreground'
+      }`}
+    >
+      {icon}
+      <span>{label}</span>
+      <span className="rounded-full bg-muted px-2 py-0.5 text-xs tabular-nums text-muted-foreground">
+        {count}
+      </span>
+    </Link>
+  )
+}
+
+export default async function MissingAccountsPage({
+  searchParams,
+}: {
+  searchParams?: { view?: string }
+}) {
+  const view: View = searchParams?.view === 'archive' ? 'archive' : 'opt-in'
+  let needsOptIn: MissingAccount[] = []
+  let needsArchive: MissingAccount[] = []
+  let unavailable = false
+
+  try {
+    const response = await getMissingAccounts()
+    needsOptIn = response.data.needsOptIn
+    needsArchive = response.data.needsArchive
+  } catch (error) {
+    unavailable = true
+    console.error('Unable to load missing-account rankings:', error)
+  }
+
+  const accounts = view === 'archive' ? needsArchive : needsOptIn
+  const title = view === 'archive' ? 'Needs an archive' : 'Needs to opt in'
+  const description =
+    view === 'archive'
+      ? 'These accounts opted into live collection, but their older posts are still missing. Uploading an X archive fills in the years before they opted in.'
+      : 'These accounts have neither opted into live collection nor uploaded an archive. Opting in is the first step toward preserving their posts.'
+
+  return (
+    <main className="min-h-screen bg-background py-12 md:py-16">
+      <div className="mx-auto w-full max-w-6xl px-4 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-3xl text-center">
+          <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+            <AtSign aria-hidden="true" className="h-3.5 w-3.5" />
+            Missing accounts
+          </div>
+          <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
+            Who should join next?
+          </h1>
+          <p className="mt-4 text-base leading-7 text-muted-foreground sm:text-lg">
+            The accounts most often mentioned or replied to by posts already in
+            the Community Archive. Help close the biggest gaps first.
+          </p>
+        </div>
+
+        <nav
+          aria-label="Missing account views"
+          className="mx-auto mt-10 flex max-w-2xl rounded-lg bg-muted p-1"
+        >
+          <ViewTab
+            href="/missing-accounts"
+            active={view === 'opt-in'}
+            icon={<Radio aria-hidden="true" className="h-4 w-4" />}
+            label="Needs opt-in"
+            count={needsOptIn.length}
+          />
+          <ViewTab
+            href="/missing-accounts?view=archive"
+            active={view === 'archive'}
+            icon={<Archive aria-hidden="true" className="h-4 w-4" />}
+            label="Needs archive"
+            count={needsArchive.length}
+          />
+        </nav>
+
+        <section aria-labelledby="ranking-title" className="mt-8">
+          <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <h2
+                id="ranking-title"
+                className="text-2xl font-semibold text-foreground"
+              >
+                {title}
+              </h2>
+              <p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">
+                {description}
+              </p>
+            </div>
+            <div className="flex shrink-0 items-center gap-2 text-xs text-muted-foreground">
+              <MessageCircle aria-hidden="true" className="h-4 w-4" />
+              Ranked by unique referencing posts
+            </div>
+          </div>
+
+          {unavailable ? (
+            <div className="rounded-lg border border-dashed border-border bg-card px-6 py-14 text-center">
+              <p className="font-medium text-foreground">
+                The ranking is temporarily unavailable.
+              </p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Please check back once the analytics service has caught up.
+              </p>
+            </div>
+          ) : (
+            <AccountRanking accounts={accounts} view={view} />
+          )}
+        </section>
+
+        <div className="mt-8 grid gap-4 rounded-lg border border-border bg-muted p-5 text-sm sm:grid-cols-2 sm:p-6">
+          <div>
+            <h2 className="font-semibold text-foreground">
+              Start collecting now
+            </h2>
+            <p className="mt-1 leading-6 text-muted-foreground">
+              Opting in lets the community preserve new public posts as they
+              appear.
+            </p>
+            <Link
+              href="/opt-in"
+              className="mt-3 inline-flex items-center gap-1 font-semibold text-brand hover:underline"
+            >
+              Opt in to streaming
+              <ArrowUpRight aria-hidden="true" className="h-4 w-4" />
+            </Link>
+          </div>
+          <div>
+            <h2 className="font-semibold text-foreground">Fill in the past</h2>
+            <p className="mt-1 leading-6 text-muted-foreground">
+              An archive upload preserves historical posts from before live
+              collection began.
+            </p>
+            <Link
+              href="/#upload-archive"
+              className="mt-3 inline-flex items-center gap-1 font-semibold text-brand hover:underline"
+            >
+              Upload an archive
+              <ArrowUpRight aria-hidden="true" className="h-4 w-4" />
+            </Link>
+          </div>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -18,6 +18,10 @@ const Footer = () => {
       <Link href="/stream-monitor" className="hover:underline">
         Stream Monitor
       </Link>
+      <span className="mx-2">•</span>
+      <Link href="/missing-accounts" className="hover:underline">
+        Missing Accounts
+      </Link>
     </footer>
   )
 }

--- a/src/lib/clickhouseGateway.ts
+++ b/src/lib/clickhouseGateway.ts
@@ -11,12 +11,8 @@ const ALLOWED_ENDPOINTS: Record<string, ReadonlySet<string>> = {
     'offset',
   ]),
   'word-trend': new Set(['q', 'bucket', 'match', 'from', 'to']),
-  'stream-stats': new Set([
-    'start',
-    'end',
-    'granularity',
-    'scope',
-  ]),
+  'stream-stats': new Set(['start', 'end', 'granularity', 'scope']),
+  'missing-accounts': new Set(['limit']),
   'top-quotes': new Set([
     'limit',
     'exclude_self',

--- a/src/lib/clickhouseLab.test.ts
+++ b/src/lib/clickhouseLab.test.ts
@@ -91,4 +91,15 @@ describe('ClickHouse staging lab guard', () => {
       'https://stream.example/analytics/stream-stats?start=2026-07-20T00%3A00%3A00.000Z&end=2026-07-27T00%3A00%3A00.000Z&granularity=day&scope=firehose',
     )
   })
+
+  test('allows only the missing-account result limit', () => {
+    const target = analyticsGatewayRequestUrl(
+      ['missing-accounts'],
+      new URLSearchParams('limit=100&raw_sql=DROP'),
+      'https://stream.example/analytics',
+    )
+    expect(target.toString()).toBe(
+      'https://stream.example/analytics/missing-accounts?limit=100',
+    )
+  })
 })

--- a/src/lib/missingAccounts.test.ts
+++ b/src/lib/missingAccounts.test.ts
@@ -1,0 +1,41 @@
+import { fetchAnalyticsGatewayJson } from './clickhouseGateway'
+import { getMissingAccounts, MissingAccountsResponse } from './missingAccounts'
+
+jest.mock('./clickhouseGateway', () => ({
+  fetchAnalyticsGatewayJson: jest.fn(),
+}))
+
+const fetchAnalyticsGatewayJsonMock =
+  fetchAnalyticsGatewayJson as jest.MockedFunction<
+    typeof fetchAnalyticsGatewayJson
+  >
+
+describe('getMissingAccounts', () => {
+  test('requests the two bounded public rankings from the analytics gateway', async () => {
+    const response: MissingAccountsResponse = {
+      data: { needsOptIn: [], needsArchive: [] },
+      query: {
+        limit: 100,
+        countMode: 'unique_referencing_tweets',
+        includesMentions: true,
+        includesReplies: true,
+      },
+      generatedAt: '2026-08-07T00:00:00.000Z',
+      timing: {
+        wallMs: 1,
+        clickhouseMs: 1,
+        rowsRead: 0,
+        bytesRead: 0,
+      },
+    }
+    fetchAnalyticsGatewayJsonMock.mockResolvedValue(response)
+
+    await expect(getMissingAccounts()).resolves.toEqual(response)
+
+    const [path, searchParams, options] =
+      fetchAnalyticsGatewayJsonMock.mock.calls[0]!
+    expect(path).toEqual(['missing-accounts'])
+    expect(searchParams?.toString()).toBe('limit=100')
+    expect(options).toEqual({ revalidate: 600, timeoutMs: 30_000 })
+  })
+})

--- a/src/lib/missingAccounts.ts
+++ b/src/lib/missingAccounts.ts
@@ -1,0 +1,41 @@
+import { fetchAnalyticsGatewayJson } from '@/lib/clickhouseGateway'
+
+export type MissingAccount = {
+  rank: number
+  accountId: string
+  username: string | null
+  displayName: string | null
+  avatarUrl: string | null
+  referenceCount: string
+  mentionCount: string
+  replyCount: string
+}
+
+export type MissingAccountsResponse = {
+  data: {
+    needsOptIn: MissingAccount[]
+    needsArchive: MissingAccount[]
+  }
+  query: {
+    limit: number
+    countMode: 'unique_referencing_tweets'
+    includesMentions: boolean
+    includesReplies: boolean
+  }
+  generatedAt: string
+  timing: {
+    wallMs: number
+    clickhouseMs: number
+    rowsRead: number
+    bytesRead: number
+    roundTrips?: number
+  }
+}
+
+export async function getMissingAccounts(): Promise<MissingAccountsResponse> {
+  return fetchAnalyticsGatewayJson<MissingAccountsResponse>(
+    ['missing-accounts'],
+    new URLSearchParams({ limit: '100' }),
+    { revalidate: 10 * 60, timeoutMs: 30_000 },
+  )
+}


### PR DESCRIPTION
## What

- add a public `/missing-accounts` ranking page linked from the footer
- show separate “Needs opt-in” and “Needs archive” views
- display the top 100 accounts with mention, reply, and unique-reference counts
- link each account to X and provide opt-in/archive-upload calls to action
- add a loading state and a graceful analytics-unavailable fallback
- allowlist the bounded missing-accounts gateway request and cover it with server tests

## Why

This makes the highest-impact archive gaps visible and actionable. Opt-in helps preserve future posts; archive upload recovers the historical posts that live collection cannot.

## Dependency and rollout

Requires [community-archive-control-panel#9](https://github.com/TheExGenesis/community-archive-control-panel/pull/9). Deploy the gateway change before the app change; until then, the page intentionally shows its unavailable fallback.

## Verification

- `pnpm type-check` — passed
- targeted server Jest suites — 2 suites, 8 tests passed
- targeted ESLint — passed
- targeted Prettier — passed
- `pnpm build` — passed
- `git diff --check` — passed