### PR TITLE
Fix Open Collective backer layout

### DIFF
--- a/src/components/TieredSupportersDisplay.tsx
+++ b/src/components/TieredSupportersDisplay.tsx
@@ -65,7 +65,7 @@ const TieredSupportersDisplay: React.FC<TieredSupportersDisplayProps> = ({
       {/* Top Row: Money, Icons, Count */}
       <div className="grid w-full max-w-3xl grid-cols-1 items-center gap-x-6 gap-y-4 md:grid-cols-3">
         {/* Column 1: Money Raised */}
-        <div className="order-1 flex h-full flex-col items-center justify-center text-center">
+        <div className="order-1 flex flex-col items-center justify-center text-center">
           <div>
             <p className="text-2xl font-bold text-brand lg:text-3xl">
               ${formatNumber(totalAmountRaised)}
@@ -75,7 +75,7 @@ const TieredSupportersDisplay: React.FC<TieredSupportersDisplayProps> = ({
         </div>
 
         {/* Column 2: Image Stack (Centered) */}
-        <div className="order-3 mt-4 flex h-full flex-col items-center justify-center md:order-2 md:mt-0">
+        <div className="order-3 mt-4 flex flex-col items-center justify-center md:order-2 md:mt-0">
           {imageStack.length > 0 && (
             <div className="relative h-24 w-full min-w-[240px] md:h-28">
               {imageStack.map((contributor, index) => {
@@ -125,7 +125,7 @@ const TieredSupportersDisplay: React.FC<TieredSupportersDisplayProps> = ({
         </div>
 
         {/* Column 3: Supporter Count */}
-        <div className="order-2 flex h-full flex-col items-center justify-center text-center md:order-3">
+        <div className="order-2 flex flex-col items-center justify-center text-center md:order-3">
           <div>
             <p className="text-2xl font-bold text-brand lg:text-3xl">
               {formatNumber(totalSupportersCount)}


### PR DESCRIPTION
## What changed

- Removed percentage-height utilities from the three Open Collective metrics columns.
- Kept the existing grid alignment and responsive ordering intact.

## Why

The columns used `h-full` inside an auto-height CSS grid. That creates circular percentage sizing and can make the metrics row inherit an ancestor-sized height, pushing the raised total, avatar stack, and supporter count outside the supporters card. Letting the grid items use their intrinsic height keeps the full Open Collective block contained.

## Impact

The raised amount, supporter avatars, supporter count, and supporter names now remain grouped inside the supporters card at desktop and responsive widths.

## Validation

- `./node_modules/.bin/prettier --check src/components/TieredSupportersDisplay.tsx`
- `./node_modules/.bin/tsc --pretty --noEmit`
- `git diff --check`

Fixes #450
