### PR TITLE
Fix opt-in timestamps and missing-account freshness

### DIFF
--- a/src/lib/missingAccounts.test.ts
+++ b/src/lib/missingAccounts.test.ts
@@ -36,6 +36,6 @@ describe('getMissingAccounts', () => {
       fetchAnalyticsGatewayJsonMock.mock.calls[0]!
     expect(path).toEqual(['missing-accounts'])
     expect(searchParams?.toString()).toBe('limit=100')
-    expect(options).toEqual({ revalidate: 600, timeoutMs: 30_000 })
+    expect(options).toEqual({ timeoutMs: 30_000, revalidate: 60 })
   })
 })

--- a/src/lib/missingAccounts.ts
+++ b/src/lib/missingAccounts.ts
@@ -36,6 +36,6 @@ export async function getMissingAccounts(): Promise<MissingAccountsResponse> {
   return fetchAnalyticsGatewayJson<MissingAccountsResponse>(
     ['missing-accounts'],
     new URLSearchParams({ limit: '100' }),
-    { revalidate: 10 * 60, timeoutMs: 30_000 },
+    { timeoutMs: 30_000, revalidate: 60 },
   )
 }

--- a/supabase/migrations/20260807223248_fix_optin_insert_timestamps.sql
+++ b/supabase/migrations/20260807223248_fix_optin_insert_timestamps.sql
@@ -1,0 +1,69 @@
+CREATE OR REPLACE FUNCTION public.update_optin_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $function$
+BEGIN
+    NEW.updated_at = NOW();
+
+    -- Inserts have no OLD row, so initialize state timestamps explicitly.
+    IF TG_OP = 'INSERT' THEN
+        IF NEW.explicit_optout IS TRUE THEN
+            NEW.opted_in = false;
+            NEW.opted_out_at = NOW();
+        ELSIF NEW.opted_in IS TRUE THEN
+            NEW.opted_in_at = NOW();
+            NEW.opted_out_at = NULL;
+            NEW.explicit_optout = false;
+            NEW.opt_out_reason = NULL;
+        END IF;
+
+        RETURN NEW;
+    END IF;
+
+    -- State timestamps are server-owned. Ignore caller-supplied rewrites unless
+    -- the opt-in state actually changes below.
+    NEW.opted_in_at = OLD.opted_in_at;
+    NEW.opted_out_at = OLD.opted_out_at;
+
+    -- Explicit opt-outs always override opt-in state.
+    IF NEW.explicit_optout IS TRUE THEN
+        NEW.opted_in = false;
+        IF OLD.explicit_optout IS DISTINCT FROM TRUE
+           OR OLD.opted_in IS TRUE
+           OR NEW.opted_out_at IS NULL THEN
+            NEW.opted_out_at = NOW();
+        END IF;
+    -- Track opt-in/opt-out timestamps.
+    ELSIF OLD.opted_in IS FALSE AND NEW.opted_in IS TRUE THEN
+        NEW.opted_in_at = NOW();
+        NEW.opted_out_at = NULL;
+        NEW.explicit_optout = false;
+        NEW.opt_out_reason = NULL;
+    ELSIF OLD.opted_in IS TRUE AND NEW.opted_in IS FALSE THEN
+        NEW.opted_out_at = NOW();
+    ELSIF NEW.opted_in IS TRUE AND NEW.opted_in_at IS NULL THEN
+        -- Repair legacy opted-in rows the next time they are updated.
+        NEW.opted_in_at = COALESCE(OLD.opted_in_at, OLD.created_at, OLD.updated_at, NOW());
+    END IF;
+
+    RETURN NEW;
+END;
+$function$;
+
+CREATE OR REPLACE TRIGGER update_optin_timestamp
+BEFORE INSERT OR UPDATE ON public.optin
+FOR EACH ROW
+EXECUTE FUNCTION public.update_optin_updated_at();
+
+-- Existing manual opt-ins were inserted before the trigger covered INSERT.
+-- Their creation time is the closest durable record of when they opted in.
+-- Preserve historical updated_at values while repairing the missing timestamp.
+ALTER TABLE public.optin DISABLE TRIGGER update_optin_timestamp;
+
+UPDATE public.optin
+SET opted_in_at = COALESCE(created_at, updated_at, NOW())
+WHERE opted_in IS TRUE
+  AND opted_in_at IS NULL;
+
+ALTER TABLE public.optin ENABLE TRIGGER update_optin_timestamp;

--- a/supabase/schemas/070_functions.sql
+++ b/supabase/schemas/070_functions.sql
@@ -54,26 +54,52 @@ ALTER FUNCTION "private"."queue_update_conversation_ids"() OWNER TO "postgres";
 -- Update updated_at and track opt-in/out timestamps on optin table
 CREATE OR REPLACE FUNCTION "public"."update_optin_updated_at"() RETURNS "trigger"
     LANGUAGE "plpgsql"
+    SET "search_path" TO ''
     AS $$
 BEGIN
     NEW.updated_at = NOW();
-    
-    -- Track opt-in/opt-out timestamps
-    IF OLD.opted_in = false AND NEW.opted_in = true THEN
+
+    -- Inserts have no OLD row, so initialize state timestamps explicitly.
+    IF TG_OP = 'INSERT' THEN
+        IF NEW.explicit_optout IS TRUE THEN
+            NEW.opted_in = false;
+            NEW.opted_out_at = NOW();
+        ELSIF NEW.opted_in IS TRUE THEN
+            NEW.opted_in_at = NOW();
+            NEW.opted_out_at = NULL;
+            NEW.explicit_optout = false;
+            NEW.opt_out_reason = NULL;
+        END IF;
+
+        RETURN NEW;
+    END IF;
+
+    -- State timestamps are server-owned. Ignore caller-supplied rewrites unless
+    -- the opt-in state actually changes below.
+    NEW.opted_in_at = OLD.opted_in_at;
+    NEW.opted_out_at = OLD.opted_out_at;
+
+    -- Explicit opt-outs always override opt-in state.
+    IF NEW.explicit_optout IS TRUE THEN
+        NEW.opted_in = false;
+        IF OLD.explicit_optout IS DISTINCT FROM TRUE
+           OR OLD.opted_in IS TRUE
+           OR NEW.opted_out_at IS NULL THEN
+            NEW.opted_out_at = NOW();
+        END IF;
+    -- Track opt-in/opt-out timestamps.
+    ELSIF OLD.opted_in IS FALSE AND NEW.opted_in IS TRUE THEN
         NEW.opted_in_at = NOW();
         NEW.opted_out_at = NULL;
         NEW.explicit_optout = false; -- Clear explicit opt-out when opting in
         NEW.opt_out_reason = NULL;
-    ELSIF OLD.opted_in = true AND NEW.opted_in = false THEN
+    ELSIF OLD.opted_in IS TRUE AND NEW.opted_in IS FALSE THEN
         NEW.opted_out_at = NOW();
+    ELSIF NEW.opted_in IS TRUE AND NEW.opted_in_at IS NULL THEN
+        -- Repair legacy opted-in rows the next time they are updated.
+        NEW.opted_in_at = COALESCE(OLD.opted_in_at, OLD.created_at, OLD.updated_at, NOW());
     END IF;
-    
-    -- Handle explicit opt-out
-    IF OLD.explicit_optout = false AND NEW.explicit_optout = true THEN
-        NEW.opted_in = false;
-        NEW.opted_out_at = NOW();
-    END IF;
-    
+
     RETURN NEW;
 END;
 $$;

--- a/supabase/schemas/080_triggers.sql
+++ b/supabase/schemas/080_triggers.sql
@@ -14,7 +14,7 @@ CREATE OR REPLACE TRIGGER "update_following_updated_at" BEFORE UPDATE ON "public
 
 CREATE OR REPLACE TRIGGER "update_likes_updated_at" BEFORE UPDATE ON "public"."likes" FOR EACH ROW EXECUTE FUNCTION "public"."update_updated_at_column"();
 
-CREATE OR REPLACE TRIGGER "update_optin_timestamp" BEFORE UPDATE ON "public"."optin" FOR EACH ROW EXECUTE FUNCTION "public"."update_optin_updated_at"();
+CREATE OR REPLACE TRIGGER "update_optin_timestamp" BEFORE INSERT OR UPDATE ON "public"."optin" FOR EACH ROW EXECUTE FUNCTION "public"."update_optin_updated_at"();
 
 CREATE OR REPLACE TRIGGER "propagate_explicit_optout_scrape_block" AFTER INSERT OR UPDATE OF "explicit_optout", "twitter_user_id", "username" ON "public"."optin" FOR EACH ROW EXECUTE FUNCTION "public"."propagate_explicit_optout_scrape_block"();
 

--- a/supabase/tests/database/optin_timestamp_trigger.test.sql
+++ b/supabase/tests/database/optin_timestamp_trigger.test.sql
@@ -1,0 +1,203 @@
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
+SET LOCAL search_path = public, extensions;
+
+SELECT plan(14);
+
+INSERT INTO public.optin (
+  username,
+  opted_in,
+  opted_in_at
+) VALUES (
+  '__pgtap_optin_insert',
+  true,
+  '2000-01-01 00:00:00+00'
+);
+
+SELECT is(
+  (SELECT opted_in FROM public.optin WHERE username = '__pgtap_optin_insert'),
+  true,
+  'opted-in inserts remain opted in'
+);
+
+SELECT is(
+  (SELECT opted_in_at FROM public.optin WHERE username = '__pgtap_optin_insert'),
+  (SELECT updated_at FROM public.optin WHERE username = '__pgtap_optin_insert'),
+  'opted-in inserts receive a server-controlled timestamp'
+);
+
+UPDATE public.optin
+SET opted_in_at = '2001-01-01 00:00:00+00'
+WHERE username = '__pgtap_optin_insert';
+
+SELECT is(
+  (SELECT opted_in_at FROM public.optin WHERE username = '__pgtap_optin_insert'),
+  (SELECT updated_at FROM public.optin WHERE username = '__pgtap_optin_insert'),
+  'same-state opted-in updates cannot rewrite the server timestamp'
+);
+
+INSERT INTO public.optin (
+  username,
+  opted_in,
+  explicit_optout,
+  opted_out_at
+) VALUES (
+  '__pgtap_explicit_optout_insert',
+  true,
+  true,
+  '2000-01-01 00:00:00+00'
+);
+
+SELECT is(
+  (SELECT opted_in FROM public.optin WHERE username = '__pgtap_explicit_optout_insert'),
+  false,
+  'explicit opt-out overrides a simultaneous inserted opt-in'
+);
+
+SELECT is(
+  (SELECT opted_out_at FROM public.optin WHERE username = '__pgtap_explicit_optout_insert'),
+  (SELECT updated_at FROM public.optin WHERE username = '__pgtap_explicit_optout_insert'),
+  'explicit opt-out inserts receive a server-controlled timestamp'
+);
+
+UPDATE public.optin
+SET opted_out_at = '2001-01-01 00:00:00+00'
+WHERE username = '__pgtap_explicit_optout_insert';
+
+SELECT is(
+  (SELECT opted_out_at FROM public.optin WHERE username = '__pgtap_explicit_optout_insert'),
+  (SELECT updated_at FROM public.optin WHERE username = '__pgtap_explicit_optout_insert'),
+  'same-state explicit opt-outs cannot rewrite the server timestamp'
+);
+
+UPDATE public.optin
+SET
+  opted_in = true,
+  explicit_optout = false,
+  opt_out_reason = 'stale reason'
+WHERE username = '__pgtap_explicit_optout_insert';
+
+SELECT is(
+  (
+    SELECT opted_in
+      AND explicit_optout IS FALSE
+      AND opted_out_at IS NULL
+      AND opt_out_reason IS NULL
+    FROM public.optin
+    WHERE username = '__pgtap_explicit_optout_insert'
+  ),
+  true,
+  'false-to-true transitions clear opt-out state'
+);
+
+SELECT is(
+  (
+    SELECT opted_in_at = updated_at
+    FROM public.optin
+    WHERE username = '__pgtap_explicit_optout_insert'
+  ),
+  true,
+  'false-to-true transitions record the opt-in time'
+);
+
+UPDATE public.optin
+SET opted_in = false
+WHERE username = '__pgtap_explicit_optout_insert';
+
+SELECT is(
+  (
+    SELECT opted_out_at = updated_at
+    FROM public.optin
+    WHERE username = '__pgtap_explicit_optout_insert'
+  ),
+  true,
+  'true-to-false transitions record the opt-out time'
+);
+
+ALTER TABLE public.optin DISABLE TRIGGER update_optin_timestamp;
+
+INSERT INTO public.optin (username, opted_in, created_at, updated_at)
+VALUES
+  ('__pgtap_legacy_repair', true, '2020-01-01 00:00:00+00', '2020-01-01 00:00:00+00'),
+  ('__pgtap_legacy_backfill', true, '2021-01-01 00:00:00+00', '2021-01-01 00:00:00+00'),
+  (
+    '__pgtap_preserved_timestamp',
+    true,
+    '2022-01-01 00:00:00+00',
+    '2022-01-01 00:00:00+00'
+  ),
+  ('__pgtap_opted_out', false, '2023-01-01 00:00:00+00', '2023-01-01 00:00:00+00');
+
+UPDATE public.optin
+SET opted_in_at = '2019-01-01 00:00:00+00'
+WHERE username = '__pgtap_preserved_timestamp';
+
+ALTER TABLE public.optin ENABLE TRIGGER update_optin_timestamp;
+
+UPDATE public.optin
+SET username = username
+WHERE username = '__pgtap_legacy_repair';
+
+SELECT is(
+  (
+    SELECT opted_in_at = created_at
+    FROM public.optin
+    WHERE username = '__pgtap_legacy_repair'
+  ),
+  true,
+  'legacy opted-in rows self-repair on their next update'
+);
+
+ALTER TABLE public.optin DISABLE TRIGGER update_optin_timestamp;
+
+UPDATE public.optin
+SET opted_in_at = COALESCE(created_at, updated_at, NOW())
+WHERE opted_in IS TRUE
+  AND opted_in_at IS NULL;
+
+ALTER TABLE public.optin ENABLE TRIGGER update_optin_timestamp;
+
+SELECT is(
+  (
+    SELECT opted_in_at = created_at
+    FROM public.optin
+    WHERE username = '__pgtap_legacy_backfill'
+  ),
+  true,
+  'the backfill fills legacy opted-in rows from their creation time'
+);
+
+SELECT is(
+  (
+    SELECT updated_at = '2021-01-01 00:00:00+00'::timestamptz
+    FROM public.optin
+    WHERE username = '__pgtap_legacy_backfill'
+  ),
+  true,
+  'the backfill preserves the historical updated-at time'
+);
+
+SELECT is(
+  (
+    SELECT opted_in_at = '2019-01-01 00:00:00+00'::timestamptz
+    FROM public.optin
+    WHERE username = '__pgtap_preserved_timestamp'
+  ),
+  true,
+  'the backfill preserves existing opt-in timestamps'
+);
+
+SELECT is(
+  (
+    SELECT opted_in_at IS NULL
+    FROM public.optin
+    WHERE username = '__pgtap_opted_out'
+  ),
+  true,
+  'the backfill leaves opted-out rows unchanged'
+);
+
+SELECT * FROM finish();
+
+ROLLBACK;


### PR DESCRIPTION
## Summary

- record server-controlled opt-in and opt-out timestamps for inserts and state transitions
- backfill legacy opted-in rows without rewriting historical updated_at values
- add pgTAP coverage for inserts, transitions, timestamp integrity, and backfill behavior
- refresh the missing-accounts gateway response every 60 seconds

## Verification

- pnpm type-check
- pnpm test:server -- --runInBand (103 tests)
- focused missing-account tests (4 tests)
- isolated Postgres migration/state-machine assertions
- final adversarial and red-team review: clean

## Release note

The Supabase migration is intentionally not applied by this PR; production database synchronization remains a separate manual deployment step.