### PR TITLE
Add historical bangers carousel

### DIFF
--- a/src/components/portal/HistoricalBangersCarousel.tsx
+++ b/src/components/portal/HistoricalBangersCarousel.tsx
@@ -7,6 +7,9 @@ import type { PortalTweet } from '@/lib/portal/types'
 import { CARD, MUTED } from './styles'
 import { TweetRow } from './TweetRow'
 
+const CAROUSEL_CONTROL =
+  'absolute top-1/2 z-10 inline-flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full border border-zinc-300 bg-white/90 text-zinc-600 shadow-md backdrop-blur-sm transition-colors hover:border-zinc-400 hover:bg-white hover:text-zinc-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand dark:border-[#3a3a40] dark:bg-[#1b1b1e]/90 dark:text-[#c4c4cc] dark:hover:border-[#55555e] dark:hover:bg-[#242428] dark:hover:text-white'
+
 export function HistoricalBangersCarousel({
   tweets,
 }: {
@@ -32,7 +35,7 @@ export function HistoricalBangersCarousel({
     <section
       aria-label="Historical bangers"
       aria-roledescription="carousel"
-      className={`${CARD} min-w-0 overflow-hidden`}
+      className={`${CARD} relative flex h-[22rem] min-w-0 flex-col overflow-hidden`}
       tabIndex={hasMultipleTweets ? 0 : undefined}
       onKeyDown={(event) => {
         if (event.target !== event.currentTarget) return
@@ -46,7 +49,7 @@ export function HistoricalBangersCarousel({
         }
       }}
     >
-      <div className="flex items-center justify-between gap-3 border-b border-zinc-200 px-4 py-3 dark:border-[#26262a]">
+      <div className="flex flex-none items-center justify-between gap-3 border-b border-zinc-200 px-4 py-3 dark:border-[#26262a]">
         <h3 className="min-w-0 truncate text-[13px] font-bold">
           Historical banger · near this day
         </h3>
@@ -58,26 +61,30 @@ export function HistoricalBangersCarousel({
         </Link>
       </div>
 
-      <div aria-live="polite" aria-atomic="true">
-        <TweetRow
-          key={currentTweet.id}
-          tweet={currentTweet}
-          collapsible
-          showDate
-        />
-      </div>
+      <div className="relative min-h-0 flex-1">
+        <div className="h-full overflow-y-auto overscroll-contain [scrollbar-gutter:stable]">
+          <TweetRow
+            key={currentTweet.id}
+            tweet={currentTweet}
+            collapsible
+            showDate
+          />
+        </div>
 
-      {hasMultipleTweets && (
-        <div className="flex items-center justify-between border-t border-zinc-100 px-4 py-2 dark:border-[#202023]">
-          <span className={`text-[11.5px] tabular-nums ${MUTED}`}>
-            {visibleIndex + 1} of {tweets.length}
-          </span>
-          <div className="flex items-center gap-1.5">
+        {hasMultipleTweets && (
+          <>
+            <span
+              aria-live="polite"
+              aria-atomic="true"
+              className={`pointer-events-none absolute bottom-3 left-1/2 z-10 -translate-x-1/2 rounded-full border border-zinc-200 bg-white/90 px-2.5 py-1 text-[11.5px] tabular-nums shadow-sm backdrop-blur-sm dark:border-[#303036] dark:bg-[#1b1b1e]/90 ${MUTED}`}
+            >
+              {visibleIndex + 1} of {tweets.length}
+            </span>
             <button
               type="button"
               onClick={showPrevious}
               aria-label="Previous historical banger"
-              className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-zinc-200 text-zinc-600 transition-colors hover:border-zinc-300 hover:bg-zinc-50 hover:text-zinc-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand dark:border-[#303036] dark:text-[#a7a7b4] dark:hover:border-[#45454c] dark:hover:bg-[#242428] dark:hover:text-white"
+              className={`${CAROUSEL_CONTROL} left-3`}
             >
               <ChevronLeft aria-hidden="true" className="h-4 w-4" />
             </button>
@@ -85,13 +92,13 @@ export function HistoricalBangersCarousel({
               type="button"
               onClick={showNext}
               aria-label="Next historical banger"
-              className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-zinc-200 text-zinc-600 transition-colors hover:border-zinc-300 hover:bg-zinc-50 hover:text-zinc-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand dark:border-[#303036] dark:text-[#a7a7b4] dark:hover:border-[#45454c] dark:hover:bg-[#242428] dark:hover:text-white"
+              className={`${CAROUSEL_CONTROL} right-3`}
             >
               <ChevronRight aria-hidden="true" className="h-4 w-4" />
             </button>
-          </div>
-        </div>
-      )}
+          </>
+        )}
+      </div>
     </section>
   )
 }

--- a/src/components/portal/HistoricalBangersCarousel.tsx
+++ b/src/components/portal/HistoricalBangersCarousel.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import type { PortalTweet } from '@/lib/portal/types'
+import { CARD, MUTED } from './styles'
+import { TweetRow } from './TweetRow'
+
+export function HistoricalBangersCarousel({
+  tweets,
+}: {
+  tweets: PortalTweet[]
+}) {
+  const [currentIndex, setCurrentIndex] = useState(0)
+
+  if (tweets.length === 0) return null
+
+  const visibleIndex = Math.min(currentIndex, tweets.length - 1)
+  const currentTweet = tweets[visibleIndex]
+  const hasMultipleTweets = tweets.length > 1
+
+  const showPrevious = () => {
+    setCurrentIndex((index) => (index - 1 + tweets.length) % tweets.length)
+  }
+
+  const showNext = () => {
+    setCurrentIndex((index) => (index + 1) % tweets.length)
+  }
+
+  return (
+    <section
+      aria-label="Historical bangers"
+      aria-roledescription="carousel"
+      className={`${CARD} min-w-0 overflow-hidden`}
+      tabIndex={hasMultipleTweets ? 0 : undefined}
+      onKeyDown={(event) => {
+        if (event.target !== event.currentTarget) return
+        if (event.key === 'ArrowLeft') {
+          event.preventDefault()
+          showPrevious()
+        }
+        if (event.key === 'ArrowRight') {
+          event.preventDefault()
+          showNext()
+        }
+      }}
+    >
+      <div className="flex items-center justify-between gap-3 border-b border-zinc-200 px-4 py-3 dark:border-[#26262a]">
+        <h3 className="min-w-0 truncate text-[13px] font-bold">
+          Historical banger · near this day
+        </h3>
+        <Link
+          href="/bangers"
+          className="flex-shrink-0 text-[12.5px] font-semibold text-brand hover:underline"
+        >
+          More bangers →
+        </Link>
+      </div>
+
+      <div aria-live="polite" aria-atomic="true">
+        <TweetRow
+          key={currentTweet.id}
+          tweet={currentTweet}
+          collapsible
+          showDate
+        />
+      </div>
+
+      {hasMultipleTweets && (
+        <div className="flex items-center justify-between border-t border-zinc-100 px-4 py-2 dark:border-[#202023]">
+          <span className={`text-[11.5px] tabular-nums ${MUTED}`}>
+            {visibleIndex + 1} of {tweets.length}
+          </span>
+          <div className="flex items-center gap-1.5">
+            <button
+              type="button"
+              onClick={showPrevious}
+              aria-label="Previous historical banger"
+              className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-zinc-200 text-zinc-600 transition-colors hover:border-zinc-300 hover:bg-zinc-50 hover:text-zinc-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand dark:border-[#303036] dark:text-[#a7a7b4] dark:hover:border-[#45454c] dark:hover:bg-[#242428] dark:hover:text-white"
+            >
+              <ChevronLeft aria-hidden="true" className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              onClick={showNext}
+              aria-label="Next historical banger"
+              className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-zinc-200 text-zinc-600 transition-colors hover:border-zinc-300 hover:bg-zinc-50 hover:text-zinc-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand dark:border-[#303036] dark:text-[#a7a7b4] dark:hover:border-[#45454c] dark:hover:bg-[#242428] dark:hover:text-white"
+            >
+              <ChevronRight aria-hidden="true" className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/portal/Portal.tsx
+++ b/src/components/portal/Portal.tsx
@@ -12,6 +12,7 @@ import {
 import { PORTAL_ARTICLES } from './articles'
 import { PORTAL_TOOLS } from './tools'
 import { CARD, MUTED, FAINT, BODY, SERIF } from './styles'
+import { HistoricalBangersCarousel } from './HistoricalBangersCarousel'
 import { TweetRow } from './TweetRow'
 import HomepageSearch from '@/components/HomepageSearch'
 
@@ -296,7 +297,6 @@ export default function Portal({
 
   const bestStrands = PORTAL_TOOLS.find((t) => t.name === 'Best Strands')
   const recentBanger = data.recentBangers[0] ?? null
-  const historicalBanger = data.historicalBangers[0] ?? null
 
   const generatedDate = useMemo(() => {
     const d = new Date(stats.generatedAt)
@@ -475,7 +475,7 @@ export default function Portal({
                 </div>
               </div>
 
-              {(recentBanger || historicalBanger) && (
+              {(recentBanger || data.historicalBangers.length > 0) && (
                 <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                   {recentBanger && (
                     <div className={`${CARD} min-w-0 overflow-hidden`}>
@@ -487,12 +487,7 @@ export default function Portal({
                     </div>
                   )}
 
-                  {historicalBanger && (
-                    <div className={`${CARD} min-w-0 overflow-hidden`}>
-                      <PanelHeader title="Historical banger · near this day" />
-                      <TweetRow tweet={historicalBanger} collapsible showDate />
-                    </div>
-                  )}
+                  <HistoricalBangersCarousel tweets={data.historicalBangers} />
                 </div>
               )}
             </div>

--- a/src/lib/portal/HistoricalBangersCarousel.test.tsx
+++ b/src/lib/portal/HistoricalBangersCarousel.test.tsx
@@ -76,4 +76,26 @@ describe('HistoricalBangersCarousel', () => {
 
     expect(screen.getByText('Historical banger 2')).toBeVisible()
   })
+
+  test('pins overlay controls around a fixed-height, scrollable tweet viewport', () => {
+    render(<HistoricalBangersCarousel tweets={[tweet('1'), tweet('2')]} />)
+
+    const carousel = screen.getByRole('region', {
+      name: 'Historical bangers',
+    })
+    const tweetArticle = screen
+      .getByText('Historical banger 1')
+      .closest('article')
+    const previous = screen.getByRole('button', {
+      name: 'Previous historical banger',
+    })
+    const next = screen.getByRole('button', {
+      name: 'Next historical banger',
+    })
+
+    expect(carousel).toHaveClass('relative', 'flex', 'h-[22rem]')
+    expect(tweetArticle?.parentElement).toHaveClass('h-full', 'overflow-y-auto')
+    expect(previous).toHaveClass('absolute', 'left-3', 'top-1/2')
+    expect(next).toHaveClass('absolute', 'right-3', 'top-1/2')
+  })
 })

--- a/src/lib/portal/HistoricalBangersCarousel.test.tsx
+++ b/src/lib/portal/HistoricalBangersCarousel.test.tsx
@@ -1,0 +1,79 @@
+/** @jest-environment jsdom */
+
+import React from 'react'
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { HistoricalBangersCarousel } from '@/components/portal/HistoricalBangersCarousel'
+import type { PortalTweet } from '@/lib/portal/types'
+;(globalThis as typeof globalThis & { React: typeof React }).React = React
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({
+    href,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={String(href)} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+const tweet = (id: string): PortalTweet => ({
+  id,
+  username: `member_${id}`,
+  name: `Member ${id}`,
+  avatar: null,
+  text: `Historical banger ${id}`,
+  observedAt: '2026-08-07T20:00:00.000Z',
+  createdAt: `2024-08-0${id}T19:00:00.000Z`,
+  likes: Number(id),
+  rts: 0,
+})
+
+describe('HistoricalBangersCarousel', () => {
+  test('cycles through historical bangers and links to the full page', () => {
+    render(
+      <HistoricalBangersCarousel
+        tweets={[tweet('1'), tweet('2'), tweet('3')]}
+      />,
+    )
+
+    expect(
+      screen.getByRole('link', { name: 'More bangers →' }),
+    ).toHaveAttribute('href', '/bangers')
+    expect(screen.getByText('Historical banger 1')).toBeVisible()
+    expect(screen.getByText('1 of 3')).toBeVisible()
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Next historical banger' }),
+    )
+    expect(screen.queryByText('Historical banger 1')).not.toBeInTheDocument()
+    expect(screen.getByText('Historical banger 2')).toBeVisible()
+    expect(screen.getByText('2 of 3')).toBeVisible()
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Previous historical banger' }),
+    )
+    expect(screen.getByText('Historical banger 1')).toBeVisible()
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Previous historical banger' }),
+    )
+    expect(screen.getByText('Historical banger 3')).toBeVisible()
+    expect(screen.getByText('3 of 3')).toBeVisible()
+  })
+
+  test('supports arrow keys when the carousel itself is focused', () => {
+    render(<HistoricalBangersCarousel tweets={[tweet('1'), tweet('2')]} />)
+
+    const carousel = screen.getByRole('region', {
+      name: 'Historical bangers',
+    })
+    carousel.focus()
+    fireEvent.keyDown(carousel, { key: 'ArrowRight' })
+
+    expect(screen.getByText('Historical banger 2')).toBeVisible()
+  })
+})

--- a/src/lib/portalTrendsRoute.test.ts
+++ b/src/lib/portalTrendsRoute.test.ts
@@ -1,3 +1,5 @@
+jest.mock('server-only', () => ({}), { virtual: true })
+
 import { NextRequest } from 'next/server'
 import { GET } from '@/app/api/portal/trends/route'
 import {


### PR DESCRIPTION
## Summary

- turn the historical banger card into an in-place carousel over the full daily candidate set
- overlay wraparound previous/next controls at fixed positions over the tweet
- keep the card at a constant height while longer tweet content scrolls inside it
- show a position counter and support keyboard arrow navigation
- link the historical card to the existing More bangers page
- cover navigation, wrapping, keyboard behavior, fixed sizing, overlay placement, and the destination link

## Why

The dashboard already fetched up to ten calendar-matched historical bangers but rendered only the first one. This exposes the rest without making people leave the dashboard, while preventing differently sized tweets from shifting the surrounding layout or carousel controls.

## Validation

- `pnpm exec jest --runInBand --runTestsByPath src/lib/portal/HistoricalBangersCarousel.test.tsx`
- `pnpm type-check`
- focused ESLint and Prettier checks
- `pnpm build`
