### PR TITLE
Enable full PostHog browser monitoring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,6 @@ ARCHIVE_PATH=<path_to_archive_folder>
 NEXT_PUBLIC_USER_ID=<>
 NEXT_PUBLIC_USER_NAME=<>
 
-# PostHog browser analytics
+# PostHog browser analytics, error monitoring, and session replay
 NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=<your-posthog-project-token>
 NEXT_PUBLIC_POSTHOG_HOST=<your-posthog-host>

--- a/docs/local-setup.md
+++ b/docs/local-setup.md
@@ -23,11 +23,15 @@ ARCHIVE_PATH=<path_to_archive_folder>
 
 Both `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` can be found in [your Supabase project's API settings](https://app.supabase.com/project/_/settings/api)
 
-PostHog product analytics is optional. Set `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN`
-and `NEXT_PUBLIC_POSTHOG_HOST` to enable the manually instrumented events. The
-integration does not send page URLs, search text, archive contents, or email
-addresses. Signed-in events use the account ID and public username; leave either
-variable unset to disable PostHog locally.
+PostHog monitoring is optional. Set `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN` and
+`NEXT_PUBLIC_POSTHOG_HOST` to enable pageviews, autocapture, session replay,
+browser exception capture, Web Vitals, network timing, and the manually
+instrumented product events. Signed-in activity uses the account ID, email,
+trusted public username, and public display name. Replay captures rendered page
+content and non-password inputs, but not console logs, network bodies, or the
+contents of a locally selected archive ZIP. PostHog uses cookies and local
+storage for device and session continuity. Leave either variable unset to
+disable PostHog locally.
 
 1. Install [node](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) and optionally [pnpm](https://pnpm.io/installation#using-npm)
 

--- a/src/app/data-policy/page.tsx
+++ b/src/app/data-policy/page.tsx
@@ -56,9 +56,11 @@ export default function DataPolicyPage() {
       </p>
 
       <h3 className="mb-3 mt-6 text-xl font-semibold">
-        What We Do Not Collect
+        What Tweet Collection Does Not Include
       </h3>
-      <p className="mb-4">Regardless of the method, we never access:</p>
+      <p className="mb-4">
+        Archive upload and browser-extension tweet collection never access:
+      </p>
 
       <ul className="my-5 list-inside list-disc space-y-2 pl-4">
         <li>Direct messages</li>
@@ -102,21 +104,30 @@ export default function DataPolicyPage() {
       <h2 className="mb-4 mt-8 text-2xl font-semibold">Website Analytics</h2>
 
       <p className="mb-4">
-        We use PostHog to measure aggregate use of website features. We send
-        only manually defined events with counts, booleans, and mode flags. We
-        do not send page URLs, search text, archive contents, email addresses,
-        or private profile fields to PostHog.
+        We use PostHog to understand website use and reliability. PostHog
+        records page views (including URLs, search parameters, referrers, and
+        campaign parameters), clicks and other page interactions, manually
+        defined product events, browser and device context, Web Vitals, network
+        timing, and unhandled browser errors with diagnostic context.
       </p>
 
       <p className="mb-4">
-        This analytics integration does not use automatic interaction capture,
-        automatic error capture, session replay, or persistent browser storage.
-        When you are signed in, these events are linked to your Community
-        Archive account ID and public username so we can understand feature use
-        and support account-specific issues. It also respects your
-        browser&apos;s Do Not Track setting. PostHog necessarily receives
-        network metadata to accept an event, but we disable IP geolocation
-        enrichment.
+        PostHog session replay records the rendered page and your interactions,
+        including non-password form values. Password values remain masked, and
+        we do not enable recording of console logs or network request and
+        response bodies. The archive ZIP selected for upload is processed
+        locally by the application; PostHog does not receive the file&apos;s
+        contents through session replay.
+      </p>
+
+      <p className="mb-4">
+        When you are signed in, PostHog links activity to your Community Archive
+        account ID, email address, public username, and public display name so
+        we can understand feature use and support account-specific issues.
+        PostHog uses cookies and local storage to maintain device and session
+        identity. The integration respects your browser&apos;s Do Not Track
+        setting. PostHog necessarily receives network metadata to accept an
+        event, but we disable IP geolocation enrichment.
       </p>
 
       <p className="mb-4">

--- a/src/lib/posthog.test.ts
+++ b/src/lib/posthog.test.ts
@@ -1,9 +1,14 @@
 import type { Session } from '@supabase/supabase-js'
-import type { CaptureResult, PostHog } from 'posthog-js/dist/module.slim'
+import type {
+  CaptureResult,
+  PostHog,
+  PostHogConfig,
+} from 'posthog-js/dist/module.slim'
 import {
   capturePostHogEventWhenReady,
   capturePostHogEventWithClient,
   createPostHogConfig,
+  getPostHogPersonProperties,
   initializePostHogClient,
   sanitizePostHogEvent,
   syncPostHogIdentity,
@@ -11,12 +16,13 @@ import {
 
 type TestPostHogClient = Pick<
   PostHog,
-  'capture' | 'identify' | 'init' | 'reset'
+  'capture' | 'get_property' | 'identify' | 'init' | 'reset'
 >
 
 function createClient(): jest.Mocked<TestPostHogClient> {
   return {
     capture: jest.fn(),
+    get_property: jest.fn(),
     identify: jest.fn(),
     init: jest.fn(),
     reset: jest.fn(),
@@ -46,7 +52,10 @@ function sessionFor(userId: string): Session {
       identities: [
         {
           provider: 'twitter',
-          identity_data: { user_name: 'archive_user' },
+          identity_data: {
+            user_name: 'archive_user',
+            full_name: 'Archive User',
+          },
         },
       ],
     },
@@ -54,7 +63,7 @@ function sessionFor(userId: string): Session {
 }
 
 describe('sanitizePostHogEvent', () => {
-  it('keeps only required SDK and event-specific aggregate properties', () => {
+  it('keeps page context while rejecting unexpected custom properties', () => {
     const event = captureResult('archive_search_submitted', {
       token: 'project-token',
       distinct_id: 'user-123',
@@ -62,6 +71,7 @@ describe('sanitizePostHogEvent', () => {
       active_filter_count: 2,
       $current_url: 'https://example.com/search?q=private-words',
       $session_entry_url: 'https://example.com/search?q=private-words',
+      utm_campaign: 'archive-launch',
       query: 'private-words',
       email: 'private@example.com',
     })
@@ -70,12 +80,15 @@ describe('sanitizePostHogEvent', () => {
       $geoip_disable: true,
       token: 'project-token',
       distinct_id: 'user-123',
+      $current_url: 'https://example.com/search?q=private-words',
+      $session_entry_url: 'https://example.com/search?q=private-words',
+      utm_campaign: 'archive-launch',
       has_query: true,
       active_filter_count: 2,
     })
   })
 
-  it('keeps only the public username on identify events', () => {
+  it('keeps the supported signed-in identity properties', () => {
     const event = {
       ...captureResult('$identify', {
         token: 'project-token',
@@ -85,7 +98,9 @@ describe('sanitizePostHogEvent', () => {
       }),
       $set: {
         username: 'archive_user',
-        email: 'private@example.com',
+        email: 'archive@example.com',
+        name: 'Archive User',
+        secret: 'not-a-person-property',
       },
       $set_once: {
         $initial_current_url: 'https://example.com/search?q=private-words',
@@ -99,9 +114,15 @@ describe('sanitizePostHogEvent', () => {
         distinct_id: 'user-123',
         $anon_distinct_id: 'anonymous-123',
       },
-      $set: { username: 'archive_user' },
+      $set: {
+        username: 'archive_user',
+        email: 'archive@example.com',
+        name: 'Archive User',
+      },
+      $set_once: {
+        $initial_current_url: 'https://example.com/search?q=private-words',
+      },
     })
-    expect(sanitizePostHogEvent(event)?.$set_once).toBeUndefined()
   })
 
   it('rejects out-of-schema values', () => {
@@ -120,47 +141,94 @@ describe('sanitizePostHogEvent', () => {
     expect(sanitizePostHogEvent(event)).toBeNull()
   })
 
-  it('drops an invalid identify username', () => {
+  it('drops invalid identify properties', () => {
     const event = {
       ...captureResult('$identify', {
         token: 'project-token',
         distinct_id: 'user-123',
       }),
-      $set: { username: 'not a valid X username' },
+      $set: {
+        username: 'not a valid X username',
+        email: 'not-an-email',
+        name: ' '.repeat(101),
+      },
     }
 
     expect(sanitizePostHogEvent(event)?.$set).toBeUndefined()
   })
 
-  it('rejects SDK-generated events that are not explicitly allowed', () => {
-    expect(sanitizePostHogEvent(captureResult('$pageview', {}))).toBeNull()
+  it('allows SDK-generated monitoring events and preserves their context', () => {
+    const pageview = captureResult('$pageview', {
+      $current_url: 'https://example.com/search?q=public-query',
+      $referrer: 'https://example.org/',
+    })
+
+    expect(sanitizePostHogEvent(pageview)?.properties).toEqual({
+      $current_url: 'https://example.com/search?q=public-query',
+      $referrer: 'https://example.org/',
+      $geoip_disable: true,
+    })
+  })
+
+  it('still rejects unknown custom product events', () => {
+    expect(sanitizePostHogEvent(captureResult('archive_text', {}))).toBeNull()
   })
 })
 
 describe('createPostHogConfig', () => {
-  it('disables passive collection, persistence, and remote features', () => {
+  it('enables full browser monitoring while retaining explicit safeguards', () => {
     expect(createPostHogConfig('https://analytics.example.com')).toMatchObject({
       api_host: 'https://analytics.example.com',
-      advanced_disable_flags: true,
-      autocapture: false,
-      capture_pageview: false,
-      capture_pageleave: false,
+      advanced_disable_flags: false,
+      advanced_disable_feature_flags: true,
+      autocapture: true,
+      capture_pageview: 'history_change',
+      capture_pageleave: 'if_capture_pageview',
       capture_dead_clicks: false,
-      capture_exceptions: false,
+      capture_exceptions: true,
       capture_heatmaps: false,
-      capture_performance: false,
+      capture_performance: {
+        network_timing: true,
+        web_vitals: true,
+        web_vitals_attribution: false,
+      },
       disable_conversations: true,
       disable_external_dependency_loading: true,
-      disable_persistence: true,
+      disable_persistence: false,
       disable_product_tours: true,
-      disable_session_recording: true,
+      disable_session_recording: false,
       disable_surveys: true,
       disable_web_experiments: true,
+      enable_recording_console_log: false,
       opt_in_site_apps: false,
+      persistence: 'localStorage+cookie',
       person_profiles: 'identified_only',
       respect_dnt: true,
-      save_campaign_params: false,
-      save_referrer: false,
+      save_campaign_params: true,
+      save_referrer: true,
+      session_recording: {
+        maskAllInputs: false,
+        maskInputOptions: { password: true },
+        recordBody: false,
+        recordHeaders: false,
+      },
+    })
+  })
+
+  it('passes selectively bundled extensions and the identity bootstrap hook', () => {
+    const extensionClasses = {} as NonNullable<
+      PostHogConfig['__extensionClasses']
+    >
+    const loaded = jest.fn()
+
+    expect(
+      createPostHogConfig('https://analytics.example.com', {
+        extensionClasses,
+        loaded,
+      }),
+    ).toMatchObject({
+      __extensionClasses: extensionClasses,
+      loaded,
     })
   })
 })
@@ -173,7 +241,7 @@ describe('initializePostHogClient', () => {
     expect(client.init).not.toHaveBeenCalled()
   })
 
-  it('initializes a configured client with the privacy-safe config', () => {
+  it('initializes a configured client with the full monitoring config', () => {
     const client = createClient()
 
     expect(
@@ -187,7 +255,8 @@ describe('initializePostHogClient', () => {
       'project-token',
       expect.objectContaining({
         api_host: 'https://analytics.example.com',
-        disable_persistence: true,
+        disable_persistence: false,
+        disable_session_recording: false,
       }),
     )
   })
@@ -215,10 +284,12 @@ describe('capturePostHogEventWithClient', () => {
     expect(
       capturePostHogEventWithClient(client, 'archive_search_submitted', {
         has_query: true,
+        active_filter_count: 0,
       }),
     ).toBe(true)
     expect(client.capture).toHaveBeenCalledWith('archive_search_submitted', {
       has_query: true,
+      active_filter_count: 0,
     })
   })
 
@@ -244,7 +315,12 @@ describe('capturePostHogEventWhenReady', () => {
       () => clientPromise,
       () => Promise.resolve(),
       'word_trend_requested',
-      { bucket: 'month' },
+      {
+        bucket: 'month',
+        match: 'all',
+        has_start_date: false,
+        has_end_date: false,
+      },
     )
     expect(client.capture).not.toHaveBeenCalled()
 
@@ -253,22 +329,27 @@ describe('capturePostHogEventWhenReady', () => {
     await expect(capturePromise).resolves.toBe(true)
     expect(client.capture).toHaveBeenCalledWith('word_trend_requested', {
       bucket: 'month',
+      match: 'all',
+      has_start_date: false,
+      has_end_date: false,
     })
   })
 
   it('waits for auth identity before sending a linked event', async () => {
     const client = createClient()
+    const loadClient = jest.fn(() => Promise.resolve(client))
     let resolveIdentity: () => void = () => undefined
     const identityPromise = new Promise<void>((resolve) => {
       resolveIdentity = resolve
     })
 
     const capturePromise = capturePostHogEventWhenReady(
-      () => Promise.resolve(client),
+      loadClient,
       () => identityPromise,
       'archive_deleted',
     )
     await Promise.resolve()
+    expect(loadClient).not.toHaveBeenCalled()
     expect(client.capture).not.toHaveBeenCalled()
 
     resolveIdentity()
@@ -281,14 +362,16 @@ describe('capturePostHogEventWhenReady', () => {
 describe('syncPostHogIdentity', () => {
   const identify = jest.fn()
   const reset = jest.fn()
-  const actions = { identify, reset }
+  const getPersistedUserId = jest.fn<ReturnType<() => string | null>, []>()
+  const actions = { identify, reset, getPersistedUserId }
 
   beforeEach(() => {
     identify.mockReset()
     reset.mockReset()
+    getPersistedUserId.mockReset().mockReturnValue(null)
   })
 
-  it('identifies an initial signed-in user by ID and public username', () => {
+  it('identifies an initial signed-in user with useful account context', () => {
     expect(
       syncPostHogIdentity(
         'INITIAL_SESSION',
@@ -297,8 +380,10 @@ describe('syncPostHogIdentity', () => {
         actions,
       ),
     ).toBe('user-123')
-    expect(reset).toHaveBeenCalledTimes(1)
+    expect(reset).not.toHaveBeenCalled()
     expect(identify).toHaveBeenCalledWith('user-123', {
+      email: 'user-123@example.com',
+      name: 'Archive User',
       username: 'archive_user',
     })
   })
@@ -315,6 +400,34 @@ describe('syncPostHogIdentity', () => {
     expect(reset).toHaveBeenCalledTimes(1)
   })
 
+  it('does not reset a matching persisted signed-in identity', () => {
+    getPersistedUserId.mockReturnValue('user-123')
+
+    expect(
+      syncPostHogIdentity(
+        'INITIAL_SESSION',
+        sessionFor('user-123'),
+        null,
+        actions,
+      ),
+    ).toBe('user-123')
+    expect(reset).not.toHaveBeenCalled()
+  })
+
+  it('resets a different persisted signed-in identity', () => {
+    getPersistedUserId.mockReturnValue('previous-user')
+
+    expect(
+      syncPostHogIdentity(
+        'INITIAL_SESSION',
+        sessionFor('user-123'),
+        null,
+        actions,
+      ),
+    ).toBe('user-123')
+    expect(reset).toHaveBeenCalledTimes(1)
+  })
+
   it('resets identity on sign-out', () => {
     expect(
       syncPostHogIdentity('SIGNED_OUT', null, 'user-123', actions),
@@ -328,5 +441,41 @@ describe('syncPostHogIdentity', () => {
     ).toBeNull()
     expect(reset).toHaveBeenCalledTimes(1)
     expect(identify).not.toHaveBeenCalled()
+  })
+
+  it('preserves an anonymous identity on an initial signed-out session', () => {
+    expect(
+      syncPostHogIdentity('INITIAL_SESSION', null, null, actions),
+    ).toBeNull()
+    expect(reset).not.toHaveBeenCalled()
+    expect(identify).not.toHaveBeenCalled()
+  })
+
+  it('clears a stale persisted signed-in identity', () => {
+    getPersistedUserId.mockReturnValue('previous-user')
+
+    expect(
+      syncPostHogIdentity('INITIAL_SESSION', null, null, actions),
+    ).toBeNull()
+    expect(reset).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('getPostHogPersonProperties', () => {
+  it('uses the authenticated email and trusted Twitter identity', () => {
+    expect(getPostHogPersonProperties(sessionFor('user-123').user)).toEqual({
+      email: 'user-123@example.com',
+      name: 'Archive User',
+      username: 'archive_user',
+    })
+  })
+
+  it('does not use mutable user metadata for identity', () => {
+    const session = sessionFor('user-123')
+    session.user.identities = []
+
+    expect(getPostHogPersonProperties(session.user)).toEqual({
+      email: 'user-123@example.com',
+    })
   })
 })

--- a/src/lib/posthog.ts
+++ b/src/lib/posthog.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import type { AuthChangeEvent, Session } from '@supabase/supabase-js'
+import type { AuthChangeEvent, Session, User } from '@supabase/supabase-js'
 import type {
   CaptureResult,
   PostHog,
@@ -9,7 +9,15 @@ import type {
 } from 'posthog-js/dist/module.slim'
 import { getSessionTwitterUsername } from '@/lib/sessionTwitterUsername'
 
-type PostHogClient = Pick<PostHog, 'capture' | 'identify' | 'init' | 'reset'>
+type PostHogClient = Pick<
+  PostHog,
+  'capture' | 'get_property' | 'identify' | 'init' | 'reset'
+>
+type PostHogExtensionClasses = NonNullable<PostHogConfig['__extensionClasses']>
+type PostHogInitializationOptions = {
+  extensionClasses?: PostHogExtensionClasses
+  loaded?: () => void
+}
 
 type SafeProperty = string | number | boolean
 type PropertyValidator = (value: unknown) => value is SafeProperty
@@ -65,7 +73,6 @@ const allowedEventProperties: Record<
     has_include_filter: isBoolean,
     has_exclude_filter: isBoolean,
   },
-  $identify: {},
 }
 
 const safeSdkProperties = new Set([
@@ -84,22 +91,7 @@ const safeSdkProperties = new Set([
   '$process_person_profile',
 ])
 
-const blockedAutoProperties = [
-  '$current_url',
-  '$pathname',
-  '$host',
-  '$referrer',
-  '$referring_domain',
-  '$session_entry_url',
-  '$session_entry_pathname',
-  '$session_entry_host',
-  '$session_entry_referrer',
-  '$session_entry_referring_domain',
-  '$initial_current_url',
-  '$initial_pathname',
-  '$initial_host',
-  '$initial_referrer',
-  '$initial_referring_domain',
+const campaignProperties = new Set([
   'utm_source',
   'utm_medium',
   'utm_campaign',
@@ -124,12 +116,23 @@ const blockedAutoProperties = [
   'sccid',
   'irclid',
   '_kx',
-]
+])
 
 const publicUsernamePattern = /^[A-Za-z0-9_]{1,15}$/
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+const isDisplayName = (value: unknown): value is string =>
+  typeof value === 'string' &&
+  value.trim().length > 0 &&
+  value.trim().length <= 100
+
+const isEmail = (value: unknown): value is string =>
+  typeof value === 'string' && value.length <= 320 && emailPattern.test(value)
 
 let posthogClient: PostHogClient | null = null
 let initializationPromise: Promise<PostHogClient | null> | null = null
+let postHogIdentifiedUserId: string | null = null
+let isPostHogBootstrapEnabled = true
 let isIdentityReady = false
 let resolveIdentityReady: () => void = () => undefined
 const identityReadyPromise = new Promise<void>((resolve) => {
@@ -142,21 +145,31 @@ export function sanitizePostHogEvent(
   if (!event) return null
 
   const eventProperties = allowedEventProperties[event.event]
-  if (!eventProperties) return null
+  const isSdkEvent = event.event.startsWith('$')
+  if (!eventProperties && !isSdkEvent) return null
 
-  for (const [key, validator] of Object.entries(eventProperties)) {
-    if (!validator(event.properties[key])) return null
+  if (eventProperties) {
+    for (const [key, validator] of Object.entries(eventProperties)) {
+      if (!validator(event.properties[key])) return null
+    }
   }
 
-  const properties: Properties = { $geoip_disable: true }
-  for (const [key, value] of Object.entries(event.properties)) {
-    const validator = eventProperties[key]
-    if (
-      (safeSdkProperties.has(key) && isSafeProperty(value)) ||
-      validator?.(value)
-    ) {
-      properties[key] = value
+  let properties: Properties
+  if (eventProperties) {
+    properties = { $geoip_disable: true }
+    for (const [key, value] of Object.entries(event.properties)) {
+      const validator = eventProperties[key]
+      if (
+        key.startsWith('$') ||
+        campaignProperties.has(key) ||
+        (safeSdkProperties.has(key) && isSafeProperty(value)) ||
+        validator?.(value)
+      ) {
+        properties[key] = value
+      }
     }
+  } else {
+    properties = { ...event.properties, $geoip_disable: true }
   }
 
   const sanitizedEvent: CaptureResult = {
@@ -164,60 +177,92 @@ export function sanitizePostHogEvent(
     properties,
   }
 
-  delete sanitizedEvent.$set_once
-  delete sanitizedEvent.$unset
-
   if (event.event === '$identify') {
+    const personProperties: Properties = {}
     const username = event.$set?.username
-    sanitizedEvent.$set =
-      typeof username === 'string' && publicUsernamePattern.test(username)
-        ? { username }
-        : undefined
-  } else {
-    delete sanitizedEvent.$set
+    const email = event.$set?.email
+    const name = event.$set?.name
+
+    if (typeof username === 'string' && publicUsernamePattern.test(username)) {
+      personProperties.username = username
+    }
+    if (isEmail(email)) personProperties.email = email
+    if (isDisplayName(name)) personProperties.name = name.trim()
+
+    sanitizedEvent.$set = Object.keys(personProperties).length
+      ? personProperties
+      : undefined
   }
 
   return sanitizedEvent
 }
 
-export function createPostHogConfig(apiHost: string): Partial<PostHogConfig> {
-  return {
+export function createPostHogConfig(
+  apiHost: string,
+  options: PostHogInitializationOptions = {},
+): Partial<PostHogConfig> {
+  const config: Partial<PostHogConfig> = {
     api_host: apiHost,
-    advanced_disable_flags: true,
-    autocapture: false,
+    defaults: '2026-06-25',
+    // Replay needs the remote recording configuration from /flags. Keep the
+    // configuration request while skipping actual feature-flag evaluation.
+    advanced_disable_flags: false,
+    advanced_disable_feature_flags: true,
+    autocapture: true,
     before_send: sanitizePostHogEvent,
-    capture_pageview: false,
-    capture_pageleave: false,
+    capture_pageview: 'history_change',
+    capture_pageleave: 'if_capture_pageview',
     capture_dead_clicks: false,
-    capture_exceptions: false,
+    capture_exceptions: true,
     capture_heatmaps: false,
-    capture_performance: false,
+    capture_performance: {
+      network_timing: true,
+      web_vitals: true,
+      web_vitals_attribution: false,
+    },
     disable_conversations: true,
     disable_external_dependency_loading: true,
-    disable_persistence: true,
+    disable_persistence: false,
     disable_product_tours: true,
-    disable_session_recording: true,
+    disable_session_recording: false,
     disable_surveys: true,
     disable_web_experiments: true,
+    enable_recording_console_log: false,
+    mask_all_element_attributes: false,
+    mask_all_text: false,
     opt_in_site_apps: false,
+    persistence: 'localStorage+cookie',
     person_profiles: 'identified_only',
-    property_denylist: blockedAutoProperties,
     respect_dnt: true,
-    save_campaign_params: false,
-    save_referrer: false,
+    save_campaign_params: true,
+    save_referrer: true,
+    session_recording: {
+      maskAllInputs: false,
+      maskInputOptions: { password: true },
+      recordBody: false,
+      recordHeaders: false,
+    },
     debug: process.env.NODE_ENV === 'development',
   }
+
+  if (options.extensionClasses) {
+    config.__extensionClasses = options.extensionClasses
+  }
+  if (options.loaded) config.loaded = options.loaded
+
+  return config
 }
 
 export function initializePostHogClient(
   client: PostHogClient,
   projectToken: string | undefined,
   posthogHost: string | undefined,
+  options: PostHogInitializationOptions = {},
 ): boolean {
   if (!projectToken || !posthogHost) return false
 
   try {
-    client.init(projectToken, createPostHogConfig(posthogHost))
+    client.init(projectToken, createPostHogConfig(posthogHost, options))
     return true
   } catch (error) {
     logPostHogError('initialization', error)
@@ -225,11 +270,21 @@ export function initializePostHogClient(
   }
 }
 
-export async function initializePostHog(): Promise<boolean> {
-  return Boolean(await loadPostHogClient())
+export async function initializePostHog(
+  initialSession: Session | null,
+): Promise<{ enabled: boolean; identifiedUserId: string | null }> {
+  const client = await loadPostHogClient(initialSession)
+  markPostHogIdentityReady()
+  return {
+    enabled: Boolean(client),
+    identifiedUserId: postHogIdentifiedUserId,
+  }
 }
 
-async function loadPostHogClient(): Promise<PostHogClient | null> {
+async function loadPostHogClient(
+  initialSession: Session | null = null,
+): Promise<PostHogClient | null> {
+  if (!isPostHogBootstrapEnabled) return null
   if (posthogClient) return posthogClient
 
   const projectToken = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN
@@ -237,9 +292,34 @@ async function loadPostHogClient(): Promise<PostHogClient | null> {
   if (!projectToken || !posthogHost) return null
 
   if (!initializationPromise) {
-    initializationPromise = import('posthog-js/dist/module.slim')
-      .then(({ default: client }) => {
-        if (!initializePostHogClient(client, projectToken, posthogHost)) {
+    initializationPromise = import('@/lib/posthogRuntime')
+      .then(({ default: client, postHogMonitoringExtensions }) => {
+        const identityActions: PostHogIdentityActions = {
+          identify: (userId, properties) => client.identify(userId, properties),
+          reset: () => client.reset(),
+          getPersistedUserId: () => {
+            const userId = client.get_property('$user_id')
+            return typeof userId === 'string' ? userId : null
+          },
+        }
+        const initialized = initializePostHogClient(
+          client,
+          projectToken,
+          posthogHost,
+          {
+            extensionClasses: postHogMonitoringExtensions,
+            loaded: () => {
+              postHogIdentifiedUserId = syncPostHogIdentity(
+                'INITIAL_SESSION',
+                initialSession,
+                postHogIdentifiedUserId,
+                identityActions,
+              )
+              markPostHogIdentityReady()
+            },
+          },
+        )
+        if (!initialized) {
           return null
         }
 
@@ -273,9 +353,9 @@ export async function capturePostHogEventWhenReady(
   eventName: string,
   properties?: Record<string, unknown>,
 ): Promise<boolean> {
+  await waitUntilIdentityReady()
   const client = await loadClient()
   if (!client) return false
-  await waitUntilIdentityReady()
   return capturePostHogEventWithClient(client, eventName, properties)
 }
 
@@ -283,6 +363,11 @@ export function markPostHogIdentityReady() {
   if (isIdentityReady) return
   isIdentityReady = true
   resolveIdentityReady()
+}
+
+export function disablePostHogAfterIdentityFailure() {
+  isPostHogBootstrapEnabled = false
+  markPostHogIdentityReady()
 }
 
 export function capturePostHogEventWithClient(
@@ -302,6 +387,7 @@ export function capturePostHogEventWithClient(
 type PostHogIdentityActions = {
   identify: (userId: string, properties: Record<string, unknown>) => void
   reset: () => void
+  getPersistedUserId?: () => string | null
 }
 
 const postHogIdentityActions: PostHogIdentityActions = {
@@ -321,6 +407,10 @@ const postHogIdentityActions: PostHogIdentityActions = {
       logPostHogError('identity reset', error)
     }
   },
+  getPersistedUserId: () => {
+    const userId = posthogClient?.get_property('$user_id')
+    return typeof userId === 'string' ? userId : null
+  },
 }
 
 export function syncPostHogIdentity(
@@ -330,9 +420,15 @@ export function syncPostHogIdentity(
   actions: PostHogIdentityActions = postHogIdentityActions,
 ): string | null {
   const user = session?.user
+  const persistedUserId = actions.getPersistedUserId?.() ?? identifiedUserId
 
-  if (event === 'SIGNED_OUT' || (event === 'INITIAL_SESSION' && !user)) {
+  if (event === 'SIGNED_OUT') {
     actions.reset()
+    return null
+  }
+
+  if (event === 'INITIAL_SESSION' && !user) {
+    if (persistedUserId) actions.reset()
     return null
   }
 
@@ -340,14 +436,42 @@ export function syncPostHogIdentity(
     return identifiedUserId
   }
 
-  if (event === 'INITIAL_SESSION' || identifiedUserId !== user.id) {
+  if (persistedUserId && persistedUserId !== user.id) {
     actions.reset()
   }
 
-  const username = getSessionTwitterUsername(user) ?? undefined
-
-  actions.identify(user.id, { username })
+  actions.identify(user.id, getPostHogPersonProperties(user))
   return user.id
+}
+
+export function getPostHogPersonProperties(user: User): Record<string, string> {
+  const properties: Record<string, string> = {}
+  const username = getSessionTwitterUsername(user)
+  const displayName = getTwitterDisplayName(user)
+
+  if (username) properties.username = username
+  if (isEmail(user.email)) properties.email = user.email
+  if (displayName) properties.name = displayName
+
+  return properties
+}
+
+function getTwitterDisplayName(user: User): string | null {
+  const identity =
+    user.identities?.find((item) =>
+      ['twitter', 'x'].includes(item.provider ?? ''),
+    ) ?? null
+  const identityData = (identity?.identity_data ?? {}) as Record<
+    string,
+    unknown
+  >
+
+  for (const key of ['full_name', 'name']) {
+    const value = identityData[key]
+    if (isDisplayName(value)) return value.trim()
+  }
+
+  return null
 }
 
 function logPostHogError(action: string, error: unknown) {

--- a/src/lib/posthogProvider.test.tsx
+++ b/src/lib/posthogProvider.test.tsx
@@ -1,0 +1,52 @@
+/** @jest-environment jsdom */
+
+import { render, waitFor } from '@testing-library/react'
+import React from 'react'
+import PostHogProvider from '@/providers/PostHogProvider'
+
+const mockGetSession = jest.fn()
+const mockOnAuthStateChange = jest.fn()
+const mockInitializePostHog = jest.fn()
+const mockDisablePostHogAfterIdentityFailure = jest.fn()
+
+jest.mock('@/utils/supabase', () => ({
+  createBrowserClient: () => ({
+    auth: {
+      getSession: mockGetSession,
+      onAuthStateChange: mockOnAuthStateChange,
+    },
+  }),
+}))
+
+jest.mock('@/lib/posthog', () => ({
+  disablePostHogAfterIdentityFailure: () =>
+    mockDisablePostHogAfterIdentityFailure(),
+  initializePostHog: (...args: unknown[]) => mockInitializePostHog(...args),
+  markPostHogIdentityReady: jest.fn(),
+  syncPostHogIdentity: jest.fn(),
+}))
+
+describe('PostHogProvider', () => {
+  beforeEach(() => {
+    mockGetSession.mockReset()
+    mockOnAuthStateChange.mockReset()
+    mockInitializePostHog.mockReset()
+    mockDisablePostHogAfterIdentityFailure.mockReset()
+  })
+
+  it('fails closed and resolves analytics readiness when auth bootstrap fails', async () => {
+    mockGetSession.mockRejectedValue(new Error('auth unavailable'))
+
+    render(
+      <PostHogProvider>
+        <div>content</div>
+      </PostHogProvider>,
+    )
+
+    await waitFor(() => {
+      expect(mockDisablePostHogAfterIdentityFailure).toHaveBeenCalledTimes(1)
+    })
+    expect(mockInitializePostHog).not.toHaveBeenCalled()
+    expect(mockOnAuthStateChange).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/posthogRuntime.ts
+++ b/src/lib/posthogRuntime.ts
@@ -1,0 +1,22 @@
+'use client'
+
+import posthog from 'posthog-js/dist/module.slim'
+import {
+  AnalyticsExtensions,
+  ErrorTrackingExtensions,
+  SessionReplayExtensions,
+} from 'posthog-js/dist/extension-bundles'
+import type { PostHogConfig } from 'posthog-js/dist/module.slim'
+import 'posthog-js/dist/exception-autocapture'
+import 'posthog-js/dist/posthog-recorder'
+import 'posthog-js/dist/web-vitals'
+
+export const postHogMonitoringExtensions: NonNullable<
+  PostHogConfig['__extensionClasses']
+> = {
+  ...AnalyticsExtensions,
+  ...ErrorTrackingExtensions,
+  ...SessionReplayExtensions,
+}
+
+export default posthog

--- a/src/providers/PostHogProvider.tsx
+++ b/src/providers/PostHogProvider.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from 'react'
 import {
+  disablePostHogAfterIdentityFailure,
   initializePostHog,
   markPostHogIdentityReady,
   syncPostHogIdentity,
@@ -19,11 +20,18 @@ export default function PostHogProvider({
     let unsubscribe: (() => void) | undefined
 
     const connectIdentity = async () => {
-      if (!(await initializePostHog()) || !isActive) return
-
       const { createBrowserClient } = await import('@/utils/supabase')
       if (!isActive) return
       const supabase = createBrowserClient()
+      const {
+        data: { session: initialSession },
+      } = await supabase.auth.getSession()
+      if (!isActive) return
+
+      const initialization = await initializePostHog(initialSession)
+      if (!isActive || !initialization.enabled) return
+      identifiedUserId.current = initialization.identifiedUserId
+
       const {
         data: { subscription },
       } = supabase.auth.onAuthStateChange((event, session) => {
@@ -45,6 +53,8 @@ export default function PostHogProvider({
     }
 
     void connectIdentity().catch((error) => {
+      if (!isActive) return
+      disablePostHogAfterIdentityFailure()
       if (process.env.NODE_ENV === 'development') {
         console.warn('PostHog identity setup failed', error)
       }


### PR DESCRIPTION
## Summary

Follow-up to #448. This enables the full PostHog browser monitoring scope requested after the original privacy-bounded integration landed.

- Loads a selectively bundled PostHog runtime asynchronously after hydration.
- Enables initial and client-side pageviews, pageleave, autocapture, session replay, unhandled browser errors, aggregate Web Vitals, network timing, referrer/campaign attribution, and the nine explicit product events from #448.
- Identifies signed-in activity with the stable Supabase account ID, authenticated email, trusted public Twitter/X username, and trusted public display name.
- Reconciles persisted PostHog identity with Supabase in the SDK loaded hook before the delayed initial pageview. Anonymous device/session identity remains stable across reloads; stale signed-in identity is reset.
- Fails closed if Supabase identity bootstrap fails, so queued manual events resolve as dropped without initializing under a potentially stale identity.
- Keeps the initial shared JavaScript bundle effectively unchanged by deferring the monitoring runtime.

## Replay and data boundaries

- Replay captures rendered page content, interactions, and non-password form values.
- Passwords stay masked.
- Console recording is pinned off, and the PostHog Logs extension is not installed.
- Network request/response headers and bodies are not recorded.
- The contents of a locally selected archive ZIP are not sent through replay.
- Page URLs and search parameters, browser/device context, errors, performance data, public archive content rendered on the page, and the signed-in identity fields above are intentionally in scope.
- Do Not Track is honored and GeoIP enrichment is disabled.
- The public data policy and local setup guide now describe the expanded behavior and deletion boundary.

## Validation

- `pnpm lint`
- `pnpm type-check`
- Server/library Jest suite: 19/19 suites, 97/97 tests
- PostHog plus provider bootstrap regression suites: 26/26 tests
- Production Next.js build
- Real headed-browser smoke test against a local PostHog endpoint:
  - remote config loaded
  - `/e/` monitoring events emitted
  - `/s/` replay snapshots emitted
  - recorder initializer present
  - replay/Web Vitals state persisted
  - anonymous device and session IDs stable across full reloads
  - no PostHog runtime console errors
- Initial shared JavaScript remains about 87.6 kB; the monitoring runtime is deferred and split into async chunks.

## Environment

The existing Preview and Production values from #448 are reused:

- `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN`
- `NEXT_PUBLIC_POSTHOG_HOST`
