### PR TITLE
Refactor archive processing around typed sink boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,11 @@ Staging synchronization is automatic; production synchronization is not:
 
 ## Supabase Invariants And Gotchas
 
+- Browser archive uploads currently overwrite
+  `archives/{username}/archive.json`, while the processor resolves that path
+  later from the username on `archive_upload`. Do not treat an upload row as an
+  immutable replay reference. A decoupled or dual-sink processor must first use
+  a unique object key recorded on the upload before it can promise exact replay.
 - The project PostgREST limit is 1,000 rows. Any operation requiring every row
   must paginate with a stable `.order()` on a unique or indexed column. For
   counts, prefer `.select('*', { count: 'exact', head: true })`.

--- a/jest.config.js
+++ b/jest.config.js
@@ -29,6 +29,7 @@ const customJestConfig = {
       testMatch: [
         '<rootDir>/src/lib/**/*.test.{js,jsx,ts,tsx}',
         '<rootDir>/tests/admin-search-sanitize.test.ts',
+        '<rootDir>/tests/archive-processor/**/*.test.{js,jsx,ts,tsx}',
       ],
       setupFilesAfterEnv: ['<rootDir>/jest.setup.server.ts'],
     },

--- a/services/process_archive/README_DOCKER.md
+++ b/services/process_archive/README_DOCKER.md
@@ -161,6 +161,20 @@ CMD ["npm", "run", "start:stream"]
 CMD ["npm", "run", "start:copy"]
 ```
 
+## Ingestion Sink Boundary
+
+The default processor normalizes archive sections in
+`archive_normalizer.ts`, then sends those typed row batches to the
+`PostgresArchiveSink` inside the existing single-archive transaction. This is
+an internal separation point for a future ClickHouse shadow sink; PostgreSQL is
+still the only configured or executed sink, and the claim/completed/failed
+state machine is unchanged.
+
+Do not enable a second sink in the production cron until immutable per-upload
+object keys, replay fixtures, outage recovery, and PostgreSQL/ClickHouse parity
+checks are in place. Cutover and retirement of the existing processor are
+separate production actions.
+
 ## Logging System
 
 The service provides **three types of logs** without requiring code changes:

--- a/services/process_archive/archive_normalizer.ts
+++ b/services/process_archive/archive_normalizer.ts
@@ -1,0 +1,321 @@
+export type TextId = string | number
+
+export interface AccountRow {
+  account_id: TextId
+  created_via: string
+  username: string
+  created_at: string
+  account_display_name: string
+  num_tweets: number
+  num_following: number
+  num_followers: number
+  num_likes: number
+}
+
+export interface ProfileRow {
+  account_id: TextId
+  avatar_media_url: string | null
+  header_media_url: string | null
+  bio: string | null
+  location: string | null
+  website: string | null
+  archive_upload_id: number
+}
+
+export interface TweetRow {
+  tweet_id: TextId
+  account_id: TextId
+  created_at: string
+  full_text: string
+  favorite_count: number
+  retweet_count: number
+  reply_to_tweet_id: string | null
+  reply_to_user_id: string | null
+  reply_to_username: string | null
+  archive_upload_id: number
+}
+
+export interface MentionedUserRow {
+  user_id: TextId
+  name: string
+  screen_name: string
+}
+
+export interface UserMentionRow {
+  tweet_id: TextId
+  mentioned_user_id: TextId
+}
+
+export interface TweetUrlRow {
+  tweet_id: TextId
+  url: string
+  expanded_url: string
+  display_url: string
+}
+
+export interface TweetMediaRow {
+  tweet_id: TextId
+  media_id: TextId
+  media_url: string
+  media_type: string
+  width: number
+  height: number
+  archive_upload_id: number
+}
+
+export interface QuoteTweetRow {
+  tweet_id: TextId
+  quoted_tweet_id: string
+}
+
+export interface RetweetRow {
+  tweet_id: TextId
+  retweeted_tweet_id: null
+}
+
+export interface LikedTweetRow {
+  tweet_id: TextId
+  full_text: string
+}
+
+export interface LikeRow {
+  account_id: TextId
+  liked_tweet_id: TextId
+  archive_upload_id: number
+}
+
+export interface FollowingRow {
+  account_id: TextId
+  following_account_id: TextId
+  archive_upload_id: number
+}
+
+export interface FollowerRow {
+  account_id: TextId
+  follower_account_id: TextId
+  archive_upload_id: number
+}
+
+export interface NormalizedUserRows {
+  accounts: AccountRow[]
+  profiles: ProfileRow[]
+}
+
+export interface NormalizedTweetRows {
+  tweets: TweetRow[]
+  mentionedUsers: MentionedUserRow[]
+  userMentions: UserMentionRow[]
+  tweetUrls: TweetUrlRow[]
+  tweetMedia: TweetMediaRow[]
+  quoteTweets: QuoteTweetRow[]
+  retweets: RetweetRow[]
+}
+
+export interface NormalizedRemainingRows {
+  likedTweets: LikedTweetRow[]
+  likes: LikeRow[]
+  following: FollowingRow[]
+  followers: FollowerRow[]
+}
+
+export function removeProblematicCharacters(
+  value: string | null | undefined,
+): string | null {
+  if (!value || value === 'NULL') return null
+  return value.replace(/[\u0000-\u001F\u007F-\u009F]/g, '')
+}
+
+export function dedupeByConflict<T extends Record<string, unknown>>(
+  items: T[],
+  conflict: string | string[] | null,
+): T[] {
+  if (!items.length || !conflict) return items
+
+  const keys = Array.isArray(conflict) ? conflict : [conflict]
+  const uniqueItems = new Map<string, T>()
+
+  for (const item of items) {
+    const key = keys.map((column) => `${item[column] ?? ''}`).join('||')
+    if (!uniqueItems.has(key)) uniqueItems.set(key, item)
+  }
+
+  return Array.from(uniqueItems.values())
+}
+
+export function normalizeUserRows(
+  archive: any,
+  archiveUploadId: number,
+): NormalizedUserRows {
+  const account = archive.account?.[0]?.account
+  const profile = archive.profile?.[0]?.profile
+
+  return {
+    accounts: account
+      ? [
+          {
+            account_id: account.accountId,
+            created_via: account.createdVia || 'twitter_archive',
+            username: account.username,
+            created_at: account.createdAt,
+            account_display_name: account.accountDisplayName,
+            num_tweets: archive.tweets?.length || 0,
+            num_following: archive.following?.length || 0,
+            num_followers: archive.follower?.length || 0,
+            num_likes: archive.like?.length || 0,
+          },
+        ]
+      : [],
+    profiles:
+      profile && account
+        ? [
+            {
+              account_id: account.accountId,
+              avatar_media_url: removeProblematicCharacters(
+                profile.avatarMediaUrl,
+              ),
+              header_media_url: removeProblematicCharacters(
+                profile.headerMediaUrl,
+              ),
+              bio: profile.description?.bio || null,
+              location: profile.description?.location || null,
+              website: profile.description?.website || null,
+              archive_upload_id: archiveUploadId,
+            },
+          ]
+        : [],
+  }
+}
+
+export function normalizeTweetRows(
+  tweetChunk: any[],
+  account: any,
+  archiveUploadId: number,
+): NormalizedTweetRows {
+  const rows: NormalizedTweetRows = {
+    tweets: [],
+    mentionedUsers: [],
+    userMentions: [],
+    tweetUrls: [],
+    tweetMedia: [],
+    quoteTweets: [],
+    retweets: [],
+  }
+  if (!account) return rows
+
+  const mentionedUsers = new Map<TextId, MentionedUserRow>()
+
+  for (const tweetData of tweetChunk) {
+    const tweet = tweetData.tweet
+    const tweetId = tweet.id_str || tweet.id
+
+    rows.tweets.push({
+      tweet_id: tweetId,
+      account_id: account.accountId,
+      created_at: tweet.created_at,
+      full_text: removeProblematicCharacters(tweet.full_text) || '',
+      favorite_count: tweet.favorite_count || 0,
+      retweet_count: tweet.retweet_count || 0,
+      reply_to_tweet_id: removeProblematicCharacters(
+        tweet.in_reply_to_status_id_str,
+      ),
+      reply_to_user_id: removeProblematicCharacters(
+        tweet.in_reply_to_user_id_str,
+      ),
+      reply_to_username: removeProblematicCharacters(
+        tweet.in_reply_to_screen_name,
+      ),
+      archive_upload_id: archiveUploadId,
+    })
+
+    for (const mention of tweet.entities?.user_mentions || []) {
+      const userId = mention.id_str
+      if (!mentionedUsers.has(userId)) {
+        mentionedUsers.set(userId, {
+          user_id: userId,
+          name: removeProblematicCharacters(mention.name) || '',
+          screen_name: removeProblematicCharacters(mention.screen_name) || '',
+        })
+      }
+      rows.userMentions.push({
+        tweet_id: tweetId,
+        mentioned_user_id: userId,
+      })
+    }
+
+    for (const url of tweet.entities?.urls || []) {
+      rows.tweetUrls.push({
+        tweet_id: tweetId,
+        url: url.url,
+        expanded_url: url.expanded_url || '',
+        display_url: url.display_url || '',
+      })
+
+      const isQuoteTweet =
+        (url.expanded_url?.includes('twitter.com/') ||
+          url.expanded_url?.includes('x.com/')) &&
+        url.expanded_url?.includes('/status/')
+      if (isQuoteTweet) {
+        const quotedTweetId = url.expanded_url?.split('/status/')[1]
+        if (quotedTweetId) {
+          rows.quoteTweets.push({
+            tweet_id: tweetId,
+            quoted_tweet_id: quotedTweetId,
+          })
+        }
+      }
+    }
+
+    for (const media of tweet.entities?.media || []) {
+      rows.tweetMedia.push({
+        tweet_id: tweetId,
+        media_id: media.id_str,
+        media_url: media.media_url_https || media.media_url,
+        media_type: media.type,
+        width: media.sizes?.large?.w || 0,
+        height: media.sizes?.large?.h || 0,
+        archive_upload_id: archiveUploadId,
+      })
+    }
+
+    if (tweet.full_text?.match(/^RT @\w+: /)) {
+      rows.retweets.push({ tweet_id: tweetId, retweeted_tweet_id: null })
+    }
+  }
+
+  rows.mentionedUsers = Array.from(mentionedUsers.values())
+  rows.tweetUrls = dedupeByConflict(rows.tweetUrls, ['tweet_id', 'url'])
+  rows.tweetMedia = dedupeByConflict(rows.tweetMedia, 'media_id')
+  return rows
+}
+
+export function normalizeRemainingRows(
+  archive: any,
+  archiveUploadId: number,
+): NormalizedRemainingRows {
+  const account = archive.account?.[0]?.account
+  if (!account) {
+    return { likedTweets: [], likes: [], following: [], followers: [] }
+  }
+
+  return {
+    likedTweets: (archive.like || []).map((like: any) => ({
+      tweet_id: like.like.tweetId,
+      full_text: like.like.fullText || '',
+    })),
+    likes: (archive.like || []).map((like: any) => ({
+      account_id: account.accountId,
+      liked_tweet_id: like.like.tweetId,
+      archive_upload_id: archiveUploadId,
+    })),
+    following: (archive.following || []).map((follow: any) => ({
+      account_id: account.accountId,
+      following_account_id: follow.following.accountId,
+      archive_upload_id: archiveUploadId,
+    })),
+    followers: (archive.follower || []).map((follower: any) => ({
+      account_id: account.accountId,
+      follower_account_id: follower.follower.accountId,
+      archive_upload_id: archiveUploadId,
+    })),
+  }
+}

--- a/services/process_archive/process_archive_upload.ts
+++ b/services/process_archive/process_archive_upload.ts
@@ -10,6 +10,15 @@ import postgres from 'postgres'
 type Sql = postgres.Sql
 
 import { createClient } from '@supabase/supabase-js'
+import {
+  type NormalizedRemainingRows,
+  type NormalizedTweetRows,
+  type NormalizedUserRows,
+  normalizeRemainingRows,
+  normalizeTweetRows,
+  normalizeUserRows,
+  removeProblematicCharacters,
+} from './archive_normalizer'
 
 // Configuration
 const CONFIG = {
@@ -167,11 +176,6 @@ const TABLE_CONFIGS: Record<string, TableConfig> = {
 }
 
 // Utility functions
-function removeProblematicCharacters(value: string | null | undefined): string | null {
-  if (!value || value === 'NULL') return null
-  return value.replace(/[\u0000-\u001F\u007F-\u009F]/g, '')
-}
-
 function getMemoryUsageMB(): number {
   const usage = process.memoryUsage()
   return Math.round(usage.heapUsed / 1024 / 1024)
@@ -284,6 +288,91 @@ async function optimizedBatchInsert<T>({
   }
 }
 
+export interface ArchiveSink {
+  writeUserRows(rows: NormalizedUserRows): Promise<void>
+  writeTweetRows(rows: NormalizedTweetRows): Promise<void>
+  writeRemainingRows(rows: NormalizedRemainingRows): Promise<void>
+}
+
+export class PostgresArchiveSink implements ArchiveSink {
+  constructor(private readonly sql: Sql) {}
+
+  async writeUserRows(rows: NormalizedUserRows): Promise<void> {
+    await this.insertIfNotEmpty('all_account', rows.accounts, (account) => [
+      account.account_id, account.created_via, account.username,
+      account.created_at, account.account_display_name, account.num_tweets,
+      account.num_following, account.num_followers, account.num_likes
+    ])
+    await this.insertIfNotEmpty('all_profile', rows.profiles, (profile) => [
+      profile.account_id, profile.avatar_media_url, profile.header_media_url,
+      profile.bio, profile.location, profile.website, profile.archive_upload_id
+    ])
+  }
+
+  async writeTweetRows(rows: NormalizedTweetRows): Promise<void> {
+    await this.insertIfNotEmpty('tweets', rows.tweets, (tweet) => [
+      tweet.tweet_id, tweet.account_id, tweet.created_at, tweet.full_text,
+      tweet.favorite_count, tweet.retweet_count, tweet.reply_to_tweet_id,
+      tweet.reply_to_user_id, tweet.reply_to_username, tweet.archive_upload_id
+    ])
+    await this.insertIfNotEmpty('mentioned_users', rows.mentionedUsers, (mention) =>
+      [mention.user_id, mention.name, mention.screen_name])
+    await this.insertIfNotEmpty('user_mentions', rows.userMentions, (mention) =>
+      [mention.tweet_id, mention.mentioned_user_id])
+    await this.insertIfNotEmpty('tweet_urls', rows.tweetUrls, (url) =>
+      [url.tweet_id, url.url, url.expanded_url, url.display_url])
+    await this.insertIfNotEmpty('tweet_media', rows.tweetMedia, (media) =>
+      [media.tweet_id, media.media_id, media.media_url, media.media_type,
+        media.width, media.height, media.archive_upload_id])
+    await this.insertIfNotEmpty('quote_tweets', rows.quoteTweets, (quote) =>
+      [quote.tweet_id, quote.quoted_tweet_id])
+    await this.insertIfNotEmpty('retweets', rows.retweets, (retweet) =>
+      [retweet.tweet_id, retweet.retweeted_tweet_id])
+  }
+
+  async writeRemainingRows(rows: NormalizedRemainingRows): Promise<void> {
+    await this.insertIfNotEmpty('liked_tweets', rows.likedTweets, (tweet) =>
+      [tweet.tweet_id, tweet.full_text])
+    await this.insertIfNotEmpty('likes', rows.likes, (like) =>
+      [like.account_id, like.liked_tweet_id, like.archive_upload_id])
+    await this.insertIfNotEmpty('following', rows.following, (follow) =>
+      [follow.account_id, follow.following_account_id, follow.archive_upload_id])
+    await this.insertIfNotEmpty('followers', rows.followers, (follower) =>
+      [follower.account_id, follower.follower_account_id, follower.archive_upload_id])
+  }
+
+  private async insertIfNotEmpty<T>(
+    tableName: string,
+    data: T[],
+    mapFn: (item: T) => any[]
+  ): Promise<void> {
+    try {
+      if (data.length > 0) {
+        const config = TABLE_CONFIGS[tableName]
+        await bulkInsertWithCopy({
+          sql: this.sql,
+          tableName,
+          columns: config.columns,
+          conflictTarget: config.conflict,
+          updateColumns: config.updates,
+          data,
+          mapFn
+        })
+      }
+    } catch (error) {
+      const errorData = {
+        tableName,
+        error: error instanceof Error ? error.message : String(error),
+        records: data.length
+      }
+      logger.error(`Error in insertIfNotEmpty ${JSON.stringify(errorData)}`)
+      // This sink runs inside the existing archive transaction. Rethrow so the
+      // transaction rolls back and main() marks the upload failed.
+      throw error
+    }
+  }
+}
+
 // Memory-efficient JSON processor with optimized batch inserts
 // We could potentially optimize it more by streaming the data in chunks instead of processing the JSON in one go.
 export class ArchiveUploadProcessor {
@@ -306,8 +395,10 @@ export class ArchiveUploadProcessor {
     
     // Process everything in a single transaction
     await this.sql.begin(async (trx: Sql) => {
+      const sink: ArchiveSink = new PostgresArchiveSink(trx)
+
       // Process small data first (account, profile, etc.)
-      await this.processUserData(trx, archive)
+      await sink.writeUserRows(normalizeUserRows(archive, this.archiveUploadId))
       
       // Process tweets in streaming chunks to avoid memory issues
       const tweets = archive.tweets || []
@@ -317,7 +408,12 @@ export class ArchiveUploadProcessor {
       // Process tweets in memory-efficient batches
       for (let i = 0; i < tweets.length; i += CONFIG.MEMORY_BATCH_SIZE) {
         const chunk = tweets.slice(i, i + CONFIG.MEMORY_BATCH_SIZE)
-        await this.processTweetChunk(trx, chunk, archive.account?.[0]?.account)
+        const rows = normalizeTweetRows(
+          chunk,
+          archive.account?.[0]?.account,
+          this.archiveUploadId
+        )
+        await sink.writeTweetRows(rows)
         
         this.processedTweets += chunk.length
         logger.info(`Processed ${this.processedTweets}/${this.totalTweets} tweets (${getMemoryUsageMB()}MB memory)`)
@@ -331,284 +427,12 @@ export class ArchiveUploadProcessor {
       }
 
       // Process remaining data that depends on all tweets being processed
-      await this.processRemainingData(trx, archive)
+      await sink.writeRemainingRows(
+        normalizeRemainingRows(archive, this.archiveUploadId)
+      )
     })
   }
 
-  private async processUserData(trx: Sql, archive: any): Promise<void> {
-    const accountObj = archive.account?.[0]?.account;
-    const profileObj = archive.profile?.[0]?.profile
-
-    // Process account
-    if (accountObj) {
-      const account = [{
-        account_id: accountObj.accountId,
-        created_via: accountObj.createdVia || 'twitter_archive',
-        username: accountObj.username,
-        created_at: accountObj.createdAt,
-        account_display_name: accountObj.accountDisplayName,
-        num_tweets: archive.tweets?.length || 0,
-        num_following: archive.following?.length || 0,
-        num_followers: archive.follower?.length || 0,
-        num_likes: archive.like?.length || 0
-      }]
-
-      await bulkInsertWithCopy({
-        sql: trx,
-        tableName: 'all_account',
-        columns: TABLE_CONFIGS.all_account.columns,
-        conflictTarget: TABLE_CONFIGS.all_account.conflict,
-        updateColumns: TABLE_CONFIGS.all_account.updates,
-        data: account,
-        mapFn: (acc: any) => [acc.account_id, acc.created_via, acc.username, acc.created_at, acc.account_display_name, acc.num_tweets, acc.num_following, acc.num_followers, acc.num_likes]
-      })
-    }
-
-    // Process profile
-    if (profileObj && accountObj) {
-      const profile = [{
-        account_id: accountObj.accountId,
-        avatar_media_url: removeProblematicCharacters(profileObj.avatarMediaUrl),
-        header_media_url: removeProblematicCharacters(profileObj.headerMediaUrl),
-        bio: profileObj.description?.bio || null,
-        location: profileObj.description?.location || null,
-        website: profileObj.description?.website || null,
-        archive_upload_id: this.archiveUploadId
-      }]
-
-      await bulkInsertWithCopy({
-        sql: trx,
-        tableName: 'all_profile',
-        columns: TABLE_CONFIGS.all_profile.columns,
-        conflictTarget: TABLE_CONFIGS.all_profile.conflict,
-        updateColumns: TABLE_CONFIGS.all_profile.updates,
-        data: profile,
-        mapFn: (p: any) => [p.account_id, p.avatar_media_url, p.header_media_url, p.bio, p.location, p.website, p.archive_upload_id]
-      })
-    }
-  }
-
-  private async processTweetChunk(trx: Sql, tweetChunk: any[], accountObj: any): Promise<void> {
-    if (!accountObj) return
-
-    const tweets: any[] = []
-    const userMentions: any[] = []
-    const mentionedUsersMap = new Map<string, any>()
-    const urls: any[] = []
-    const media: any[] = []
-    const quotes: any[] = []
-    const retweets: any[] = []
-
-    // Process each tweet in the chunk
-    for (const tweetData of tweetChunk) {
-      const tweet = tweetData.tweet
-      const tweetId = tweet.id_str || tweet.id
-
-      // Process tweet
-      tweets.push({
-        tweet_id: tweetId,
-        account_id: accountObj.accountId,
-        created_at: tweet.created_at,
-        full_text: removeProblematicCharacters(tweet.full_text) || '',
-        favorite_count: tweet.favorite_count || 0,
-        retweet_count: tweet.retweet_count || 0,
-        reply_to_tweet_id: removeProblematicCharacters(tweet.in_reply_to_status_id_str),
-        reply_to_user_id: removeProblematicCharacters(tweet.in_reply_to_user_id_str),
-        reply_to_username: removeProblematicCharacters(tweet.in_reply_to_screen_name),
-        archive_upload_id: this.archiveUploadId
-      })
-
-      // Process mentions
-      for (const mention of tweet.entities?.user_mentions || []) {
-        const userId = mention.id_str
-        
-        if (!mentionedUsersMap.has(userId)) {
-          mentionedUsersMap.set(userId, {
-            user_id: userId,
-            name: removeProblematicCharacters(mention.name) || '',
-            screen_name: removeProblematicCharacters(mention.screen_name) || ''
-          })
-        }
-        
-        userMentions.push({ tweet_id: tweetId, mentioned_user_id: userId })
-      }
-
-      // Process URLs and quotes
-      for (const url of tweet.entities?.urls || []) {
-        urls.push({
-          tweet_id: tweetId,
-          url: url.url,
-          expanded_url: url.expanded_url || '',
-          display_url: url.display_url || ''
-        })
-
-        const isQuoteTweet = (url.expanded_url?.includes('twitter.com/') || 
-                            url.expanded_url?.includes('x.com/')) && 
-                           url.expanded_url?.includes('/status/')
-        
-        if (isQuoteTweet) {
-          const quotedTweetId = url.expanded_url?.split('/status/')[1]
-          if (quotedTweetId) {
-            quotes.push({ tweet_id: tweetId, quoted_tweet_id: quotedTweetId })
-          }
-        }
-      }
-
-      // Process media
-      for (const mediaItem of tweet.entities?.media || []) {
-        media.push({
-          tweet_id: tweetId,
-          media_id: mediaItem.id_str,
-          media_url: mediaItem.media_url_https || mediaItem.media_url,
-          media_type: mediaItem.type,
-          width: mediaItem.sizes?.large?.w || 0,
-          height: mediaItem.sizes?.large?.h || 0,
-          archive_upload_id: this.archiveUploadId
-        })
-      }
-
-      // Process retweets
-      const retweetMatch = tweet.full_text?.match(/^RT @\w+: /)
-      if (retweetMatch) {
-        retweets.push({ tweet_id: tweetId, retweeted_tweet_id: null })
-      }
-    }
-
-    // Insert tweets first
-    await this.insertIfNotEmpty(trx, 'tweets', tweets, (t: any) => 
-      [t.tweet_id, t.account_id, t.created_at, t.full_text, t.favorite_count, t.retweet_count, t.reply_to_tweet_id, t.reply_to_user_id, t.reply_to_username, t.archive_upload_id])
-
-    await this.insertIfNotEmpty(trx, 'mentioned_users', Array.from(mentionedUsersMap.values()), (m: any) => [m.user_id, m.name, m.screen_name]);
-    
-
-    // Insert chunk data in parallel using COPY
-    const promisesToWork=[    
-      () => this.insertIfNotEmpty(trx, 'user_mentions', userMentions, (um: any) => 
-        [um.tweet_id, um.mentioned_user_id]),
-      
-      () => this.insertIfNotEmpty(trx, 'tweet_urls', this.dedupeByConflict(urls, TABLE_CONFIGS.tweet_urls.conflict), (u: any) => 
-        [u.tweet_id, u.url, u.expanded_url, u.display_url]),
-      
-      () => this.insertIfNotEmpty(trx, 'tweet_media', this.dedupeByConflict(media, TABLE_CONFIGS.tweet_media.conflict), (m: any) => 
-        [m.tweet_id, m.media_id, m.media_url, m.media_type, m.width, m.height, m.archive_upload_id]),
-      
-      () => this.insertIfNotEmpty(trx, 'quote_tweets', quotes, (qt: any) => 
-        [qt.tweet_id, qt.quoted_tweet_id]),
-      
-      () => this.insertIfNotEmpty(trx, 'retweets', retweets, (rt: any) => 
-        [rt.tweet_id, rt.retweeted_tweet_id])
-    ];
-
-    for(const promiseCreator of promisesToWork){
-      await promiseCreator();
-    }
-
-    // Clear references to help GC
-    tweets.length = 0
-    userMentions.length = 0
-    urls.length = 0
-    media.length = 0
-    quotes.length = 0
-    retweets.length = 0
-  }
-
-  private async processRemainingData(trx: Sql, archive: any): Promise<void> {
-    const accountObj = archive.account?.[0]?.account
-    if (!accountObj) return
-
-
-    // Process likes, following, followers (these are typically smaller)
-    const operations = [
-      {
-        table: 'liked_tweets',
-        data: (archive.like || []).map((like: any) => ({
-          tweet_id: like.like.tweetId,
-          full_text: like.like.fullText || ''
-        })),
-        mapFn: (lt: any) => [lt.tweet_id, lt.full_text]
-      },
-      {
-        table: 'likes',
-        data: (archive.like || []).map((like: any) => ({
-          account_id: accountObj.accountId,
-          liked_tweet_id: like.like.tweetId,
-          archive_upload_id: this.archiveUploadId
-        })),
-        mapFn: (l: any) => [l.account_id, l.liked_tweet_id, l.archive_upload_id]
-      },
-      {
-        table: 'following',
-        data: (archive.following || []).map((follow: any) => ({
-          account_id: accountObj.accountId,
-          following_account_id: follow.following.accountId,
-          archive_upload_id: this.archiveUploadId
-        })),
-        mapFn: (f: any) => [f.account_id, f.following_account_id, f.archive_upload_id]
-      },
-      {
-        table: 'followers',
-        data: (archive.follower || []).map((follower: any) => ({
-          account_id: accountObj.accountId,
-          follower_account_id: follower.follower.accountId,
-          archive_upload_id: this.archiveUploadId
-        })),
-        mapFn: (f: any) => [f.account_id, f.follower_account_id, f.archive_upload_id]
-      }
-    ]
-
-    for (const operation of operations) {
-      await this.insertIfNotEmpty(trx, operation.table, operation.data, operation.mapFn)
-    }
-  }
-
-  private async insertIfNotEmpty(trx: Sql, tableName: string, data: any[], mapFn: (item: any) => any[]): Promise<void> {
-    try{
-      if (data.length > 0) {
-        const config = TABLE_CONFIGS[tableName]
-        await bulkInsertWithCopy({
-          sql: trx,
-          tableName,
-          columns: config.columns,
-          conflictTarget: config.conflict,
-          updateColumns: config.updates,
-          data,
-          mapFn
-        })
-      }
-    } catch (error) {
-      const errorData = {
-        tableName,
-        error: error instanceof Error ? error.message : String(error),
-        records: data.length
-      }
-      logger.error(`Error in insertIfNotEmpty ${JSON.stringify(errorData)}`)
-      // Rethrow: these inserts run inside a single transaction (sql.begin). A failed
-      // statement aborts the whole transaction, so swallowing the error here let the
-      // archive be marked 'completed' while every row was rolled back (silent data
-      // loss). Propagating it lets main()'s catch mark the upload 'failed' instead.
-      throw error
-    }
-  }
-
-  private dedupeByConflict<T extends Record<string, any>>(
-    items: T[], 
-    conflict: string | string[] | null
-  ): T[] {
-    if (!items?.length || !conflict) return items
-
-    const keys = Array.isArray(conflict) ? conflict : [conflict]
-    const makeKey = (item: T) => keys.map(k => `${item[k] ?? ''}`).join('||')
-    const uniqueItems = new Map<string, T>()
-
-    for (const item of items) {
-      const key = makeKey(item)
-      if (!uniqueItems.has(key)) {
-        uniqueItems.set(key, item)
-      }
-    }
-
-    return Array.from(uniqueItems.values())
-  }
 }
 
 // Twitter handle rules: 1-15 chars, alphanumerics and underscore only.

--- a/tests/archive-processor/archive-normalizer.test.ts
+++ b/tests/archive-processor/archive-normalizer.test.ts
@@ -1,0 +1,209 @@
+import {
+  normalizeRemainingRows,
+  normalizeTweetRows,
+  normalizeUserRows,
+} from '../../services/process_archive/archive_normalizer'
+
+const archiveUploadId = 42
+const account = {
+  accountId: '100',
+  username: 'archivist',
+  createdAt: '2020-01-01T00:00:00.000Z',
+  accountDisplayName: 'The Archivist',
+}
+
+const archive = {
+  account: [{ account }],
+  profile: [
+    {
+      profile: {
+        avatarMediaUrl: 'https://img.example/avatar\u0000.jpg',
+        headerMediaUrl: 'NULL',
+        description: {
+          bio: 'Preserving things',
+          location: '',
+          website: 'https://example.com',
+        },
+      },
+    },
+  ],
+  tweets: [
+    {
+      tweet: {
+        id_str: '200',
+        created_at: '2024-01-02T03:04:05.000Z',
+        full_text: 'RT @someone: hello\u0000',
+        favorite_count: 7,
+        retweet_count: 3,
+        in_reply_to_status_id_str: '199',
+        in_reply_to_user_id_str: '101',
+        in_reply_to_screen_name: 'friend',
+        entities: {
+          user_mentions: [
+            { id_str: '101', name: 'Friend\u0000', screen_name: 'friend' },
+            { id_str: '101', name: 'Friend', screen_name: 'friend' },
+          ],
+          urls: [
+            {
+              url: 'https://t.co/quote',
+              expanded_url: 'https://x.com/someone/status/555',
+              display_url: null,
+            },
+            {
+              url: 'https://t.co/quote',
+              expanded_url: 'https://x.com/someone/status/555',
+              display_url: null,
+            },
+          ],
+          media: [
+            {
+              id_str: '300',
+              media_url: 'http://img.example/media.jpg',
+              media_url_https: 'https://img.example/media.jpg',
+              type: 'photo',
+              sizes: { large: { w: 1200, h: 800 } },
+            },
+            {
+              id_str: '300',
+              media_url: 'http://img.example/duplicate.jpg',
+              type: 'photo',
+            },
+          ],
+        },
+      },
+    },
+  ],
+  like: [{ like: { tweetId: '400', fullText: 'liked tweet' } }],
+  following: [{ following: { accountId: '500' } }],
+  follower: [{ follower: { accountId: '600' } }],
+}
+
+describe('archive normalizer', () => {
+  test('normalizes account and profile rows without sink-specific values', () => {
+    expect(normalizeUserRows(archive, archiveUploadId)).toEqual({
+      accounts: [
+        {
+          account_id: '100',
+          created_via: 'twitter_archive',
+          username: 'archivist',
+          created_at: '2020-01-01T00:00:00.000Z',
+          account_display_name: 'The Archivist',
+          num_tweets: 1,
+          num_following: 1,
+          num_followers: 1,
+          num_likes: 1,
+        },
+      ],
+      profiles: [
+        {
+          account_id: '100',
+          avatar_media_url: 'https://img.example/avatar.jpg',
+          header_media_url: null,
+          bio: 'Preserving things',
+          location: null,
+          website: 'https://example.com',
+          archive_upload_id: 42,
+        },
+      ],
+    })
+  })
+
+  test('normalizes one tweet chunk with the legacy dedupe semantics', () => {
+    expect(
+      normalizeTweetRows(archive.tweets, account, archiveUploadId),
+    ).toEqual({
+      tweets: [
+        {
+          tweet_id: '200',
+          account_id: '100',
+          created_at: '2024-01-02T03:04:05.000Z',
+          full_text: 'RT @someone: hello',
+          favorite_count: 7,
+          retweet_count: 3,
+          reply_to_tweet_id: '199',
+          reply_to_user_id: '101',
+          reply_to_username: 'friend',
+          archive_upload_id: 42,
+        },
+      ],
+      mentionedUsers: [
+        { user_id: '101', name: 'Friend', screen_name: 'friend' },
+      ],
+      userMentions: [
+        { tweet_id: '200', mentioned_user_id: '101' },
+        { tweet_id: '200', mentioned_user_id: '101' },
+      ],
+      tweetUrls: [
+        {
+          tweet_id: '200',
+          url: 'https://t.co/quote',
+          expanded_url: 'https://x.com/someone/status/555',
+          display_url: '',
+        },
+      ],
+      tweetMedia: [
+        {
+          tweet_id: '200',
+          media_id: '300',
+          media_url: 'https://img.example/media.jpg',
+          media_type: 'photo',
+          width: 1200,
+          height: 800,
+          archive_upload_id: 42,
+        },
+      ],
+      quoteTweets: [
+        { tweet_id: '200', quoted_tweet_id: '555' },
+        { tweet_id: '200', quoted_tweet_id: '555' },
+      ],
+      retweets: [{ tweet_id: '200', retweeted_tweet_id: null }],
+    })
+  })
+
+  test('normalizes likes and relationship rows', () => {
+    expect(normalizeRemainingRows(archive, archiveUploadId)).toEqual({
+      likedTweets: [{ tweet_id: '400', full_text: 'liked tweet' }],
+      likes: [
+        {
+          account_id: '100',
+          liked_tweet_id: '400',
+          archive_upload_id: 42,
+        },
+      ],
+      following: [
+        {
+          account_id: '100',
+          following_account_id: '500',
+          archive_upload_id: 42,
+        },
+      ],
+      followers: [
+        {
+          account_id: '100',
+          follower_account_id: '600',
+          archive_upload_id: 42,
+        },
+      ],
+    })
+  })
+
+  test('emits no rows when the archive has no account', () => {
+    expect(
+      normalizeTweetRows(archive.tweets, undefined, archiveUploadId),
+    ).toEqual({
+      tweets: [],
+      mentionedUsers: [],
+      userMentions: [],
+      tweetUrls: [],
+      tweetMedia: [],
+      quoteTweets: [],
+      retweets: [],
+    })
+    expect(normalizeRemainingRows({}, archiveUploadId)).toEqual({
+      likedTweets: [],
+      likes: [],
+      following: [],
+      followers: [],
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- extract archive account, profile, tweet, entity, like, and relationship normalization into typed pure functions
- route the unchanged PostgreSQL writes through an exported ArchiveSink boundary and PostgresArchiveSink adapter
- preserve the existing single-archive transaction, table order, claim states, completion/failure handling, batching, and production configuration
- record that exact replay requires immutable per-upload object keys before a second sink can be enabled

## Runtime safety

This PR adds no ClickHouse client, environment variable, database migration, deployment change, or feature flag. PostgreSQL remains the only sink. The current production cron should remain in place and unchanged.

## Validation

- pnpm lint
- pnpm type-check
- pnpm test:ci: 39 suites, 165 tests
- focused archive normalizer parity tests: 4 tests
- archive worker runtime smoke test on Node 22
- git diff --check

Docker image validation was not available because the local Docker daemon is stopped. Database integration tests were not run because this worktree has no test Supabase credentials.

## Follow-up sequence

1. store a unique object key on every archive upload
2. add the complete archive ClickHouse schema and replay fixtures
3. implement a disabled-by-default shadow sink with outage replay and parity checks
4. authorize cutover and retirement separately after shadow evidence is healthy