### PR TITLE
Add authenticated trends explorer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,12 @@ Staging synchronization is automatic; production synchronization is not:
   gateway lacks a required portal corpus endpoint, add a narrow endpoint rather
   than a production Supabase read fallback. Cache expensive snapshots at an
   interval appropriate to the UI.
+- The control-plane query gateway permits only one authenticated `/search` or
+  `/analytics/search` request at a time and returns `503` with `Retry-After: 1`
+  for overlap. Serialize multi-search fan-out in server callers; this limit does
+  not apply to `/analytics/word-trend`. The source of truth is
+  `TheExGenesis/community-archive-control-panel` under
+  `ops/clickhouse-query-gateway/server.mjs` and `docs/clickhouse-operations.md`.
 - Keep Supabase authoritative for authentication, writes, canonical membership,
   consent/policy state, editorial application data, and records not represented
   in ClickHouse. Do not use the daily ClickHouse `memberAccounts` summary as the

--- a/src/app/api/portal/trends/route.ts
+++ b/src/app/api/portal/trends/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  fetchPortalTrendEvidence,
+  fetchPortalTrendSeries,
+  portalTrendTokens,
+} from '@/lib/portal/analytics'
+import { getIsMember } from '@/lib/portal/auth'
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 60
+
+const MAX_TERMS = 8
+const MAX_TERM_LENGTH = 80
+
+function normalizedTerms(values: string[]): string[] {
+  const terms = Array.from(
+    new Set(
+      values.map((value) => value.trim().toLocaleLowerCase()).filter(Boolean),
+    ),
+  )
+  if (terms.length > MAX_TERMS) {
+    throw new Error(`Choose at most ${MAX_TERMS} terms at a time`)
+  }
+  if (
+    terms.some(
+      (term) =>
+        term.length > MAX_TERM_LENGTH || portalTrendTokens(term).length === 0,
+    )
+  ) {
+    throw new Error('Enter searchable terms of 80 characters or fewer')
+  }
+  return terms
+}
+
+function privateJson(body: unknown, status = 200) {
+  return NextResponse.json(body, {
+    status,
+    headers: { 'Cache-Control': 'private, no-store' },
+  })
+}
+
+export async function GET(request: NextRequest) {
+  if (!(await getIsMember())) {
+    return privateJson({ error: 'Sign in to explore trends' }, 401)
+  }
+
+  try {
+    const params = new URL(request.url).searchParams
+    const view = params.get('view')
+
+    if (view === 'series') {
+      const terms = normalizedTerms(params.getAll('q'))
+      if (terms.length === 0) throw new Error('Enter at least one term')
+      return privateJson(await fetchPortalTrendSeries(terms))
+    }
+
+    if (view === 'feed') {
+      const includeTerms = normalizedTerms(params.getAll('include'))
+      const excludeTerms = normalizedTerms(params.getAll('exclude'))
+      if (includeTerms.length === 0) {
+        throw new Error('Include at least one term to load matching tweets')
+      }
+      return privateJson({
+        tweets: await fetchPortalTrendEvidence(includeTerms, excludeTerms, 30),
+      })
+    }
+
+    return privateJson({ error: 'Choose a trends view' }, 400)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Invalid request'
+    const isInputError =
+      message.startsWith('Enter') ||
+      message.startsWith('Choose') ||
+      message.startsWith('Include')
+    if (!isInputError) console.error('Portal trends request failed:', error)
+    return privateJson(
+      {
+        error: isInputError
+          ? message
+          : 'The trends explorer is temporarily unavailable',
+      },
+      isInputError ? 400 : 502,
+    )
+  }
+}

--- a/src/app/trends/page.tsx
+++ b/src/app/trends/page.tsx
@@ -1,13 +1,30 @@
 import { redirect } from 'next/navigation'
+import PortalComponentErrorBoundary from '@/components/portal/PortalComponentErrorBoundary'
 import TrendsExplorer from '@/components/portal/TrendsExplorer'
 import { getIsMember } from '@/lib/portal/auth'
-import { getPortalTrendSnapshot } from '@/lib/portal/data'
+import {
+  getPortalTrendSnapshot,
+  loadPortalComponentData,
+} from '@/lib/portal/data'
+import { emptyPortalTrends } from '@/lib/portal/trendConfig'
 
 export const metadata = { title: 'Trends · Community Archive' }
 export const maxDuration = 60
 
 export default async function TrendsPage() {
   if (!(await getIsMember())) redirect('/')
-  const trends = await getPortalTrendSnapshot()
-  return <TrendsExplorer initialTrends={trends} />
+  const initial = await loadPortalComponentData(
+    'trends-explorer',
+    getPortalTrendSnapshot,
+    emptyPortalTrends(),
+  )
+
+  return (
+    <PortalComponentErrorBoundary componentName="Trends explorer">
+      <TrendsExplorer
+        initialTrends={initial.data}
+        initialLoadFailed={initial.failed}
+      />
+    </PortalComponentErrorBoundary>
+  )
 }

--- a/src/app/trends/page.tsx
+++ b/src/app/trends/page.tsx
@@ -1,6 +1,13 @@
 import { redirect } from 'next/navigation'
+import TrendsExplorer from '@/components/portal/TrendsExplorer'
+import { getIsMember } from '@/lib/portal/auth'
+import { getPortalTrendSnapshot } from '@/lib/portal/data'
 
-// Trends now lives on the Stream page.
-export default function TrendsPage() {
-  redirect('/stream#trends')
+export const metadata = { title: 'Trends · Community Archive' }
+export const maxDuration = 60
+
+export default async function TrendsPage() {
+  if (!(await getIsMember())) redirect('/')
+  const trends = await getPortalTrendSnapshot()
+  return <TrendsExplorer initialTrends={trends} />
 }

--- a/src/components/portal/Portal.tsx
+++ b/src/components/portal/Portal.tsx
@@ -418,7 +418,7 @@ export default function Portal({
               <div className={`${CARD} flex flex-1 flex-col`}>
                 <PanelHeader
                   title="Trending terms · 7 days"
-                  action={{ label: 'Trends explorer', href: '/stream#trends' }}
+                  action={{ label: 'Trends explorer', href: '/trends' }}
                 />
                 <div className="flex flex-1 flex-col justify-evenly px-4 pb-3 pt-2">
                   {weeklyBars.length > 0 && (

--- a/src/components/portal/PortalComponentErrorBoundary.tsx
+++ b/src/components/portal/PortalComponentErrorBoundary.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { Component } from 'react'
+import type { ErrorInfo, ReactNode } from 'react'
+import { CARD, MUTED, SERIF } from './styles'
+
+interface Props {
+  children: ReactNode
+  componentName: string
+}
+
+interface State {
+  failed: boolean
+}
+
+/** Keeps an unexpected client render failure inside one portal component. */
+export default class PortalComponentErrorBoundary extends Component<
+  Props,
+  State
+> {
+  state: State = { failed: false }
+
+  static getDerivedStateFromError(): State {
+    return { failed: true }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error(
+      JSON.stringify({
+        level: 'error',
+        message: 'Portal component render failed',
+        component: this.props.componentName,
+        error: error.message,
+        componentStack: info.componentStack,
+      }),
+    )
+  }
+
+  render() {
+    if (!this.state.failed) return this.props.children
+
+    return (
+      <main className="min-h-screen bg-zinc-100/80 px-4 py-8 dark:bg-transparent sm:px-6">
+        <div
+          className={`${CARD} mx-auto max-w-[760px] px-6 py-12 text-center`}
+          role="alert"
+        >
+          <h1 className="text-[24px] font-semibold" style={SERIF}>
+            {this.props.componentName} is temporarily unavailable
+          </h1>
+          <p className={`mx-auto mt-2 max-w-md text-[13px] ${MUTED}`}>
+            The rest of the dashboard is still available. Retry just this
+            component when you’re ready.
+          </p>
+          <button
+            type="button"
+            onClick={() => this.setState({ failed: false })}
+            className="mt-5 rounded-[4px] bg-brand px-4 py-2 text-[13px] font-bold text-white hover:opacity-90"
+          >
+            Retry component
+          </button>
+        </div>
+      </main>
+    )
+  }
+}

--- a/src/components/portal/TrendsExplorer.tsx
+++ b/src/components/portal/TrendsExplorer.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { FormEvent } from 'react'
 import Link from 'next/link'
+import { CHART_TERMS } from '@/lib/portal/trendConfig'
 import type { PortalTrends, PortalTweet, TermSeries } from '@/lib/portal/types'
 import { TweetRow } from './TweetRow'
 import { BODY, CARD, MUTED, SERIF } from './styles'
@@ -44,6 +45,23 @@ const SERIES_COLORS = [
   '#f97316',
   '#84cc16',
 ]
+const DEFAULT_TREND_TERMS = CHART_TERMS.map(({ term }) => term)
+
+async function requestTrendSeries(terms: string[]): Promise<SeriesResponse> {
+  const params = new URLSearchParams({ view: 'series' })
+  terms.forEach((term) => params.append('q', term))
+  const response = await fetch(`/api/portal/trends?${params.toString()}`)
+  const body = (await response
+    .json()
+    .catch(() => null)) as SeriesResponse | null
+  if (!response.ok) {
+    throw new Error(body?.error || 'Could not load those trends')
+  }
+  if (!body || !Array.isArray(body.years) || !Array.isArray(body.series)) {
+    throw new Error('The trends service returned an invalid response')
+  }
+  return body
+}
 
 function niceCeiling(value: number): number {
   if (value <= 0) return 1
@@ -74,8 +92,10 @@ function filterLabel(term: string, filter: FeedFilter): string {
 
 export default function TrendsExplorer({
   initialTrends,
+  initialLoadFailed = false,
 }: {
   initialTrends: PortalTrends
+  initialLoadFailed?: boolean
 }) {
   const [years, setYears] = useState(initialTrends.years)
   const [series, setSeries] = useState(initialTrends.series)
@@ -97,7 +117,11 @@ export default function TrendsExplorer({
   const [scale, setScale] = useState<TrendScale>('normalized')
   const [termInput, setTermInput] = useState('')
   const [isAdding, setIsAdding] = useState(false)
+  const [isRetryingDefaults, setIsRetryingDefaults] = useState(false)
   const [addError, setAddError] = useState<string | null>(null)
+  const [chartError, setChartError] = useState<string | null>(
+    initialLoadFailed ? 'The default trends could not be loaded.' : null,
+  )
   const [evidence, setEvidence] = useState<PortalTweet[]>([])
   const [isLoadingEvidence, setIsLoadingEvidence] = useState(true)
   const [feedError, setFeedError] = useState<string | null>(null)
@@ -145,9 +169,14 @@ export default function TrendsExplorer({
             signal: controller.signal,
           },
         )
-        const body = (await response.json()) as FeedResponse
+        const body = (await response
+          .json()
+          .catch(() => null)) as FeedResponse | null
         if (!response.ok) {
-          throw new Error(body.error || 'Could not load matching tweets')
+          throw new Error(body?.error || 'Could not load matching tweets')
+        }
+        if (!body || !Array.isArray(body.tweets)) {
+          throw new Error('The tweet feed returned an invalid response')
         }
         setEvidence(body.tweets)
       } catch (error) {
@@ -204,14 +233,8 @@ export default function TrendsExplorer({
     }
 
     setIsAdding(true)
-    const params = new URLSearchParams({ view: 'series' })
-    newTerms.forEach((term) => params.append('q', term))
     try {
-      const response = await fetch(`/api/portal/trends?${params.toString()}`)
-      const body = (await response.json()) as SeriesResponse
-      if (!response.ok) {
-        throw new Error(body.error || 'Could not add those trends')
-      }
+      const body = await requestTrendSeries(newTerms)
 
       const firstColorIndex = series.length
       const additions = body.series.map((item, index) => ({
@@ -230,6 +253,7 @@ export default function TrendsExplorer({
           additions.map(({ term }) => [term, 'include' as const]),
         ),
       }))
+      setChartError(null)
       setTermInput('')
     } catch (error) {
       setAddError(
@@ -237,6 +261,44 @@ export default function TrendsExplorer({
       )
     } finally {
       setIsAdding(false)
+    }
+  }
+
+  const retryDefaultTrends = async () => {
+    setIsRetryingDefaults(true)
+    try {
+      const body = await requestTrendSeries(DEFAULT_TREND_TERMS)
+      const defaultColors = new Map(
+        CHART_TERMS.map(({ term, color }) => [term, color]),
+      )
+      const defaults = body.series.map((item) => ({
+        ...item,
+        color: defaultColors.get(item.term) ?? item.color,
+      }))
+      setYears(body.years)
+      setSeries(defaults)
+      setChartEnabled(
+        Object.fromEntries(
+          defaults.map(({ term }, index) => [term, index < 4]),
+        ),
+      )
+      setFeedFilters(
+        Object.fromEntries(
+          defaults.map(({ term }, index) => [
+            term,
+            index === 0 ? 'include' : 'off',
+          ]),
+        ),
+      )
+      setChartError(null)
+    } catch (error) {
+      setChartError(
+        error instanceof Error
+          ? error.message
+          : 'The default trends could not be loaded.',
+      )
+    } finally {
+      setIsRetryingDefaults(false)
     }
   }
 
@@ -309,7 +371,7 @@ export default function TrendsExplorer({
                 />
                 <button
                   type="submit"
-                  disabled={isAdding}
+                  disabled={isAdding || isRetryingDefaults}
                   className="h-10 rounded-[4px] bg-brand px-4 text-[13px] font-bold text-white transition-opacity hover:opacity-90 disabled:cursor-wait disabled:opacity-60"
                 >
                   {isAdding ? 'Adding…' : 'Add trends'}
@@ -363,6 +425,29 @@ export default function TrendsExplorer({
                   ))}
                 </div>
               </div>
+
+              {chartError && (
+                <div
+                  className="mx-4 mt-4 flex flex-wrap items-center justify-between gap-3 rounded-[4px] border border-amber-300 bg-amber-50 px-3 py-2.5 text-amber-950 dark:border-amber-700/70 dark:bg-amber-950/30 dark:text-amber-100 sm:mx-5"
+                  role="alert"
+                >
+                  <div className="text-[12.5px]">
+                    <span className="font-bold">Chart data unavailable.</span>{' '}
+                    {chartError} Retry this chart without reloading the page;
+                    other dashboard areas are unaffected.
+                  </div>
+                  {series.length === 0 && (
+                    <button
+                      type="button"
+                      onClick={() => void retryDefaultTrends()}
+                      disabled={isRetryingDefaults}
+                      className="rounded-[4px] border border-amber-400 bg-white px-2.5 py-1.5 text-[11.5px] font-bold text-amber-950 hover:bg-amber-100 disabled:cursor-wait disabled:opacity-60 dark:border-amber-600 dark:bg-amber-950/40 dark:text-amber-100"
+                    >
+                      {isRetryingDefaults ? 'Retrying…' : 'Retry defaults'}
+                    </button>
+                  )}
+                </div>
+              )}
 
               <div className="px-2 pb-1 pt-3 sm:px-4">
                 <svg
@@ -448,7 +533,9 @@ export default function TrendsExplorer({
                       fontSize={13}
                       className="fill-zinc-400 dark:fill-[#6d6d78]"
                     >
-                      Select a trend below to draw it.
+                      {series.length === 0
+                        ? 'Add a trend above to start charting.'
+                        : 'Select a trend below to draw it.'}
                     </text>
                   )}
                 </svg>
@@ -491,6 +578,11 @@ export default function TrendsExplorer({
                       </button>
                     )
                   })}
+                  {series.length === 0 && (
+                    <span className={`py-1 text-[12px] ${MUTED}`}>
+                      No trend series loaded.
+                    </span>
+                  )}
                 </div>
               </div>
             </div>

--- a/src/components/portal/TrendsExplorer.tsx
+++ b/src/components/portal/TrendsExplorer.tsx
@@ -1,0 +1,604 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import type { FormEvent } from 'react'
+import Link from 'next/link'
+import type { PortalTrends, PortalTweet, TermSeries } from '@/lib/portal/types'
+import { TweetRow } from './TweetRow'
+import { BODY, CARD, MUTED, SERIF } from './styles'
+
+type FeedFilter = 'include' | 'exclude' | 'off'
+type TrendScale = 'raw' | 'normalized'
+
+interface SeriesResponse {
+  years: number[]
+  series: TermSeries[]
+  computedAt: string
+  error?: string
+}
+
+interface FeedResponse {
+  tweets: PortalTweet[]
+  error?: string
+}
+
+const MAX_SERIES = 12
+const compactAxisFormatter = new Intl.NumberFormat('en', {
+  notation: 'compact',
+  maximumFractionDigits: 1,
+})
+const plainAxisFormatter = new Intl.NumberFormat('en', {
+  maximumFractionDigits: 1,
+})
+const SERIES_COLORS = [
+  '#3b82f6',
+  '#f59e0b',
+  '#a78bfa',
+  '#f87171',
+  '#2acf80',
+  '#38bdf8',
+  '#e879f9',
+  '#fb7185',
+  '#14b8a6',
+  '#8b5cf6',
+  '#f97316',
+  '#84cc16',
+]
+
+function niceCeiling(value: number): number {
+  if (value <= 0) return 1
+  const magnitude = 10 ** Math.floor(Math.log10(value))
+  const normalized = value / magnitude
+  const step =
+    normalized <= 1 ? 1 : normalized <= 2 ? 2 : normalized <= 5 ? 5 : 10
+  return step * magnitude
+}
+
+function compactAxis(value: number): string {
+  return (value >= 1_000 ? compactAxisFormatter : plainAxisFormatter).format(
+    value,
+  )
+}
+
+function nextFeedFilter(filter: FeedFilter): FeedFilter {
+  if (filter === 'off') return 'include'
+  if (filter === 'include') return 'exclude'
+  return 'off'
+}
+
+function filterLabel(term: string, filter: FeedFilter): string {
+  if (filter === 'include') return `${term} is included. Click to exclude it.`
+  if (filter === 'exclude') return `${term} is excluded. Click to turn it off.`
+  return `${term} is off. Click to include it.`
+}
+
+export default function TrendsExplorer({
+  initialTrends,
+}: {
+  initialTrends: PortalTrends
+}) {
+  const [years, setYears] = useState(initialTrends.years)
+  const [series, setSeries] = useState(initialTrends.series)
+  const [chartEnabled, setChartEnabled] = useState<Record<string, boolean>>(
+    () =>
+      Object.fromEntries(
+        initialTrends.series.map(({ term }, index) => [term, index < 4]),
+      ),
+  )
+  const [feedFilters, setFeedFilters] = useState<Record<string, FeedFilter>>(
+    () =>
+      Object.fromEntries(
+        initialTrends.series.map(({ term }, index) => [
+          term,
+          index === 0 ? 'include' : 'off',
+        ]),
+      ),
+  )
+  const [scale, setScale] = useState<TrendScale>('normalized')
+  const [termInput, setTermInput] = useState('')
+  const [isAdding, setIsAdding] = useState(false)
+  const [addError, setAddError] = useState<string | null>(null)
+  const [evidence, setEvidence] = useState<PortalTweet[]>([])
+  const [isLoadingEvidence, setIsLoadingEvidence] = useState(true)
+  const [feedError, setFeedError] = useState<string | null>(null)
+  const [refreshKey, setRefreshKey] = useState(0)
+
+  const enabledSeries = useMemo(
+    () => series.filter(({ term }) => chartEnabled[term]),
+    [chartEnabled, series],
+  )
+  const includeTerms = useMemo(
+    () =>
+      series
+        .map(({ term }) => term)
+        .filter((term) => feedFilters[term] === 'include'),
+    [feedFilters, series],
+  )
+  const excludeTerms = useMemo(
+    () =>
+      series
+        .map(({ term }) => term)
+        .filter((term) => feedFilters[term] === 'exclude'),
+    [feedFilters, series],
+  )
+
+  useEffect(() => {
+    if (includeTerms.length === 0) {
+      setEvidence([])
+      setFeedError(null)
+      setIsLoadingEvidence(false)
+      return
+    }
+
+    const controller = new AbortController()
+    const loadEvidence = async () => {
+      setIsLoadingEvidence(true)
+      setFeedError(null)
+      const params = new URLSearchParams({ view: 'feed' })
+      includeTerms.forEach((term) => params.append('include', term))
+      excludeTerms.forEach((term) => params.append('exclude', term))
+
+      try {
+        const response = await fetch(
+          `/api/portal/trends?${params.toString()}`,
+          {
+            signal: controller.signal,
+          },
+        )
+        const body = (await response.json()) as FeedResponse
+        if (!response.ok) {
+          throw new Error(body.error || 'Could not load matching tweets')
+        }
+        setEvidence(body.tweets)
+      } catch (error) {
+        if (controller.signal.aborted) return
+        setEvidence([])
+        setFeedError(
+          error instanceof Error
+            ? error.message
+            : 'Could not load matching tweets',
+        )
+      } finally {
+        if (!controller.signal.aborted) setIsLoadingEvidence(false)
+      }
+    }
+
+    void loadEvidence()
+    return () => controller.abort()
+  }, [excludeTerms, includeTerms, refreshKey])
+
+  const addTerms = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setAddError(null)
+
+    const requested = Array.from(
+      new Set(
+        termInput
+          .split(',')
+          .map((term) => term.trim().toLocaleLowerCase())
+          .filter(Boolean),
+      ),
+    )
+    if (requested.length === 0) {
+      setAddError('Enter at least one word or phrase.')
+      return
+    }
+
+    const existing = new Set(series.map(({ term }) => term))
+    const alreadyPresent = requested.filter((term) => existing.has(term))
+    const newTerms = requested.filter((term) => !existing.has(term))
+    if (series.length + newTerms.length > MAX_SERIES) {
+      setAddError(`Show up to ${MAX_SERIES} trends at once.`)
+      return
+    }
+
+    if (alreadyPresent.length > 0) {
+      setChartEnabled((current) => ({
+        ...current,
+        ...Object.fromEntries(alreadyPresent.map((term) => [term, true])),
+      }))
+    }
+    if (newTerms.length === 0) {
+      setTermInput('')
+      return
+    }
+
+    setIsAdding(true)
+    const params = new URLSearchParams({ view: 'series' })
+    newTerms.forEach((term) => params.append('q', term))
+    try {
+      const response = await fetch(`/api/portal/trends?${params.toString()}`)
+      const body = (await response.json()) as SeriesResponse
+      if (!response.ok) {
+        throw new Error(body.error || 'Could not add those trends')
+      }
+
+      const firstColorIndex = series.length
+      const additions = body.series.map((item, index) => ({
+        ...item,
+        color: SERIES_COLORS[(firstColorIndex + index) % SERIES_COLORS.length],
+      }))
+      setYears(body.years)
+      setSeries((current) => [...current, ...additions])
+      setChartEnabled((current) => ({
+        ...current,
+        ...Object.fromEntries(additions.map(({ term }) => [term, true])),
+      }))
+      setFeedFilters((current) => ({
+        ...current,
+        ...Object.fromEntries(
+          additions.map(({ term }) => [term, 'include' as const]),
+        ),
+      }))
+      setTermInput('')
+    } catch (error) {
+      setAddError(
+        error instanceof Error ? error.message : 'Could not add those trends',
+      )
+    } finally {
+      setIsAdding(false)
+    }
+  }
+
+  const valuesFor = (item: TermSeries) =>
+    scale === 'normalized' ? item.perYear : item.tweetsPerYear
+  const maxValue = Math.max(
+    1,
+    ...enabledSeries.flatMap((item) => valuesFor(item)),
+  )
+  const chartMax = niceCeiling(maxValue)
+  const gridValues = [
+    0,
+    chartMax / 4,
+    chartMax / 2,
+    (chartMax * 3) / 4,
+    chartMax,
+  ]
+  const W = 760
+  const H = 360
+  const X0 = 62
+  const X1 = 732
+  const Y0 = 326
+  const Y1 = 24
+  const xPositions = years.map(
+    (_, index) => X0 + (index * (X1 - X0)) / Math.max(years.length - 1, 1),
+  )
+  const yPosition = (value: number) => Y0 - (value / chartMax) * (Y0 - Y1)
+
+  return (
+    <main className="min-h-screen bg-zinc-100/80 dark:bg-transparent">
+      <div className="mx-auto max-w-[1480px] px-4 py-6 sm:px-6">
+        <Link
+          href="/"
+          className={`mb-2 inline-flex items-center text-[12.5px] font-semibold ${MUTED} hover:text-brand`}
+        >
+          ← Dashboard
+        </Link>
+        <div className="mb-6 flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <h1 className="text-[30px] font-semibold" style={SERIF}>
+              Trends explorer
+            </h1>
+            <p className={`mt-1 max-w-[680px] text-[13.5px] ${MUTED}`}>
+              Compare the archive’s vocabulary over time, then inspect the posts
+              behind each line.
+            </p>
+          </div>
+          <div className={`text-[12px] ${MUTED}`}>
+            Full corpus · {years[0]}–{years.at(-1)}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(360px,0.8fr)]">
+          <section className="min-w-0">
+            <div className={`${CARD} mb-4 p-4 sm:p-5`}>
+              <form
+                onSubmit={addTerms}
+                className="flex flex-col gap-2 sm:flex-row"
+              >
+                <label className="sr-only" htmlFor="trend-terms">
+                  Words or phrases to chart
+                </label>
+                <input
+                  id="trend-terms"
+                  value={termInput}
+                  onChange={(event) => setTermInput(event.target.value)}
+                  placeholder="Add words or phrases, separated by commas"
+                  maxLength={500}
+                  className="focus:ring-brand/15 h-10 min-w-0 flex-1 rounded-[4px] border border-zinc-300 bg-white px-3 text-[13.5px] outline-none transition-colors placeholder:text-zinc-400 focus:border-brand focus:ring-2 dark:border-[#34343a] dark:bg-[#121214]"
+                />
+                <button
+                  type="submit"
+                  disabled={isAdding}
+                  className="h-10 rounded-[4px] bg-brand px-4 text-[13px] font-bold text-white transition-opacity hover:opacity-90 disabled:cursor-wait disabled:opacity-60"
+                >
+                  {isAdding ? 'Adding…' : 'Add trends'}
+                </button>
+              </form>
+              <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
+                <span
+                  className={`text-[11.5px] ${addError ? 'text-red-600 dark:text-red-400' : MUTED}`}
+                >
+                  {addError ||
+                    'Multi-word trends match all words; up to four distinct words are counted.'}
+                </span>
+                <span className={`text-[11.5px] tabular-nums ${MUTED}`}>
+                  {series.length}/{MAX_SERIES} trends
+                </span>
+              </div>
+            </div>
+
+            <div className={`${CARD} overflow-hidden`}>
+              <div className="flex flex-wrap items-start justify-between gap-3 border-b border-zinc-200 px-4 py-3.5 dark:border-[#26262a] sm:px-5">
+                <div>
+                  <h2 className="text-[14px] font-bold">
+                    {scale === 'normalized'
+                      ? 'Frequency per 100k tweets'
+                      : 'Matching tweets by year'}
+                  </h2>
+                  <p className={`mt-0.5 text-[11.5px] ${MUTED}`}>
+                    {scale === 'normalized'
+                      ? 'Adjusted for the archive’s changing annual volume.'
+                      : 'Raw matching tweet count in each calendar year.'}
+                  </p>
+                </div>
+                <div
+                  className="inline-flex rounded-[4px] border border-zinc-300 p-0.5 dark:border-[#34343a]"
+                  aria-label="Trend scale"
+                >
+                  {(['raw', 'normalized'] as const).map((option) => (
+                    <button
+                      key={option}
+                      type="button"
+                      aria-pressed={scale === option}
+                      onClick={() => setScale(option)}
+                      className={`rounded-[3px] px-2.5 py-1.5 text-[11.5px] font-semibold transition-colors ${
+                        scale === option
+                          ? 'bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900'
+                          : `${MUTED} hover:text-foreground`
+                      }`}
+                    >
+                      {option === 'raw' ? 'Raw count' : 'Per 100k'}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div className="px-2 pb-1 pt-3 sm:px-4">
+                <svg
+                  viewBox={`0 0 ${W} ${H}`}
+                  className="block w-full"
+                  role="img"
+                  aria-label={`Yearly term trends shown as ${scale === 'normalized' ? 'occurrences per 100,000 tweets' : 'raw tweet counts'}`}
+                >
+                  {gridValues.map((value) => (
+                    <g key={value}>
+                      <line
+                        x1={X0 - 5}
+                        y1={yPosition(value)}
+                        x2={X1}
+                        y2={yPosition(value)}
+                        className="stroke-zinc-200 dark:stroke-[#202023]"
+                        strokeWidth={1}
+                      />
+                      <text
+                        x={X0 - 10}
+                        y={yPosition(value) + 4}
+                        textAnchor="end"
+                        fontSize={10}
+                        className="fill-zinc-400 dark:fill-[#6d6d78]"
+                      >
+                        {compactAxis(value)}
+                      </text>
+                    </g>
+                  ))}
+                  {years.map((year, index) => (
+                    <text
+                      key={year}
+                      x={xPositions[index]}
+                      y={350}
+                      textAnchor="middle"
+                      fontSize={11}
+                      className="fill-zinc-400 dark:fill-[#6d6d78]"
+                    >
+                      {year}
+                    </text>
+                  ))}
+                  {enabledSeries.map((item) => {
+                    const values = valuesFor(item)
+                    return (
+                      <g key={item.term}>
+                        <polyline
+                          fill="none"
+                          stroke={item.color}
+                          strokeWidth={2.75}
+                          strokeLinejoin="round"
+                          strokeLinecap="round"
+                          points={values
+                            .map(
+                              (value, index) =>
+                                `${xPositions[index]},${yPosition(value).toFixed(1)}`,
+                            )
+                            .join(' ')}
+                        />
+                        {values.map((value, index) => (
+                          <circle
+                            key={years[index]}
+                            cx={xPositions[index]}
+                            cy={yPosition(value)}
+                            r={3}
+                            fill={item.color}
+                            className="stroke-white dark:stroke-[#1b1b1e]"
+                            strokeWidth={1.5}
+                            aria-label={`${item.term} · ${years[index]} · ${
+                              scale === 'normalized'
+                                ? `${compactAxis(value)} per 100k`
+                                : `${Math.round(value).toLocaleString('en-US')} tweets`
+                            }`}
+                          />
+                        ))}
+                      </g>
+                    )
+                  })}
+                  {enabledSeries.length === 0 && (
+                    <text
+                      x={(X0 + X1) / 2}
+                      y={(Y0 + Y1) / 2}
+                      textAnchor="middle"
+                      fontSize={13}
+                      className="fill-zinc-400 dark:fill-[#6d6d78]"
+                    >
+                      Select a trend below to draw it.
+                    </text>
+                  )}
+                </svg>
+              </div>
+
+              <div className="border-t border-zinc-100 px-4 py-3 dark:border-[#202023] sm:px-5">
+                <div
+                  className={`mb-2 text-[11px] font-semibold uppercase tracking-[0.08em] ${MUTED}`}
+                >
+                  Series shown
+                </div>
+                <div className="flex flex-wrap gap-1.5">
+                  {series.map((item) => {
+                    const active = !!chartEnabled[item.term]
+                    return (
+                      <button
+                        key={item.term}
+                        type="button"
+                        aria-pressed={active}
+                        onClick={() =>
+                          setChartEnabled((current) => ({
+                            ...current,
+                            [item.term]: !current[item.term],
+                          }))
+                        }
+                        className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1.5 text-[12px] font-semibold transition-colors ${
+                          active
+                            ? 'border-zinc-400 bg-zinc-50 text-foreground dark:border-[#45454c] dark:bg-[#202024]'
+                            : `border-zinc-200 bg-white dark:border-[#29292e] dark:bg-[#171719] ${MUTED}`
+                        }`}
+                      >
+                        <span
+                          className="h-2 w-2 rounded-full"
+                          style={{
+                            backgroundColor: item.color,
+                            opacity: active ? 1 : 0.3,
+                          }}
+                        />
+                        {item.term}
+                      </button>
+                    )
+                  })}
+                </div>
+              </div>
+            </div>
+
+            <p className={`mt-3 text-[12px] leading-relaxed ${BODY}`}>
+              Normalization divides each term’s annual count by all archived
+              tweets from that year, then scales the result to 100,000. This
+              makes years with different archive coverage comparable.
+            </p>
+          </section>
+
+          <aside className="min-w-0 lg:sticky lg:top-20">
+            <div className="mb-2.5 flex items-end justify-between gap-3">
+              <div>
+                <h2 className="text-[18px] font-semibold" style={SERIF}>
+                  Tweets counted
+                </h2>
+                <p className={`mt-0.5 text-[11.5px] ${MUTED}`}>
+                  Latest posts matching any included trend.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setRefreshKey((key) => key + 1)}
+                disabled={isLoadingEvidence || includeTerms.length === 0}
+                className={`text-[11.5px] font-semibold ${MUTED} hover:text-brand disabled:opacity-40`}
+              >
+                Refresh
+              </button>
+            </div>
+
+            <div className={`${CARD} mb-3 p-3`}>
+              <div className="flex flex-wrap gap-1.5">
+                {series.map(({ term }) => {
+                  const filter = feedFilters[term] ?? 'off'
+                  return (
+                    <button
+                      key={term}
+                      type="button"
+                      aria-label={filterLabel(term, filter)}
+                      onClick={() =>
+                        setFeedFilters((current) => ({
+                          ...current,
+                          [term]: nextFeedFilter(current[term] ?? 'off'),
+                        }))
+                      }
+                      className={`rounded-full border px-2.5 py-1.5 text-[11.5px] font-bold transition-colors ${
+                        filter === 'include'
+                          ? 'border-brand bg-brand/10 text-blue-700 dark:text-blue-300'
+                          : filter === 'exclude'
+                            ? 'border-red-400 bg-red-50 text-red-700 dark:border-red-500/70 dark:bg-red-950/30 dark:text-red-300'
+                            : `border-zinc-200 bg-white dark:border-[#29292e] dark:bg-[#171719] ${MUTED}`
+                      }`}
+                    >
+                      {filter === 'include'
+                        ? '+ '
+                        : filter === 'exclude'
+                          ? '− '
+                          : ''}
+                      {term}
+                    </button>
+                  )
+                })}
+              </div>
+              <div className={`mt-2.5 text-[10.5px] leading-normal ${MUTED}`}>
+                Click a pill to cycle: include → exclude → off. Includes are OR;
+                exclusions remove matching posts.
+              </div>
+            </div>
+
+            <div
+              className={`${CARD} max-h-[760px] overflow-y-auto`}
+              aria-live="polite"
+            >
+              {isLoadingEvidence && (
+                <div className={`px-4 py-12 text-center text-[13px] ${MUTED}`}>
+                  Finding matching tweets…
+                </div>
+              )}
+              {!isLoadingEvidence && includeTerms.length === 0 && (
+                <div className={`px-4 py-12 text-center text-[13px] ${MUTED}`}>
+                  Include at least one term to inspect its tweets.
+                </div>
+              )}
+              {!isLoadingEvidence && feedError && (
+                <div className="px-4 py-10 text-center text-[13px] text-red-600 dark:text-red-400">
+                  {feedError}
+                </div>
+              )}
+              {!isLoadingEvidence &&
+                !feedError &&
+                includeTerms.length > 0 &&
+                evidence.length === 0 && (
+                  <div
+                    className={`px-4 py-12 text-center text-[13px] ${MUTED}`}
+                  >
+                    No matching tweets after exclusions.
+                  </div>
+                )}
+              {!isLoadingEvidence &&
+                !feedError &&
+                evidence.map((tweet) => (
+                  <TweetRow key={tweet.id} tweet={tweet} collapsible />
+                ))}
+            </div>
+          </aside>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -15,6 +15,7 @@ export const getPrimaryNav = (isMember: boolean): NavItem[] =>
     ? [
         { href: '/', label: 'Home' },
         { href: '/stream', label: 'Stream' },
+        { href: '/trends', label: 'Trends' },
         { href: '/research', label: 'Research' },
         { href: '/tools', label: 'Tools' },
       ]

--- a/src/lib/portal/TrendsExplorerResilience.test.tsx
+++ b/src/lib/portal/TrendsExplorerResilience.test.tsx
@@ -1,0 +1,111 @@
+/** @jest-environment jsdom */
+
+import '@testing-library/jest-dom'
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import TrendsExplorer from '@/components/portal/TrendsExplorer'
+import { emptyPortalTrends } from './trendConfig'
+import type { PortalTrends } from './types'
+;(globalThis as typeof globalThis & { React: typeof React }).React = React
+
+const successfulTrends: PortalTrends = {
+  years: [2025, 2026],
+  series: [
+    {
+      term: 'tpot',
+      color: '#3b82f6',
+      tweetsPerYear: [10, 20],
+      perYear: [100, 200],
+    },
+  ],
+  weekly: [],
+  computedAt: '2026-08-07T12:00:00.000Z',
+}
+
+describe('TrendsExplorer request isolation', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test('keeps the explorer controls available when its initial snapshot fails', () => {
+    const fetchMock = jest.spyOn(global, 'fetch')
+
+    render(
+      <TrendsExplorer
+        initialTrends={emptyPortalTrends(new Date('2026-08-07T12:00:00.000Z'))}
+        initialLoadFailed
+      />,
+    )
+
+    expect(
+      screen.getByRole('heading', { name: 'Trends explorer' }),
+    ).toBeVisible()
+    expect(screen.getByLabelText('Words or phrases to chart')).toBeEnabled()
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Chart data unavailable',
+    )
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  test('keeps the chart rendered when the matching-tweet request fails', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: 'Matching tweets are unavailable' }),
+    } as Response)
+
+    render(<TrendsExplorer initialTrends={successfulTrends} />)
+
+    expect(
+      await screen.findByText('Matching tweets are unavailable'),
+    ).toBeVisible()
+    expect(screen.getByText('Frequency per 100k tweets')).toBeVisible()
+    expect(
+      screen.getByRole('img', { name: /Yearly term trends/ }),
+    ).toBeVisible()
+  })
+
+  test('retries only the failed chart data', async () => {
+    const user = userEvent.setup()
+    const years = [2019, 2020]
+    const series = [
+      {
+        term: 'tpot',
+        color: '#3b82f6',
+        tweetsPerYear: [1, 2],
+        perYear: [10, 20],
+      },
+    ]
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          years,
+          series,
+          computedAt: '2026-08-07T12:00:00.000Z',
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tweets: [] }),
+      } as Response)
+
+    render(
+      <TrendsExplorer
+        initialTrends={emptyPortalTrends(new Date('2026-08-07T12:00:00.000Z'))}
+        initialLoadFailed
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Retry defaults' }))
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText('Chart data unavailable.'),
+      ).not.toBeInTheDocument(),
+    )
+    expect(screen.getByText('1/12 trends')).toBeVisible()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/lib/portal/analytics.test.ts
+++ b/src/lib/portal/analytics.test.ts
@@ -1,4 +1,6 @@
 import {
+  fetchPortalTrendEvidence,
+  fetchPortalTrendSeries,
   fetchPortalLiveAnalytics,
   fetchPortalHistoricalBangers,
   fetchPortalRecentBangers,
@@ -121,6 +123,9 @@ describe('ClickHouse-backed portal analytics', () => {
     expect(trends.series.find(({ term }) => term === 'tpot')?.perYear).toEqual([
       1000, 0, 0, 0, 0, 0, 0, 2000,
     ])
+    expect(
+      trends.series.find(({ term }) => term === 'tpot')?.tweetsPerYear,
+    ).toEqual([10, 0, 0, 0, 0, 0, 0, 40])
     expect(trends.weekly.find(({ term }) => term === 'tpot')).toEqual({
       term: 'tpot',
       last7: 8,
@@ -134,6 +139,100 @@ describe('ClickHouse-backed portal analytics', () => {
     expect(trends.weekly.find(({ term }) => term === 'jhana')?.status).toBe(
       'inactive',
     )
+  })
+
+  test('fetches several user-selected trend series concurrently', async () => {
+    const fetcher = jest.fn(
+      async (_path: string[], params: URLSearchParams) => ({
+        data: [
+          {
+            bucket: '2026-01-01 00:00:00.000',
+            tweets: params.get('q') === 'alpha' ? '20' : '5',
+            totalTweets: '1000',
+            ratePerThousand: 0,
+          },
+        ],
+      }),
+    ) as unknown as AnalyticsFetcher
+
+    const result = await fetchPortalTrendSeries(
+      ['alpha', 'beta'],
+      new Date('2026-08-07T12:00:00.000Z'),
+      fetcher,
+    )
+
+    expect(fetcher).toHaveBeenCalledTimes(2)
+    expect(result.series).toEqual([
+      expect.objectContaining({
+        term: 'alpha',
+        tweetsPerYear: [0, 0, 0, 0, 0, 0, 0, 20],
+        perYear: [0, 0, 0, 0, 0, 0, 0, 2000],
+      }),
+      expect.objectContaining({
+        term: 'beta',
+        tweetsPerYear: [0, 0, 0, 0, 0, 0, 0, 5],
+        perYear: [0, 0, 0, 0, 0, 0, 0, 500],
+      }),
+    ])
+  })
+
+  test('merges included evidence and removes tweets matching excluded terms', async () => {
+    const tweet = (tweetId: string, fullText: string, createdAt: string) => ({
+      tweetId,
+      accountId: '42',
+      createdAt,
+      fullText,
+      favoriteCount: '3',
+      retweetCount: '1',
+      username: 'alice',
+      accountDisplayName: 'Alice',
+      avatarMediaUrl: null,
+    })
+    const fetcher = jest.fn(
+      async (_path: string[], params: URLSearchParams) => ({
+        data: {
+          tweets:
+            params.get('q') === 'alpha'
+              ? [
+                  tweet(
+                    '100',
+                    'alpha without the excluded idea',
+                    '2026-08-07 10:00:00.000',
+                  ),
+                  tweet(
+                    '101',
+                    'alpha and moloch together',
+                    '2026-08-07 11:00:00.000',
+                  ),
+                ]
+              : [
+                  tweet('102', 'beta arrives later', '2026-08-07 12:00:00.000'),
+                  tweet(
+                    '100',
+                    'alpha without the excluded idea',
+                    '2026-08-07 10:00:00.000',
+                  ),
+                ],
+          nextOffset: null,
+        },
+      }),
+    ) as unknown as AnalyticsFetcher
+
+    const result = await fetchPortalTrendEvidence(
+      ['alpha', 'beta'],
+      ['moloch'],
+      30,
+      fetcher,
+    )
+
+    expect(fetcher).toHaveBeenCalledTimes(2)
+    expect(result.map(({ id }) => id)).toEqual(['102', '100'])
+    expect(result[0]).toMatchObject({
+      username: 'alice',
+      createdAt: '2026-08-07T12:00:00.000Z',
+      likes: 3,
+      rts: 1,
+    })
   })
 
   test('rejects invalid ClickHouse counts instead of rendering false zeros', async () => {

--- a/src/lib/portal/analytics.ts
+++ b/src/lib/portal/analytics.ts
@@ -14,6 +14,21 @@ export const CHART_TERMS: { term: string; color: string }[] = [
   { term: 'ai agents', color: '#e879f9' },
 ]
 
+export const TREND_COLORS = [
+  '#3b82f6',
+  '#f59e0b',
+  '#a78bfa',
+  '#f87171',
+  '#2acf80',
+  '#38bdf8',
+  '#e879f9',
+  '#fb7185',
+  '#14b8a6',
+  '#8b5cf6',
+  '#f97316',
+  '#84cc16',
+]
+
 /** Wider watchlist used for the weekly rising/cooling panels. */
 export const WATCHLIST = [
   'ai agents',
@@ -58,6 +73,25 @@ interface ClickHouseTrendRow {
 
 interface ClickHouseTrendResponse {
   data: ClickHouseTrendRow[]
+}
+
+interface ClickHouseSearchTweet {
+  tweetId: string
+  accountId: string
+  createdAt: string
+  fullText: string
+  favoriteCount: string | number
+  retweetCount: string | number
+  username: string | null
+  accountDisplayName: string | null
+  avatarMediaUrl: string | null
+}
+
+interface ClickHouseSearchResponse {
+  data: {
+    tweets: ClickHouseSearchTweet[]
+    nextOffset: number | null
+  }
 }
 
 interface ClickHouseRecentBanger {
@@ -192,6 +226,157 @@ function ratePerHundredThousand(row: ClickHouseTrendRow): number {
   const tweets = safeCount(row.tweets, 'trend tweet count')
   const totalTweets = safeCount(row.totalTweets, 'trend corpus count')
   return totalTweets === 0 ? 0 : (tweets / totalTweets) * 100_000
+}
+
+/** Matches the gateway's word normalization for word-trend and search. */
+export function portalTrendTokens(value: string): string[] {
+  return normalizedTextTokens(value).slice(0, 4)
+}
+
+function normalizedTextTokens(value: string): string[] {
+  return Array.from(
+    new Set(
+      value
+        .toLocaleLowerCase()
+        .split(/[^\p{L}\p{N}_]+/u)
+        .filter((token) => token.length > 0 && token.length <= 48),
+    ),
+  )
+}
+
+function stableTrendColor(term: string): string {
+  let hash = 0
+  for (const character of term) {
+    hash = (Math.imul(hash, 31) + character.charCodeAt(0)) >>> 0
+  }
+  return TREND_COLORS[hash % TREND_COLORS.length]
+}
+
+function textMatchesTrend(text: string, term: string): boolean {
+  const textTokens = new Set(normalizedTextTokens(text))
+  return portalTrendTokens(term).every((token) => textTokens.has(token))
+}
+
+/** Fetch one or more user-selected yearly series in parallel. */
+export async function fetchPortalTrendSeries(
+  terms: string[],
+  now = new Date(),
+  fetcher: AnalyticsFetcher = fetchAnalyticsGatewayJson,
+): Promise<Pick<PortalTrends, 'years' | 'series' | 'computedAt'>> {
+  const currentYear = now.getUTCFullYear()
+  const years = Array.from(
+    { length: currentYear - FIRST_TREND_YEAR + 1 },
+    (_, index) => FIRST_TREND_YEAR + index,
+  )
+  const responses = await runBatched(
+    terms.map(
+      (term) => () =>
+        fetchTrend(
+          term,
+          'year',
+          `${FIRST_TREND_YEAR}-01-01`,
+          `${currentYear + 1}-01-01`,
+          fetcher,
+        ),
+    ),
+  )
+
+  const series = terms.map((term, index): TermSeries => {
+    const rows = new Map<number, ClickHouseTrendRow>()
+    for (const row of responses[index].data) {
+      const bucket = new Date(normalizeClickHouseTimestamp(row.bucket))
+      if (Number.isNaN(bucket.getTime())) {
+        throw new Error('ClickHouse word-trend returned an invalid bucket')
+      }
+      rows.set(bucket.getUTCFullYear(), row)
+    }
+    return {
+      term,
+      color: stableTrendColor(term),
+      tweetsPerYear: years.map((year) => {
+        const row = rows.get(year)
+        return row ? safeCount(row.tweets, 'trend tweet count') : 0
+      }),
+      perYear: years.map((year) => {
+        const row = rows.get(year)
+        return row ? ratePerHundredThousand(row) : 0
+      }),
+    }
+  })
+
+  return { years, series, computedAt: now.toISOString() }
+}
+
+/**
+ * Latest posts counted by at least one included trend, minus posts matching an
+ * excluded trend. Each query uses the same all-token semantics as word-trend.
+ */
+export async function fetchPortalTrendEvidence(
+  includeTerms: string[],
+  excludeTerms: string[],
+  limit = 30,
+  fetcher: AnalyticsFetcher = fetchAnalyticsGatewayJson,
+): Promise<PortalTweet[]> {
+  const safeLimit = Math.max(1, Math.min(50, Math.trunc(limit)))
+  const candidateLimit = Math.min(50, Math.max(safeLimit * 2, 30))
+  const responses = await runBatched(
+    includeTerms.map(
+      (term) => () =>
+        fetcher<ClickHouseSearchResponse>(
+          ['search'],
+          new URLSearchParams({
+            q: term,
+            mode: 'all',
+            limit: String(candidateLimit),
+            offset: '0',
+          }),
+          { timeoutMs: 30_000 },
+        ),
+    ),
+    // The current query gateway intentionally serializes corpus searches.
+    // Keep evidence requests ordered while trend aggregation stays concurrent.
+    1,
+  )
+
+  const unique = new Map<string, PortalTweet>()
+  for (const response of responses) {
+    if (!Array.isArray(response.data?.tweets)) {
+      throw new Error('ClickHouse search returned an invalid response')
+    }
+    for (const row of response.data.tweets) {
+      if (
+        !/^\d{1,32}$/.test(row.tweetId) ||
+        !/^\d{1,32}$/.test(row.accountId) ||
+        typeof row.fullText !== 'string'
+      ) {
+        throw new Error('ClickHouse search returned an invalid tweet')
+      }
+      if (excludeTerms.some((term) => textMatchesTrend(row.fullText, term))) {
+        continue
+      }
+      const username = row.username || 'unknown'
+      const createdAt = safeTimestamp(row.createdAt, 'trend tweet timestamp')
+      unique.set(row.tweetId, {
+        id: row.tweetId,
+        username,
+        name: row.accountDisplayName || username,
+        avatar: row.avatarMediaUrl || null,
+        text: row.fullText,
+        observedAt: createdAt,
+        createdAt,
+        likes: safeCount(row.favoriteCount, 'trend tweet favorite count'),
+        rts: safeCount(row.retweetCount, 'trend tweet repost count'),
+      })
+    }
+  }
+
+  return Array.from(unique.values())
+    .sort(
+      (left, right) =>
+        new Date(right.createdAt).getTime() -
+          new Date(left.createdAt).getTime() || right.id.localeCompare(left.id),
+    )
+    .slice(0, safeLimit)
 }
 
 export async function fetchPortalLiveAnalytics(
@@ -372,18 +557,25 @@ export async function fetchPortalTrends(
   const weeklyResponses = responses.slice(CHART_TERMS.length)
 
   const series: TermSeries[] = CHART_TERMS.map(({ term, color }, index) => {
-    const values = new Map<number, number>()
+    const rows = new Map<number, ClickHouseTrendRow>()
     for (const row of yearlyResponses[index].data) {
       const bucket = new Date(normalizeClickHouseTimestamp(row.bucket))
       if (Number.isNaN(bucket.getTime())) {
         throw new Error('ClickHouse word-trend returned an invalid bucket')
       }
-      values.set(bucket.getUTCFullYear(), ratePerHundredThousand(row))
+      rows.set(bucket.getUTCFullYear(), row)
     }
     return {
       term,
       color,
-      perYear: years.map((year) => values.get(year) ?? 0),
+      tweetsPerYear: years.map((year) => {
+        const row = rows.get(year)
+        return row ? safeCount(row.tweets, 'trend tweet count') : 0
+      }),
+      perYear: years.map((year) => {
+        const row = rows.get(year)
+        return row ? ratePerHundredThousand(row) : 0
+      }),
     }
   })
 

--- a/src/lib/portal/analytics.ts
+++ b/src/lib/portal/analytics.ts
@@ -1,33 +1,6 @@
 import { fetchAnalyticsGatewayJson } from '@/lib/clickhouseGateway'
+import { CHART_TERMS, FIRST_TREND_YEAR, TREND_COLORS } from './trendConfig'
 import type { PortalTrends, PortalTweet, TermSeries, TermWeek } from './types'
-
-export const FIRST_TREND_YEAR = 2019
-
-/** Terms plotted in the trends explorer chart. */
-export const CHART_TERMS: { term: string; color: string }[] = [
-  { term: 'tpot', color: '#3b82f6' },
-  { term: 'postrat', color: '#f59e0b' },
-  { term: 'egregore', color: '#a78bfa' },
-  { term: 'moloch', color: '#f87171' },
-  { term: 'vibecamp', color: '#2acf80' },
-  { term: 'sensemaking', color: '#38bdf8' },
-  { term: 'ai agents', color: '#e879f9' },
-]
-
-export const TREND_COLORS = [
-  '#3b82f6',
-  '#f59e0b',
-  '#a78bfa',
-  '#f87171',
-  '#2acf80',
-  '#38bdf8',
-  '#e879f9',
-  '#fb7185',
-  '#14b8a6',
-  '#8b5cf6',
-  '#f97316',
-  '#84cc16',
-]
 
 /** Wider watchlist used for the weekly rising/cooling panels. */
 export const WATCHLIST = [

--- a/src/lib/portal/data.test.ts
+++ b/src/lib/portal/data.test.ts
@@ -8,6 +8,7 @@ import {
   getPortalStreamPage,
   getPortalStreamUpdates,
   loadOptionalPortalData,
+  loadPortalComponentData,
   portalDataSourceKey,
   resolvePortalReadConfig,
   selectDailyBangers,
@@ -56,6 +57,25 @@ describe('portal read source', () => {
 })
 
 describe('optional portal data', () => {
+  test('reports a component failure while returning its local fallback', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation()
+
+    await expect(
+      loadPortalComponentData(
+        'trends-explorer',
+        async () => {
+          throw new Error('Analytics gateway is temporarily unavailable')
+        },
+        { series: [] },
+      ),
+    ).resolves.toEqual({ data: { series: [] }, failed: true })
+
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('"section":"trends-explorer"'),
+    )
+    consoleError.mockRestore()
+  })
+
   test('returns a fallback without rejecting the page when a section fails', async () => {
     const consoleError = jest.spyOn(console, 'error').mockImplementation()
 

--- a/src/lib/portal/data.ts
+++ b/src/lib/portal/data.ts
@@ -475,6 +475,11 @@ export async function getPortalBangers(): Promise<PortalTweet[]> {
   return getCachedRecentBangers(portalDataSourceKey())
 }
 
+/** Cached corpus-wide seed series for the authenticated trends explorer. */
+export async function getPortalTrendSnapshot(): Promise<PortalTrends> {
+  return (await getCachedCorpusSnapshot(portalDataSourceKey())).trends
+}
+
 export async function getPortalData(
   view: 'home' | 'stream' = 'home',
 ): Promise<PortalData> {

--- a/src/lib/portal/data.ts
+++ b/src/lib/portal/data.ts
@@ -456,8 +456,16 @@ export async function loadOptionalPortalData<T>(
   loader: () => Promise<T>,
   fallback: T,
 ): Promise<T> {
+  return (await loadPortalComponentData(section, loader, fallback)).data
+}
+
+export async function loadPortalComponentData<T>(
+  section: string,
+  loader: () => Promise<T>,
+  fallback: T,
+): Promise<{ data: T; failed: boolean }> {
   try {
-    return await loader()
+    return { data: await loader(), failed: false }
   } catch (error) {
     console.error(
       JSON.stringify({
@@ -467,7 +475,7 @@ export async function loadOptionalPortalData<T>(
         error: error instanceof Error ? error.message : String(error),
       }),
     )
-    return fallback
+    return { data: fallback, failed: true }
   }
 }
 

--- a/src/lib/portal/trendConfig.ts
+++ b/src/lib/portal/trendConfig.ts
@@ -1,0 +1,42 @@
+import type { PortalTrends } from './types'
+
+export const FIRST_TREND_YEAR = 2019
+
+/** Default terms plotted when the trends explorer first loads. */
+export const CHART_TERMS: { term: string; color: string }[] = [
+  { term: 'tpot', color: '#3b82f6' },
+  { term: 'postrat', color: '#f59e0b' },
+  { term: 'egregore', color: '#a78bfa' },
+  { term: 'moloch', color: '#f87171' },
+  { term: 'vibecamp', color: '#2acf80' },
+  { term: 'sensemaking', color: '#38bdf8' },
+  { term: 'ai agents', color: '#e879f9' },
+]
+
+export const TREND_COLORS = [
+  '#3b82f6',
+  '#f59e0b',
+  '#a78bfa',
+  '#f87171',
+  '#2acf80',
+  '#38bdf8',
+  '#e879f9',
+  '#fb7185',
+  '#14b8a6',
+  '#8b5cf6',
+  '#f97316',
+  '#84cc16',
+]
+
+export function emptyPortalTrends(now = new Date()): PortalTrends {
+  const currentYear = now.getUTCFullYear()
+  return {
+    years: Array.from(
+      { length: currentYear - FIRST_TREND_YEAR + 1 },
+      (_, index) => FIRST_TREND_YEAR + index,
+    ),
+    series: [],
+    weekly: [],
+    computedAt: now.toISOString(),
+  }
+}

--- a/src/lib/portal/types.ts
+++ b/src/lib/portal/types.ts
@@ -35,6 +35,8 @@ export interface TermWeek {
 export interface TermSeries {
   term: string
   color: string
+  /** raw matching tweet counts, one entry per year */
+  tweetsPerYear: number[]
   /** occurrences per 100k tweets, one entry per year */
   perYear: number[]
 }

--- a/src/lib/portalTrendsRoute.test.ts
+++ b/src/lib/portalTrendsRoute.test.ts
@@ -1,0 +1,98 @@
+import { NextRequest } from 'next/server'
+import { GET } from '@/app/api/portal/trends/route'
+import {
+  fetchPortalTrendEvidence,
+  fetchPortalTrendSeries,
+} from '@/lib/portal/analytics'
+import { getIsMember } from '@/lib/portal/auth'
+
+jest.mock('@/lib/portal/analytics', () => ({
+  fetchPortalTrendEvidence: jest.fn(),
+  fetchPortalTrendSeries: jest.fn(),
+  portalTrendTokens: jest.fn((value: string) =>
+    value
+      .toLocaleLowerCase()
+      .split(/[^a-z0-9_]+/)
+      .filter(Boolean)
+      .slice(0, 4),
+  ),
+}))
+jest.mock('@/lib/portal/auth', () => ({ getIsMember: jest.fn() }))
+
+const fetchPortalTrendEvidenceMock =
+  fetchPortalTrendEvidence as jest.MockedFunction<
+    typeof fetchPortalTrendEvidence
+  >
+const fetchPortalTrendSeriesMock =
+  fetchPortalTrendSeries as jest.MockedFunction<typeof fetchPortalTrendSeries>
+const getIsMemberMock = getIsMember as jest.MockedFunction<typeof getIsMember>
+
+describe('portal trends route', () => {
+  beforeEach(() => {
+    fetchPortalTrendEvidenceMock.mockReset()
+    fetchPortalTrendSeriesMock.mockReset()
+    getIsMemberMock.mockReset()
+    getIsMemberMock.mockResolvedValue(true)
+  })
+
+  test('requires a signed-in member', async () => {
+    getIsMemberMock.mockResolvedValue(false)
+
+    const response = await GET(
+      new NextRequest(
+        'https://community-archive.org/api/portal/trends?view=series&q=tpot',
+      ),
+    )
+
+    expect(response.status).toBe(401)
+    expect(fetchPortalTrendSeriesMock).not.toHaveBeenCalled()
+  })
+
+  test('normalizes and deduplicates concurrent series terms', async () => {
+    fetchPortalTrendSeriesMock.mockResolvedValue({
+      years: [2026],
+      series: [],
+      computedAt: '2026-08-07T12:00:00.000Z',
+    })
+
+    const response = await GET(
+      new NextRequest(
+        'https://community-archive.org/api/portal/trends?view=series&q=Alpha&q=alpha&q=AI%20Agents',
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    expect(fetchPortalTrendSeriesMock).toHaveBeenCalledWith([
+      'alpha',
+      'ai agents',
+    ])
+  })
+
+  test('forwards include and exclude filters to the evidence search', async () => {
+    fetchPortalTrendEvidenceMock.mockResolvedValue([])
+
+    const response = await GET(
+      new NextRequest(
+        'https://community-archive.org/api/portal/trends?view=feed&include=Alpha&include=Beta&exclude=Moloch',
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    expect(fetchPortalTrendEvidenceMock).toHaveBeenCalledWith(
+      ['alpha', 'beta'],
+      ['moloch'],
+      30,
+    )
+  })
+
+  test('rejects an evidence query without an included term', async () => {
+    const response = await GET(
+      new NextRequest(
+        'https://community-archive.org/api/portal/trends?view=feed&exclude=moloch',
+      ),
+    )
+
+    expect(response.status).toBe(400)
+    expect(fetchPortalTrendEvidenceMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## What changed

- restore the authenticated `/trends` page and add it to member navigation
- let members add and compare multiple word or phrase trends
- support raw counts and normalization per 100,000 archive tweets
- show matching tweets beside the chart
- add include, exclude, and off feed filters for each trend
- contain initial snapshot, chart, feed, and client-render failures inside the Trends component
- add local retry behavior plus a reusable portal component error boundary
- add a member-only trends API plus analytics, route, and failure-path coverage

## Why

Members need to investigate archive vocabulary over time while seeing the source tweets behind each trend, without losing comparability as yearly archive volume changes. A failed analytics request must not replace the entire page with the route-level error screen.

## Validation

- `pnpm type-check`
- `pnpm test:server -- --runInBand` — 28 suites, 137 tests
- `pnpm lint`
- `pnpm build`
- responsive browser QA for term entry, concurrent series, normalization, and include/exclude filters
- browser failure injection confirming the page and unaffected panels remain usable while failed chart requests render and retry locally

The repository pre-commit hook's local Supabase type-generation step could not run because Docker was unavailable; application typecheck, the full production build, and remote PR checks validate the change.
