### PR TITLE
fix: make missing-account copy more conversational

### DIFF
--- a/src/app/missing-accounts/page.tsx
+++ b/src/app/missing-accounts/page.tsx
@@ -17,7 +17,7 @@ export const dynamic = 'force-dynamic'
 export const metadata: Metadata = {
   title: 'Missing accounts | Community Archive',
   description:
-    'The most-replied-to accounts that still need to opt in or upload their Twitter archive.',
+    'See the accounts mentioned most often in the Community Archive that have not opted in or uploaded their archive yet.',
 }
 
 type View = 'opt-in' | 'archive'
@@ -115,7 +115,7 @@ function AccountRanking({
       <div className="overflow-x-auto">
         <table className="w-full min-w-[520px] border-collapse text-left">
           <caption className="sr-only">
-            Accounts ranked by unique archived tweets that reply to them
+            Accounts ordered by how often archived posts reply to them
           </caption>
           <thead className="bg-muted text-xs uppercase tracking-wide text-muted-foreground">
             <tr>
@@ -209,11 +209,16 @@ export default async function MissingAccountsPage({
   }
 
   const accounts = view === 'archive' ? needsArchive : needsOptIn
-  const title = view === 'archive' ? 'Needs an archive' : 'Needs to opt in'
+  const title =
+    view === 'archive' ? 'Opted in, no archive yet' : 'Not opted in yet'
+  const introduction =
+    view === 'archive'
+      ? 'These are the opted-in accounts mentioned most often in the Community Archive that haven’t uploaded an archive yet.'
+      : 'These are the accounts mentioned most often in the Community Archive that haven’t opted in yet.'
   const description =
     view === 'archive'
-      ? 'These accounts opted into live collection, but their older posts are still missing. Uploading an X archive fills in the years before they opted in.'
-      : 'These accounts have neither opted into live collection nor uploaded an archive. Opting in is the first step toward preserving their posts.'
+      ? 'Uploading their X archive would bring in the older posts from before they opted in.'
+      : 'Opting in would let the community start preserving their new public posts.'
 
   return (
     <main className="min-h-screen bg-background py-12 md:py-16">
@@ -227,8 +232,7 @@ export default async function MissingAccountsPage({
             Who should join next?
           </h1>
           <p className="mt-4 text-base leading-7 text-muted-foreground sm:text-lg">
-            The accounts most often replied to by posts already in the Community
-            Archive. Help close the biggest gaps first.
+            {introduction}
           </p>
         </div>
 
@@ -240,14 +244,14 @@ export default async function MissingAccountsPage({
             href="/missing-accounts"
             active={view === 'opt-in'}
             icon={<Radio aria-hidden="true" className="h-4 w-4" />}
-            label="Needs opt-in"
+            label="Not opted in"
             count={needsOptIn.length}
           />
           <ViewTab
             href="/missing-accounts?view=archive"
             active={view === 'archive'}
             icon={<Archive aria-hidden="true" className="h-4 w-4" />}
-            label="Needs archive"
+            label="No archive yet"
             count={needsArchive.length}
           />
         </nav>
@@ -267,7 +271,7 @@ export default async function MissingAccountsPage({
             </div>
             <div className="flex shrink-0 items-center gap-2 text-xs text-muted-foreground">
               <MessageCircle aria-hidden="true" className="h-4 w-4" />
-              Ranked by unique reply posts
+              Most replied to first
             </div>
           </div>
 

--- a/src/lib/missingAccountsPage.test.tsx
+++ b/src/lib/missingAccountsPage.test.tsx
@@ -1,0 +1,99 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import React from 'react'
+
+import MissingAccountsPage, { metadata } from '@/app/missing-accounts/page'
+import {
+  getMissingAccounts,
+  type MissingAccountsResponse,
+} from '@/lib/missingAccounts'
+
+jest.mock('@/lib/missingAccounts', () => ({
+  getMissingAccounts: jest.fn(),
+}))
+
+Object.defineProperty(globalThis, 'React', { value: React })
+
+const getMissingAccountsMock = getMissingAccounts as jest.MockedFunction<
+  typeof getMissingAccounts
+>
+
+const response: MissingAccountsResponse = {
+  data: {
+    needsOptIn: [
+      {
+        rank: 1,
+        accountId: '1',
+        username: 'deepfates',
+        displayName: 'deepfates',
+        avatarUrl: null,
+        referenceCount: '19558',
+        mentionCount: '0',
+        replyCount: '19558',
+      },
+    ],
+    needsArchive: [
+      {
+        rank: 1,
+        accountId: '2',
+        username: 'tszzl',
+        displayName: 'roon',
+        avatarUrl: null,
+        referenceCount: '18024',
+        mentionCount: '0',
+        replyCount: '18024',
+      },
+    ],
+  },
+  query: {
+    limit: 100,
+    countMode: 'unique_reply_tweets',
+    includesMentions: false,
+    includesReplies: true,
+  },
+  generatedAt: '2026-08-07T00:00:00.000Z',
+  timing: {
+    wallMs: 1,
+    clickhouseMs: 1,
+    rowsRead: 1,
+    bytesRead: 1,
+  },
+}
+
+beforeEach(() => {
+  getMissingAccountsMock.mockResolvedValue(response)
+})
+
+test('uses the same plain-language framing in page metadata', () => {
+  expect(metadata.description).toBe(
+    'See the accounts mentioned most often in the Community Archive that have not opted in or uploaded their archive yet.',
+  )
+})
+
+test('explains the not-opted-in view in plain language', async () => {
+  const html = renderToStaticMarkup(
+    await MissingAccountsPage({ searchParams: {} }),
+  )
+
+  expect(html).toContain(
+    'These are the accounts mentioned most often in the Community Archive that haven’t opted in yet.',
+  )
+  expect(html).toContain('Not opted in yet')
+  expect(html).toContain('Not opted in')
+  expect(html).toContain('Most replied to first')
+  expect(html).not.toMatch(/needs? to opt in/i)
+  expect(html).not.toContain('Needs opt-in')
+})
+
+test('uses the same conversational framing for the archive view', async () => {
+  const html = renderToStaticMarkup(
+    await MissingAccountsPage({ searchParams: { view: 'archive' } }),
+  )
+
+  expect(html).toContain(
+    'These are the opted-in accounts mentioned most often in the Community Archive that haven’t uploaded an archive yet.',
+  )
+  expect(html).toContain('Opted in, no archive yet')
+  expect(html).toContain('No archive yet')
+  expect(html).not.toMatch(/needs? an archive/i)
+  expect(html).not.toContain('Needs archive')
+})


### PR DESCRIPTION
## Summary

- explain the default ranking as the accounts mentioned most often in the Community Archive that have not opted in yet
- replace “Needs opt-in” / “Needs archive” with “Not opted in” / “No archive yet”
- keep the underlying ranking clear with “Most replied to first”
- add server-rendered coverage for metadata and both page views

No ClickHouse query or response contract changed in this PR.

## Test Coverage

- 3 copy-rendering paths covered: metadata, not-opted-in view, and archive view
- existing missing-accounts query contract test also passes
- Tests: 34 → 35 test files (+1)

## Pre-Landing Review

- Added direct coverage for the changed metadata description.
- “Mentioned most often” is intentional product language requested for this page; the adjacent “Most replied to first” label still discloses the reply-based ordering.
- No remaining actionable findings.

## Design Review

Design Review (lite): no issues found. No layout or styling changed.

## Verification Results

- [x] Focused missing-accounts tests: 4 passed
- [x] Server unit suite: 111 passed
- [x] TypeScript: passed
- [x] Prettier: passed
- [x] Next.js production build: passed

The full unscoped Jest command also attempts environment-dependent database suites and the currently broken client Jest setup. Those unrelated checks fail because database credentials are absent and the existing jsdom resolver cannot load `msw/node`.

## Plan Completion

No plan file detected.

## Test plan

- [x] Default view avoids “needs to opt in” and “Needs opt-in”
- [x] Archive view avoids “needs an archive” and “Needs archive”
- [x] Both views preserve reply-ordering disclosure
- [x] Page metadata uses the same conversational framing
