### PR TITLE
Show quoting tweets on tweet pages

### DIFF
--- a/src/app/tweets/[tweet_id]/page.tsx
+++ b/src/app/tweets/[tweet_id]/page.tsx
@@ -2,6 +2,7 @@ import { getTweetPageData } from '@/lib/getTweetPageData'
 import { notFound } from 'next/navigation'
 import TweetComponent from '@/components/TweetComponent'
 import ThreadView from '@/components/ThreadView'
+import QuotingTweetsSidebar from '@/components/QuotingTweetsSidebar'
 import Link from 'next/link'
 import { ArrowLeft, Link2, MessagesSquare } from 'lucide-react'
 
@@ -10,7 +11,8 @@ export const revalidate = 3600
 
 export default async function TweetPage({ params }: any) {
   const { tweet_id } = params
-  const { tweet, threadTree } = await getTweetPageData(tweet_id)
+  const { tweet, threadTree, quotingTweets, quotingTweetCount } =
+    await getTweetPageData(tweet_id)
 
   if (!tweet) {
     notFound()
@@ -20,7 +22,7 @@ export default async function TweetPage({ params }: any) {
 
   return (
     <main className="min-h-screen bg-background">
-      <section className="mx-auto w-full max-w-4xl px-4 py-10 sm:px-6 sm:py-14 lg:px-8">
+      <section className="mx-auto w-full max-w-7xl px-4 py-10 sm:px-6 sm:py-14 lg:px-8">
         <Link
           href="/search"
           className="inline-flex items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
@@ -48,17 +50,27 @@ export default async function TweetPage({ params }: any) {
           </p>
         </header>
 
-        {isThread && threadTree ? (
-          <ThreadView tree={threadTree} highlightTweetId={tweet_id} />
-        ) : (
-          <article className="rounded-xl border border-border bg-card p-5 shadow-sm sm:p-6">
-            <TweetComponent key={tweet.tweet_id} tweet={tweet} />
-          </article>
-        )}
+        <div className="grid items-start gap-8 lg:grid-cols-[minmax(0,1fr)_22rem] xl:gap-10">
+          <div className="min-w-0">
+            {isThread && threadTree ? (
+              <ThreadView tree={threadTree} highlightTweetId={tweet_id} />
+            ) : (
+              <article className="rounded-xl border border-border bg-card p-5 shadow-sm sm:p-6">
+                <TweetComponent key={tweet.tweet_id} tweet={tweet} />
+              </article>
+            )}
 
-        <div className="mt-8 rounded-xl border border-dashed border-border bg-card px-5 py-4 text-sm leading-6 text-muted-foreground">
-          This permalink preserves the archived version. Use the Twitter link on
-          the tweet to compare it with the live post when it is still available.
+            <div className="mt-8 rounded-xl border border-dashed border-border bg-card px-5 py-4 text-sm leading-6 text-muted-foreground">
+              This permalink preserves the archived version. Use the Twitter
+              link on the tweet to compare it with the live post when it is
+              still available.
+            </div>
+          </div>
+
+          <QuotingTweetsSidebar
+            tweets={quotingTweets}
+            totalCount={quotingTweetCount}
+          />
         </div>
       </section>
     </main>

--- a/src/components/QuotingTweetsSidebar.test.tsx
+++ b/src/components/QuotingTweetsSidebar.test.tsx
@@ -1,0 +1,53 @@
+/** @jest-environment node */
+
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import QuotingTweetsSidebar from './QuotingTweetsSidebar'
+import type { TweetData } from './TweetComponent'
+
+jest.mock('@/components/TweetAvatarImage', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+
+const quotingTweet: TweetData = {
+  tweet_id: 'quote-1',
+  account_id: 'account-1',
+  created_at: '2026-08-01T12:00:00Z',
+  full_text: 'A useful perspective &amp; a second thought.',
+  retweet_count: 4,
+  favorite_count: 21,
+  reply_to_tweet_id: null,
+  quote_tweet_id: 'original-1',
+  retweeted_tweet_id: null,
+  avatar_media_url: 'https://example.com/avatar.jpg',
+  username: 'quote_author',
+  account_display_name: 'Quote Author',
+  media: [],
+  urls: [],
+}
+
+describe('QuotingTweetsSidebar', () => {
+  it('renders quoting tweets, engagement, and the complete result count', () => {
+    const markup = renderToStaticMarkup(
+      <QuotingTweetsSidebar tweets={[quotingTweet]} totalCount={15} />,
+    )
+
+    expect(markup).toContain('aria-labelledby="quoting-tweets-heading"')
+    expect(markup).toContain('Tweets quoting this')
+    expect(markup).toContain('Quote Author')
+    expect(markup).toContain('A useful perspective &amp; a second thought.')
+    expect(markup).toContain('href="/tweets/quote-1"')
+    expect(markup).toContain('aria-label="15 quotes"')
+    expect(markup).toContain('Showing the top 1 of 15')
+  })
+
+  it('shows an archive-specific empty state', () => {
+    const markup = renderToStaticMarkup(
+      <QuotingTweetsSidebar tweets={[]} totalCount={0} />,
+    )
+
+    expect(markup).toContain('No archived quotes yet')
+    expect(markup).toContain('Tweets in Community Archive that quote this post')
+  })
+})

--- a/src/components/QuotingTweetsSidebar.test.tsx
+++ b/src/components/QuotingTweetsSidebar.test.tsx
@@ -39,7 +39,7 @@ describe('QuotingTweetsSidebar', () => {
     expect(markup).toContain('A useful perspective &amp; a second thought.')
     expect(markup).toContain('href="/tweets/quote-1"')
     expect(markup).toContain('aria-label="15 quotes"')
-    expect(markup).toContain('Showing the top 1 of 15')
+    expect(markup).toContain('Showing 1 of 15')
   })
 
   it('shows an archive-specific empty state', () => {

--- a/src/components/QuotingTweetsSidebar.tsx
+++ b/src/components/QuotingTweetsSidebar.tsx
@@ -1,0 +1,156 @@
+import React from 'react'
+import Link from 'next/link'
+import { FaHeart, FaRetweet } from 'react-icons/fa'
+import { Quote } from 'lucide-react'
+import { Avatar, AvatarFallback } from '@/components/ui/avatar'
+import TweetAvatarImage from '@/components/TweetAvatarImage'
+import type { TweetData } from '@/components/TweetComponent'
+import { formatNumber } from '@/lib/formatNumber'
+
+interface QuotingTweetsSidebarProps {
+  tweets: TweetData[]
+  totalCount: number
+}
+
+const dateFormatter = new Intl.DateTimeFormat('en', {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+  timeZone: 'UTC',
+})
+
+function decodeTweetText(text: string) {
+  return text
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#039;|&#x27;/g, "'")
+}
+
+function getAvatarInitial(...values: Array<string | undefined>) {
+  for (const value of values) {
+    const initial = Array.from(value?.trim() ?? '')[0]
+    if (initial) return initial
+  }
+  return 'U'
+}
+
+export default function QuotingTweetsSidebar({
+  tweets,
+  totalCount,
+}: QuotingTweetsSidebarProps) {
+  return (
+    <aside
+      aria-labelledby="quoting-tweets-heading"
+      className="lg:sticky lg:top-24"
+    >
+      <div className="overflow-hidden rounded-xl border border-border bg-card shadow-sm">
+        <div className="flex items-center justify-between gap-3 border-b border-border px-5 py-4">
+          <div className="flex items-center gap-2">
+            <Quote className="h-4 w-4 text-brand" aria-hidden="true" />
+            <h2
+              id="quoting-tweets-heading"
+              className="font-semibold text-foreground"
+            >
+              Tweets quoting this
+            </h2>
+          </div>
+          <span
+            className="rounded-full bg-muted px-2.5 py-1 text-xs font-semibold tabular-nums text-muted-foreground"
+            aria-label={`${totalCount} ${totalCount === 1 ? 'quote' : 'quotes'}`}
+          >
+            {formatNumber(totalCount)}
+          </span>
+        </div>
+
+        {tweets.length === 0 ? (
+          <div className="px-5 py-8 text-center">
+            <Quote
+              className="mx-auto h-7 w-7 text-muted-foreground/60"
+              aria-hidden="true"
+            />
+            <p className="mt-3 text-sm font-medium text-foreground">
+              No archived quotes yet
+            </p>
+            <p className="mt-1 text-xs leading-5 text-muted-foreground">
+              Tweets in Community Archive that quote this post will appear here.
+            </p>
+          </div>
+        ) : (
+          <div className="divide-y divide-border">
+            {tweets.map((tweet) => (
+              <article key={tweet.tweet_id} className="px-5 py-4">
+                <div className="flex items-start gap-3">
+                  <Avatar className="h-9 w-9 flex-shrink-0">
+                    <TweetAvatarImage
+                      src={tweet.avatar_media_url}
+                      alt={`${tweet.account_display_name}'s profile picture`}
+                      username={tweet.username}
+                      tweetId={tweet.tweet_id}
+                    />
+                    <AvatarFallback className="text-xs">
+                      {getAvatarInitial(
+                        tweet.account_display_name,
+                        tweet.username,
+                      )}
+                    </AvatarFallback>
+                  </Avatar>
+
+                  <div className="min-w-0 flex-1">
+                    <div className="flex min-w-0 items-baseline gap-1.5">
+                      <span className="truncate text-sm font-semibold text-foreground">
+                        {tweet.account_display_name}
+                      </span>
+                      <span className="truncate text-xs text-muted-foreground">
+                        @{tweet.username}
+                      </span>
+                    </div>
+                    <time
+                      dateTime={tweet.created_at}
+                      className="text-xs text-muted-foreground"
+                    >
+                      {dateFormatter.format(new Date(tweet.created_at))}
+                    </time>
+                  </div>
+                </div>
+
+                <p className="mt-3 line-clamp-4 whitespace-pre-wrap break-words text-sm leading-5 text-foreground">
+                  {decodeTweetText(tweet.full_text)}
+                </p>
+
+                <div className="mt-3 flex items-center justify-between gap-3 text-xs text-muted-foreground">
+                  <div className="flex items-center gap-3">
+                    <span className="inline-flex items-center gap-1">
+                      <FaHeart aria-hidden="true" />
+                      {formatNumber(tweet.favorite_count)}
+                      <span className="sr-only">likes</span>
+                    </span>
+                    <span className="inline-flex items-center gap-1">
+                      <FaRetweet aria-hidden="true" />
+                      {formatNumber(tweet.retweet_count ?? 0)}
+                      <span className="sr-only">reposts</span>
+                    </span>
+                  </div>
+                  <Link
+                    href={`/tweets/${tweet.tweet_id}`}
+                    className="font-medium text-brand underline-offset-2 hover:underline"
+                  >
+                    Open quote
+                  </Link>
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+
+        {totalCount > tweets.length && (
+          <p className="border-t border-border bg-muted/40 px-5 py-3 text-center text-xs text-muted-foreground">
+            Showing the top {tweets.length} of {formatNumber(totalCount)}{' '}
+            archived quotes
+          </p>
+        )}
+      </div>
+    </aside>
+  )
+}

--- a/src/components/QuotingTweetsSidebar.tsx
+++ b/src/components/QuotingTweetsSidebar.tsx
@@ -146,8 +146,8 @@ export default function QuotingTweetsSidebar({
 
         {totalCount > tweets.length && (
           <p className="border-t border-border bg-muted/40 px-5 py-3 text-center text-xs text-muted-foreground">
-            Showing the top {tweets.length} of {formatNumber(totalCount)}{' '}
-            archived quotes
+            Showing {tweets.length} of {formatNumber(totalCount)} archived
+            quotes
           </p>
         )}
       </div>

--- a/src/lib/clickhouseGateway.ts
+++ b/src/lib/clickhouseGateway.ts
@@ -70,6 +70,19 @@ export function analyticsGatewayRequestUrl(
     /^\d{1,20}$/.test(cleanPath[1])
   ) {
     allowedParams = new Set()
+  } else if (
+    cleanPath.length === 2 &&
+    cleanPath[0] === 'quote-posts' &&
+    /^\d{1,20}$/.test(cleanPath[1])
+  ) {
+    allowedParams = new Set([
+      'limit',
+      'offset',
+      'exclude_self',
+      'quote_ca_users_only',
+      'include_usernames',
+      'exclude_usernames',
+    ])
   }
 
   if (!allowedParams)

--- a/src/lib/clickhouseLab.test.ts
+++ b/src/lib/clickhouseLab.test.ts
@@ -149,4 +149,24 @@ describe('ClickHouse staging lab guard', () => {
       ),
     ).toThrow('Unsupported ClickHouse analytics endpoint')
   })
+
+  test('allows bounded reverse-quote parameters for numeric tweet IDs', () => {
+    const target = analyticsGatewayRequestUrl(
+      ['quote-posts', '2085375983708692599'],
+      new URLSearchParams(
+        'limit=12&offset=0&exclude_self=true&quote_ca_users_only=true&raw_sql=DROP',
+      ),
+      'https://stream.example/analytics',
+    )
+    expect(target.toString()).toBe(
+      'https://stream.example/analytics/quote-posts/2085375983708692599?limit=12&offset=0&exclude_self=true&quote_ca_users_only=true',
+    )
+    expect(() =>
+      analyticsGatewayRequestUrl(
+        ['quote-posts', 'not-a-tweet'],
+        new URLSearchParams(),
+        'https://stream.example/analytics',
+      ),
+    ).toThrow('Unsupported ClickHouse analytics endpoint')
+  })
 })

--- a/src/lib/clickhouseQuotePosts.test.ts
+++ b/src/lib/clickhouseQuotePosts.test.ts
@@ -1,0 +1,63 @@
+import { fetchClickHouseQuotePosts } from './clickhouseQuotePosts'
+
+describe('fetchClickHouseQuotePosts', () => {
+  test('maps current-member reverse quotes into sidebar tweet data', async () => {
+    const fetcher = jest.fn().mockResolvedValue({
+      data: [
+        {
+          tweetId: '2085742928454951350',
+          accountId: '701664918588755968',
+          username: 'puheenix',
+          displayName: 'Puheenjohtaja',
+          avatarUrl: 'https://pbs.twimg.com/puheenix.jpg',
+          createdAt: '2026-08-07 15:00:40.000',
+          fullText: 'Quoted commentary',
+          favoriteCount: '13',
+          retweetCount: '3',
+        },
+      ],
+      query: { total: '7' },
+    })
+
+    const result = await fetchClickHouseQuotePosts(
+      '2085375983708692599',
+      12,
+      fetcher,
+    )
+
+    expect(fetcher).toHaveBeenCalledWith(
+      ['quote-posts', '2085375983708692599'],
+      new URLSearchParams({
+        limit: '12',
+        offset: '0',
+        exclude_self: 'true',
+        quote_ca_users_only: 'true',
+      }),
+      { revalidate: 600 },
+    )
+    expect(result).toEqual({
+      totalCount: 7,
+      tweets: [
+        expect.objectContaining({
+          tweet_id: '2085742928454951350',
+          quote_tweet_id: '2085375983708692599',
+          created_at: '2026-08-07T15:00:40.000Z',
+          username: 'puheenix',
+          account_display_name: 'Puheenjohtaja',
+          favorite_count: 13,
+          retweet_count: 3,
+          media: [],
+        }),
+      ],
+    })
+  })
+
+  test('rejects non-numeric route IDs before calling the gateway', async () => {
+    const fetcher = jest.fn()
+
+    await expect(
+      fetchClickHouseQuotePosts('not-a-tweet', 12, fetcher),
+    ).resolves.toEqual({ tweets: [], totalCount: 0 })
+    expect(fetcher).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/clickhouseQuotePosts.ts
+++ b/src/lib/clickhouseQuotePosts.ts
@@ -1,0 +1,110 @@
+import type { TweetData } from '@/components/TweetComponent'
+import { fetchAnalyticsGatewayJson } from './clickhouseGateway'
+
+interface ClickHouseQuotePost {
+  tweetId: string
+  accountId: string
+  username: string | null
+  displayName: string | null
+  avatarUrl: string | null
+  createdAt: string
+  fullText: string
+  favoriteCount: string | number
+  retweetCount: string | number
+}
+
+interface ClickHouseQuotePostsResponse {
+  data: ClickHouseQuotePost[]
+  query: {
+    total: string | number
+  }
+}
+
+export interface ClickHouseQuotePostsData {
+  tweets: TweetData[]
+  totalCount: number
+}
+
+const EMPTY_QUOTE_POSTS: ClickHouseQuotePostsData = {
+  tweets: [],
+  totalCount: 0,
+}
+
+function count(value: string | number | null | undefined): number {
+  const parsed = Number(value || 0)
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : 0
+}
+
+function timestamp(value: string): string {
+  if (/[zZ]$|[+-]\d\d:\d\d$/.test(value)) return value
+  return `${value.replace(' ', 'T')}Z`
+}
+
+function quotePost(
+  tweet: ClickHouseQuotePost,
+  targetTweetId: string,
+): TweetData {
+  if (
+    !/^\d{1,20}$/.test(tweet.tweetId) ||
+    !/^\d{1,20}$/.test(tweet.accountId) ||
+    typeof tweet.createdAt !== 'string' ||
+    typeof tweet.fullText !== 'string'
+  ) {
+    throw new Error('ClickHouse quote-posts returned an invalid tweet')
+  }
+
+  const username = tweet.username || 'unknown_user'
+  const displayName = tweet.displayName || username
+  return {
+    tweet_id: tweet.tweetId,
+    account_id: tweet.accountId,
+    created_at: timestamp(tweet.createdAt),
+    full_text: tweet.fullText,
+    retweet_count: count(tweet.retweetCount),
+    favorite_count: count(tweet.favoriteCount),
+    reply_to_tweet_id: null,
+    quote_tweet_id: targetTweetId,
+    retweeted_tweet_id: null,
+    avatar_media_url: tweet.avatarUrl,
+    username,
+    account_display_name: displayName,
+    media: [],
+    urls: [],
+    account: {
+      username,
+      account_display_name: displayName,
+      profile: tweet.avatarUrl
+        ? { avatar_media_url: tweet.avatarUrl }
+        : undefined,
+    },
+  }
+}
+
+export async function fetchClickHouseQuotePosts(
+  tweetId: string,
+  limit = 12,
+  fetcher = fetchAnalyticsGatewayJson,
+): Promise<ClickHouseQuotePostsData> {
+  if (!/^\d{1,20}$/.test(tweetId)) return EMPTY_QUOTE_POSTS
+
+  const safeLimit = Math.max(1, Math.min(100, Math.trunc(limit)))
+  const response = await fetcher<ClickHouseQuotePostsResponse>(
+    ['quote-posts', tweetId],
+    new URLSearchParams({
+      limit: String(safeLimit),
+      offset: '0',
+      exclude_self: 'true',
+      quote_ca_users_only: 'true',
+    }),
+    { revalidate: 600 },
+  )
+  if (!Array.isArray(response.data)) {
+    throw new Error('ClickHouse quote-posts returned an invalid response')
+  }
+
+  const tweets = response.data.map((tweet) => quotePost(tweet, tweetId))
+  return {
+    tweets,
+    totalCount: Math.max(count(response.query?.total), tweets.length),
+  }
+}

--- a/src/lib/getTweetPageData.test.ts
+++ b/src/lib/getTweetPageData.test.ts
@@ -3,6 +3,7 @@ import { cookies } from 'next/headers'
 import { createServerClient } from '@/utils/supabase'
 import { isClickHouseReadsEnabled } from './clickhouseGateway'
 import { fetchClickHouseTweetPageData } from './clickhouseTweetPage'
+import { fetchClickHouseQuotePosts } from './clickhouseQuotePosts'
 import { getTweetPageData } from './getTweetPageData'
 
 jest.mock('next/headers', () => ({ cookies: jest.fn() }))
@@ -12,6 +13,9 @@ jest.mock('./clickhouseGateway', () => ({
 }))
 jest.mock('./clickhouseTweetPage', () => ({
   fetchClickHouseTweetPageData: jest.fn(),
+}))
+jest.mock('./clickhouseQuotePosts', () => ({
+  fetchClickHouseQuotePosts: jest.fn(),
 }))
 jest.mock('./twitterSyndication', () => ({
   fetchSyndicatedTweets: jest.fn().mockResolvedValue(new Map()),
@@ -23,6 +27,10 @@ const clickHouseEnabledMock = isClickHouseReadsEnabled as jest.MockedFunction<
 const fetchClickHouseTweetPageDataMock =
   fetchClickHouseTweetPageData as jest.MockedFunction<
     typeof fetchClickHouseTweetPageData
+  >
+const fetchClickHouseQuotePostsMock =
+  fetchClickHouseQuotePosts as jest.MockedFunction<
+    typeof fetchClickHouseQuotePosts
   >
 const createServerClientMock = createServerClient as jest.MockedFunction<
   typeof createServerClient
@@ -64,12 +72,16 @@ describe('getTweetPageData', () => {
     jest.clearAllMocks()
     clickHouseEnabledMock.mockReturnValue(false)
     fetchClickHouseTweetPageDataMock.mockResolvedValue(null)
+    fetchClickHouseQuotePostsMock.mockResolvedValue({
+      tweets: [],
+      totalCount: 0,
+    })
     ;(cookies as jest.Mock).mockResolvedValue({})
     createServerClientMock.mockReturnValue({ rpc } as never)
     rpc.mockResolvedValue({ data: emptyRpcResult, error: null })
   })
 
-  test('combines a ClickHouse permalink tweet with Supabase quote metadata', async () => {
+  test('loads a ClickHouse permalink and its quote posts without Supabase', async () => {
     const tweet = {
       tweet_id: '2085473085399150817',
       account_id: '10',
@@ -88,38 +100,25 @@ describe('getTweetPageData', () => {
     } satisfies TweetData
     clickHouseEnabledMock.mockReturnValue(true)
     fetchClickHouseTweetPageDataMock.mockResolvedValue(tweet)
-    rpc.mockResolvedValue({
-      data: {
-        ...emptyRpcResult,
-        quoting_tweet_count: 1,
-        quoting_tweets: [
-          {
-            tweet_id: 'quote-1',
-            account_id: 'account-quote',
-            username: 'quote_author',
-            account_display_name: 'Quote Author',
-            created_at: '2026-08-02T10:00:00Z',
-            full_text: 'My comment',
-            retweet_count: 3,
-            favorite_count: 13,
-            reply_to_tweet_id: null,
-            reply_to_username: null,
-            quoted_tweet_id: tweet.tweet_id,
-            avatar_media_url: null,
-            media: [],
-          },
-        ],
-      },
-      error: null,
+    fetchClickHouseQuotePostsMock.mockResolvedValue({
+      totalCount: 7,
+      tweets: [
+        {
+          ...tweet,
+          tweet_id: '2085742928454951350',
+          quote_tweet_id: tweet.tweet_id,
+          full_text: 'My comment',
+        },
+      ],
     })
 
     await expect(getTweetPageData(tweet.tweet_id)).resolves.toMatchObject({
       tweet,
       threadTree: null,
-      quotingTweetCount: 1,
+      quotingTweetCount: 7,
       quotingTweets: [
         expect.objectContaining({
-          tweet_id: 'quote-1',
+          tweet_id: '2085742928454951350',
           quote_tweet_id: tweet.tweet_id,
         }),
       ],
@@ -127,9 +126,51 @@ describe('getTweetPageData', () => {
     expect(fetchClickHouseTweetPageDataMock).toHaveBeenCalledWith(
       tweet.tweet_id,
     )
-    expect(rpc).toHaveBeenCalledWith('get_tweet_page_data', {
-      p_tweet_id: tweet.tweet_id,
+    expect(fetchClickHouseQuotePostsMock).toHaveBeenCalledWith(tweet.tweet_id)
+    expect(createServerClientMock).not.toHaveBeenCalled()
+    expect(rpc).not.toHaveBeenCalled()
+  })
+
+  test('keeps the ClickHouse permalink available when quote posts fail', async () => {
+    const tweet = {
+      tweet_id: '2085473085399150817',
+      account_id: '10',
+      created_at: '2026-08-07T12:00:00.000Z',
+      full_text: 'The linked portal tweet',
+      retweet_count: 4,
+      favorite_count: 25,
+      reply_to_tweet_id: null,
+      quote_tweet_id: null,
+      retweeted_tweet_id: null,
+      avatar_media_url: null,
+      username: 'alice',
+      account_display_name: 'Alice',
+      media: [],
+      urls: [],
+    } satisfies TweetData
+    clickHouseEnabledMock.mockReturnValue(true)
+    fetchClickHouseTweetPageDataMock.mockResolvedValue(tweet)
+    fetchClickHouseQuotePostsMock.mockRejectedValue(new Error('gateway down'))
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+
+    await expect(getTweetPageData(tweet.tweet_id)).resolves.toEqual({
+      tweet,
+      threadTree: null,
+      quotingTweets: [],
+      quotingTweetCount: 0,
     })
+    expect(consoleError).toHaveBeenCalledWith(
+      'ClickHouse quote posts failed:',
+      {
+        tweetId: tweet.tweet_id,
+        error: 'gateway down',
+      },
+    )
+    expect(createServerClientMock).not.toHaveBeenCalled()
+
+    consoleError.mockRestore()
   })
 
   test('maps reverse quote results into sidebar-ready tweet data', async () => {

--- a/src/lib/getTweetPageData.test.ts
+++ b/src/lib/getTweetPageData.test.ts
@@ -1,0 +1,124 @@
+import { cookies } from 'next/headers'
+import { createServerClient } from '@/utils/supabase'
+import { getTweetPageData } from './getTweetPageData'
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(),
+}))
+
+jest.mock('@/utils/supabase', () => ({
+  createServerClient: jest.fn(),
+}))
+
+jest.mock('./twitterSyndication', () => ({
+  fetchSyndicatedTweets: jest.fn().mockResolvedValue(new Map()),
+}))
+
+const mainTweet = {
+  tweet_id: 'original-1',
+  account_id: 'account-original',
+  username: 'original_author',
+  account_display_name: 'Original Author',
+  created_at: '2026-08-01T10:00:00Z',
+  full_text: 'Original tweet',
+  retweet_count: 2,
+  favorite_count: 8,
+  reply_to_tweet_id: null,
+  reply_to_user_id: null,
+  reply_to_username: null,
+  quoted_tweet_id: null,
+  conversation_id: null,
+  avatar_media_url: null,
+  archive_upload_id: 1,
+}
+
+describe('getTweetPageData', () => {
+  const rpc = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(cookies as jest.Mock).mockResolvedValue({})
+    ;(createServerClient as jest.Mock).mockReturnValue({ rpc })
+  })
+
+  it('maps reverse quote results into sidebar-ready tweet data', async () => {
+    rpc.mockResolvedValue({
+      data: {
+        tweet: mainTweet,
+        media: [],
+        mentioned_users: [],
+        conversation_tweets: [mainTweet],
+        conversation_media: [],
+        quoted_tweets: [],
+        quoting_tweet_count: 17,
+        quoting_tweets: [
+          {
+            tweet_id: 'quote-1',
+            account_id: 'account-quote',
+            username: 'quote_author',
+            account_display_name: 'Quote Author',
+            created_at: '2026-08-02T10:00:00Z',
+            full_text: 'My comment',
+            retweet_count: 3,
+            favorite_count: 13,
+            reply_to_tweet_id: null,
+            reply_to_username: null,
+            quoted_tweet_id: 'original-1',
+            avatar_media_url: 'https://example.com/avatar.jpg',
+            media: [
+              {
+                tweet_id: 'quote-1',
+                media_url: 'https://example.com/photo.jpg',
+                media_type: 'photo',
+                width: 800,
+                height: 600,
+              },
+            ],
+          },
+        ],
+      },
+      error: null,
+    })
+
+    const result = await getTweetPageData('original-1')
+
+    expect(rpc).toHaveBeenCalledWith('get_tweet_page_data', {
+      p_tweet_id: 'original-1',
+    })
+    expect(result.quotingTweetCount).toBe(17)
+    expect(result.quotingTweets).toEqual([
+      expect.objectContaining({
+        tweet_id: 'quote-1',
+        quote_tweet_id: 'original-1',
+        username: 'quote_author',
+        media: [
+          {
+            media_url: 'https://example.com/photo.jpg',
+            media_type: 'photo',
+            width: 800,
+            height: 600,
+          },
+        ],
+      }),
+    ])
+  })
+
+  it('defaults reverse quote data when an older RPC response omits it', async () => {
+    rpc.mockResolvedValue({
+      data: {
+        tweet: mainTweet,
+        media: [],
+        mentioned_users: [],
+        conversation_tweets: [mainTweet],
+        conversation_media: [],
+        quoted_tweets: [],
+      },
+      error: null,
+    })
+
+    const result = await getTweetPageData('original-1')
+
+    expect(result.quotingTweets).toEqual([])
+    expect(result.quotingTweetCount).toBe(0)
+  })
+})

--- a/src/lib/getTweetPageData.ts
+++ b/src/lib/getTweetPageData.ts
@@ -12,6 +12,10 @@ import {
 } from './twitterSyndication'
 import { isClickHouseReadsEnabled } from './clickhouseGateway'
 import { fetchClickHouseTweetPageData } from './clickhouseTweetPage'
+import {
+  fetchClickHouseQuotePosts,
+  type ClickHouseQuotePostsData,
+} from './clickhouseQuotePosts'
 
 interface RpcTweet {
   tweet_id: string
@@ -99,28 +103,29 @@ interface TweetPageResult {
 }
 
 /**
- * Load the permalink tweet from ClickHouse when enabled while reading reverse
- * quote metadata from the canonical Supabase relationship table. The Supabase
- * RPC remains the complete tweet/thread fallback.
+ * Load portal permalink records and incoming quote posts from the same
+ * ClickHouse snapshot when enabled. The Supabase RPC remains the complete
+ * tweet/thread fallback for environments without ClickHouse reads.
  */
 export async function getTweetPageData(
   tweetId: string,
 ): Promise<TweetPageResult> {
-  const clickHouseTweetPromise = fetchClickHouseTweet(tweetId)
+  const clickHousePage = await fetchClickHousePage(tweetId)
+  if (clickHousePage) return clickHousePage
+
   const cookieStore = await cookies()
   const supabase = createServerClient(cookieStore)
 
-  const [clickHouseTweet, { data, error }] = await Promise.all([
-    clickHouseTweetPromise,
-    supabase.rpc('get_tweet_page_data' as any, { p_tweet_id: tweetId }),
-  ])
+  const { data, error } = await supabase.rpc('get_tweet_page_data' as any, {
+    p_tweet_id: tweetId,
+  })
 
   if (error || !data) {
     console.error('get_tweet_page_data RPC failed:', error?.message, {
       tweetId,
     })
     return {
-      tweet: clickHouseTweet,
+      tweet: null,
       threadTree: null,
       quotingTweets: [],
       quotingTweetCount: 0,
@@ -132,15 +137,6 @@ export async function getTweetPageData(
   const quotingTweetCount = Number(
     result.quoting_tweet_count ?? quotingTweets.length,
   )
-
-  if (clickHouseTweet) {
-    return {
-      tweet: clickHouseTweet,
-      threadTree: null,
-      quotingTweets,
-      quotingTweetCount,
-    }
-  }
 
   if (!result.tweet) {
     return {
@@ -211,13 +207,29 @@ export async function getTweetPageData(
   return { tweet: mainTweet, threadTree, quotingTweets, quotingTweetCount }
 }
 
-async function fetchClickHouseTweet(
+async function fetchClickHousePage(
   tweetId: string,
-): Promise<TweetData | null> {
+): Promise<TweetPageResult | null> {
   if (!isClickHouseReadsEnabled()) return null
 
   try {
-    return await fetchClickHouseTweetPageData(tweetId)
+    const [tweet, quotePosts] = await Promise.all([
+      fetchClickHouseTweetPageData(tweetId),
+      fetchClickHouseQuotePosts(tweetId).catch((error) => {
+        console.error('ClickHouse quote posts failed:', {
+          tweetId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        return { tweets: [], totalCount: 0 } satisfies ClickHouseQuotePostsData
+      }),
+    ])
+    if (!tweet) return null
+    return {
+      tweet,
+      threadTree: null,
+      quotingTweets: quotePosts.tweets,
+      quotingTweetCount: quotePosts.totalCount,
+    }
   } catch (error) {
     console.error('ClickHouse tweet detail failed; falling back to Supabase:', {
       tweetId,

--- a/src/lib/getTweetPageData.ts
+++ b/src/lib/getTweetPageData.ts
@@ -1,6 +1,10 @@
 import { createServerClient } from '@/utils/supabase'
 import { cookies } from 'next/headers'
-import { ConversationTree, ThreadTweet, buildConversationTree } from './threadUtils'
+import {
+  ConversationTree,
+  ThreadTweet,
+  buildConversationTree,
+} from './threadUtils'
 import { TweetData } from '@/components/TweetComponent'
 import {
   fetchSyndicatedTweets,
@@ -58,6 +62,22 @@ interface RpcQuotedTweet {
   media: RpcMedia[]
 }
 
+interface RpcQuotingTweet {
+  tweet_id: string
+  account_id: string
+  created_at: string
+  full_text: string
+  retweet_count: number | null
+  favorite_count: number
+  reply_to_tweet_id: string | null
+  reply_to_username: string | null
+  quoted_tweet_id: string
+  username: string
+  account_display_name: string
+  avatar_media_url: string | null
+  media: RpcMedia[]
+}
+
 interface RpcResult {
   tweet: RpcTweet | null
   media: RpcMedia[]
@@ -65,18 +85,24 @@ interface RpcResult {
   conversation_tweets: RpcTweet[]
   conversation_media: RpcMedia[]
   quoted_tweets: RpcQuotedTweet[]
+  quoting_tweet_count?: number
+  quoting_tweets?: RpcQuotingTweet[]
 }
 
 interface TweetPageResult {
   tweet: TweetData | null
   threadTree: ConversationTree | null
+  quotingTweets: TweetData[]
+  quotingTweetCount: number
 }
 
 /**
  * Fetch all data needed for the tweet page in a single RPC call.
  * Replaces ~24 separate Supabase HTTP calls with 1.
  */
-export async function getTweetPageData(tweetId: string): Promise<TweetPageResult> {
+export async function getTweetPageData(
+  tweetId: string,
+): Promise<TweetPageResult> {
   const cookieStore = await cookies()
   const supabase = createServerClient(cookieStore)
 
@@ -85,14 +111,26 @@ export async function getTweetPageData(tweetId: string): Promise<TweetPageResult
   })
 
   if (error || !data) {
-    console.error('get_tweet_page_data RPC failed:', error?.message, { tweetId })
-    return { tweet: null, threadTree: null }
+    console.error('get_tweet_page_data RPC failed:', error?.message, {
+      tweetId,
+    })
+    return {
+      tweet: null,
+      threadTree: null,
+      quotingTweets: [],
+      quotingTweetCount: 0,
+    }
   }
 
   const result = data as unknown as RpcResult
 
   if (!result.tweet) {
-    return { tweet: null, threadTree: null }
+    return {
+      tweet: null,
+      threadTree: null,
+      quotingTweets: [],
+      quotingTweetCount: 0,
+    }
   }
 
   // Collect every tweet id referenced by the conversation that the RPC couldn't
@@ -152,7 +190,44 @@ export async function getTweetPageData(tweetId: string): Promise<TweetPageResult
     syndicated,
   )
 
-  return { tweet: mainTweet, threadTree }
+  const quotingTweets = (result.quoting_tweets ?? []).map(buildQuotingTweetData)
+  const quotingTweetCount = Number(
+    result.quoting_tweet_count ?? quotingTweets.length,
+  )
+
+  return { tweet: mainTweet, threadTree, quotingTweets, quotingTweetCount }
+}
+
+function buildQuotingTweetData(tweet: RpcQuotingTweet): TweetData {
+  return {
+    tweet_id: tweet.tweet_id,
+    account_id: tweet.account_id,
+    created_at: tweet.created_at,
+    full_text: tweet.full_text,
+    retweet_count: tweet.retweet_count,
+    favorite_count: tweet.favorite_count,
+    reply_to_tweet_id: tweet.reply_to_tweet_id,
+    reply_to_username: tweet.reply_to_username ?? undefined,
+    quote_tweet_id: tweet.quoted_tweet_id,
+    retweeted_tweet_id: null,
+    avatar_media_url: tweet.avatar_media_url,
+    username: tweet.username,
+    account_display_name: tweet.account_display_name,
+    media: (tweet.media ?? []).map((media) => ({
+      media_url: media.media_url,
+      media_type: media.media_type,
+      width: media.width ?? undefined,
+      height: media.height ?? undefined,
+    })),
+    urls: [],
+    account: {
+      username: tweet.username,
+      account_display_name: tweet.account_display_name,
+      profile: tweet.avatar_media_url
+        ? { avatar_media_url: tweet.avatar_media_url }
+        : undefined,
+    },
+  }
 }
 
 // Convert a SyndicatedTweet into the quoted-tweet shape both ThreadTweet and TweetData
@@ -210,7 +285,9 @@ function buildTweetData(
   }))
 
   // Find the quoted tweet for this tweet
-  const quotedTweet = quotedTweets.find((qt) => qt.source_tweet_id === tweet.tweet_id)
+  const quotedTweet = quotedTweets.find(
+    (qt) => qt.source_tweet_id === tweet.tweet_id,
+  )
 
   // Build mentioned_users in the shape TweetComponent expects
   const mentions = mentionedUsers
@@ -316,7 +393,9 @@ function buildThreadTree(
         height: m.height,
       }))
 
-    const quotedTweet = quotedTweets.find((qt) => qt.source_tweet_id === ct.tweet_id)
+    const quotedTweet = quotedTweets.find(
+      (qt) => qt.source_tweet_id === ct.tweet_id,
+    )
 
     return {
       tweet_id: ct.tweet_id,
@@ -335,7 +414,8 @@ function buildThreadTree(
       // ct.quoted_tweet_id is sourced from enriched_tweets and survives even if the
       // quoted tweet itself was deleted; the RPC's quoted_tweets list won't contain it
       // in that case. Preserve the relationship and surface a placeholder.
-      quote_tweet_id: ct.quoted_tweet_id ?? (quotedTweet ? quotedTweet.tweet_id : null),
+      quote_tweet_id:
+        ct.quoted_tweet_id ?? (quotedTweet ? quotedTweet.tweet_id : null),
       quoted_tweet: quotedTweet
         ? {
             tweet_id: quotedTweet.tweet_id,

--- a/supabase/migrations/20260808014043_add_quoting_tweets_to_tweet_page.sql
+++ b/supabase/migrations/20260808014043_add_quoting_tweets_to_tweet_page.sql
@@ -1,0 +1,174 @@
+-- Add reverse quote relationships to the tweet-page payload. The list is bounded
+-- for predictable page weight; quoting_tweet_count preserves the complete total.
+CREATE OR REPLACE FUNCTION "public"."get_tweet_page_data"("p_tweet_id" "text")
+RETURNS "jsonb"
+LANGUAGE "plpgsql" STABLE SECURITY INVOKER
+AS $$
+DECLARE
+    v_result jsonb;
+    v_tweet_row record;
+    v_conversation_id text;
+    v_conversation_tweet_ids text[];
+BEGIN
+    SELECT * INTO v_tweet_row
+    FROM public.enriched_tweets
+    WHERE tweet_id = p_tweet_id;
+
+    IF v_tweet_row IS NULL THEN
+        RETURN jsonb_build_object(
+            'tweet', NULL,
+            'media', '[]'::jsonb,
+            'mentioned_users', '[]'::jsonb,
+            'conversation_tweets', '[]'::jsonb,
+            'conversation_media', '[]'::jsonb,
+            'quoted_tweets', '[]'::jsonb,
+            'quoting_tweet_count', 0,
+            'quoting_tweets', '[]'::jsonb
+        );
+    END IF;
+
+    v_conversation_id := v_tweet_row.conversation_id;
+
+    SELECT array_agg(sub.tweet_id) INTO v_conversation_tweet_ids
+    FROM (
+        SELECT et.tweet_id
+        FROM public.enriched_tweets et
+        WHERE (
+            (v_conversation_id IS NOT NULL AND et.conversation_id = v_conversation_id)
+            OR
+            (v_conversation_id IS NULL AND (
+                et.tweet_id = p_tweet_id
+                OR et.reply_to_tweet_id = p_tweet_id
+            ))
+        )
+        ORDER BY et.created_at ASC
+        LIMIT 500
+    ) sub;
+
+    SELECT jsonb_build_object(
+        'tweet', to_jsonb(v_tweet_row),
+        'media', COALESCE((
+            SELECT jsonb_agg(to_jsonb(tm))
+            FROM public.tweet_media tm
+            WHERE tm.tweet_id = p_tweet_id
+        ), '[]'::jsonb),
+        'mentioned_users', COALESCE((
+            SELECT jsonb_agg(jsonb_build_object(
+                'tweet_id', um.tweet_id,
+                'user_id', mu.user_id,
+                'name', mu.name,
+                'screen_name', mu.screen_name,
+                'account_id', aa.account_id,
+                'account_username', aa.username,
+                'account_display_name', aa.account_display_name,
+                'avatar_media_url', ap.avatar_media_url
+            ))
+            FROM public.user_mentions um
+            JOIN public.mentioned_users mu ON um.mentioned_user_id = mu.user_id
+            LEFT JOIN public.all_account aa ON aa.username = mu.screen_name
+            LEFT JOIN LATERAL (
+                SELECT all_profile.avatar_media_url
+                FROM public.all_profile
+                WHERE all_profile.account_id = aa.account_id
+                ORDER BY all_profile.archive_upload_id DESC
+                LIMIT 1
+            ) ap ON true
+            WHERE um.tweet_id = p_tweet_id
+        ), '[]'::jsonb),
+        'conversation_tweets', COALESCE((
+            SELECT jsonb_agg(to_jsonb(ct) ORDER BY ct.created_at)
+            FROM public.enriched_tweets ct
+            WHERE ct.tweet_id = ANY(v_conversation_tweet_ids)
+        ), '[]'::jsonb),
+        'conversation_media', COALESCE((
+            SELECT jsonb_agg(to_jsonb(cm))
+            FROM public.tweet_media cm
+            WHERE cm.tweet_id = ANY(v_conversation_tweet_ids)
+        ), '[]'::jsonb),
+        'quoted_tweets', COALESCE((
+            SELECT jsonb_agg(jsonb_build_object(
+                'tweet_id', qt_tweet.tweet_id,
+                'source_tweet_id', qt.tweet_id,
+                'account_id', qt_tweet.account_id,
+                'created_at', qt_tweet.created_at,
+                'full_text', qt_tweet.full_text,
+                'retweet_count', qt_tweet.retweet_count,
+                'favorite_count', qt_tweet.favorite_count,
+                'username', qt_tweet.username,
+                'account_display_name', qt_tweet.account_display_name,
+                'avatar_media_url', qt_tweet.avatar_media_url,
+                'media', COALESCE((
+                    SELECT jsonb_agg(to_jsonb(qtm))
+                    FROM public.tweet_media qtm
+                    WHERE qtm.tweet_id = qt_tweet.tweet_id
+                ), '[]'::jsonb)
+            ))
+            FROM public.quote_tweets qt
+            JOIN public.enriched_tweets qt_tweet ON qt_tweet.tweet_id = qt.quoted_tweet_id
+            WHERE qt.tweet_id = ANY(v_conversation_tweet_ids)
+            AND qt.quoted_tweet_id IS NOT NULL
+        ), '[]'::jsonb),
+        'quoting_tweet_count', (
+            SELECT COUNT(DISTINCT incoming_quote.tweet_id)
+            FROM public.quote_tweets incoming_quote
+            WHERE incoming_quote.quoted_tweet_id = p_tweet_id
+        ),
+        'quoting_tweets', COALESCE((
+            SELECT jsonb_agg(
+                jsonb_build_object(
+                    'tweet_id', quoting_tweet.tweet_id,
+                    'account_id', quoting_tweet.account_id,
+                    'created_at', quoting_tweet.created_at,
+                    'full_text', quoting_tweet.full_text,
+                    'retweet_count', quoting_tweet.retweet_count,
+                    'favorite_count', quoting_tweet.favorite_count,
+                    'reply_to_tweet_id', quoting_tweet.reply_to_tweet_id,
+                    'reply_to_username', quoting_tweet.reply_to_username,
+                    'quoted_tweet_id', p_tweet_id,
+                    'username', quoting_tweet.username,
+                    'account_display_name', quoting_tweet.account_display_name,
+                    'avatar_media_url', quoting_tweet.avatar_media_url,
+                    'media', COALESCE((
+                        SELECT jsonb_agg(to_jsonb(qtm))
+                        FROM public.tweet_media qtm
+                        WHERE qtm.tweet_id = quoting_tweet.tweet_id
+                    ), '[]'::jsonb)
+                )
+                ORDER BY quoting_tweet.favorite_count DESC NULLS LAST,
+                         quoting_tweet.created_at DESC
+            )
+            FROM (
+                SELECT
+                    t.tweet_id,
+                    t.account_id,
+                    t.created_at,
+                    t.full_text,
+                    t.retweet_count,
+                    t.favorite_count,
+                    t.reply_to_tweet_id,
+                    t.reply_to_username,
+                    a.username,
+                    a.account_display_name,
+                    profile.avatar_media_url
+                FROM public.quote_tweets incoming_quote
+                JOIN public.tweets t ON t.tweet_id = incoming_quote.tweet_id
+                JOIN public.all_account a ON a.account_id = t.account_id
+                LEFT JOIN LATERAL (
+                    SELECT ap.avatar_media_url
+                    FROM public.all_profile ap
+                    WHERE ap.account_id = t.account_id
+                    ORDER BY ap.archive_upload_id DESC
+                    LIMIT 1
+                ) profile ON true
+                WHERE incoming_quote.quoted_tweet_id = p_tweet_id
+                ORDER BY t.favorite_count DESC NULLS LAST, t.created_at DESC
+                LIMIT 12
+            ) quoting_tweet
+        ), '[]'::jsonb)
+    ) INTO v_result;
+
+    RETURN v_result;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_tweet_page_data"("p_tweet_id" "text") OWNER TO "postgres";

--- a/supabase/migrations/20260808014920_harden_tweet_page_data_search_path.sql
+++ b/supabase/migrations/20260808014920_harden_tweet_page_data_search_path.sql
@@ -1,0 +1,4 @@
+-- Keep unqualified built-ins deterministic and satisfy the database security
+-- advisor. All table references in the function remain explicitly qualified.
+ALTER FUNCTION public.get_tweet_page_data(text)
+SET search_path = public, pg_temp;

--- a/supabase/schemas/070_functions.sql
+++ b/supabase/schemas/070_functions.sql
@@ -2745,6 +2745,7 @@ ALTER FUNCTION "public"."get_main_thread"("p_conversation_id" "text") OWNER TO "
 CREATE OR REPLACE FUNCTION "public"."get_tweet_page_data"("p_tweet_id" "text")
 RETURNS "jsonb"
 LANGUAGE "plpgsql" STABLE SECURITY INVOKER
+SET search_path = public, pg_temp
 AS $$
 DECLARE
     v_result jsonb;
@@ -2764,7 +2765,9 @@ BEGIN
             'mentioned_users', '[]'::jsonb,
             'conversation_tweets', '[]'::jsonb,
             'conversation_media', '[]'::jsonb,
-            'quoted_tweets', '[]'::jsonb
+            'quoted_tweets', '[]'::jsonb,
+            'quoting_tweet_count', 0,
+            'quoting_tweets', '[]'::jsonb
         );
     END IF;
 
@@ -2851,6 +2854,63 @@ BEGIN
             JOIN public.enriched_tweets qt_tweet ON qt_tweet.tweet_id = qt.quoted_tweet_id
             WHERE qt.tweet_id = ANY(v_conversation_tweet_ids)
             AND qt.quoted_tweet_id IS NOT NULL
+        ), '[]'::jsonb),
+        'quoting_tweet_count', (
+            SELECT COUNT(DISTINCT incoming_quote.tweet_id)
+            FROM public.quote_tweets incoming_quote
+            WHERE incoming_quote.quoted_tweet_id = p_tweet_id
+        ),
+        'quoting_tweets', COALESCE((
+            SELECT jsonb_agg(
+                jsonb_build_object(
+                    'tweet_id', quoting_tweet.tweet_id,
+                    'account_id', quoting_tweet.account_id,
+                    'created_at', quoting_tweet.created_at,
+                    'full_text', quoting_tweet.full_text,
+                    'retweet_count', quoting_tweet.retweet_count,
+                    'favorite_count', quoting_tweet.favorite_count,
+                    'reply_to_tweet_id', quoting_tweet.reply_to_tweet_id,
+                    'reply_to_username', quoting_tweet.reply_to_username,
+                    'quoted_tweet_id', p_tweet_id,
+                    'username', quoting_tweet.username,
+                    'account_display_name', quoting_tweet.account_display_name,
+                    'avatar_media_url', quoting_tweet.avatar_media_url,
+                    'media', COALESCE((
+                        SELECT jsonb_agg(to_jsonb(qtm))
+                        FROM public.tweet_media qtm
+                        WHERE qtm.tweet_id = quoting_tweet.tweet_id
+                    ), '[]'::jsonb)
+                )
+                ORDER BY quoting_tweet.favorite_count DESC NULLS LAST,
+                         quoting_tweet.created_at DESC
+            )
+            FROM (
+                SELECT
+                    t.tweet_id,
+                    t.account_id,
+                    t.created_at,
+                    t.full_text,
+                    t.retweet_count,
+                    t.favorite_count,
+                    t.reply_to_tweet_id,
+                    t.reply_to_username,
+                    a.username,
+                    a.account_display_name,
+                    profile.avatar_media_url
+                FROM public.quote_tweets incoming_quote
+                JOIN public.tweets t ON t.tweet_id = incoming_quote.tweet_id
+                JOIN public.all_account a ON a.account_id = t.account_id
+                LEFT JOIN LATERAL (
+                    SELECT ap.avatar_media_url
+                    FROM public.all_profile ap
+                    WHERE ap.account_id = t.account_id
+                    ORDER BY ap.archive_upload_id DESC
+                    LIMIT 1
+                ) profile ON true
+                WHERE incoming_quote.quoted_tweet_id = p_tweet_id
+                ORDER BY t.favorite_count DESC NULLS LAST, t.created_at DESC
+                LIMIT 12
+            ) quoting_tweet
         ), '[]'::jsonb)
     ) INTO v_result;
 

--- a/tests/db-schema/schema-validation.test.ts
+++ b/tests/db-schema/schema-validation.test.ts
@@ -115,6 +115,8 @@ describe('Database Schema Validation', () => {
       expect(result).toHaveProperty('conversation_media')
       expect(result).toHaveProperty('mentioned_users')
       expect(result).toHaveProperty('quoted_tweets')
+      expect(result).toHaveProperty('quoting_tweet_count')
+      expect(result).toHaveProperty('quoting_tweets')
 
       // tweet should have core fields
       if (result.tweet) {


### PR DESCRIPTION
## What changed

- add a responsive “Tweets quoting this” sidebar to tweet permalinks
- load the permalink tweet and incoming quote posts from the ClickHouse analytics gateway when ClickHouse reads are enabled
- request the complete reverse-quote count plus the latest 12 quote posts, limited to current Community Archive members and excluding self-quotes
- keep the Supabase `get_tweet_page_data` RPC as the complete fallback for environments without ClickHouse reads
- add focused gateway allowlist, response-mapping, page-routing, resilience, component, and schema-contract coverage

## Why

The first implementation mixed production ClickHouse for the permalink tweet with the PR’s Supabase Preview Branch for reverse quotes. Supabase Preview Branches intentionally do not copy production data, so a tweet that Bangers reported with 7 archive quotes rendered a zero-count sidebar.

ClickHouse already exposes `quote-posts/:tweetId`. Using it keeps a Bangers record and its detail page on the same corpus snapshot, aligns the sidebar with Bangers’ current-member/non-self filtering, and avoids a second datastore dependency on the normal page path.

## Impact

- desktop: a sticky sidebar beside the tweet/thread
- smaller screens: the same panel flows below the main content
- counts now agree with the Bangers definition of archive quotes
- page weight stays bounded to 12 quote posts while preserving the complete count
- if only the reverse-quote request fails, the permalink still renders with an empty sidebar and logs the partial failure
- environments without ClickHouse reads retain the existing Supabase fallback

## Validation

- focused server Jest: 19 passed
- focused client Jest: 2 passed
- full server Jest: 148 passed
- `pnpm type-check`
- `pnpm lint` (one pre-existing `<img>` warning in `UnifiedTweetList.test.tsx`)
- targeted Prettier check
- `pnpm build` (successful, with existing dynamic-route diagnostics)
- production data diagnosis for tweet `2085375983708692599`: Bangers/ClickHouse reports 7 current-member non-self quotes; production Supabase contains 10 raw reverse-quote relationships; the PR Supabase branch contains no row for this tweet

## Infrastructure

The required ClickHouse `quote-posts/:tweetId` gateway endpoint is already deployed. This PR only adds the application allowlist and consumer mapping; it does not require a new backend rollout.