### PR TITLE
Repair client Jest harness

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,7 +10,10 @@ const commonConfig = {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
   transform: {
-    '^.+\\.(t|j)sx?$': '@swc/jest',
+    '^.+\\.(t|j)sx?$': [
+      '@swc/jest',
+      { jsc: { transform: { react: { runtime: 'automatic' } } } },
+    ],
   },
 }
 
@@ -22,7 +25,7 @@ const customJestConfig = {
       testEnvironment: 'node',
       testMatch: [
         '<rootDir>/src/lib/**/*.test.{js,jsx,ts,tsx}',
-        '<rootDir>/tests/**/*.test.{js,jsx,ts,tsx}'
+        '<rootDir>/tests/**/*.test.{js,jsx,ts,tsx}',
       ],
       setupFilesAfterEnv: ['<rootDir>/jest.setup.server.ts'],
     },
@@ -30,10 +33,13 @@ const customJestConfig = {
       ...commonConfig,
       displayName: 'client',
       testEnvironment: 'jsdom',
-      testMatch: [
-        '<rootDir>/src/**/*.test.{js,jsx,ts,tsx}',
-        '!<rootDir>/src/lib/**/*.test.{js,jsx,ts,tsx}',
-      ],
+      // Client tests use jsdom, but the shared MSW lifecycle runs the
+      // node-only setupServer entry from jest.setup.ts.
+      testEnvironmentOptions: {
+        customExportConditions: ['node', 'node-addons'],
+      },
+      testMatch: ['<rootDir>/src/**/*.test.{js,jsx,ts,tsx}'],
+      testPathIgnorePatterns: ['<rootDir>/src/lib/'],
       setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
     },
   ],

--- a/jest.polyfills.js
+++ b/jest.polyfills.js
@@ -8,23 +8,32 @@
  * you don't want to deal with this.
  */
 
-const { TextDecoder, TextEncoder, ReadableStream } = require('node:util')
+const { TextDecoder, TextEncoder } = require('node:util')
+const { BroadcastChannel } = require('node:worker_threads')
+const {
+  ReadableStream,
+  TransformStream,
+  WritableStream,
+} = require('node:stream/web')
 
 Object.defineProperties(globalThis, {
   TextDecoder: { value: TextDecoder },
   TextEncoder: { value: TextEncoder },
+  BroadcastChannel: { value: BroadcastChannel },
   ReadableStream: { value: ReadableStream },
+  TransformStream: { value: TransformStream },
+  WritableStream: { value: WritableStream },
 })
 
 const { Blob, File } = require('node:buffer')
 const { fetch, Headers, FormData, Request, Response } = require('undici')
 
 Object.defineProperties(globalThis, {
-  fetch: { value: fetch, writable: true },
-  Blob: { value: Blob },
-  File: { value: File },
-  Headers: { value: Headers },
-  FormData: { value: FormData },
-  Request: { value: Request },
-  Response: { value: Response },
+  fetch: { value: fetch, writable: true, configurable: true },
+  Blob: { value: Blob, configurable: true },
+  File: { value: File, configurable: true },
+  Headers: { value: Headers, configurable: true },
+  FormData: { value: FormData, configurable: true },
+  Request: { value: Request, configurable: true },
+  Response: { value: Response, configurable: true },
 })


### PR DESCRIPTION
## Summary

- let the jsdom Jest project resolve the node-only MSW server entry used by the shared client setup
- provide the Web Streams and `BroadcastChannel` globals required by MSW 2 under Node 20
- make fetch globals configurable so MSW can install and restore its interceptors
- use the automatic JSX runtime and reliably keep `src/lib` tests in the server project

## Why

The default client test project failed before discovering tests because jsdom selected MSW’s browser export conditions while `jest.setup.ts` imports `msw/node`. Resolving that exposed missing Node web-platform globals and the classic JSX transform. The client exclusion glob also did not prevent server-owned `src/lib` tests from running under jsdom.

## Impact

Client tests now run through the documented `pnpm test -- --selectProjects client` path instead of requiring an isolated Jest configuration.

## Validation

- full client project: 9 suites, 14 tests passed
- representative server project: 3 suites, 18 tests passed
- TypeScript type-check
- Next.js lint
- Prettier and `git diff --check`
