### PR TITLE
Load tweet permalink pages from ClickHouse

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,7 @@ const commonConfig = {
   setupFiles: ['<rootDir>/jest.polyfills.js'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
+    '^server-only$': '<rootDir>/jest.server-only.js',
   },
   transform: {
     '^.+\\.(t|j)sx?$': [

--- a/jest.server-only.js
+++ b/jest.server-only.js
@@ -1,0 +1,3 @@
+// Next.js replaces this marker at build time. Jest needs an inert module so
+// server route tests can import the same production modules.
+module.exports = {}

--- a/src/lib/clickhouseGateway.ts
+++ b/src/lib/clickhouseGateway.ts
@@ -64,6 +64,12 @@ export function analyticsGatewayRequestUrl(
     /^[A-Za-z0-9_@]{1,80}$/.test(cleanPath[1])
   ) {
     allowedParams = new Set(['limit'])
+  } else if (
+    cleanPath.length === 2 &&
+    cleanPath[0] === 'tweet' &&
+    /^\d{1,20}$/.test(cleanPath[1])
+  ) {
+    allowedParams = new Set()
   }
 
   if (!allowedParams)

--- a/src/lib/clickhouseLab.test.ts
+++ b/src/lib/clickhouseLab.test.ts
@@ -131,4 +131,22 @@ describe('ClickHouse staging lab guard', () => {
       'https://stream.example/analytics/recent-bangers?limit=50&hours=48',
     )
   })
+
+  test('allows only numeric tweet-detail paths and no query parameters', () => {
+    const target = analyticsGatewayRequestUrl(
+      ['tweet', '2085473085399150817'],
+      new URLSearchParams('raw_sql=DROP'),
+      'https://stream.example/analytics',
+    )
+    expect(target.toString()).toBe(
+      'https://stream.example/analytics/tweet/2085473085399150817',
+    )
+    expect(() =>
+      analyticsGatewayRequestUrl(
+        ['tweet', 'not-a-tweet'],
+        new URLSearchParams(),
+        'https://stream.example/analytics',
+      ),
+    ).toThrow('Unsupported ClickHouse analytics endpoint')
+  })
 })

--- a/src/lib/clickhouseTweetPage.test.ts
+++ b/src/lib/clickhouseTweetPage.test.ts
@@ -1,0 +1,90 @@
+import { fetchClickHouseTweetPageData } from './clickhouseTweetPage'
+
+describe('fetchClickHouseTweetPageData', () => {
+  test('maps a portal tweet detail from ClickHouse into the permalink renderer', async () => {
+    const fetcher = jest.fn().mockResolvedValue({
+      data: {
+        tweet: {
+          tweetId: '2085473085399150817',
+          accountId: '10',
+          createdAt: '2026-08-07 12:00:00.000',
+          fullText: 'The linked portal tweet',
+          replyToTweetId: null,
+          replyToUsername: null,
+          favoriteCount: '25',
+          retweetCount: '4',
+          username: 'alice',
+          accountDisplayName: 'Alice',
+          avatarMediaUrl: 'https://pbs.twimg.com/alice.jpg',
+          quoteTweetId: '202',
+          retweetedTweetId: null,
+          media: [
+            {
+              mediaUrl: 'https://pbs.twimg.com/media/example.jpg',
+              mediaType: 'photo',
+              width: 1200,
+              height: 800,
+            },
+          ],
+        },
+        quotedTweet: {
+          tweetId: '202',
+          accountId: '20',
+          createdAt: '2026-08-06T10:00:00.000Z',
+          fullText: 'Quoted context',
+          replyToTweetId: null,
+          replyToUsername: null,
+          favoriteCount: '7',
+          retweetCount: '1',
+          username: 'bob',
+          accountDisplayName: 'Bob',
+          avatarMediaUrl: null,
+          media: [],
+        },
+      },
+    })
+
+    const tweet = await fetchClickHouseTweetPageData(
+      '2085473085399150817',
+      fetcher,
+    )
+
+    expect(fetcher).toHaveBeenCalledWith(
+      ['tweet', '2085473085399150817'],
+      expect.any(URLSearchParams),
+      { revalidate: 3600 },
+    )
+    expect(tweet).toMatchObject({
+      tweet_id: '2085473085399150817',
+      created_at: '2026-08-07T12:00:00.000Z',
+      full_text: 'The linked portal tweet',
+      favorite_count: 25,
+      retweet_count: 4,
+      username: 'alice',
+      account_display_name: 'Alice',
+      quote_tweet_id: '202',
+      quoted_tweet: {
+        tweet_id: '202',
+        username: 'bob',
+        full_text: 'Quoted context',
+      },
+      media: [
+        {
+          media_url: 'https://pbs.twimg.com/media/example.jpg',
+          media_type: 'photo',
+          width: 1200,
+          height: 800,
+        },
+      ],
+    })
+  })
+
+  test('rejects non-numeric route IDs before calling the gateway', async () => {
+    const fetcher = jest.fn()
+
+    await expect(
+      fetchClickHouseTweetPageData('not-a-tweet', fetcher),
+    ).resolves.toBeNull()
+    expect(fetcher).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/clickhouseTweetPage.ts
+++ b/src/lib/clickhouseTweetPage.ts
@@ -1,0 +1,128 @@
+import type { TweetData } from '@/components/TweetComponent'
+import { fetchAnalyticsGatewayJson } from './clickhouseGateway'
+
+interface ClickHouseTweetDetail {
+  tweetId: string
+  accountId: string
+  createdAt: string
+  fullText: string
+  replyToTweetId: string | null
+  replyToUsername: string | null
+  favoriteCount: string | number
+  retweetCount: string | number | null
+  username: string | null
+  accountDisplayName: string | null
+  avatarMediaUrl: string | null
+  media: Array<{
+    mediaUrl: string
+    mediaType: string
+    width: number | null
+    height: number | null
+  }>
+}
+
+interface ClickHouseTweetDetailResponse {
+  data: {
+    tweet: ClickHouseTweetDetail & {
+      quoteTweetId: string | null
+      retweetedTweetId: string | null
+    }
+    quotedTweet: ClickHouseTweetDetail | null
+  }
+}
+
+function count(value: string | number | null): number {
+  const parsed = Number(value || 0)
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : 0
+}
+
+function timestamp(value: string): string {
+  if (/[zZ]$|[+-]\d\d:\d\d$/.test(value)) return value
+  return `${value.replace(' ', 'T')}Z`
+}
+
+function media(tweet: ClickHouseTweetDetail) {
+  return (tweet.media || []).map((item) => ({
+    media_url: item.mediaUrl,
+    media_type: item.mediaType,
+    width: item.width ?? undefined,
+    height: item.height ?? undefined,
+  }))
+}
+
+function quotedTweet(
+  tweet: ClickHouseTweetDetail,
+): NonNullable<TweetData['quoted_tweet']> {
+  const username = tweet.username || 'unknown_user'
+  return {
+    tweet_id: tweet.tweetId,
+    account_id: tweet.accountId,
+    created_at: timestamp(tweet.createdAt),
+    full_text: tweet.fullText,
+    retweet_count:
+      tweet.retweetCount === null ? null : count(tweet.retweetCount),
+    favorite_count: count(tweet.favoriteCount),
+    avatar_media_url: tweet.avatarMediaUrl || undefined,
+    username,
+    account_display_name: tweet.accountDisplayName || username,
+    media: media(tweet),
+  }
+}
+
+export async function fetchClickHouseTweetPageData(
+  tweetId: string,
+  fetcher = fetchAnalyticsGatewayJson,
+): Promise<TweetData | null> {
+  if (!/^\d{1,20}$/.test(tweetId)) return null
+
+  const response = await fetcher<ClickHouseTweetDetailResponse>(
+    ['tweet', tweetId],
+    new URLSearchParams(),
+    { revalidate: 3600 },
+  )
+  if (!response.data?.tweet) return null
+
+  const tweet = response.data.tweet
+  const username = tweet.username || 'unknown_user'
+  const quote = response.data.quotedTweet
+  return {
+    tweet_id: tweet.tweetId,
+    account_id: tweet.accountId,
+    created_at: timestamp(tweet.createdAt),
+    full_text: tweet.fullText,
+    retweet_count:
+      tweet.retweetCount === null ? null : count(tweet.retweetCount),
+    favorite_count: count(tweet.favoriteCount),
+    reply_to_tweet_id: tweet.replyToTweetId,
+    reply_to_username: tweet.replyToUsername || undefined,
+    quote_tweet_id: tweet.quoteTweetId,
+    retweeted_tweet_id: tweet.retweetedTweetId,
+    avatar_media_url: tweet.avatarMediaUrl,
+    username,
+    account_display_name: tweet.accountDisplayName || username,
+    media: media(tweet),
+    urls: [],
+    account: {
+      username,
+      account_display_name: tweet.accountDisplayName || username,
+      profile: tweet.avatarMediaUrl
+        ? { avatar_media_url: tweet.avatarMediaUrl }
+        : undefined,
+    },
+    quoted_tweet: quote
+      ? quotedTweet(quote)
+      : tweet.quoteTweetId
+        ? {
+            tweet_id: tweet.quoteTweetId,
+            account_id: '',
+            created_at: '',
+            full_text: '',
+            retweet_count: 0,
+            favorite_count: 0,
+            username: '',
+            account_display_name: '',
+            is_deleted: true,
+          }
+        : undefined,
+  }
+}

--- a/src/lib/getTweetPageData.test.ts
+++ b/src/lib/getTweetPageData.test.ts
@@ -1,0 +1,61 @@
+import type { TweetData } from '@/components/TweetComponent'
+import { createServerClient } from '@/utils/supabase'
+import { isClickHouseReadsEnabled } from './clickhouseGateway'
+import { fetchClickHouseTweetPageData } from './clickhouseTweetPage'
+import { getTweetPageData } from './getTweetPageData'
+
+jest.mock('next/headers', () => ({ cookies: jest.fn() }))
+jest.mock('@/utils/supabase', () => ({ createServerClient: jest.fn() }))
+jest.mock('./clickhouseGateway', () => ({
+  isClickHouseReadsEnabled: jest.fn(),
+}))
+jest.mock('./clickhouseTweetPage', () => ({
+  fetchClickHouseTweetPageData: jest.fn(),
+}))
+
+const clickHouseEnabledMock = isClickHouseReadsEnabled as jest.MockedFunction<
+  typeof isClickHouseReadsEnabled
+>
+const fetchClickHouseTweetPageDataMock =
+  fetchClickHouseTweetPageData as jest.MockedFunction<
+    typeof fetchClickHouseTweetPageData
+  >
+const createServerClientMock = createServerClient as jest.MockedFunction<
+  typeof createServerClient
+>
+
+describe('getTweetPageData ClickHouse routing', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('renders a portal tweet without querying the staging Supabase seed', async () => {
+    const tweet = {
+      tweet_id: '2085473085399150817',
+      account_id: '10',
+      created_at: '2026-08-07T12:00:00.000Z',
+      full_text: 'The linked portal tweet',
+      retweet_count: 4,
+      favorite_count: 25,
+      reply_to_tweet_id: null,
+      quote_tweet_id: null,
+      retweeted_tweet_id: null,
+      avatar_media_url: null,
+      username: 'alice',
+      account_display_name: 'Alice',
+      media: [],
+      urls: [],
+    } satisfies TweetData
+    clickHouseEnabledMock.mockReturnValue(true)
+    fetchClickHouseTweetPageDataMock.mockResolvedValue(tweet)
+
+    await expect(getTweetPageData('2085473085399150817')).resolves.toEqual({
+      tweet,
+      threadTree: null,
+    })
+    expect(fetchClickHouseTweetPageDataMock).toHaveBeenCalledWith(
+      '2085473085399150817',
+    )
+    expect(createServerClientMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/getTweetPageData.ts
+++ b/src/lib/getTweetPageData.ts
@@ -1,11 +1,17 @@
 import { createServerClient } from '@/utils/supabase'
 import { cookies } from 'next/headers'
-import { ConversationTree, ThreadTweet, buildConversationTree } from './threadUtils'
+import {
+  ConversationTree,
+  ThreadTweet,
+  buildConversationTree,
+} from './threadUtils'
 import { TweetData } from '@/components/TweetComponent'
 import {
   fetchSyndicatedTweets,
   type SyndicatedTweet,
 } from './twitterSyndication'
+import { isClickHouseReadsEnabled } from './clickhouseGateway'
+import { fetchClickHouseTweetPageData } from './clickhouseTweetPage'
 
 interface RpcTweet {
   tweet_id: string
@@ -76,7 +82,24 @@ interface TweetPageResult {
  * Fetch all data needed for the tweet page in a single RPC call.
  * Replaces ~24 separate Supabase HTTP calls with 1.
  */
-export async function getTweetPageData(tweetId: string): Promise<TweetPageResult> {
+export async function getTweetPageData(
+  tweetId: string,
+): Promise<TweetPageResult> {
+  if (isClickHouseReadsEnabled()) {
+    try {
+      const tweet = await fetchClickHouseTweetPageData(tweetId)
+      if (tweet) return { tweet, threadTree: null }
+    } catch (error) {
+      console.error(
+        'ClickHouse tweet detail failed; falling back to Supabase:',
+        {
+          tweetId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      )
+    }
+  }
+
   const cookieStore = await cookies()
   const supabase = createServerClient(cookieStore)
 
@@ -85,7 +108,9 @@ export async function getTweetPageData(tweetId: string): Promise<TweetPageResult
   })
 
   if (error || !data) {
-    console.error('get_tweet_page_data RPC failed:', error?.message, { tweetId })
+    console.error('get_tweet_page_data RPC failed:', error?.message, {
+      tweetId,
+    })
     return { tweet: null, threadTree: null }
   }
 
@@ -210,7 +235,9 @@ function buildTweetData(
   }))
 
   // Find the quoted tweet for this tweet
-  const quotedTweet = quotedTweets.find((qt) => qt.source_tweet_id === tweet.tweet_id)
+  const quotedTweet = quotedTweets.find(
+    (qt) => qt.source_tweet_id === tweet.tweet_id,
+  )
 
   // Build mentioned_users in the shape TweetComponent expects
   const mentions = mentionedUsers
@@ -316,7 +343,9 @@ function buildThreadTree(
         height: m.height,
       }))
 
-    const quotedTweet = quotedTweets.find((qt) => qt.source_tweet_id === ct.tweet_id)
+    const quotedTweet = quotedTweets.find(
+      (qt) => qt.source_tweet_id === ct.tweet_id,
+    )
 
     return {
       tweet_id: ct.tweet_id,
@@ -335,7 +364,8 @@ function buildThreadTree(
       // ct.quoted_tweet_id is sourced from enriched_tweets and survives even if the
       // quoted tweet itself was deleted; the RPC's quoted_tweets list won't contain it
       // in that case. Preserve the relationship and surface a placeholder.
-      quote_tweet_id: ct.quoted_tweet_id ?? (quotedTweet ? quotedTweet.tweet_id : null),
+      quote_tweet_id:
+        ct.quoted_tweet_id ?? (quotedTweet ? quotedTweet.tweet_id : null),
       quoted_tweet: quotedTweet
         ? {
             tweet_id: quotedTweet.tweet_id,


### PR DESCRIPTION
## What changed

- Allowlist the tweet-detail gateway route and map its payload into the existing `TweetData` shape.
- Prefer ClickHouse for permalink reads when ClickHouse reads are enabled.
- Preserve the Supabase RPC as a fallback for absent records or gateway failures.
- Add regression coverage for path validation, payload mapping, and data-source routing.
- Add a Jest-only `server-only` resolver stub so the full server suite runs outside the Next.js compiler.

## Root cause

Portal cards read from ClickHouse, but `/tweets/[tweet_id]` still read from the staging Supabase seed. A real corpus tweet could appear in staging navigation and then 404 on its permalink.

## Dependency and rollout

The required gateway change was merged in https://github.com/TheExGenesis/community-archive-control-panel/pull/20 and deployed to production on 2026-08-08. The production endpoint now resolves the exact previously missing tweet.

## Validation

- GitHub Actions `pull_request_workflow` passed.
- Full server suite: 31 suites and 143 tests passed.
- `pnpm type-check` passed.
- `pnpm lint` passed with one pre-existing `<img>` warning.
- `pnpm build` completed successfully and emitted `/tweets/[tweet_id]`.
- Production gateway health is green and the deployed source checksum matches the merged gateway source.
- Vercel preview returned HTTP 200 for the exact previously missing tweet, included its external tweet permalink, and did not render the 404 message.