### PR TITLE
Make search results compact

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -47,6 +47,8 @@ function SearchPageContent() {
     replyToUsername: normalizedSearchParams.get('replyToUser') || undefined,
     startDate: normalizedSearchParams.get('sinceDate') || undefined,
     endDate: normalizedSearchParams.get('untilDate') || undefined,
+    excludeRetweets: true,
+    includeQuoteTweets: true,
   }
 
   const tweetListKey = normalizedSearchParams.toString()

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -57,23 +57,37 @@ function SearchPageContent() {
 
   return (
     <main className="min-h-screen bg-background">
-      <section className="mx-auto w-full max-w-5xl px-4 py-10 sm:px-6 sm:py-14 lg:px-8">
-        <div className="mb-8 max-w-2xl">
-          <div className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.16em] text-brand">
+      <section className="mx-auto w-full max-w-[1500px] px-4 py-6 sm:px-6 sm:py-8 lg:px-8">
+        <div className={hasSearch ? 'mb-4' : 'mb-8 max-w-2xl'}>
+          <div
+            className={`flex items-center gap-2 font-semibold uppercase tracking-[0.16em] text-brand ${
+              hasSearch ? 'mb-1 text-xs' : 'mb-3 text-sm'
+            }`}
+          >
             <Search className="h-4 w-4" />
             Archive search
           </div>
-          <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
+          <h1
+            className={`font-bold tracking-tight text-foreground ${
+              hasSearch ? 'text-2xl sm:text-3xl' : 'text-4xl sm:text-5xl'
+            }`}
+          >
             Search the archive
           </h1>
-          <p className="mt-3 text-base leading-7 text-muted-foreground sm:text-lg">
+          <p
+            className={`text-muted-foreground ${
+              hasSearch
+                ? 'mt-1 text-sm leading-5'
+                : 'mt-3 text-base leading-7 sm:text-lg'
+            }`}
+          >
             Find public conversations by keyword, author, reply, or date.
           </p>
         </div>
 
         <AdvancedSearchForm />
 
-        <div className="mt-10">
+        <div className={hasSearch ? 'mt-5' : 'mt-10'}>
           {hasSearch ? (
             <TweetList
               key={tweetListKey}
@@ -81,6 +95,7 @@ function SearchPageContent() {
               resultsHeading="Search results"
               resultsDescription={searchDescription}
               collapseLongTweets
+              compact
             />
           ) : (
             <div className="rounded-xl border border-dashed border-border bg-card px-6 py-10 text-center sm:px-10">

--- a/src/components/AdvancedSearchForm.tsx
+++ b/src/components/AdvancedSearchForm.tsx
@@ -94,40 +94,39 @@ export default function AdvancedSearchForm() {
   return (
     <form
       onSubmit={handleSubmit}
-      className="rounded-xl border border-border bg-card p-4 shadow-sm sm:p-6"
+      className="rounded-xl border border-border bg-card p-3 shadow-sm sm:p-4"
     >
       <Label htmlFor="main-search" className="sr-only">
         Search the archive
       </Label>
-      <div className="flex flex-col gap-3 sm:flex-row">
+      <div className="flex flex-col gap-2.5 sm:flex-row">
         <div className="relative flex-1">
-          <Search className="absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />
+          <Search className="absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <UserSearchInput
             id="main-search"
             value={query}
             onValueChange={setQuery}
             placeholder="Search words, phrases, or from:username"
-            className="h-12 rounded-lg bg-background pl-12 pr-4 text-base"
+            className="h-10 rounded-lg bg-background pl-10 pr-4 text-sm"
             autoComplete="off"
           />
         </div>
         <Button
           type="submit"
-          size="lg"
-          className="h-12 bg-green-600 px-7 text-white hover:bg-green-700 dark:bg-green-400 dark:text-green-950 dark:hover:bg-green-300"
+          className="h-10 bg-green-600 px-6 text-white hover:bg-green-700 dark:bg-green-400 dark:text-green-950 dark:hover:bg-green-300"
         >
           <Search className="mr-2 h-4 w-4" />
           Search
         </Button>
       </div>
 
-      <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+      <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
         <Button
           type="button"
           variant="ghost"
           size="sm"
           onClick={() => setShowAdvancedOptions(!showAdvancedOptions)}
-          className="-ml-3 text-muted-foreground hover:text-foreground"
+          className="-ml-2 h-8 text-muted-foreground hover:text-foreground"
           aria-expanded={showAdvancedOptions}
         >
           <SlidersHorizontal className="mr-2 h-4 w-4" />
@@ -163,7 +162,7 @@ export default function AdvancedSearchForm() {
       </div>
 
       {showAdvancedOptions && (
-        <div className="mt-4 grid gap-4 border-t border-border pt-5 sm:grid-cols-2">
+        <div className="mt-3 grid gap-3 border-t border-border pt-4 sm:grid-cols-2 lg:grid-cols-4">
           <div className="space-y-2">
             <Label htmlFor="from-user">From user</Label>
             <Input

--- a/src/components/TweetComponent.tsx
+++ b/src/components/TweetComponent.tsx
@@ -2,7 +2,14 @@
 
 import React from 'react'
 import { formatDistanceToNow } from 'date-fns'
-import { FaHeart, FaRetweet, FaExternalLinkAlt, FaReply } from 'react-icons/fa'
+import {
+  FaHeart,
+  FaRetweet,
+  FaExternalLinkAlt,
+  FaReply,
+  FaTwitter,
+} from 'react-icons/fa'
+import { Archive } from 'lucide-react'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { formatNumber } from '@/lib/formatNumber'
 import NextImage from 'next/image'
@@ -88,7 +95,10 @@ interface TweetComponentProps {
 }
 
 export const compactTweetGridClass =
-  'grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-3 gap-y-2 px-3 py-3 sm:px-4 md:grid-cols-[minmax(190px,0.95fr)_minmax(300px,2.6fr)_6.5rem_6rem_4.5rem] md:gap-x-4'
+  'grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-3 gap-y-2 px-3 py-3 sm:px-4 md:grid-cols-[minmax(190px,0.95fr)_minmax(300px,2.6fr)_6.5rem_6rem_10rem] md:gap-x-4'
+
+const compactActionClass =
+  'inline-flex h-7 items-center gap-1.5 rounded-md border px-2 text-[11px] font-semibold leading-none transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
 
 // Helper function to decode HTML entities
 const decodeHtmlEntities = (text: string): string => {
@@ -424,6 +434,35 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
     )
   }
 
+  const renderCompactActions = () => (
+    <div
+      className="inline-flex items-center gap-1.5"
+      role="group"
+      aria-label="Tweet links"
+    >
+      <a
+        href={`/tweets/${tweet.tweet_id}`}
+        className={`${compactActionClass} border-brand/30 bg-brand/10 text-brand hover:bg-brand/20`}
+        aria-label="View tweet in Community Archive"
+        title="View tweet in Community Archive"
+      >
+        <Archive className="h-3.5 w-3.5" aria-hidden="true" />
+        Archive
+      </a>
+      <a
+        href={`https://twitter.com/${displayUsername}/status/${tweet.tweet_id}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={`${compactActionClass} border-sky-300/70 bg-sky-50 text-sky-700 hover:bg-sky-100 dark:border-sky-800 dark:bg-sky-950/40 dark:text-sky-300 dark:hover:bg-sky-950/70`}
+        aria-label="View original tweet on Twitter"
+        title="View original tweet on Twitter"
+      >
+        <FaTwitter className="h-3.5 w-3.5" aria-hidden="true" />
+        Twitter
+      </a>
+    </div>
+  )
+
   if (compact) {
     const createdAt = new Date(tweet.created_at)
     const formattedDate = createdAt.toLocaleDateString(undefined, {
@@ -512,26 +551,7 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
               <span className="sr-only">reposts</span>
             </span>
           </span>
-          <span className="flex items-center gap-3 text-muted-foreground">
-            <a
-              href={`/tweets/${tweet.tweet_id}`}
-              className="rounded p-1 transition-colors hover:bg-accent hover:text-foreground"
-              title="Open archived tweet"
-            >
-              <FaExternalLinkAlt className="h-3.5 w-3.5" aria-hidden="true" />
-              <span className="sr-only">Open archived tweet</span>
-            </a>
-            <a
-              href={`https://twitter.com/${displayUsername}/status/${tweet.tweet_id}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="rounded p-1 transition-colors hover:bg-accent hover:text-foreground"
-              title="Open tweet on Twitter"
-            >
-              <FaExternalLinkAlt className="h-3.5 w-3.5" aria-hidden="true" />
-              <span className="sr-only">Open tweet on Twitter</span>
-            </a>
-          </span>
+          {renderCompactActions()}
         </div>
 
         <div
@@ -560,26 +580,9 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
 
         <div
           role="cell"
-          className="hidden items-center justify-end gap-3 self-center text-muted-foreground md:flex"
+          className="hidden items-center justify-end self-center md:flex"
         >
-          <a
-            href={`/tweets/${tweet.tweet_id}`}
-            className="rounded p-1 transition-colors hover:bg-accent hover:text-foreground"
-            title="Open archived tweet"
-          >
-            <FaExternalLinkAlt className="h-3.5 w-3.5" aria-hidden="true" />
-            <span className="sr-only">Open archived tweet</span>
-          </a>
-          <a
-            href={`https://twitter.com/${displayUsername}/status/${tweet.tweet_id}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="rounded p-1 transition-colors hover:bg-accent hover:text-foreground"
-            title="Open tweet on Twitter"
-          >
-            <FaExternalLinkAlt className="h-3.5 w-3.5" aria-hidden="true" />
-            <span className="sr-only">Open tweet on Twitter</span>
-          </a>
+          {renderCompactActions()}
         </div>
       </div>
     )

--- a/src/components/TweetComponent.tsx
+++ b/src/components/TweetComponent.tsx
@@ -84,7 +84,11 @@ interface TweetComponentProps {
   tweet: TweetData
   className?: string
   collapseLongText?: boolean
+  compact?: boolean
 }
+
+export const compactTweetGridClass =
+  'grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-3 gap-y-2 px-3 py-3 sm:px-4 md:grid-cols-[minmax(190px,0.95fr)_minmax(300px,2.6fr)_6.5rem_6rem_4.5rem] md:gap-x-4'
 
 // Helper function to decode HTML entities
 const decodeHtmlEntities = (text: string): string => {
@@ -109,6 +113,7 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
   tweet,
   className = '',
   collapseLongText = false,
+  compact = false,
 }) => {
   const [isTextExpanded, setIsTextExpanded] = React.useState(false)
   // Support both interface formats for backwards compatibility
@@ -124,7 +129,8 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
 
   const isRetweet = !!tweet.retweeted_tweet_id
   const isQuoteTweet = !!tweet.quote_tweet_id
-  const canCollapseText = collapseLongText && tweet.full_text.length > 700
+  const canCollapseText =
+    collapseLongText && tweet.full_text.length > (compact ? 180 : 700)
 
   // Check if this is a retweet that starts with "RT @username"
   const rtMatch = tweet.full_text.match(/^RT @([A-Za-z0-9_]+):/)
@@ -361,6 +367,176 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
               </div>
             </div>
           </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (compact) {
+    const mediaCount = tweet.media?.length ?? 0
+    const createdAt = new Date(tweet.created_at)
+    const formattedDate = createdAt.toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    })
+
+    return (
+      <div className={`${compactTweetGridClass} ${className}`}>
+        <div
+          role="cell"
+          className="col-span-2 flex min-w-0 items-center gap-2.5 md:col-span-1"
+        >
+          <Avatar className="h-8 w-8 flex-shrink-0">
+            <TweetAvatarImage
+              src={profilePicUrl}
+              alt={`${displayName}'s profile picture`}
+              username={displayUsername}
+              tweetId={tweet.retweeted_tweet_id || tweet.tweet_id}
+            />
+            <AvatarFallback className="text-xs">
+              {displayName?.charAt(0) || displayUsername?.charAt(0) || 'U'}
+            </AvatarFallback>
+          </Avatar>
+          <div className="min-w-0 leading-tight">
+            <div className="truncate text-sm font-semibold text-foreground">
+              {displayName}
+            </div>
+            <div className="truncate text-xs text-muted-foreground">
+              @{displayUsername}
+            </div>
+            {(isRetweet || isRtFormat) && (
+              <div className="mt-1 flex items-center truncate text-[11px] text-muted-foreground">
+                <FaRetweet className="mr-1 flex-shrink-0" />@{originalUsername}{' '}
+                retweeted
+              </div>
+            )}
+            {replyToUsername && (
+              <div className="mt-1 flex items-center truncate text-[11px] text-muted-foreground">
+                <FaReply className="mr-1 flex-shrink-0" />
+                Replying to @{replyToUsername}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div role="cell" className="col-span-2 min-w-0 md:col-span-1">
+          <p
+            className={`whitespace-pre-wrap break-words text-sm leading-5 text-foreground ${
+              canCollapseText && !isTextExpanded ? 'line-clamp-2' : ''
+            }`}
+          >
+            {formatText(tweet.full_text)}
+          </p>
+          <div className="mt-1.5 flex flex-wrap items-center gap-2">
+            {canCollapseText && (
+              <button
+                type="button"
+                onClick={() => setIsTextExpanded((expanded) => !expanded)}
+                className="text-xs font-medium text-brand hover:underline"
+              >
+                {isTextExpanded ? 'Show less' : 'Show more'}
+              </button>
+            )}
+            {mediaCount > 0 && (
+              <span className="rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+                {mediaCount} {mediaCount === 1 ? 'media item' : 'media items'}
+              </span>
+            )}
+            {isQuoteTweet && (
+              <span className="rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+                Quoted tweet
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div
+          role="cell"
+          className="col-span-2 flex items-center justify-between text-xs text-muted-foreground md:hidden"
+          title={createdAt.toLocaleString()}
+        >
+          <span>{formatDistanceToNow(createdAt, { addSuffix: true })}</span>
+          <span className="flex items-center gap-3">
+            <span className="inline-flex items-center gap-1">
+              <FaHeart aria-hidden="true" />
+              {formatNumber(tweet.favorite_count)}
+              <span className="sr-only">likes</span>
+            </span>
+            <span className="inline-flex items-center gap-1">
+              <FaRetweet aria-hidden="true" />
+              {formatNumber(tweet.retweet_count ?? 0)}
+              <span className="sr-only">reposts</span>
+            </span>
+          </span>
+          <span className="flex items-center gap-3 text-muted-foreground">
+            <a
+              href={`/tweets/${tweet.tweet_id}`}
+              className="rounded p-1 transition-colors hover:bg-accent hover:text-foreground"
+              title="Open archived tweet"
+            >
+              <FaExternalLinkAlt className="h-3.5 w-3.5" aria-hidden="true" />
+              <span className="sr-only">Open archived tweet</span>
+            </a>
+            <a
+              href={`https://twitter.com/${displayUsername}/status/${tweet.tweet_id}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded p-1 transition-colors hover:bg-accent hover:text-foreground"
+              title="Open tweet on Twitter"
+            >
+              <FaExternalLinkAlt className="h-3.5 w-3.5" aria-hidden="true" />
+              <span className="sr-only">Open tweet on Twitter</span>
+            </a>
+          </span>
+        </div>
+
+        <div
+          role="cell"
+          className="hidden self-center text-xs text-muted-foreground md:block"
+          title={createdAt.toLocaleString()}
+        >
+          {formattedDate}
+        </div>
+
+        <div
+          role="cell"
+          className="hidden items-center gap-3 self-center text-xs text-muted-foreground md:flex"
+        >
+          <span className="inline-flex items-center gap-1">
+            <FaHeart aria-hidden="true" />
+            {formatNumber(tweet.favorite_count)}
+            <span className="sr-only">likes</span>
+          </span>
+          <span className="inline-flex items-center gap-1">
+            <FaRetweet aria-hidden="true" />
+            {formatNumber(tweet.retweet_count ?? 0)}
+            <span className="sr-only">reposts</span>
+          </span>
+        </div>
+
+        <div
+          role="cell"
+          className="hidden items-center justify-end gap-3 self-center text-muted-foreground md:flex"
+        >
+          <a
+            href={`/tweets/${tweet.tweet_id}`}
+            className="rounded p-1 transition-colors hover:bg-accent hover:text-foreground"
+            title="Open archived tweet"
+          >
+            <FaExternalLinkAlt className="h-3.5 w-3.5" aria-hidden="true" />
+            <span className="sr-only">Open archived tweet</span>
+          </a>
+          <a
+            href={`https://twitter.com/${displayUsername}/status/${tweet.tweet_id}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="rounded p-1 transition-colors hover:bg-accent hover:text-foreground"
+            title="Open tweet on Twitter"
+          >
+            <FaExternalLinkAlt className="h-3.5 w-3.5" aria-hidden="true" />
+            <span className="sr-only">Open tweet on Twitter</span>
+          </a>
         </div>
       </div>
     )

--- a/src/components/TweetComponent.tsx
+++ b/src/components/TweetComponent.tsx
@@ -222,31 +222,58 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
     const mediaArray = tweet.media || (tweet as any).media || []
     if (!mediaArray || mediaArray.length === 0) return null
 
-    return (
-      <div
-        className={`my-3 grid gap-2 ${mediaArray.length > 1 ? 'grid-cols-2' : 'grid-cols-1'}`}
-      >
-        {mediaArray
-          .filter(
-            (m: any) =>
-              m.media_type === 'photo' ||
-              m.media_type.startsWith('image/') ||
-              m.media_type === 'video',
-          )
-          .map((mediaItem: any, index: number) => (
+    const renderableMedia = mediaArray.filter(
+      (mediaItem: any) =>
+        mediaItem.media_type === 'photo' ||
+        mediaItem.media_type.startsWith('image/') ||
+        mediaItem.media_type === 'video',
+    )
+    if (renderableMedia.length === 0) return null
+
+    if (compact) {
+      return (
+        <div className="mt-2 flex gap-2 overflow-x-auto pb-1">
+          {renderableMedia.slice(0, 4).map((mediaItem: any, index: number) => (
             <div
               key={index}
-              className="relative overflow-hidden rounded-lg border border-border bg-muted"
+              className="relative h-20 w-28 flex-none overflow-hidden rounded-md border border-border bg-muted sm:h-24 sm:w-36"
             >
               <NextImage
                 src={mediaItem.media_url}
                 alt={`Tweet image ${index + 1}`}
-                width={mediaItem.width || 600}
-                height={mediaItem.height || 400}
-                className="min-h-40 h-full max-h-96 w-full object-cover"
+                width={mediaItem.width || 240}
+                height={mediaItem.height || 160}
+                className="h-full w-full object-cover"
               />
             </div>
           ))}
+          {renderableMedia.length > 4 && (
+            <div className="flex h-20 w-20 flex-none items-center justify-center rounded-md border border-border bg-muted text-xs text-muted-foreground sm:h-24">
+              +{renderableMedia.length - 4} more
+            </div>
+          )}
+        </div>
+      )
+    }
+
+    return (
+      <div
+        className={`my-3 grid gap-2 ${mediaArray.length > 1 ? 'grid-cols-2' : 'grid-cols-1'}`}
+      >
+        {renderableMedia.map((mediaItem: any, index: number) => (
+          <div
+            key={index}
+            className="relative overflow-hidden rounded-lg border border-border bg-muted"
+          >
+            <NextImage
+              src={mediaItem.media_url}
+              alt={`Tweet image ${index + 1}`}
+              width={mediaItem.width || 600}
+              height={mediaItem.height || 400}
+              className="min-h-40 h-full max-h-96 w-full object-cover"
+            />
+          </div>
+        ))}
       </div>
     )
   }
@@ -260,7 +287,9 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
     // show an empty card.
     if (quotedTweet.is_deleted) {
       return (
-        <div className="mt-3 rounded-lg border border-dashed border-border bg-muted p-3 text-sm italic text-muted-foreground dark:bg-card">
+        <div
+          className={`${compact ? 'mt-2 p-2 text-xs' : 'mt-3 p-3 text-sm'} rounded-lg border border-dashed border-border bg-muted italic text-muted-foreground dark:bg-card`}
+        >
           [Quoted tweet deleted]
         </div>
       )
@@ -273,14 +302,20 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
       : 'border-border bg-muted dark:bg-card'
 
     return (
-      <div className={`relative mt-3 rounded-lg border p-3 ${externalClasses}`}>
+      <div
+        className={`relative rounded-lg border ${compact ? 'mt-2 p-2' : 'mt-3 p-3'} ${externalClasses}`}
+      >
         {quotedTweet.from_external && (
           <span className="absolute right-2 top-2 rounded bg-amber-100 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
             from Twitter · not archived
           </span>
         )}
-        <div className="flex items-start space-x-3">
-          <Avatar className="h-8 w-8 flex-shrink-0">
+        <div
+          className={`flex items-start ${compact ? 'space-x-2' : 'space-x-3'}`}
+        >
+          <Avatar
+            className={`${compact ? 'h-6 w-6' : 'h-8 w-8'} flex-shrink-0`}
+          >
             <TweetAvatarImage
               src={quotedProfilePic}
               alt={`${quotedTweet.account_display_name}'s profile picture`}
@@ -308,11 +343,21 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
                 })}
               </span>
             </div>
-            <p className="whitespace-pre-wrap break-words text-sm leading-6 text-foreground">
+            <p
+              className={`whitespace-pre-wrap break-words text-foreground ${
+                compact ? 'line-clamp-3 text-xs leading-4' : 'text-sm leading-6'
+              }`}
+            >
               {decodeHtmlEntities(quotedTweet.full_text)}
             </p>
             {quotedTweet.media && quotedTweet.media.length > 0 && (
-              <div className="mt-2 flex flex-col space-y-1">
+              <div
+                className={
+                  compact
+                    ? 'mt-2 flex gap-1.5 overflow-x-auto'
+                    : 'mt-2 flex flex-col space-y-1'
+                }
+              >
                 {quotedTweet.media
                   .filter(
                     (m: any) =>
@@ -320,17 +365,24 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
                       m.media_type.startsWith('image/') ||
                       m.media_type === 'video',
                   )
+                  .slice(0, compact ? 3 : undefined)
                   .map((mediaItem: any, index: number) => (
                     <div
                       key={index}
-                      className="relative overflow-hidden rounded-md border dark:border-border"
+                      className={`relative overflow-hidden rounded-md border dark:border-border ${
+                        compact ? 'h-16 w-24 flex-none' : ''
+                      }`}
                     >
                       <NextImage
                         src={mediaItem.media_url}
                         alt={`Quoted tweet image ${index + 1}`}
                         width={300}
                         height={200}
-                        className="h-auto max-h-48 w-full object-contain"
+                        className={
+                          compact
+                            ? 'h-full w-full object-cover'
+                            : 'h-auto max-h-48 w-full object-contain'
+                        }
                       />
                     </div>
                   ))}
@@ -373,7 +425,6 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
   }
 
   if (compact) {
-    const mediaCount = tweet.media?.length ?? 0
     const createdAt = new Date(tweet.created_at)
     const formattedDate = createdAt.toLocaleDateString(undefined, {
       month: 'short',
@@ -438,17 +489,9 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
                 {isTextExpanded ? 'Show less' : 'Show more'}
               </button>
             )}
-            {mediaCount > 0 && (
-              <span className="rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
-                {mediaCount} {mediaCount === 1 ? 'media item' : 'media items'}
-              </span>
-            )}
-            {isQuoteTweet && (
-              <span className="rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
-                Quoted tweet
-              </span>
-            )}
           </div>
+          {renderMedia()}
+          {renderQuotedTweet()}
         </div>
 
         <div

--- a/src/components/TweetList.tsx
+++ b/src/components/TweetList.tsx
@@ -154,12 +154,18 @@ export default function TweetList({
   // Convert TimelineTweet to raw tweet format for consistency
   const rawTweets = tweets.map((tweet) => ({
     tweet_id: tweet.tweet_id,
-    account_id: '', // TimelineTweet doesn't have this
+    account_id: tweet.account_id || '',
     created_at: tweet.created_at,
     full_text: tweet.full_text,
     retweet_count: tweet.retweet_count,
     favorite_count: tweet.favorite_count,
     reply_to_tweet_id: tweet.reply_to_tweet_id,
+    quote_tweet_id: tweet.quote_tweet_id || null,
+    quoted_tweet: tweet.quoted_tweet,
+    retweeted_tweet_id: null,
+    avatar_media_url: tweet.account.profile?.avatar_media_url || null,
+    username: tweet.account.username,
+    account_display_name: tweet.account.account_display_name,
     // Use raw format for account data
     account: {
       username: tweet.account.username,
@@ -171,6 +177,7 @@ export default function TweetList({
         : undefined,
     },
     media: tweet.media || [],
+    urls: [],
     mentioned_users: [], // TimelineTweet doesn't have this
   }))
 

--- a/src/components/TweetList.tsx
+++ b/src/components/TweetList.tsx
@@ -19,6 +19,7 @@ interface TweetListProps {
   resultsHeading?: string
   resultsDescription?: string
   collapseLongTweets?: boolean
+  compact?: boolean
 }
 
 const DEFAULT_ITEMS_PER_PAGE = 20
@@ -31,6 +32,7 @@ export default function TweetList({
   resultsHeading,
   resultsDescription,
   collapseLongTweets = false,
+  compact = false,
 }: TweetListProps) {
   const [tweets, setTweets] = useState<TimelineTweet[]>([])
   const [isLoading, setIsLoading] = useState(true)
@@ -173,7 +175,7 @@ export default function TweetList({
   }))
 
   return (
-    <div className="space-y-8">
+    <div className={compact ? 'space-y-5' : 'space-y-8'}>
       <UnifiedTweetList
         tweets={rawTweets}
         isLoading={isLoading}
@@ -190,6 +192,7 @@ export default function TweetList({
         }
         headerDescription={resultsDescription}
         collapseLongTweets={collapseLongTweets}
+        compact={compact}
       />
 
       {error && tweets.length > 0 && (

--- a/src/components/UnifiedTweetList.test.tsx
+++ b/src/components/UnifiedTweetList.test.tsx
@@ -72,9 +72,19 @@ describe('UnifiedTweetList compact view', () => {
     ).toBeInTheDocument()
     expect(
       screen
-        .getAllByRole('link', { name: 'Open archived tweet' })
+        .getAllByRole('link', { name: 'View tweet in Community Archive' })
         .every(
           (link) => link.getAttribute('href') === '/tweets/2085447310574793145',
+        ),
+    ).toBe(true)
+    expect(
+      screen
+        .getAllByRole('link', { name: 'View original tweet on Twitter' })
+        .every(
+          (link) =>
+            link.getAttribute('href') ===
+              'https://twitter.com/archive_user/status/2085447310574793145' &&
+            link.getAttribute('target') === '_blank',
         ),
     ).toBe(true)
 

--- a/src/components/UnifiedTweetList.test.tsx
+++ b/src/components/UnifiedTweetList.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom'
+import UnifiedTweetList from './UnifiedTweetList'
+
+jest.mock('@/components/TweetAvatarImage', () => ({
+  __esModule: true,
+  default: ({ alt }: { alt: string }) => <img alt={alt} />,
+}))
+
+const tweet = {
+  tweet_id: '2085447310574793145',
+  account_id: '123',
+  created_at: '2026-08-06T12:00:00.000Z',
+  full_text: `A compact search result with enough text to demonstrate that long tweets are kept scannable in the table view. ${'More details. '.repeat(12)}`,
+  retweet_count: 12,
+  favorite_count: 34,
+  reply_to_tweet_id: null,
+  quote_tweet_id: null,
+  retweeted_tweet_id: null,
+  avatar_media_url: 'https://example.com/avatar.jpg',
+  username: 'archive_user',
+  account_display_name: 'Archive User',
+  media: [],
+  urls: [],
+}
+
+describe('UnifiedTweetList compact view', () => {
+  it('renders table-like columns and expands collapsed tweet text', async () => {
+    render(
+      <UnifiedTweetList
+        tweets={[tweet]}
+        headerTitle="Search results · 1"
+        collapseLongTweets
+        compact
+      />,
+    )
+
+    expect(
+      screen.getByRole('table', { name: 'Search results · 1' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getAllByRole('columnheader').map((header) => header.textContent),
+    ).toEqual(['Author', 'Tweet', 'Date', 'Engagement', 'Links'])
+    expect(screen.getByText('Archive User')).toBeInTheDocument()
+    expect(
+      screen
+        .getAllByRole('link', { name: 'Open archived tweet' })
+        .every(
+          (link) => link.getAttribute('href') === '/tweets/2085447310574793145',
+        ),
+    ).toBe(true)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Show more' }))
+    expect(
+      screen.getByRole('button', { name: 'Show less' }),
+    ).toBeInTheDocument()
+  })
+})

--- a/src/components/UnifiedTweetList.test.tsx
+++ b/src/components/UnifiedTweetList.test.tsx
@@ -17,13 +17,32 @@ const tweet = {
   retweet_count: 12,
   favorite_count: 34,
   reply_to_tweet_id: null,
-  quote_tweet_id: null,
+  quote_tweet_id: 'quoted-1',
   retweeted_tweet_id: null,
   avatar_media_url: 'https://example.com/avatar.jpg',
   username: 'archive_user',
   account_display_name: 'Archive User',
-  media: [],
+  media: [
+    {
+      media_url: 'https://example.com/photo.jpg',
+      media_type: 'photo',
+      width: 800,
+      height: 600,
+    },
+  ],
   urls: [],
+  quoted_tweet: {
+    tweet_id: 'quoted-1',
+    account_id: '456',
+    created_at: '2026-08-05T12:00:00.000Z',
+    full_text: 'The quoted tweet is visible in compact search results.',
+    retweet_count: 2,
+    favorite_count: 8,
+    avatar_media_url: 'https://example.com/quoted-avatar.jpg',
+    username: 'quoted_user',
+    account_display_name: 'Quoted User',
+    media: [],
+  },
 }
 
 describe('UnifiedTweetList compact view', () => {
@@ -44,6 +63,13 @@ describe('UnifiedTweetList compact view', () => {
       screen.getAllByRole('columnheader').map((header) => header.textContent),
     ).toEqual(['Author', 'Tweet', 'Date', 'Engagement', 'Links'])
     expect(screen.getByText('Archive User')).toBeInTheDocument()
+    expect(screen.getByAltText('Tweet image 1')).toBeInTheDocument()
+    expect(screen.getByText('Quoted User')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'The quoted tweet is visible in compact search results.',
+      ),
+    ).toBeInTheDocument()
     expect(
       screen
         .getAllByRole('link', { name: 'Open archived tweet' })

--- a/src/components/UnifiedTweetList.tsx
+++ b/src/components/UnifiedTweetList.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React from 'react'
-import TweetComponent from './TweetComponent'
+import TweetComponent, { compactTweetGridClass } from './TweetComponent'
 import { Button } from '@/components/ui/button'
 import { Download, SearchX } from 'lucide-react'
 
@@ -15,6 +15,7 @@ interface UnifiedTweetListProps {
   headerTitle?: string
   headerDescription?: string
   collapseLongTweets?: boolean
+  compact?: boolean
 }
 
 /**
@@ -32,6 +33,7 @@ export default function UnifiedTweetList({
   headerTitle,
   headerDescription,
   collapseLongTweets = false,
+  compact = false,
 }: UnifiedTweetListProps) {
   const handleExportCsv = () => {
     if (tweets.length === 0) {
@@ -107,12 +109,18 @@ export default function UnifiedTweetList({
   }
 
   return (
-    <div className="space-y-4">
+    <div className={compact ? 'space-y-3' : 'space-y-4'}>
       {(headerTitle || headerDescription || showCsvExport) && (
-        <div className="flex flex-col gap-4 border-b border-border pb-5 sm:flex-row sm:items-end sm:justify-between">
+        <div
+          className={`flex flex-col gap-3 border-b border-border sm:flex-row sm:items-end sm:justify-between ${
+            compact ? 'pb-3' : 'pb-5'
+          }`}
+        >
           <div>
             {headerTitle && (
-              <h2 className="text-2xl font-semibold text-foreground">
+              <h2
+                className={`${compact ? 'text-lg' : 'text-2xl'} font-semibold text-foreground`}
+              >
                 {headerTitle}
               </h2>
             )}
@@ -136,19 +144,57 @@ export default function UnifiedTweetList({
         </div>
       )}
 
-      <div className={className}>
-        {tweets.map((tweet) => (
-          <div
-            key={tweet.tweet_id}
-            className="rounded-xl border border-border bg-card p-4 transition-colors hover:border-foreground/20 sm:p-5"
-          >
-            <TweetComponent
-              tweet={tweet}
-              collapseLongText={collapseLongTweets}
-            />
+      {compact ? (
+        <div
+          role="table"
+          aria-label={headerTitle || 'Tweets'}
+          className="overflow-hidden rounded-lg border border-border bg-card"
+        >
+          <div role="rowgroup" className="hidden bg-muted/60 md:block">
+            <div
+              role="row"
+              className={`${compactTweetGridClass} py-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground`}
+            >
+              <div role="columnheader">Author</div>
+              <div role="columnheader">Tweet</div>
+              <div role="columnheader">Date</div>
+              <div role="columnheader">Engagement</div>
+              <div role="columnheader" className="text-right">
+                Links
+              </div>
+            </div>
           </div>
-        ))}
-      </div>
+          <div role="rowgroup" className="divide-y divide-border">
+            {tweets.map((tweet) => (
+              <div
+                key={tweet.tweet_id}
+                role="row"
+                className="hover:bg-muted/35 transition-colors"
+              >
+                <TweetComponent
+                  tweet={tweet}
+                  collapseLongText={collapseLongTweets}
+                  compact
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : (
+        <div className={className}>
+          {tweets.map((tweet) => (
+            <div
+              key={tweet.tweet_id}
+              className="rounded-xl border border-border bg-card p-4 transition-colors hover:border-foreground/20 sm:p-5"
+            >
+              <TweetComponent
+                tweet={tweet}
+                collapseLongText={collapseLongTweets}
+              />
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/lib/clickhouseSearch.ts
+++ b/src/lib/clickhouseSearch.ts
@@ -3,6 +3,7 @@ import type { FilterCriteria } from './queries/tweetQueries'
 
 interface ClickHouseSearchTweet {
   tweetId: string
+  accountId: string
   createdAt: string
   fullText: string
   replyToTweetId: string | null
@@ -72,6 +73,7 @@ export async function searchTweetsWithClickHouse(
 
   return result.data.tweets.map((tweet) => ({
     tweet_id: tweet.tweetId,
+    account_id: tweet.accountId,
     created_at: tweet.createdAt,
     full_text: tweet.fullText,
     favorite_count: Number(tweet.favoriteCount || 0),

--- a/src/lib/queries/tweetQueries.test.ts
+++ b/src/lib/queries/tweetQueries.test.ts
@@ -1,4 +1,9 @@
-import { buildAndTsQuery, fetchTweets, FilterCriteria } from './tweetQueries'
+import {
+  buildAndTsQuery,
+  fetchTweets,
+  FilterCriteria,
+  isRetweetText,
+} from './tweetQueries'
 
 // Mock both RPC search functions
 const mockRpcSearch = jest.fn()
@@ -39,6 +44,7 @@ function buildMockSupabase() {
     gte: jest.fn().mockReturnThis(),
     lte: jest.fn().mockReturnThis(),
     is: jest.fn().mockReturnThis(),
+    not: jest.fn().mockReturnThis(),
     order: jest.fn().mockReturnThis(),
     range: jest.fn().mockResolvedValue({ data: [], error: null }),
   }
@@ -68,6 +74,90 @@ describe('buildAndTsQuery', () => {
 
   it('handles empty string', () => {
     expect(buildAndTsQuery('')).toBe('')
+  })
+})
+
+describe('retweet filtering', () => {
+  beforeEach(() => {
+    mockRpcSearch.mockReset()
+    mockRpcExactPhrase.mockReset()
+    mockClickHouseSearch.mockReset()
+    delete process.env.NEXT_PUBLIC_ENABLE_CLICKHOUSE_SEARCH
+  })
+
+  it('recognizes archive-native RT text', () => {
+    expect(isRetweetText('RT @alice: hello')).toBe(true)
+    expect(isRetweetText('RT @alice hello')).toBe(true)
+    expect(isRetweetText('Talking about RT @alice')).toBe(false)
+  })
+
+  it('removes retweets from Supabase RPC results as a deployment-safe fallback', async () => {
+    mockRpcSearch.mockResolvedValueOnce([
+      makeRpcTweet('rt', 'RT @alice: hello'),
+      makeRpcTweet('original', 'hello from me'),
+    ])
+
+    const result = await fetchTweets(
+      buildMockSupabase(),
+      {
+        searchQuery: 'hello',
+        rawSearchQuery: 'hello',
+        excludeRetweets: true,
+      },
+      1,
+      20,
+    )
+
+    expect(result.tweets.map((tweet) => tweet.tweet_id)).toEqual(['original'])
+  })
+
+  it('tops up filtered ClickHouse pages with original tweets', async () => {
+    process.env.NEXT_PUBLIC_ENABLE_CLICKHOUSE_SEARCH = 'true'
+    const clickHouseTweet = (id: string, fullText: string) => ({
+      tweet_id: id,
+      account_id: 'acc_1',
+      created_at: '2025-01-01T00:00:00Z',
+      full_text: fullText,
+      favorite_count: 0,
+      retweet_count: 0,
+      reply_to_tweet_id: null,
+      account: {
+        username: 'testuser',
+        account_display_name: 'Test User',
+      },
+      media: [],
+    })
+    mockClickHouseSearch
+      .mockResolvedValueOnce([
+        ...Array.from({ length: 35 }, (_, index) =>
+          clickHouseTweet(`rt-${index}`, `RT @alice: result ${index}`),
+        ),
+        ...Array.from({ length: 15 }, (_, index) =>
+          clickHouseTweet(`original-${index}`, `Original result ${index}`),
+        ),
+      ])
+      .mockResolvedValueOnce(
+        Array.from({ length: 20 }, (_, index) =>
+          clickHouseTweet(`more-${index}`, `More original ${index}`),
+        ),
+      )
+
+    const result = await fetchTweets(
+      buildMockSupabase(),
+      {
+        searchQuery: 'result',
+        rawSearchQuery: 'result',
+        excludeRetweets: true,
+      },
+      1,
+      20,
+    )
+
+    expect(mockClickHouseSearch).toHaveBeenCalledTimes(2)
+    expect(result.tweets).toHaveLength(20)
+    expect(
+      result.tweets.every((tweet) => !isRetweetText(tweet.full_text)),
+    ).toBe(true)
   })
 })
 
@@ -147,7 +237,9 @@ describe('fetchTweets — exact phrase search via FTS simple', () => {
     const result = await fetchTweets(supabase, criteria, 1, 5)
 
     expect(mockRpcExactPhrase).toHaveBeenCalledTimes(1)
-    expect(mockRpcExactPhrase.mock.calls[0][1].exact_phrase).toBe('cool project')
+    expect(mockRpcExactPhrase.mock.calls[0][1].exact_phrase).toBe(
+      'cool project',
+    )
     // Only exact phrase RPC is called, no FTS fallback
     expect(mockRpcSearch).not.toHaveBeenCalled()
     expect(result.tweets).toHaveLength(2)
@@ -289,12 +381,7 @@ describe('fetchTweets — direct profile embeds', () => {
       count: 1,
     })
 
-    const result = await fetchTweets(
-      supabase,
-      { userId: 'account-1' },
-      1,
-      20,
-    )
+    const result = await fetchTweets(supabase, { userId: 'account-1' }, 1, 20)
 
     expect(result.error).toBeNull()
     expect(result.tweets[0].account.profile?.avatar_media_url).toBe(

--- a/src/lib/queries/tweetQueries.ts
+++ b/src/lib/queries/tweetQueries.ts
@@ -1,84 +1,167 @@
-import { SupabaseClient } from '@supabase/supabase-js';
-import { TimelineTweet, RawSupabaseTweet, RawSupabaseAccount, RawSupabaseProfile } from '@/lib/types';
-import { searchTweets as rpcSearchTweets, searchTweetsExactPhrase as rpcSearchExactPhrase } from '../pgSearch';
-import { type SearchParams } from '../types';
-import { getLatestAvatarMediaUrl } from '@/lib/avatar';
-import { searchTweetsWithClickHouse } from '../clickhouseSearch';
+import { SupabaseClient } from '@supabase/supabase-js'
+import {
+  TimelineTweet,
+  RawSupabaseTweet,
+  RawSupabaseAccount,
+  RawSupabaseProfile,
+} from '@/lib/types'
+import {
+  searchTweets as rpcSearchTweets,
+  searchTweetsExactPhrase as rpcSearchExactPhrase,
+} from '../pgSearch'
+import { type SearchParams } from '../types'
+import { getLatestAvatarMediaUrl } from '@/lib/avatar'
+import { searchTweetsWithClickHouse } from '../clickhouseSearch'
+import { enrichSearchTweets } from '../searchTweetEnrichments'
 
 export interface FilterCriteria {
-  userId?: string; // For fetching tweets by a specific user
-  searchQuery?: string; // For text search in tweets (tsquery-formatted)
-  rawSearchQuery?: string; // Original unformatted search text (for two-query exact-match-first logic)
-  mentionedUser?: string; // For tweets mentioning a specific user
-  fromUsername?: string; // For tweets from a specific username
-  replyToUsername?: string; // For tweets in reply to a specific username
-  isRootTweet?: boolean; // To fetch only root-level tweets (no replies)
-  hashtags?: string[]; // For tweets containing specific hashtags
-  startDate?: string; // For tweets created after this date
-  endDate?: string; // For tweets created before this date
+  userId?: string // For fetching tweets by a specific user
+  searchQuery?: string // For text search in tweets (tsquery-formatted)
+  rawSearchQuery?: string // Original unformatted search text (for two-query exact-match-first logic)
+  mentionedUser?: string // For tweets mentioning a specific user
+  fromUsername?: string // For tweets from a specific username
+  replyToUsername?: string // For tweets in reply to a specific username
+  isRootTweet?: boolean // To fetch only root-level tweets (no replies)
+  hashtags?: string[] // For tweets containing specific hashtags
+  startDate?: string // For tweets created after this date
+  endDate?: string // For tweets created before this date
+  excludeRetweets?: boolean // Exclude native archive retweets that start with "RT @"
+  includeQuoteTweets?: boolean // Batch-load quoted tweet bodies for rich rendering
 }
 
-const DEFAULT_PAGE_SIZE = 50;
+const DEFAULT_PAGE_SIZE = 50
+const CLICKHOUSE_FILTER_PAGE_SIZE = 50
+const MAX_CLICKHOUSE_FILTER_PAGES = 10
+
+export function isRetweetText(text: string): boolean {
+  return /^RT @[A-Za-z0-9_]+/.test(text)
+}
 
 // Helper to transform data from either source
-function transformRawTweetsToTimelineTweets(rawData: any[], isRpcResult: boolean = false): TimelineTweet[] {
-  return (rawData as any[]).map(rawTweet => {
+function transformRawTweetsToTimelineTweets(
+  rawData: any[],
+  isRpcResult: boolean = false,
+): TimelineTweet[] {
+  return (rawData as any[]).map((rawTweet) => {
     let timelineAccount: TimelineTweet['account'] = {
-      username: "unknown_user",
-      account_display_name: "Unknown User",
+      username: 'unknown_user',
+      account_display_name: 'Unknown User',
       profile: undefined,
-    };
+    }
 
     if (isRpcResult) {
       // RPC result likely has flat account data on rawTweet itself
       if (rawTweet.username) {
         timelineAccount = {
           username: rawTweet.username,
-          account_display_name: rawTweet.account_display_name || rawTweet.username,
+          account_display_name:
+            rawTweet.account_display_name || rawTweet.username,
           profile: rawTweet.avatar_media_url
-            ? { avatar_media_url: rawTweet.avatar_media_url === null ? undefined : rawTweet.avatar_media_url }
+            ? {
+                avatar_media_url:
+                  rawTweet.avatar_media_url === null
+                    ? undefined
+                    : rawTweet.avatar_media_url,
+              }
             : undefined,
-        };
+        }
       } else {
-        console.error(`RPC Tweet ${rawTweet.tweet_id} is missing account username. Using fallback.`);
+        console.error(
+          `RPC Tweet ${rawTweet.tweet_id} is missing account username. Using fallback.`,
+        )
       }
     } else {
       // Direct query result has nested account data
-      const accountData = rawTweet.account as RawSupabaseAccount | undefined;
+      const accountData = rawTweet.account as RawSupabaseAccount | undefined
       if (accountData && accountData.username) {
-        const profileData = accountData.profile as RawSupabaseProfile | RawSupabaseProfile[] | null | undefined;
-        const avatarMediaUrl = getLatestAvatarMediaUrl(profileData);
+        const profileData = accountData.profile as
+          | RawSupabaseProfile
+          | RawSupabaseProfile[]
+          | null
+          | undefined
+        const avatarMediaUrl = getLatestAvatarMediaUrl(profileData)
         timelineAccount = {
           username: accountData.username,
           account_display_name: accountData.account_display_name,
           profile: avatarMediaUrl
             ? { avatar_media_url: avatarMediaUrl }
             : undefined,
-        };
+        }
       } else {
-        console.error(`Direct Query Tweet ${rawTweet.tweet_id} is missing account data. Using fallback.`);
+        console.error(
+          `Direct Query Tweet ${rawTweet.tweet_id} is missing account data. Using fallback.`,
+        )
       }
     }
-    
+
     return {
       tweet_id: rawTweet.tweet_id,
+      account_id: rawTweet.account_id,
       created_at: rawTweet.created_at,
       full_text: rawTweet.full_text,
       favorite_count: rawTweet.favorite_count,
       retweet_count: rawTweet.retweet_count,
       reply_to_tweet_id: rawTweet.reply_to_tweet_id,
       account: timelineAccount,
-      media: rawTweet.media || [], 
-    } as TimelineTweet;
-  });
+      media: rawTweet.media || [],
+    } as TimelineTweet
+  })
+}
+
+async function finalizeTweets(
+  supabase: SupabaseClient,
+  tweets: TimelineTweet[],
+  criteria: FilterCriteria,
+): Promise<TimelineTweet[]> {
+  const filteredTweets = criteria.excludeRetweets
+    ? tweets.filter((tweet) => !isRetweetText(tweet.full_text))
+    : tweets
+
+  return criteria.includeQuoteTweets
+    ? enrichSearchTweets(supabase, filteredTweets)
+    : filteredTweets
+}
+
+async function searchClickHousePage(
+  criteria: FilterCriteria,
+  page: number,
+  pageSize: number,
+): Promise<TimelineTweet[]> {
+  if (!criteria.excludeRetweets) {
+    return searchTweetsWithClickHouse(criteria, page, pageSize)
+  }
+
+  const pageStart = (page - 1) * pageSize
+  const pageEnd = page * pageSize
+  const nonRetweets: TimelineTweet[] = []
+
+  // ClickHouse does not yet expose a retweet predicate, so scan bounded raw
+  // pages from the start to keep filtered pagination deterministic and full.
+  for (
+    let rawPage = 1;
+    rawPage <= MAX_CLICKHOUSE_FILTER_PAGES && nonRetweets.length < pageEnd;
+    rawPage += 1
+  ) {
+    const chunk = await searchTweetsWithClickHouse(
+      criteria,
+      rawPage,
+      CLICKHOUSE_FILTER_PAGE_SIZE,
+    )
+    nonRetweets.push(
+      ...chunk.filter((tweet) => !isRetweetText(tweet.full_text)),
+    )
+    if (chunk.length < CLICKHOUSE_FILTER_PAGE_SIZE) break
+  }
+
+  return nonRetweets.slice(pageStart, pageEnd)
 }
 
 /**
  * Build AND tsquery string from raw search text.
  */
 export function buildAndTsQuery(raw: string): string {
-  const words = raw.trim().split(/\s+/).filter(Boolean);
-  return words.join(' & ');
+  const words = raw.trim().split(/\s+/).filter(Boolean)
+  return words.join(' & ')
 }
 
 /**
@@ -106,16 +189,16 @@ async function searchExactPhrase(
     },
     pageSize,
     offset,
-  );
+  )
 
-  return data ? transformRawTweetsToTimelineTweets(data, true) : [];
+  return data ? transformRawTweetsToTimelineTweets(data, true) : []
 }
 
 export async function fetchTweets(
   supabase: SupabaseClient,
   criteria: FilterCriteria,
   page: number,
-  pageSize: number = DEFAULT_PAGE_SIZE
+  pageSize: number = DEFAULT_PAGE_SIZE,
 ): Promise<{ tweets: TimelineTweet[]; totalCount: number | null; error: any }> {
   // Use RPC if a text search query is provided OR if any filters supported by the RPC are used.
   if (
@@ -130,32 +213,37 @@ export async function fetchTweets(
       to_user: criteria.replyToUsername || null,
       since_date: criteria.startDate || null,
       until_date: criteria.endDate || null,
-    };
+    }
 
     try {
-      const offset = (page - 1) * pageSize;
-      const rawText = criteria.rawSearchQuery;
+      const offset = (page - 1) * pageSize
+      const rawText = criteria.rawSearchQuery
 
       if (
         rawText &&
         process.env.NEXT_PUBLIC_ENABLE_CLICKHOUSE_SEARCH === 'true'
       ) {
         try {
-          const clickHouseTweets = await searchTweetsWithClickHouse(
+          const clickHouseTweets = await searchClickHousePage(
             criteria,
             page,
             pageSize,
-          );
+          )
+          const finalizedTweets = await finalizeTweets(
+            supabase,
+            clickHouseTweets,
+            criteria,
+          )
           return {
-            tweets: clickHouseTweets,
-            totalCount: clickHouseTweets.length === 0 ? 0 : null,
+            tweets: finalizedTweets,
+            totalCount: finalizedTweets.length === 0 ? 0 : null,
             error: null,
-          };
+          }
         } catch (error) {
           console.warn(
             'ClickHouse tweet search failed; falling back to Supabase:',
             error,
-          );
+          )
         }
       }
 
@@ -164,35 +252,68 @@ export async function fetchTweets(
       // matches exact word order for ALL words (including "you", "can", etc.).
       // Backed by a GIN index on to_tsvector('simple', full_text).
       if (rawText && rawText.trim().split(/\s+/).length > 1) {
-        const phraseResults = await searchExactPhrase(supabase, rawText, criteria, pageSize, offset);
-        return { tweets: phraseResults, totalCount: null, error: null };
+        const phraseResults = await searchExactPhrase(
+          supabase,
+          rawText,
+          criteria,
+          pageSize,
+          offset,
+        )
+        return {
+          tweets: await finalizeTweets(supabase, phraseResults, criteria),
+          totalCount: null,
+          error: null,
+        }
       }
 
       // Single-word or pre-formatted query — single query path
       const searchParams: SearchParams = {
         search_query: criteria.searchQuery || '',
         ...baseParams,
-      };
-      const rpcData = await rpcSearchTweets(supabase, searchParams, pageSize, offset);
+      }
+      const rpcData = await rpcSearchTweets(
+        supabase,
+        searchParams,
+        pageSize,
+        offset,
+      )
 
       if (!rpcData || rpcData.length === 0) {
-        return { tweets: [], totalCount: rpcData?.length === 0 ? 0 : null, error: null };
+        return {
+          tweets: [],
+          totalCount: rpcData?.length === 0 ? 0 : null,
+          error: null,
+        }
       }
-      return { tweets: transformRawTweetsToTimelineTweets(rpcData, true), totalCount: null, error: null };
+      return {
+        tweets: await finalizeTweets(
+          supabase,
+          transformRawTweetsToTimelineTweets(rpcData, true),
+          criteria,
+        ),
+        totalCount: null,
+        error: null,
+      }
     } catch (error: any) {
-      console.error('Error fetching tweets via RPC:', error);
+      console.error('Error fetching tweets via RPC:', error)
       if (error.message && error.message.includes('statement timeout')) {
-         return { tweets: [], totalCount: 0, error: { message: 'Search query timed out. Please try a more specific search.', details: error } };
+        return {
+          tweets: [],
+          totalCount: 0,
+          error: {
+            message:
+              'Search query timed out. Please try a more specific search.',
+            details: error,
+          },
+        }
       }
-      return { tweets: [], totalCount: 0, error };
+      return { tweets: [], totalCount: 0, error }
     }
   } else {
     // Fallback to direct Supabase query for filters not supported by the main search_tweets RPC
     // (e.g., specific userId, isRootTweet, mentionedUser, hashtags without other search terms)
-    let query = supabase
-      .from('tweets')
-      .select(
-        `
+    let query = supabase.from('tweets').select(
+      `
         tweet_id,
         created_at,
         full_text,
@@ -215,32 +336,36 @@ export async function fetchTweets(
           height
         )
       `,
-        { count: 'estimated' }
-      );
+      { count: 'estimated' },
+    )
 
     if (criteria.userId) {
-      query = query.eq('account_id', criteria.userId);
+      query = query.eq('account_id', criteria.userId)
     }
 
     // Note: fromUsername is handled by RPC path. If it reaches here, it means no other RPC criteria were met.
     // However, if we wanted to support fromUsername directly here (e.g. if RPC path was removed),
     // it would need to be: query = query.eq('all_account.username', criteria.fromUsername);
     // Same for replyToUsername: query = query.eq('reply_to_username', criteria.replyToUsername);
-    
+
     if (criteria.mentionedUser) {
       // Ensure 'all_account' is the correct alias if filtering on joined table.
       // Here, mentionedUser is likely in 'full_text' of the 'tweets' table.
-      query = query.ilike('full_text', `%@${criteria.mentionedUser}%`);
+      query = query.ilike('full_text', `%@${criteria.mentionedUser}%`)
     }
 
     if (criteria.isRootTweet) {
-      query = query.is('reply_to_tweet_id', null);
+      query = query.is('reply_to_tweet_id', null)
     }
 
     if (criteria.hashtags && criteria.hashtags.length > 0) {
-      criteria.hashtags.forEach(tag => {
-        query = query.ilike('full_text', `%#${tag}%`);
-      });
+      criteria.hashtags.forEach((tag) => {
+        query = query.ilike('full_text', `%#${tag}%`)
+      })
+    }
+
+    if (criteria.excludeRetweets) {
+      query = query.not('full_text', 'like', 'RT @%')
     }
 
     // Date filters are handled by RPC path if present.
@@ -251,24 +376,35 @@ export async function fetchTweets(
     // if (criteria.endDate) {
     //   query = query.lte('created_at', criteria.endDate);
     // }
-    
-    query = query.order('created_at', { ascending: false });
-    query = query.range((page - 1) * pageSize, page * pageSize - 1);
 
-    const { data: rawData, error, count } = await query;
+    query = query.order('created_at', { ascending: false })
+    query = query.range((page - 1) * pageSize, page * pageSize - 1)
+
+    const { data: rawData, error, count } = await query
 
     if (error) {
-      console.error('Error fetching tweets directly:', error); // Clarified error source
+      console.error('Error fetching tweets directly:', error) // Clarified error source
       if (error.message && error.message.includes('statement timeout')) {
-        return { tweets: [], totalCount: 0, error: { message: 'Query timed out. Please try a more specific query.', details: error } };
+        return {
+          tweets: [],
+          totalCount: 0,
+          error: {
+            message: 'Query timed out. Please try a more specific query.',
+            details: error,
+          },
+        }
       }
-      return { tweets: [], totalCount: 0, error };
+      return { tweets: [], totalCount: 0, error }
     }
     if (!rawData) {
-      return { tweets: [], totalCount: 0, error: null };
+      return { tweets: [], totalCount: 0, error: null }
     }
-    
-    const transformedTweets = transformRawTweetsToTimelineTweets(rawData, false);
-    return { tweets: transformedTweets, totalCount: count, error: null };
+
+    const transformedTweets = transformRawTweetsToTimelineTweets(rawData, false)
+    return {
+      tweets: await finalizeTweets(supabase, transformedTweets, criteria),
+      totalCount: count,
+      error: null,
+    }
   }
 }

--- a/src/lib/searchTweetEnrichments.test.ts
+++ b/src/lib/searchTweetEnrichments.test.ts
@@ -1,0 +1,84 @@
+import { enrichSearchTweets } from './searchTweetEnrichments'
+import type { TimelineTweet } from './types'
+
+function queryResult(data: any[]) {
+  return {
+    select: jest.fn().mockReturnThis(),
+    in: jest.fn().mockResolvedValue({ data, error: null }),
+  }
+}
+
+describe('enrichSearchTweets', () => {
+  it('attaches quoted tweet content and media in one batched enrichment', async () => {
+    const quoteRelations = queryResult([
+      { tweet_id: 'source-1', quoted_tweet_id: 'quoted-1' },
+    ])
+    const quotedTweets = queryResult([
+      {
+        tweet_id: 'quoted-1',
+        account_id: 'account-2',
+        created_at: '2026-08-06T12:00:00Z',
+        full_text: 'Quoted body',
+        retweet_count: 2,
+        favorite_count: 5,
+        account: {
+          username: 'quoted_user',
+          account_display_name: 'Quoted User',
+          profile: [
+            {
+              avatar_media_url: 'https://example.com/avatar.jpg',
+              archive_upload_id: 9,
+            },
+          ],
+        },
+        media: [
+          {
+            media_url: 'https://example.com/quoted-photo.jpg',
+            media_type: 'photo',
+            width: 800,
+            height: 600,
+          },
+        ],
+      },
+    ])
+    const supabase = {
+      from: jest.fn((table: string) =>
+        table === 'quote_tweets' ? quoteRelations : quotedTweets,
+      ),
+    } as any
+    const tweets: TimelineTweet[] = [
+      {
+        tweet_id: 'source-1',
+        account_id: 'account-1',
+        created_at: '2026-08-07T12:00:00Z',
+        full_text: 'My comment',
+        favorite_count: 1,
+        retweet_count: 0,
+        reply_to_tweet_id: null,
+        account: {
+          username: 'source_user',
+          account_display_name: 'Source User',
+        },
+        media: [],
+      },
+    ]
+
+    const result = await enrichSearchTweets(supabase, tweets)
+
+    expect(result[0]).toMatchObject({
+      quote_tweet_id: 'quoted-1',
+      quoted_tweet: {
+        tweet_id: 'quoted-1',
+        username: 'quoted_user',
+        avatar_media_url: 'https://example.com/avatar.jpg',
+        media: [
+          {
+            media_url: 'https://example.com/quoted-photo.jpg',
+            media_type: 'photo',
+          },
+        ],
+      },
+    })
+    expect(supabase.from).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/lib/searchTweetEnrichments.ts
+++ b/src/lib/searchTweetEnrichments.ts
@@ -1,0 +1,125 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { getLatestAvatarMediaUrl } from '@/lib/avatar'
+import type { TimelineTweet } from '@/lib/types'
+
+type QuoteRelation = {
+  tweet_id: string
+  quoted_tweet_id: string
+}
+
+function deletedQuotedTweet(tweetId: string) {
+  return {
+    tweet_id: tweetId,
+    account_id: '',
+    created_at: '',
+    full_text: '',
+    retweet_count: 0,
+    favorite_count: 0,
+    username: '',
+    account_display_name: '',
+    is_deleted: true as const,
+  }
+}
+
+/**
+ * Batch-load quote relationships and quoted tweet bodies for search results.
+ * Original tweet media is already returned by both search backends.
+ */
+export async function enrichSearchTweets(
+  supabase: SupabaseClient,
+  tweets: TimelineTweet[],
+): Promise<TimelineTweet[]> {
+  if (tweets.length === 0) return tweets
+
+  const tweetIds = tweets.map((tweet) => tweet.tweet_id)
+  const { data: quoteRows, error: quoteError } = await supabase
+    .from('quote_tweets')
+    .select('tweet_id, quoted_tweet_id')
+    .in('tweet_id', tweetIds)
+
+  if (quoteError) {
+    console.warn('Could not load quote relationships for search:', quoteError)
+    return tweets
+  }
+
+  const quoteRelations = (quoteRows || []) as QuoteRelation[]
+  if (quoteRelations.length === 0) return tweets
+
+  const quotedTweetIds = Array.from(
+    new Set(quoteRelations.map((row) => row.quoted_tweet_id)),
+  )
+  const { data: quotedRows, error: quotedError } = await supabase
+    .from('tweets')
+    .select(
+      `
+        tweet_id,
+        account_id,
+        created_at,
+        full_text,
+        retweet_count,
+        favorite_count,
+        account:all_account!inner (
+          username,
+          account_display_name,
+          profile:all_profile (
+            avatar_media_url,
+            archive_upload_id
+          )
+        ),
+        media:tweet_media (
+          media_url,
+          media_type,
+          width,
+          height
+        )
+      `,
+    )
+    .in('tweet_id', quotedTweetIds)
+
+  if (quotedError) {
+    console.warn('Could not load quoted tweets for search:', quotedError)
+  }
+
+  const quotedById = new Map(
+    ((quotedRows || []) as any[]).map((quotedTweet) => {
+      const account = Array.isArray(quotedTweet.account)
+        ? quotedTweet.account[0]
+        : quotedTweet.account
+      const avatarMediaUrl = getLatestAvatarMediaUrl(account?.profile)
+
+      return [
+        quotedTweet.tweet_id,
+        {
+          tweet_id: quotedTweet.tweet_id,
+          account_id: quotedTweet.account_id,
+          created_at: quotedTweet.created_at,
+          full_text: quotedTweet.full_text,
+          retweet_count: quotedTweet.retweet_count,
+          favorite_count: quotedTweet.favorite_count,
+          avatar_media_url: avatarMediaUrl || undefined,
+          username: account?.username || 'unknown_user',
+          account_display_name:
+            account?.account_display_name ||
+            account?.username ||
+            'Unknown User',
+          media: quotedTweet.media || [],
+        },
+      ] as const
+    }),
+  )
+  const relationByTweetId = new Map(
+    quoteRelations.map((row) => [row.tweet_id, row.quoted_tweet_id]),
+  )
+
+  return tweets.map((tweet) => {
+    const quotedTweetId = relationByTweetId.get(tweet.tweet_id)
+    if (!quotedTweetId) return tweet
+
+    return {
+      ...tweet,
+      quote_tweet_id: quotedTweetId,
+      quoted_tweet:
+        quotedById.get(quotedTweetId) || deletedQuotedTweet(quotedTweetId),
+    }
+  })
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -229,6 +229,7 @@ export interface RawSupabaseTweet {
 
 export interface TimelineTweet {
   tweet_id: string;
+  account_id?: string;
   created_at: string;
   full_text: string;
   favorite_count: number;
@@ -242,6 +243,20 @@ export interface TimelineTweet {
     };
   };
   media?: Array<TweetMediaItem>;
+  quote_tweet_id?: string | null;
+  quoted_tweet?: {
+    tweet_id: string;
+    account_id: string;
+    created_at: string;
+    full_text: string;
+    retweet_count: number | null;
+    favorite_count: number;
+    avatar_media_url?: string;
+    username: string;
+    account_display_name: string;
+    media?: Array<TweetMediaItem>;
+    is_deleted?: boolean;
+  };
 }
 
 export interface TweetMediaItem {

--- a/supabase/migrations/20260807154232_exclude_retweets_from_search.sql
+++ b/supabase/migrations/20260807154232_exclude_retweets_from_search.sql
@@ -1,0 +1,181 @@
+-- Search results should surface original tweets, not archive-native retweet
+-- copies whose text begins with Twitter's "RT @handle:" convention. Apply the
+-- predicate before OFFSET/LIMIT so filtered pagination still returns full pages.
+
+CREATE OR REPLACE FUNCTION "public"."search_tweets"("search_query" "text", "from_user" "text" DEFAULT NULL::"text", "to_user" "text" DEFAULT NULL::"text", "since_date" "date" DEFAULT NULL::"date", "until_date" "date" DEFAULT NULL::"date", "limit_" integer DEFAULT 50, "offset_" integer DEFAULT 0) RETURNS TABLE("tweet_id" "text", "account_id" "text", "created_at" timestamp with time zone, "full_text" "text", "retweet_count" integer, "favorite_count" integer, "reply_to_tweet_id" "text", "avatar_media_url" "text", "archive_upload_id" bigint, "username" "text", "account_display_name" "text", "media" "jsonb")
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "statement_timeout" TO '5min'
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+    from_account_id TEXT;
+    to_account_id TEXT;
+    current_user_account_id TEXT;
+BEGIN
+    BEGIN
+        current_user_account_id := (SELECT (auth.jwt() -> 'app_metadata'::text) ->> 'account_id'::text);
+    EXCEPTION
+        WHEN OTHERS THEN
+            current_user_account_id := NULL;
+    END;
+
+    IF from_user IS NOT NULL THEN
+        SELECT a.account_id INTO from_account_id
+        FROM public.all_account AS a
+        WHERE LOWER(a.username) = LOWER(from_user);
+
+        IF from_account_id IS NULL THEN
+            RETURN;
+        END IF;
+    END IF;
+
+    IF to_user IS NOT NULL THEN
+        SELECT a.account_id INTO to_account_id
+        FROM public.all_account AS a
+        WHERE LOWER(a.username) = LOWER(to_user);
+
+        IF to_account_id IS NULL THEN
+            RETURN;
+        END IF;
+    END IF;
+
+    RETURN QUERY
+    WITH matching_tweets AS (
+        SELECT t.tweet_id
+        FROM public.tweets t
+        LEFT JOIN public.archive_upload au ON t.archive_upload_id = au.id
+        WHERE (search_query = '' OR search_query IS NULL OR t.fts @@ to_tsquery('english', search_query))
+          AND t.full_text NOT LIKE 'RT @%'
+          AND (from_account_id IS NULL OR t.account_id = from_account_id)
+          AND (to_account_id IS NULL OR t.reply_to_user_id = to_account_id)
+          AND (since_date IS NULL OR t.created_at >= since_date)
+          AND (until_date IS NULL OR t.created_at <= until_date)
+          AND (au.id IS NULL OR au.keep_private IS FALSE OR t.account_id = current_user_account_id OR current_user_account_id IS NULL)
+        ORDER BY t.created_at DESC
+        OFFSET offset_
+        LIMIT limit_
+    )
+    SELECT
+        t.tweet_id,
+        t.account_id,
+        t.created_at,
+        t.full_text,
+        t.retweet_count,
+        t.favorite_count,
+        t.reply_to_tweet_id,
+        p.avatar_media_url,
+        p.archive_upload_id AS profile_archive_upload_id,
+        a.username,
+        a.account_display_name,
+        (
+            SELECT jsonb_agg(jsonb_build_object(
+                'media_url', tm.media_url,
+                'media_type', tm.media_type,
+                'width', tm.width,
+                'height', tm.height
+            ) ORDER BY tm.media_id)
+            FROM public.tweet_media tm
+            WHERE tm.tweet_id = t.tweet_id
+        ) AS media
+    FROM matching_tweets mt
+    JOIN public.tweets t ON mt.tweet_id = t.tweet_id
+    JOIN public.all_account a ON t.account_id = a.account_id
+    LEFT JOIN LATERAL (
+        SELECT prof.avatar_media_url, prof.archive_upload_id
+        FROM public.all_profile AS prof
+        WHERE prof.account_id = t.account_id
+        ORDER BY prof.archive_upload_id DESC NULLS LAST, prof.updated_at DESC
+        LIMIT 1
+    ) p ON true
+    ORDER BY t.created_at DESC;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION "public"."search_tweets_exact_phrase"("exact_phrase" "text", "from_user" "text" DEFAULT NULL::"text", "to_user" "text" DEFAULT NULL::"text", "since_date" "date" DEFAULT NULL::"date", "until_date" "date" DEFAULT NULL::"date", "limit_" integer DEFAULT 50, "offset_" integer DEFAULT 0) RETURNS TABLE("tweet_id" "text", "account_id" "text", "created_at" timestamp with time zone, "full_text" "text", "retweet_count" integer, "favorite_count" integer, "reply_to_tweet_id" "text", "avatar_media_url" "text", "archive_upload_id" bigint, "username" "text", "account_display_name" "text", "media" "jsonb")
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "statement_timeout" TO '5min'
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+    from_account_id TEXT;
+    to_account_id TEXT;
+    current_user_account_id TEXT;
+BEGIN
+    BEGIN
+        current_user_account_id := (SELECT (auth.jwt() -> 'app_metadata'::text) ->> 'account_id'::text);
+    EXCEPTION
+        WHEN OTHERS THEN
+            current_user_account_id := NULL;
+    END;
+
+    IF from_user IS NOT NULL THEN
+        SELECT a.account_id INTO from_account_id
+        FROM public.all_account AS a
+        WHERE LOWER(a.username) = LOWER(from_user);
+
+        IF from_account_id IS NULL THEN
+            RETURN;
+        END IF;
+    END IF;
+
+    IF to_user IS NOT NULL THEN
+        SELECT a.account_id INTO to_account_id
+        FROM public.all_account AS a
+        WHERE LOWER(a.username) = LOWER(to_user);
+
+        IF to_account_id IS NULL THEN
+            RETURN;
+        END IF;
+    END IF;
+
+    RETURN QUERY
+    WITH matching_tweets AS (
+        SELECT t.tweet_id
+        FROM public.tweets t
+        LEFT JOIN public.archive_upload au ON t.archive_upload_id = au.id
+        WHERE to_tsvector('simple'::regconfig, t.full_text) @@ phraseto_tsquery('simple'::regconfig, exact_phrase)
+          AND t.full_text NOT LIKE 'RT @%'
+          AND (from_account_id IS NULL OR t.account_id = from_account_id)
+          AND (to_account_id IS NULL OR t.reply_to_user_id = to_account_id)
+          AND (since_date IS NULL OR t.created_at >= since_date)
+          AND (until_date IS NULL OR t.created_at <= until_date)
+          AND (au.id IS NULL OR au.keep_private IS FALSE OR t.account_id = current_user_account_id OR current_user_account_id IS NULL)
+        ORDER BY t.created_at DESC
+        OFFSET offset_
+        LIMIT limit_
+    )
+    SELECT
+        t.tweet_id,
+        t.account_id,
+        t.created_at,
+        t.full_text,
+        t.retweet_count,
+        t.favorite_count,
+        t.reply_to_tweet_id,
+        p.avatar_media_url,
+        p.archive_upload_id AS profile_archive_upload_id,
+        a.username,
+        a.account_display_name,
+        (
+            SELECT jsonb_agg(jsonb_build_object(
+                'media_url', tm.media_url,
+                'media_type', tm.media_type,
+                'width', tm.width,
+                'height', tm.height
+            ) ORDER BY tm.media_id)
+            FROM public.tweet_media tm
+            WHERE tm.tweet_id = t.tweet_id
+        ) AS media
+    FROM matching_tweets mt
+    JOIN public.tweets t ON mt.tweet_id = t.tweet_id
+    JOIN public.all_account a ON t.account_id = a.account_id
+    LEFT JOIN LATERAL (
+        SELECT prof.avatar_media_url, prof.archive_upload_id
+        FROM public.all_profile AS prof
+        WHERE prof.account_id = t.account_id
+        ORDER BY prof.archive_upload_id DESC NULLS LAST, prof.updated_at DESC
+        LIMIT 1
+    ) p ON true
+    ORDER BY t.created_at DESC;
+END;
+$$;

--- a/supabase/schemas/070_functions.sql
+++ b/supabase/schemas/070_functions.sql
@@ -2484,6 +2484,7 @@ BEGIN
         FROM public.tweets t
         LEFT JOIN public.archive_upload au ON t.archive_upload_id = au.id
         WHERE (search_query = '' OR search_query IS NULL OR t.fts @@ to_tsquery('english', search_query))
+          AND t.full_text NOT LIKE 'RT @%'
           AND (from_account_id IS NULL OR t.account_id = from_account_id)
           AND (to_account_id IS NULL OR t.reply_to_user_id = to_account_id)
           AND (since_date IS NULL OR t.created_at >= since_date)
@@ -2582,6 +2583,7 @@ BEGIN
         FROM public.tweets t
         LEFT JOIN public.archive_upload au ON t.archive_upload_id = au.id
         WHERE to_tsvector('simple'::regconfig, t.full_text) @@ phraseto_tsquery('simple'::regconfig, exact_phrase)
+          AND t.full_text NOT LIKE 'RT @%'
           AND (from_account_id IS NULL OR t.account_id = from_account_id)
           AND (to_account_id IS NULL OR t.reply_to_user_id = to_account_id)
           AND (since_date IS NULL OR t.created_at >= since_date)


### PR DESCRIPTION
## Summary

- replace standalone search-result cards with a compact, table-like layout
- organize desktop results into Author, Tweet, Date, Engagement, and Links columns
- keep mobile results dense without horizontal scrolling
- distinguish Community Archive and Twitter destinations with labeled, branded icon actions
- exclude archive-native retweets whose text begins with `RT @handle` before pagination
- render original tweet images and embedded quoted tweets directly in compact results
- preserve the existing roomy tweet presentation outside search

## Why

Search reused the feed-style tweet card, so repeated padding, borders, and footer chrome limited how many tweets could be scanned per screen. The compact mode prioritizes information density while retaining the rich content needed to understand each result.

Retweets are removed at the Supabase search-function level so pages stay full. The client also applies a deployment-safe fallback, and the ClickHouse path scans bounded source pages to top up filtered result pages. Quote relationships, quoted authors, and quoted media are loaded in batches rather than one request per result.

## User impact

Users can scan substantially more original tweets per viewport on desktop and mobile without losing images or quote-tweet context. The Archive and Twitter destinations are now visually and semantically distinct. Longer tweets remain accessible through “Show more,” and CSV export continues to work.

## Validation

- `pnpm type-check`
- `pnpm build`
- server search/enrichment tests: 2 suites, 19 tests
- compact-result rendering test covering media, quoted tweets, and both link destinations

## Deployment

This PR includes `20260807154232_exclude_retweets_from_search.sql`. Staging database sync runs from the PR push; the production migration must be applied before or with merge.
