### PR TITLE
Keep portal available when optional feeds fail

### DIFF
--- a/src/lib/portal/data.test.ts
+++ b/src/lib/portal/data.test.ts
@@ -7,6 +7,7 @@ import {
   fetchPortalMemberCount,
   getPortalStreamPage,
   getPortalStreamUpdates,
+  loadOptionalPortalData,
   portalDataSourceKey,
   resolvePortalReadConfig,
   selectDailyBangers,
@@ -51,6 +52,27 @@ describe('portal read source', () => {
     expect(key).toBe(
       'portal-v5:preview:analytics.example:prod-project.supabase.co',
     )
+  })
+})
+
+describe('optional portal data', () => {
+  test('returns a fallback without rejecting the page when a section fails', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation()
+
+    await expect(
+      loadOptionalPortalData(
+        'historical-bangers',
+        async () => {
+          throw new Error('Analytics gateway is temporarily unavailable')
+        },
+        [],
+      ),
+    ).resolves.toEqual([])
+
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('"section":"historical-bangers"'),
+    )
+    consoleError.mockRestore()
   })
 })
 

--- a/src/lib/portal/data.ts
+++ b/src/lib/portal/data.ts
@@ -451,6 +451,26 @@ const getCachedRecentBangers = unstable_cache(
   { revalidate: 1_800 },
 )
 
+export async function loadOptionalPortalData<T>(
+  section: string,
+  loader: () => Promise<T>,
+  fallback: T,
+): Promise<T> {
+  try {
+    return await loader()
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        level: 'error',
+        message: 'Optional portal data failed',
+        section,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    )
+    return fallback
+  }
+}
+
 export async function getPortalBangers(): Promise<PortalTweet[]> {
   return getCachedRecentBangers(portalDataSourceKey())
 }
@@ -471,10 +491,22 @@ export async function getPortalData(
     getCachedCorpusSnapshot(sourceKey),
     getCachedStatsSnapshot(sourceKey),
     getCachedInitialStream(sourceKey),
-    view === 'home' ? getResearchPosts() : Promise.resolve([]),
-    view === 'home' ? getCachedRecentBangers(sourceKey) : Promise.resolve([]),
     view === 'home'
-      ? getCachedHistoricalBangers(sourceKey, today)
+      ? loadOptionalPortalData('research', getResearchPosts, [])
+      : Promise.resolve([]),
+    view === 'home'
+      ? loadOptionalPortalData(
+          'recent-bangers',
+          () => getCachedRecentBangers(sourceKey),
+          [],
+        )
+      : Promise.resolve([]),
+    view === 'home'
+      ? loadOptionalPortalData(
+          'historical-bangers',
+          () => getCachedHistoricalBangers(sourceKey, today),
+          [],
+        )
       : Promise.resolve([]),
   ])
   const stats: PortalStats = {


### PR DESCRIPTION
## Summary
- prevent research and banger feed failures from taking down the portal home page
- emit structured errors identifying the failed optional section
- add a targeted regression test for fallback behavior

## Root cause
The historical banger request hit the ClickHouse gateway 25-second query timeout. Because all home data was loaded in one `Promise.all`, that optional failure rendered the global error boundary.

## Verification
- `npx jest --selectProjects server --runTestsByPath src/lib/portal/data.test.ts --runInBand` (9 passed)
- `git diff --check`