### PR TITLE
Render quotes and media across dashboard and search

### DIFF
--- a/src/app/api/portal/trends/route.ts
+++ b/src/app/api/portal/trends/route.ts
@@ -5,6 +5,7 @@ import {
   portalTrendTokens,
 } from '@/lib/portal/analytics'
 import { getIsMember } from '@/lib/portal/auth'
+import { enrichPortalTweets } from '@/lib/portal/data'
 
 export const dynamic = 'force-dynamic'
 export const maxDuration = 60
@@ -61,7 +62,9 @@ export async function GET(request: NextRequest) {
         throw new Error('Include at least one term to load matching tweets')
       }
       return privateJson({
-        tweets: await fetchPortalTrendEvidence(includeTerms, excludeTerms, 30),
+        tweets: await enrichPortalTweets(
+          await fetchPortalTrendEvidence(includeTerms, excludeTerms, 30),
+        ),
       })
     }
 

--- a/src/components/ImageLightbox.tsx
+++ b/src/components/ImageLightbox.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import Image from 'next/image'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { cn } from '@/utils/tailwind'
+
+interface ImageLightboxProps {
+  src: string
+  alt: string
+  width?: number
+  height?: number
+  className?: string
+  imageClassName?: string
+  sizes?: string
+}
+
+export default function ImageLightbox({
+  src,
+  alt,
+  width = 1200,
+  height = 800,
+  className,
+  imageClassName,
+  sizes,
+}: ImageLightboxProps) {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            'relative block cursor-zoom-in overflow-hidden text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2',
+            className,
+          )}
+          aria-label={`Enlarge ${alt.toLowerCase()}`}
+        >
+          <Image
+            src={src}
+            alt={alt}
+            width={width}
+            height={height}
+            sizes={sizes}
+            className={imageClassName}
+          />
+        </button>
+      </DialogTrigger>
+      <DialogContent className="w-auto max-w-[96vw] border-0 bg-transparent p-0 shadow-none [&>button:hover]:bg-black/90 [&>button]:right-2 [&>button]:top-2 [&>button]:rounded-full [&>button]:bg-black/70 [&>button]:p-2 [&>button]:text-white [&>button]:opacity-100">
+        <DialogTitle className="sr-only">{alt}</DialogTitle>
+        <DialogDescription className="sr-only">
+          Enlarged image. Press Escape or click outside the image to close.
+        </DialogDescription>
+        <Image
+          src={src}
+          alt={alt}
+          width={width}
+          height={height}
+          sizes="96vw"
+          className="max-h-[92vh] w-auto max-w-[96vw] rounded-md object-contain"
+        />
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/TweetComponent.tsx
+++ b/src/components/TweetComponent.tsx
@@ -12,8 +12,8 @@ import {
 import { Archive } from 'lucide-react'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { formatNumber } from '@/lib/formatNumber'
-import NextImage from 'next/image'
 import TweetAvatarImage from '@/components/TweetAvatarImage'
+import ImageLightbox from '@/components/ImageLightbox'
 
 export interface TweetMedia {
   media_url: string
@@ -244,18 +244,16 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
       return (
         <div className="mt-2 flex gap-2 overflow-x-auto pb-1">
           {renderableMedia.slice(0, 4).map((mediaItem: any, index: number) => (
-            <div
+            <ImageLightbox
               key={index}
-              className="relative h-20 w-28 flex-none overflow-hidden rounded-md border border-border bg-muted sm:h-24 sm:w-36"
-            >
-              <NextImage
-                src={mediaItem.media_url}
-                alt={`Tweet image ${index + 1}`}
-                width={mediaItem.width || 240}
-                height={mediaItem.height || 160}
-                className="h-full w-full object-cover"
-              />
-            </div>
+              src={mediaItem.media_url}
+              alt={`Tweet image ${index + 1}`}
+              width={mediaItem.width || 1200}
+              height={mediaItem.height || 800}
+              sizes="(max-width: 640px) 7rem, 9rem"
+              className="h-20 w-28 flex-none rounded-md border border-border bg-muted sm:h-24 sm:w-36"
+              imageClassName="h-full w-full object-cover transition-transform hover:scale-[1.02]"
+            />
           ))}
           {renderableMedia.length > 4 && (
             <div className="flex h-20 w-20 flex-none items-center justify-center rounded-md border border-border bg-muted text-xs text-muted-foreground sm:h-24">
@@ -268,21 +266,23 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
 
     return (
       <div
-        className={`my-3 grid gap-2 ${mediaArray.length > 1 ? 'grid-cols-2' : 'grid-cols-1'}`}
+        className={`my-3 grid gap-2 ${renderableMedia.length > 1 ? 'grid-cols-2' : 'grid-cols-1'}`}
       >
         {renderableMedia.map((mediaItem: any, index: number) => (
-          <div
+          <ImageLightbox
             key={index}
-            className="relative overflow-hidden rounded-lg border border-border bg-muted"
-          >
-            <NextImage
-              src={mediaItem.media_url}
-              alt={`Tweet image ${index + 1}`}
-              width={mediaItem.width || 600}
-              height={mediaItem.height || 400}
-              className="min-h-40 h-full max-h-96 w-full object-cover"
-            />
-          </div>
+            src={mediaItem.media_url}
+            alt={`Tweet image ${index + 1}`}
+            width={mediaItem.width || 1200}
+            height={mediaItem.height || 800}
+            sizes={
+              renderableMedia.length > 1
+                ? '(max-width: 640px) 50vw, 360px'
+                : '(max-width: 640px) 100vw, 720px'
+            }
+            className="rounded-lg border border-border bg-muted"
+            imageClassName="h-full max-h-96 min-h-40 w-full object-cover transition-transform hover:scale-[1.01]"
+          />
         ))}
       </div>
     )
@@ -308,8 +308,8 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
     // Border + marker for syndication-hydrated quotes so it's clear the data isn't
     // from this archive.
     const externalClasses = quotedTweet.from_external
-      ? 'border-dashed border-amber-300 dark:border-amber-700 bg-amber-50/60 dark:bg-amber-900/10'
-      : 'border-border bg-muted dark:bg-card'
+      ? 'border-dashed border-amber-300 bg-background dark:border-amber-700 dark:bg-card'
+      : 'border-border bg-background dark:bg-card'
 
     return (
       <div
@@ -377,24 +377,24 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
                   )
                   .slice(0, compact ? 3 : undefined)
                   .map((mediaItem: any, index: number) => (
-                    <div
+                    <ImageLightbox
                       key={index}
+                      src={mediaItem.media_url}
+                      alt={`Quoted tweet image ${index + 1}`}
+                      width={mediaItem.width || 1200}
+                      height={mediaItem.height || 800}
+                      sizes={
+                        compact ? '6rem' : '(max-width: 640px) 100vw, 640px'
+                      }
                       className={`relative overflow-hidden rounded-md border dark:border-border ${
                         compact ? 'h-16 w-24 flex-none' : ''
                       }`}
-                    >
-                      <NextImage
-                        src={mediaItem.media_url}
-                        alt={`Quoted tweet image ${index + 1}`}
-                        width={300}
-                        height={200}
-                        className={
-                          compact
-                            ? 'h-full w-full object-cover'
-                            : 'h-auto max-h-48 w-full object-contain'
-                        }
-                      />
-                    </div>
+                      imageClassName={
+                        compact
+                          ? 'h-full w-full object-cover transition-transform hover:scale-[1.02]'
+                          : 'h-auto max-h-48 w-full object-contain transition-transform hover:scale-[1.01]'
+                      }
+                    />
                   ))}
               </div>
             )}

--- a/src/components/portal/TweetRow.tsx
+++ b/src/components/portal/TweetRow.tsx
@@ -2,7 +2,8 @@
 
 import Link from 'next/link'
 import { useState } from 'react'
-import { PortalTweet } from '@/lib/portal/types'
+import ImageLightbox from '@/components/ImageLightbox'
+import { PortalMedia, PortalQuotedTweet, PortalTweet } from '@/lib/portal/types'
 
 const HUES = [262, 32, 145, 4, 155, 200, 217, 88, 240, 190, 340, 45, 280, 20]
 
@@ -44,7 +45,7 @@ export function TweetAvatar({
   tweet,
   size = 34,
 }: {
-  tweet: PortalTweet
+  tweet: Pick<PortalTweet, 'username' | 'avatar'>
   size?: number
 }) {
   const initials = tweet.username.slice(0, 2).toUpperCase()
@@ -72,6 +73,118 @@ export function TweetAvatar({
       }}
     >
       {initials}
+    </div>
+  )
+}
+
+function imageMedia(media: PortalMedia[] | undefined): PortalMedia[] {
+  return (media ?? []).filter(
+    (item) => item.type === 'photo' || item.type.startsWith('image/'),
+  )
+}
+
+function TweetImages({
+  media,
+  compact,
+  label,
+}: {
+  media: PortalMedia[] | undefined
+  compact: boolean
+  label: string
+}) {
+  const images = imageMedia(media)
+  if (images.length === 0) return null
+
+  if (compact) {
+    return (
+      <div className="mt-2 flex gap-1.5 overflow-x-auto pb-0.5">
+        {images.slice(0, 4).map((item, index) => (
+          <ImageLightbox
+            key={`${item.url}-${index}`}
+            src={item.url}
+            alt={`${label} ${index + 1}`}
+            width={item.width || 1200}
+            height={item.height || 800}
+            sizes="6rem"
+            className="h-16 w-24 flex-none rounded-[4px] border border-zinc-200 bg-zinc-100 dark:border-[#303036] dark:bg-[#202023]"
+            imageClassName="h-full w-full object-cover transition-transform hover:scale-[1.02]"
+          />
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className={`mt-2 grid gap-1.5 ${images.length > 1 ? 'grid-cols-2' : 'grid-cols-1'}`}
+    >
+      {images.slice(0, 4).map((item, index) => (
+        <ImageLightbox
+          key={`${item.url}-${index}`}
+          src={item.url}
+          alt={`${label} ${index + 1}`}
+          width={item.width || 1200}
+          height={item.height || 800}
+          sizes={
+            images.length > 1
+              ? '(max-width: 640px) 50vw, 320px'
+              : '(max-width: 640px) 100vw, 640px'
+          }
+          className="max-h-72 rounded-[4px] border border-zinc-200 bg-zinc-100 dark:border-[#303036] dark:bg-[#202023]"
+          imageClassName="h-full max-h-72 w-full object-cover transition-transform hover:scale-[1.01]"
+        />
+      ))}
+    </div>
+  )
+}
+
+function QuotedTweet({
+  tweet,
+  compact,
+}: {
+  tweet: PortalQuotedTweet
+  compact: boolean
+}) {
+  if (tweet.isDeleted) {
+    return (
+      <div className="mt-2 rounded-[4px] border border-dashed border-zinc-300 bg-white px-3 py-2 text-[12px] italic text-zinc-500 dark:border-[#3a3a40] dark:bg-[#18181b] dark:text-[#a7a7b4]">
+        Quoted tweet deleted
+      </div>
+    )
+  }
+
+  return (
+    <div className="mt-2 rounded-[4px] border border-zinc-200 bg-white p-2.5 dark:border-[#303036] dark:bg-[#18181b]">
+      <Link
+        href={`/tweets/${tweet.id}`}
+        className="block rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+      >
+        <div className="flex items-center gap-2">
+          <TweetAvatar tweet={tweet} size={compact ? 24 : 28} />
+          <div className="min-w-0 text-[12px] leading-tight">
+            <span className="font-bold">{tweet.name}</span>{' '}
+            <span className="text-zinc-500 dark:text-[#a7a7b4]">
+              @{tweet.username} · {relativeTime(tweet.createdAt)}
+            </span>
+          </div>
+        </div>
+        <div
+          className={`${compact ? 'line-clamp-3' : ''} mt-1.5 whitespace-pre-wrap break-words text-[13px] leading-relaxed text-zinc-700 dark:text-[#d9d9de]`}
+        >
+          {tweet.text}
+        </div>
+      </Link>
+      <TweetImages
+        media={tweet.media}
+        compact={compact}
+        label="Quoted tweet image"
+      />
+      {!compact && (
+        <div className="mt-1.5 flex gap-4 text-[11.5px] tabular-nums text-zinc-500 dark:text-[#a7a7b4]">
+          <span>♥ {formatCount(tweet.likes)}</span>
+          <span>⇄ {formatCount(tweet.rts)}</span>
+        </div>
+      )}
     </div>
   )
 }
@@ -127,13 +240,12 @@ export function TweetRow({
 
   const details = (
     <div className="min-w-0 flex-1">
-      {collapsible ? (
-        <Link href={href} className="block">
-          {tweetContent}
-        </Link>
-      ) : (
-        tweetContent
-      )}
+      <Link
+        href={href}
+        className="block rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+      >
+        {tweetContent}
+      </Link>
       {canExpand && (
         <button
           type="button"
@@ -143,6 +255,10 @@ export function TweetRow({
         >
           {isExpanded ? 'Show less' : 'Read more'}
         </button>
+      )}
+      <TweetImages media={tweet.media} compact={compact} label="Tweet image" />
+      {tweet.quotedTweet && (
+        <QuotedTweet tweet={tweet.quotedTweet} compact={compact} />
       )}
       {!compact && (
         <div className="mt-1.5 flex flex-wrap gap-x-4 gap-y-1 text-[12px] tabular-nums text-zinc-500 dark:text-[#a7a7b4]">
@@ -159,26 +275,17 @@ export function TweetRow({
     </div>
   )
 
-  if (collapsible) {
-    return (
-      <article className={rowClassName}>
-        <Link href={href} aria-label={`View tweet by @${tweet.username}`}>
-          <TweetAvatar tweet={tweet} />
-        </Link>
-        {details}
-      </article>
-    )
-  }
-
   return (
-    <Link href={href} className={rowClassName}>
-      <TweetAvatar tweet={tweet} />
+    <article className={rowClassName}>
+      <Link href={href} aria-label={`View tweet by @${tweet.username}`}>
+        <TweetAvatar tweet={tweet} />
+      </Link>
       {details}
       {compact && (
         <div className="whitespace-nowrap text-[11.5px] tabular-nums text-zinc-500 dark:text-[#a7a7b4]">
           ♥ {formatCount(tweet.likes)}
         </div>
       )}
-    </Link>
+    </article>
   )
 }

--- a/src/lib/portal/TweetRow.test.tsx
+++ b/src/lib/portal/TweetRow.test.tsx
@@ -1,0 +1,100 @@
+/** @jest-environment jsdom */
+
+import React from 'react'
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { TweetRow } from '@/components/portal/TweetRow'
+import type { PortalTweet } from '@/lib/portal/types'
+;(globalThis as typeof globalThis & { React: typeof React }).React = React
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: ({
+    src,
+    alt,
+    ...props
+  }: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src={String(src)} alt={alt} {...props} />
+  ),
+}))
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({
+    href,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={String(href)} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+const tweet: PortalTweet = {
+  id: '42',
+  username: 'archive_member',
+  name: 'Archive Member',
+  avatar: null,
+  text: 'A quote with a picture',
+  observedAt: '2026-08-07T20:00:00.000Z',
+  createdAt: '2026-08-07T19:00:00.000Z',
+  likes: 3,
+  rts: 2,
+  media: [
+    {
+      url: 'https://pbs.twimg.com/media/main.jpg',
+      type: 'photo',
+      width: 1200,
+      height: 800,
+    },
+  ],
+  quotedTweet: {
+    id: '99',
+    username: 'quoted_member',
+    name: 'Quoted Member',
+    avatar: null,
+    text: 'The quoted thought',
+    createdAt: '2026-08-06T19:00:00.000Z',
+    likes: 12,
+    rts: 4,
+    media: [
+      {
+        url: 'https://pbs.twimg.com/media/quoted.jpg',
+        type: 'photo',
+      },
+    ],
+  },
+}
+
+describe('portal TweetRow media', () => {
+  test('renders quotes and closes an enlarged image when the backdrop is clicked', async () => {
+    render(<TweetRow tweet={tweet} />)
+
+    expect(screen.getByText('The quoted thought')).toBeVisible()
+    expect(
+      screen.getByRole('button', { name: 'Enlarge tweet image 1' }),
+    ).toBeVisible()
+    expect(
+      screen.getByRole('button', { name: 'Enlarge quoted tweet image 1' }),
+    ).toBeVisible()
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Enlarge tweet image 1' }),
+    )
+    expect(screen.getByRole('dialog')).toBeVisible()
+
+    const overlay = document.querySelector<HTMLElement>(
+      '[data-state="open"].fixed.inset-0',
+    )
+    expect(overlay).not.toBeNull()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    fireEvent.pointerDown(overlay!, { button: 0, pointerType: 'mouse' })
+    fireEvent.click(overlay!)
+
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument(),
+    )
+  })
+})

--- a/src/lib/portal/data.test.ts
+++ b/src/lib/portal/data.test.ts
@@ -151,6 +151,16 @@ describe('portal REST reads', () => {
           },
         ],
       } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => [],
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => [],
+      } as Response)
 
     await expect(getPortalStreamPage(30)).resolves.toEqual([
       {
@@ -163,10 +173,11 @@ describe('portal REST reads', () => {
         createdAt: '2026-08-07T19:00:00.000Z',
         likes: 3,
         rts: 2,
+        media: [],
       },
     ])
 
-    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock).toHaveBeenCalledTimes(4)
     const [tweetsUrl, tweetsInit] = fetchMock.mock.calls[0]
     expect(
       String(tweetsUrl).startsWith(
@@ -185,6 +196,129 @@ describe('portal REST reads', () => {
       },
     })
     expect(tweetsInit?.signal).toBeInstanceOf(AbortSignal)
+  })
+
+  test('batch-loads stream images and quoted tweets', async () => {
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockImplementation(async (input): Promise<Response> => {
+        const url = new URL(String(input))
+        const table = url.pathname.split('/').at(-1)
+        const tweetFilter = url.searchParams.get('tweet_id')
+
+        if (table === 'tweets') {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => [
+              {
+                tweet_id: '42',
+                account_id: '7',
+                created_at: '2026-08-07T19:00:00.000Z',
+                updated_at: '2026-08-07T20:00:00.000Z',
+                full_text: 'A quote with a picture',
+                retweet_count: 2,
+                favorite_count: 3,
+                account: {
+                  username: 'archive_member',
+                  account_display_name: 'Archive Member',
+                },
+              },
+            ],
+          } as Response
+        }
+        if (table === 'all_profile') {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => [],
+          } as Response
+        }
+        if (table === 'quote_tweets') {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => [{ tweet_id: '42', quoted_tweet_id: '99' }],
+          } as Response
+        }
+        if (table === 'enriched_tweets') {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => [
+              {
+                tweet_id: '99',
+                created_at: '2026-08-06T19:00:00.000Z',
+                full_text: 'The quoted thought',
+                retweet_count: 4,
+                favorite_count: 12,
+                username: 'quoted_member',
+                account_display_name: 'Quoted Member',
+                avatar_media_url: 'https://example.com/quoted-avatar.jpg',
+              },
+            ],
+          } as Response
+        }
+        if (table === 'tweet_media' && tweetFilter === 'in.(42)') {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => [
+              {
+                tweet_id: '42',
+                media_url: 'https://pbs.twimg.com/media/main.jpg',
+                media_type: 'photo',
+                width: 1200,
+                height: 800,
+              },
+            ],
+          } as Response
+        }
+        if (table === 'tweet_media' && tweetFilter === 'in.(99)') {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => [
+              {
+                tweet_id: '99',
+                media_url: 'https://pbs.twimg.com/media/quoted.jpg',
+                media_type: 'photo',
+                width: null,
+                height: null,
+              },
+            ],
+          } as Response
+        }
+        throw new Error(`Unexpected portal request: ${url}`)
+      })
+
+    const [tweet] = await getPortalStreamPage(30)
+
+    expect(tweet.media).toEqual([
+      {
+        url: 'https://pbs.twimg.com/media/main.jpg',
+        type: 'photo',
+        width: 1200,
+        height: 800,
+      },
+    ])
+    expect(tweet.quotedTweet).toEqual({
+      id: '99',
+      username: 'quoted_member',
+      name: 'Quoted Member',
+      avatar: 'https://example.com/quoted-avatar.jpg',
+      text: 'The quoted thought',
+      createdAt: '2026-08-06T19:00:00.000Z',
+      likes: 12,
+      rts: 4,
+      media: [
+        {
+          url: 'https://pbs.twimg.com/media/quoted.jpg',
+          type: 'photo',
+        },
+      ],
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(6)
   })
 
   test('encodes the composite polling cursor as a PostgREST or filter', async () => {

--- a/src/lib/portal/data.ts
+++ b/src/lib/portal/data.ts
@@ -11,6 +11,8 @@ import type { PortalLiveAnalytics } from './analytics'
 import { getResearchPosts } from './research'
 import type {
   PortalData,
+  PortalMedia,
+  PortalQuotedTweet,
   PortalStats,
   PortalTrends,
   PortalTweet,
@@ -162,6 +164,27 @@ async function portalRestRows<T>(
   return data as T[]
 }
 
+async function optionalPortalRestRows<T>(
+  table: string,
+  params: URLSearchParams,
+  label: string,
+): Promise<T[]> {
+  return (await optionalPortalRestResult<T>(table, params, label)).rows
+}
+
+async function optionalPortalRestResult<T>(
+  table: string,
+  params: URLSearchParams,
+  label: string,
+): Promise<{ rows: T[]; failed: boolean }> {
+  try {
+    return { rows: await portalRestRows<T>(table, params), failed: false }
+  } catch (error) {
+    console.error(`Portal ${label} query failed:`, error)
+    return { rows: [], failed: true }
+  }
+}
+
 function exactCount(response: Response, label: string): number {
   const contentRange = response.headers.get('content-range')
   const countText = contentRange?.split('/').at(-1)
@@ -267,40 +290,206 @@ async function toPortalTweets(tweets: any[]): Promise<PortalTweet[]> {
   const accountIds = Array.from(
     new Set(tweets.map((tweet: any) => tweet.account_id).filter(Boolean)),
   )
-  const avatarMap = new Map<string, string>()
+  const profilesPromise =
+    accountIds.length > 0
+      ? optionalPortalRestRows<any>(
+          'all_profile',
+          new URLSearchParams({
+            select: 'account_id,avatar_media_url',
+            account_id: `in.(${accountIds.join(',')})`,
+            order: 'archive_upload_id.desc',
+          }),
+          'avatar',
+        )
+      : Promise.resolve([])
 
-  if (accountIds.length > 0) {
-    try {
-      const profiles = await portalRestRows<any>(
-        'all_profile',
-        new URLSearchParams({
-          select: 'account_id,avatar_media_url',
-          account_id: `in.(${accountIds.join(',')})`,
-          order: 'archive_upload_id.desc',
-        }),
-      )
-      profiles.forEach((profile: any) => {
-        if (profile.avatar_media_url && !avatarMap.has(profile.account_id)) {
-          avatarMap.set(profile.account_id, profile.avatar_media_url)
-        }
-      })
-    } catch (error) {
-      console.error('Portal avatar query failed:', error)
-    }
-  }
-
-  return tweets.map((tweet: any) => {
+  const portalTweets = tweets.map((tweet: any): PortalTweet => {
     const account = accountOf(tweet)
     return {
       id: tweet.tweet_id,
       username: account?.username ?? 'unknown',
       name: account?.account_display_name ?? account?.username ?? 'Unknown',
-      avatar: avatarMap.get(tweet.account_id) ?? null,
+      avatar: null,
       text: tweet.full_text ?? '',
       observedAt: tweet.updated_at ?? tweet.created_at,
       createdAt: tweet.created_at,
       likes: tweet.favorite_count ?? 0,
       rts: tweet.retweet_count ?? 0,
+    }
+  })
+
+  const [profiles, enrichedTweets] = await Promise.all([
+    profilesPromise,
+    enrichPortalTweets(portalTweets),
+  ])
+  const avatarMap = new Map<string, string>()
+  profiles.forEach((profile: any) => {
+    if (profile.avatar_media_url && !avatarMap.has(profile.account_id)) {
+      avatarMap.set(profile.account_id, profile.avatar_media_url)
+    }
+  })
+
+  return enrichedTweets.map((tweet, index) => ({
+    ...tweet,
+    avatar: avatarMap.get(tweets[index]?.account_id) ?? null,
+  }))
+}
+
+interface PortalMediaRow {
+  tweet_id: string
+  media_url: string
+  media_type: string
+  width: number | null
+  height: number | null
+}
+
+interface PortalQuoteRelationRow {
+  tweet_id: string
+  quoted_tweet_id: string
+}
+
+interface PortalQuotedTweetRow {
+  tweet_id: string
+  created_at: string
+  full_text: string
+  retweet_count: number | null
+  favorite_count: number | null
+  username: string | null
+  account_display_name: string | null
+  avatar_media_url: string | null
+}
+
+function portalIdFilter(ids: string[]): string | null {
+  const safeIds = Array.from(new Set(ids.filter((id) => /^\d{1,32}$/.test(id))))
+  return safeIds.length > 0 ? `in.(${safeIds.join(',')})` : null
+}
+
+function portalCount(value: number | null): number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? value
+    : 0
+}
+
+function mediaByTweet(rows: PortalMediaRow[]): Map<string, PortalMedia[]> {
+  const grouped = new Map<string, PortalMedia[]>()
+  for (const row of rows) {
+    if (!row.media_url || !row.media_type) continue
+    const media = grouped.get(row.tweet_id) ?? []
+    media.push({
+      url: row.media_url,
+      type: row.media_type,
+      ...(row.width && row.width > 0 ? { width: row.width } : {}),
+      ...(row.height && row.height > 0 ? { height: row.height } : {}),
+    })
+    grouped.set(row.tweet_id, media)
+  }
+  return grouped
+}
+
+/** Attach image and quoted-tweet data to portal rows in bounded batch reads. */
+export async function enrichPortalTweets(
+  tweets: PortalTweet[],
+): Promise<PortalTweet[]> {
+  const tweetIdFilter = portalIdFilter(tweets.map(({ id }) => id))
+  if (!tweetIdFilter) return tweets
+
+  const [mediaRows, quoteRelations] = await Promise.all([
+    optionalPortalRestRows<PortalMediaRow>(
+      'tweet_media',
+      new URLSearchParams({
+        select: 'tweet_id,media_url,media_type,width,height',
+        tweet_id: tweetIdFilter,
+        order: 'media_id.asc',
+      }),
+      'media',
+    ),
+    optionalPortalRestRows<PortalQuoteRelationRow>(
+      'quote_tweets',
+      new URLSearchParams({
+        select: 'tweet_id,quoted_tweet_id',
+        tweet_id: tweetIdFilter,
+      }),
+      'quote relationship',
+    ),
+  ])
+
+  const quoteByTweetId = new Map(
+    quoteRelations.map((row) => [row.tweet_id, row.quoted_tweet_id]),
+  )
+  const quotedTweetIdFilter = portalIdFilter(
+    quoteRelations.map(({ quoted_tweet_id }) => quoted_tweet_id),
+  )
+  const ownMediaByTweetId = mediaByTweet(mediaRows)
+
+  if (!quotedTweetIdFilter) {
+    return tweets.map((tweet) => ({
+      ...tweet,
+      media: ownMediaByTweetId.get(tweet.id) ?? tweet.media ?? [],
+    }))
+  }
+
+  const [quotedResult, quotedMediaRows] = await Promise.all([
+    optionalPortalRestResult<PortalQuotedTweetRow>(
+      'enriched_tweets',
+      new URLSearchParams({
+        select:
+          'tweet_id,created_at,full_text,retweet_count,favorite_count,username,account_display_name,avatar_media_url',
+        tweet_id: quotedTweetIdFilter,
+      }),
+      'quoted tweet',
+    ),
+    optionalPortalRestRows<PortalMediaRow>(
+      'tweet_media',
+      new URLSearchParams({
+        select: 'tweet_id,media_url,media_type,width,height',
+        tweet_id: quotedTweetIdFilter,
+        order: 'media_id.asc',
+      }),
+      'quoted tweet media',
+    ),
+  ])
+
+  const quotedMediaByTweetId = mediaByTweet(quotedMediaRows)
+  const quotedTweets = new Map<string, PortalQuotedTweet>()
+  for (const row of quotedResult.rows) {
+    const username = row.username || 'unknown'
+    quotedTweets.set(row.tweet_id, {
+      id: row.tweet_id,
+      username,
+      name: row.account_display_name || username,
+      avatar: row.avatar_media_url,
+      text: row.full_text || '',
+      createdAt: row.created_at,
+      likes: portalCount(row.favorite_count),
+      rts: portalCount(row.retweet_count),
+      media: quotedMediaByTweetId.get(row.tweet_id) ?? [],
+    })
+  }
+
+  return tweets.map((tweet) => {
+    const quotedTweetId = quoteByTweetId.get(tweet.id)
+    const quotedTweet = quotedTweetId
+      ? (quotedTweets.get(quotedTweetId) ??
+        (quotedResult.failed
+          ? undefined
+          : {
+              id: quotedTweetId,
+              username: 'unknown',
+              name: 'Unknown',
+              avatar: null,
+              text: '',
+              createdAt: tweet.createdAt,
+              likes: 0,
+              rts: 0,
+              media: [],
+              isDeleted: true,
+            }))
+      : undefined
+
+    return {
+      ...tweet,
+      media: ownMediaByTweetId.get(tweet.id) ?? tweet.media ?? [],
+      ...(quotedTweet ? { quotedTweet } : {}),
     }
   })
 }
@@ -434,20 +623,23 @@ const getCachedStatsSnapshot = unstable_cache(
 )
 const getCachedInitialStream = unstable_cache(
   async (_sourceKey: string) => getPortalStreamPage(30),
-  ['portal-initial-stream-v4'],
+  ['portal-initial-stream-v5'],
   { revalidate: 60 },
 )
 const getCachedHistoricalBangers = unstable_cache(
   async (_sourceKey: string, day: string) => {
     const ranked = await fetchPortalHistoricalBangers(100)
-    return selectDailyBangers(ranked, new Date(`${day}T12:00:00.000Z`))
+    return enrichPortalTweets(
+      selectDailyBangers(ranked, new Date(`${day}T12:00:00.000Z`)),
+    )
   },
-  ['portal-bangers-v5'],
+  ['portal-bangers-v6'],
   { revalidate: 86_400 },
 )
 const getCachedRecentBangers = unstable_cache(
-  async (_sourceKey: string) => fetchPortalRecentBangers(50, 48),
-  ['portal-recent-bangers-v1'],
+  async (_sourceKey: string) =>
+    enrichPortalTweets(await fetchPortalRecentBangers(50, 48)),
+  ['portal-recent-bangers-v2'],
   { revalidate: 1_800 },
 )
 

--- a/src/lib/portal/types.ts
+++ b/src/lib/portal/types.ts
@@ -1,3 +1,23 @@
+export interface PortalMedia {
+  url: string
+  type: string
+  width?: number
+  height?: number
+}
+
+export interface PortalQuotedTweet {
+  id: string
+  username: string
+  name: string
+  avatar: string | null
+  text: string
+  createdAt: string
+  likes: number
+  rts: number
+  media: PortalMedia[]
+  isDeleted?: boolean
+}
+
 export interface PortalTweet {
   id: string
   username: string
@@ -10,6 +30,8 @@ export interface PortalTweet {
   createdAt: string
   likes: number
   rts: number
+  media?: PortalMedia[]
+  quotedTweet?: PortalQuotedTweet
   /** Distinct non-self quote tweets from archive uploaders and opt-ins. */
   quoteCount?: number
 }


### PR DESCRIPTION
## Summary

- render tweet images and quoted tweets throughout the signed-in portal, including the live stream, bangers, and trends evidence
- give quote cards a white background in search and the portal
- add a shared, accessible image lightbox that closes from the backdrop, Escape key, or close control
- batch portal media and quote enrichment with graceful fallbacks and refreshed cache keys

## Why

The signed-in portal used a compact tweet payload and renderer that omitted media and quote relationships. Search already received richer tweet data, but quote cards used a gray fill and images were not interactive.

## Impact

Members can now see the full visual and quoted context of tweets without leaving the dashboard or search results, and can enlarge any rendered image in place.

## Validation

- `pnpm type-check`
- `pnpm lint` (passes with one pre-existing image warning in `UnifiedTweetList.test.tsx`)
- `pnpm exec jest --selectProjects server --runInBand src/lib/portal/TweetRow.test.tsx src/lib/portal/data.test.ts src/lib/portal/analytics.test.ts` — 19 tests passed
- `pnpm build`
