### PR TITLE
Load homepage top accounts from ClickHouse

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,6 +20,7 @@ import AppGallery from '@/components/AppGallery'
 import HomepageSearch from '@/components/HomepageSearch'
 import { canShowHomepageSearch } from '@/lib/homepageAccess'
 import { formatNumber } from '@/lib/formatNumber'
+import { getTopFollowedAccounts } from '@/lib/clickhouseAnalytics'
 
 export const revalidate = 60 // Cache for 60s to reduce server load from scrapers
 
@@ -48,7 +49,7 @@ const DynamicUploadArchiveSection = dynamic(
   },
 )
 
-const getMostFollowedAccounts = async (supabase: SupabaseClient) => {
+const getLegacyMostFollowedAccounts = async (supabase: SupabaseClient) => {
   let { data, error } = await supabase
     .from('global_activity_summary')
     .select('top_accounts_with_followers')
@@ -59,6 +60,18 @@ const getMostFollowedAccounts = async (supabase: SupabaseClient) => {
     return []
   }
   return data?.top_accounts_with_followers || []
+}
+
+const getMostFollowedAccounts = async (supabase: SupabaseClient) => {
+  try {
+    return await getTopFollowedAccounts(7)
+  } catch (error) {
+    console.error(
+      'Failed to fetch top accounts from ClickHouse; using the legacy summary:',
+      error,
+    )
+    return getLegacyMostFollowedAccounts(supabase)
+  }
 }
 
 async function getOpenCollectiveContributors(): Promise<Contributor[]> {
@@ -145,9 +158,26 @@ const InfoPanel: React.FC<InfoPanelProps> = ({
 export default async function Homepage() {
   const cookieStore = await cookies()
   const supabase = createServerClient(cookieStore)
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  const [
+    {
+      data: { user },
+    },
+    mostFollowedAccounts,
+    financialContributors,
+    stats,
+  ] = await Promise.all([
+    supabase.auth.getUser(),
+    getMostFollowedAccounts(supabase),
+    getOpenCollectiveContributors(),
+    getStats(supabase).catch((error) => {
+      console.error('Failed to fetch stats for homepage:', error)
+      return {
+        userCount: null,
+        tweetCount: null,
+        userMentionsCount: null,
+      }
+    }),
+  ])
 
   let optedInStatus: boolean | null = null
   if (user) {
@@ -165,9 +195,7 @@ export default async function Homepage() {
   }
 
   const isOptedIn = canShowHomepageSearch(user?.id, optedInStatus)
-
-  const mostFollowed = (await getMostFollowedAccounts(supabase)).slice(0, 7)
-  const financialContributors = await getOpenCollectiveContributors()
+  const mostFollowed = mostFollowedAccounts.slice(0, 7)
 
   const totalAmountRaised = financialContributors.reduce(
     (sum, contributor) => sum + contributor.totalAmountDonated,
@@ -186,15 +214,6 @@ export default async function Homepage() {
     0,
     financialContributors.length - topTenNames.length,
   )
-
-  const stats = await getStats(supabase).catch((error) => {
-    console.error('Failed to fetch stats for homepage:', error)
-    return {
-      userCount: null,
-      tweetCount: null,
-      userMentionsCount: null,
-    }
-  })
 
   const sectionPaddingClasses = 'py-12 md:py-16 lg:py-20'
   const contentWrapperClasses =

--- a/src/lib/clickhouseAnalytics.test.ts
+++ b/src/lib/clickhouseAnalytics.test.ts
@@ -1,0 +1,71 @@
+import { getTopFollowedAccounts } from './clickhouseAnalytics'
+
+describe('getTopFollowedAccounts', () => {
+  const originalApiUrl = process.env.CLICKHOUSE_ANALYTICS_API_URL
+  const originalApiToken = process.env.CLICKHOUSE_ANALYTICS_API_TOKEN
+
+  beforeEach(() => {
+    process.env.CLICKHOUSE_ANALYTICS_API_URL =
+      'https://analytics.community-archive.org/analytics/'
+    process.env.CLICKHOUSE_ANALYTICS_API_TOKEN = 'test-token'
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    if (originalApiUrl === undefined) {
+      delete process.env.CLICKHOUSE_ANALYTICS_API_URL
+    } else {
+      process.env.CLICKHOUSE_ANALYTICS_API_URL = originalApiUrl
+    }
+    if (originalApiToken === undefined) {
+      delete process.env.CLICKHOUSE_ANALYTICS_API_TOKEN
+    } else {
+      process.env.CLICKHOUSE_ANALYTICS_API_TOKEN = originalApiToken
+    }
+  })
+
+  it('maps the membership-aware ClickHouse ranking for the homepage', async () => {
+    const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [
+          {
+            accountId: '123',
+            username: 'tszzl',
+            displayName: 'tszzl',
+            avatarUrl: 'https://pbs.twimg.com/profile_images/tszzl.jpg',
+            followerCount: '250000',
+          },
+        ],
+      }),
+    } as Response)
+
+    await expect(getTopFollowedAccounts(7)).resolves.toEqual([
+      {
+        account_id: '123',
+        username: 'tszzl',
+        avatar_media_url: 'https://pbs.twimg.com/profile_images/tszzl.jpg',
+        num_followers: 250000,
+      },
+    ])
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://analytics.community-archive.org/analytics/top-followed-accounts?limit=7',
+      {
+        headers: {
+          Accept: 'application/json',
+          Authorization: 'Bearer test-token',
+        },
+        next: { revalidate: 60 },
+      },
+    )
+  })
+
+  it('fails closed when the server-only gateway configuration is missing', async () => {
+    delete process.env.CLICKHOUSE_ANALYTICS_API_TOKEN
+
+    await expect(getTopFollowedAccounts()).rejects.toThrow(
+      'ClickHouse analytics API is not configured',
+    )
+  })
+})

--- a/src/lib/clickhouseAnalytics.ts
+++ b/src/lib/clickhouseAnalytics.ts
@@ -1,0 +1,86 @@
+import type { AvatarType } from '@/lib/types'
+
+type TopFollowedAccount = {
+  accountId?: unknown
+  username?: unknown
+  avatarUrl?: unknown
+  followerCount?: unknown
+}
+
+type TopFollowedAccountsResponse = {
+  data?: unknown
+}
+
+const DEFAULT_LIMIT = 7
+const MAX_LIMIT = 30
+const ACCOUNT_ID_PATTERN = /^\d{1,20}$/
+
+export async function getTopFollowedAccounts(
+  requestedLimit = DEFAULT_LIMIT,
+): Promise<AvatarType[]> {
+  const apiUrl = process.env.CLICKHOUSE_ANALYTICS_API_URL?.replace(/\/$/, '')
+  const token = process.env.CLICKHOUSE_ANALYTICS_API_TOKEN
+
+  if (!apiUrl || !token) {
+    throw new Error('ClickHouse analytics API is not configured')
+  }
+
+  const finiteLimit = Number.isFinite(requestedLimit)
+    ? requestedLimit
+    : DEFAULT_LIMIT
+  const limit = Math.max(
+    1,
+    Math.min(MAX_LIMIT, Math.trunc(finiteLimit || DEFAULT_LIMIT)),
+  )
+  const response = await fetch(
+    `${apiUrl}/top-followed-accounts?limit=${limit}`,
+    {
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      next: { revalidate: 60 },
+    },
+  )
+
+  if (!response.ok) {
+    throw new Error(
+      `ClickHouse top-followed request failed with status ${response.status}`,
+    )
+  }
+
+  const payload = (await response.json()) as TopFollowedAccountsResponse
+  if (!Array.isArray(payload.data)) {
+    throw new Error('ClickHouse top-followed response did not contain data')
+  }
+
+  return payload.data.flatMap((value): AvatarType[] => {
+    const account = value as TopFollowedAccount
+    const hasFollowerCount =
+      typeof account.followerCount === 'string' ||
+      typeof account.followerCount === 'number'
+    const followerCount = Number(account.followerCount)
+
+    if (
+      typeof account.accountId !== 'string' ||
+      !ACCOUNT_ID_PATTERN.test(account.accountId) ||
+      typeof account.username !== 'string' ||
+      account.username.length === 0 ||
+      !hasFollowerCount ||
+      !Number.isFinite(followerCount) ||
+      followerCount < 0
+    ) {
+      return []
+    }
+
+    return [
+      {
+        account_id: account.accountId,
+        username: account.username,
+        avatar_media_url:
+          typeof account.avatarUrl === 'string' ? account.avatarUrl : '',
+        num_followers: followerCount,
+      },
+    ]
+  })
+}


### PR DESCRIPTION
## What changed

- replace the homepage's primary top-followed source with the authenticated ClickHouse analytics gateway
- validate and map the gateway response into the existing avatar-list contract
- retain the legacy Supabase summary only as an outage/configuration fallback
- keep the gateway token server-only and revalidate the response every minute
- run independent homepage requests in parallel while preserving the current opt-in-aware homepage behavior

## Why

The homepage used a stale Supabase materialized summary even though current membership already lives in `public.user_directory`. Newly opted-in members such as `tszzl` could therefore appear in the directory but not in the homepage ranking.

The companion control-plane PR adds the membership-aware ClickHouse endpoint this client consumes: https://github.com/TheExGenesis/community-archive-control-panel/pull/12

## Validation

- `pnpm exec tsc --pretty --noEmit`
- focused server tests — 4 passing
- `next lint` on the changed page and data client
- Prettier check on changed TypeScript/TSX files
- `git diff --check`
