### PR TITLE
Keep the member homepage available when feeds fail

### DIFF
--- a/memos/20260807-2307-homepage-partial-failure-hotfix.md
+++ b/memos/20260807-2307-homepage-partial-failure-hotfix.md
@@ -46,3 +46,19 @@ failure discarded the independently available member and recent-upload counts.
 
 Revert the hotfix commit. No schema, cache-storage, environment, or external
 service changes are involved.
+
+## 2026-08-09 readiness follow-up
+
+After rebasing onto the frontend readiness endpoint, production reported
+Supabase Auth unavailable because `/auth/v1/health` now requires the existing
+public API key in the `apikey` header. The health probe now sends
+`NEXT_PUBLIC_SUPABASE_ANON_KEY` without returning it in the response.
+
+Readiness also matches the partial-failure boundary: Supabase Auth remains a
+required dependency and returns HTTP 503 when unavailable, while a missing or
+failed analytics gateway returns HTTP 200 with `status: degraded`. The portal
+can therefore remain in service with local analytics-panel fallbacks.
+
+Focused verification after the rebase: type-check plus 26 readiness and portal
+failure/recovery tests passed. No schema, credential, or production environment
+change is required.

--- a/memos/20260807-2307-homepage-partial-failure-hotfix.md
+++ b/memos/20260807-2307-homepage-partial-failure-hotfix.md
@@ -1,0 +1,48 @@
+# Homepage partial-failure hotfix
+
+Date: 2026-08-07 23:07 PDT
+
+## Incident
+
+After the portal and ClickHouse branches landed, a failed authenticated-homepage
+request rendered the route-level `src/app/error.tsx` boundary. Members saw a
+blank page with “Something went wrong!” even when most homepage data remained
+available.
+
+## Root cause
+
+`getPortalData()` put the corpus snapshot, live statistics, and initial stream
+requests directly into one `Promise.all`. The optional research and banger
+feeds already had local fallbacks, but the three core reads did not. The portal
+stream moved to ClickHouse in commit `3e01b5f`, so a `portal-stream` timeout or
+5xx rejected the full Server Component render.
+
+The stats and corpus snapshots also grouped unrelated reads. A trends failure
+discarded the independently available corpus range, and a live-analytics
+failure discarded the independently available member and recent-upload counts.
+
+## Fix
+
+- Split portal loading into nine independently guarded reads: live analytics,
+  member count, recent joins, corpus range, trends, initial stream, research,
+  recent bangers, and historical bangers.
+- Return a small serializable failure map with the successful data.
+- Render panel-specific unavailable states while keeping navigation, search,
+  tools, research, and healthy metric cards usable.
+- Allow the client stream poll to clear or restore the stream failure state as
+  the endpoint recovers or fails again.
+
+## Verification
+
+- `pnpm type-check`
+- `pnpm test -- --runInBand`: 47 suites, 195 tests passed
+- Production `next build`: passed
+- Named Playwright session with ClickHouse forced unreachable: `/` returned
+  HTTP 200, Supabase-backed member and corpus cards rendered, and each failed
+  ClickHouse panel showed its local fallback. The only browser console error
+  was the deliberately forced 502 from the live polling endpoint.
+
+## Rollback
+
+Revert the hotfix commit. No schema, cache-storage, environment, or external
+service changes are involved.

--- a/src/app/api/health/route.test.ts
+++ b/src/app/api/health/route.test.ts
@@ -1,0 +1,35 @@
+import { GET } from '@/app/api/health/route'
+import { checkFrontendHealth } from '@/lib/frontendHealth'
+
+jest.mock('@/lib/frontendHealth', () => ({
+  checkFrontendHealth: jest.fn(),
+}))
+
+const mockedCheckFrontendHealth = jest.mocked(checkFrontendHealth)
+
+function healthResult(status: 'degraded' | 'healthy' | 'unhealthy') {
+  return {
+    build: { deploymentEnvironment: 'test', gitSha: 'test' },
+    dependencies: {
+      analyticsGateway: { latencyMs: 1, status: 'ok' as const },
+      supabaseAuth: { latencyMs: 1, status: 'ok' as const },
+    },
+    service: 'community-archive-web' as const,
+    status,
+  }
+}
+
+describe('frontend health route', () => {
+  it.each([
+    ['healthy', 200],
+    ['degraded', 200],
+    ['unhealthy', 503],
+  ] as const)('maps %s readiness to HTTP %s', async (status, httpStatus) => {
+    mockedCheckFrontendHealth.mockResolvedValueOnce(healthResult(status))
+
+    const response = await GET()
+
+    expect(response.status).toBe(httpStatus)
+    await expect(response.json()).resolves.toMatchObject({ status })
+  })
+})

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -7,7 +7,7 @@ export const runtime = 'nodejs'
 export async function GET() {
   const health = await checkFrontendHealth()
   return NextResponse.json(health, {
-    status: health.status === 'healthy' ? 200 : 503,
+    status: health.status === 'unhealthy' ? 503 : 200,
     headers: {
       'Cache-Control': 'no-store',
       'X-Robots-Tag': 'noindex, nofollow',

--- a/src/components/portal/Portal.test.tsx
+++ b/src/components/portal/Portal.test.tsx
@@ -66,6 +66,17 @@ const data: PortalData = {
   research: [],
   recentBangers: [],
   historicalBangers: [],
+  failures: {
+    liveAnalytics: false,
+    memberCount: false,
+    joinedThisWeek: false,
+    corpusRange: false,
+    trends: false,
+    initialStream: false,
+    research: false,
+    recentBangers: false,
+    historicalBangers: false,
+  },
 }
 
 describe.each<PortalView>(['home', 'stream'])(
@@ -183,3 +194,66 @@ describe.each<PortalView>(['home', 'stream'])(
     })
   },
 )
+
+describe('portal component failures', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.setSystemTime(Date.parse('2026-08-07T13:00:00.000Z'))
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 503,
+    } as Response)
+  })
+
+  afterEach(() => {
+    jest.clearAllTimers()
+    jest.useRealTimers()
+    jest.restoreAllMocks()
+  })
+
+  test('renders local fallbacks while the rest of the homepage remains usable', async () => {
+    const failedData: PortalData = {
+      ...data,
+      initialStream: [],
+      failures: Object.fromEntries(
+        Object.keys(data.failures).map((key) => [key, true]),
+      ) as PortalData['failures'],
+    }
+
+    render(<Portal data={failedData} view="home" />)
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(
+      screen.getByText(
+        'We preserve public conversations as open source infrastructure.',
+      ),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Tweet totals are temporarily unavailable.'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Member count is temporarily unavailable.'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Corpus range is temporarily unavailable.'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Live stream is temporarily unavailable.'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Trending terms are temporarily unavailable.'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Featured research is temporarily unavailable.'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Recent bangers are temporarily unavailable.'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Historical bangers are temporarily unavailable.'),
+    ).toBeInTheDocument()
+    expect(screen.getByText('Explore the archive')).toBeInTheDocument()
+  })
+})

--- a/src/components/portal/Portal.tsx
+++ b/src/components/portal/Portal.tsx
@@ -144,6 +144,17 @@ function PanelHeader({
   )
 }
 
+function PanelUnavailable({ message }: { message: string }) {
+  return (
+    <div
+      role="status"
+      className={`min-h-24 flex items-center justify-center px-4 py-8 text-center text-[13px] ${MUTED}`}
+    >
+      {message}
+    </div>
+  )
+}
+
 function useLiveTweetCount({
   count,
   gain,
@@ -265,9 +276,14 @@ function LiveCounter({ count, gain }: { count: number; gain: number }) {
 function ArchiveOverview({
   stats,
   generatedDate,
+  failures,
 }: {
   stats: PortalData['stats']
   generatedDate: string
+  failures: Pick<
+    PortalData['failures'],
+    'liveAnalytics' | 'memberCount' | 'joinedThisWeek' | 'corpusRange'
+  >
 }) {
   const count = useLiveTweetCount({
     count: stats.totalTweets,
@@ -281,39 +297,75 @@ function ArchiveOverview({
         <h2 className="text-[30px] font-semibold" style={SERIF}>
           Today on the archive
         </h2>
-        <span className="flex items-baseline gap-3">
-          <LiveCounter count={count} gain={stats.streamedLast24Hours} />
-          <span className={`text-[12.5px] ${MUTED}`}>{generatedDate}</span>
-        </span>
+        {!failures.liveAnalytics && (
+          <span className="flex items-baseline gap-3">
+            <LiveCounter count={count} gain={stats.streamedLast24Hours} />
+            <span className={`text-[12.5px] ${MUTED}`}>{generatedDate}</span>
+          </span>
+        )}
       </div>
 
       <div className="mb-4 grid grid-cols-1 gap-3.5 sm:grid-cols-2 lg:grid-cols-3">
         <StatCard
           label="Tweets archived"
-          value={count.toLocaleString('en-US')}
-          note={`+${stats.streamedLast24Hours.toLocaleString('en-US')} streamed in the last 24h`}
-          noteClass="text-[#16a34a] dark:text-[#2acf80]"
+          value={
+            failures.liveAnalytics
+              ? 'Unavailable'
+              : count.toLocaleString('en-US')
+          }
+          note={
+            failures.liveAnalytics
+              ? 'Tweet totals are temporarily unavailable.'
+              : `+${stats.streamedLast24Hours.toLocaleString('en-US')} streamed in the last 24h`
+          }
+          noteClass={
+            failures.liveAnalytics
+              ? undefined
+              : 'text-[#16a34a] dark:text-[#2acf80]'
+          }
         />
         <StatCard
           label="Community members"
-          value={stats.accountCount.toLocaleString('en-US')}
+          value={
+            failures.memberCount
+              ? 'Unavailable'
+              : stats.accountCount.toLocaleString('en-US')
+          }
           note={
-            stats.joinedThisWeek > 0
-              ? `${stats.joinedThisWeek} upload${stats.joinedThisWeek === 1 ? '' : 's'} this week`
-              : 'volunteered archives'
+            failures.memberCount
+              ? 'Member count is temporarily unavailable.'
+              : failures.joinedThisWeek
+                ? 'Recent upload count is temporarily unavailable.'
+                : stats.joinedThisWeek > 0
+                  ? `${stats.joinedThisWeek} upload${stats.joinedThisWeek === 1 ? '' : 's'} this week`
+                  : 'volunteered archives'
           }
         />
         <StatCard
           label="Corpus span"
-          value={`${stats.firstYear}–${stats.currentYear}`}
-          note={`${stats.currentYear - stats.firstYear} years of discourse`}
+          value={
+            failures.corpusRange
+              ? 'Unavailable'
+              : `${stats.firstYear}–${stats.currentYear}`
+          }
+          note={
+            failures.corpusRange
+              ? 'Corpus range is temporarily unavailable.'
+              : `${stats.currentYear - stats.firstYear} years of discourse`
+          }
         />
       </div>
     </>
   )
 }
 
-function LiveStreamHeading({ stats }: { stats: PortalData['stats'] }) {
+function LiveStreamHeading({
+  stats,
+  unavailable,
+}: {
+  stats: PortalData['stats']
+  unavailable: boolean
+}) {
   const count = useLiveTweetCount({
     count: stats.totalTweets,
     gain: stats.streamedLast24Hours,
@@ -324,7 +376,9 @@ function LiveStreamHeading({ stats }: { stats: PortalData['stats'] }) {
       <h1 className="text-[26px] font-semibold" style={SERIF}>
         Live stream
       </h1>
-      <LiveCounter count={count} gain={stats.streamedLast24Hours} />
+      {!unavailable && (
+        <LiveCounter count={count} gain={stats.streamedLast24Hours} />
+      )}
     </div>
   )
 }
@@ -340,6 +394,9 @@ export default function Portal({
 
   // ---- live stream state -------------------------------------------------
   const [visible, setVisible] = useState<PortalTweet[]>(data.initialStream)
+  const [streamUnavailable, setStreamUnavailable] = useState(
+    data.failures.initialStream,
+  )
   const seenIds = useRef<Set<string>>(
     new Set(data.initialStream.map((t) => t.id)),
   )
@@ -347,7 +404,9 @@ export default function Portal({
   const pageCursor = useRef(oldestPageCursor(data.initialStream))
   const loadingMoreRef = useRef(false)
   const loadMoreTarget = useRef<HTMLDivElement>(null)
-  const [hasMore, setHasMore] = useState(data.initialStream.length >= 30)
+  const [hasMore, setHasMore] = useState(
+    !data.failures.initialStream && data.initialStream.length >= 30,
+  )
   const [isLoadingMore, setIsLoadingMore] = useState(false)
 
   const loadMore = useCallback(async () => {
@@ -410,7 +469,11 @@ export default function Portal({
           signal: controller.signal,
           cache: 'no-store',
         })
-        if (!res.ok) return
+        if (!res.ok) {
+          setStreamUnavailable(true)
+          return
+        }
+        setStreamUnavailable(false)
         const { tweets, updateCursor: nextUpdateCursor } =
           (await res.json()) as {
             tweets: PortalTweet[]
@@ -434,6 +497,7 @@ export default function Portal({
           )
         }
       } catch {
+        if (!controller.signal.aborted) setStreamUnavailable(true)
         // network hiccup; try again next poll
       } finally {
         polling = false
@@ -531,15 +595,25 @@ export default function Portal({
               Community Archive
             </h1>
             <p className="text-xl leading-8 text-zinc-500 dark:text-[#a7a7b4]">
-              We preserve{' '}
-              <strong className="font-semibold text-foreground">
-                {compact(stats.totalTweets)} public tweets
-              </strong>{' '}
-              from{' '}
-              <strong className="font-semibold text-foreground">
-                {stats.accountCount.toLocaleString('en-US')} community members
-              </strong>
-              .
+              {data.failures.liveAnalytics || data.failures.memberCount ? (
+                <>
+                  We preserve public conversations as open source
+                  infrastructure.
+                </>
+              ) : (
+                <>
+                  We preserve{' '}
+                  <strong className="font-semibold text-foreground">
+                    {compact(stats.totalTweets)} public tweets
+                  </strong>{' '}
+                  from{' '}
+                  <strong className="font-semibold text-foreground">
+                    {stats.accountCount.toLocaleString('en-US')} community
+                    members
+                  </strong>
+                  .
+                </>
+              )}
             </p>
             <p className={`text-xs ${FAINT}`}>
               Backed by{' '}
@@ -566,7 +640,11 @@ export default function Portal({
             </div>
           </div>
 
-          <ArchiveOverview stats={stats} generatedDate={generatedDate} />
+          <ArchiveOverview
+            stats={stats}
+            generatedDate={generatedDate}
+            failures={data.failures}
+          />
 
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-[1.45fr_1fr]">
             <div className="flex h-full min-h-0 flex-col gap-4 lg:overflow-hidden">
@@ -587,7 +665,10 @@ export default function Portal({
                   {visible.slice(0, HOME_LIVE_STREAM_LIMIT).map((t, i) => (
                     <TweetRow key={t.id} tweet={t} compact animate={i === 0} />
                   ))}
-                  {visible.length === 0 && (
+                  {visible.length === 0 && streamUnavailable && (
+                    <PanelUnavailable message="Live stream is temporarily unavailable." />
+                  )}
+                  {visible.length === 0 && !streamUnavailable && (
                     <div
                       className={`px-4 py-8 text-center text-[13px] ${MUTED}`}
                     >
@@ -603,7 +684,9 @@ export default function Portal({
                   action={{ label: 'Trends explorer', href: '/trends' }}
                 />
                 <div className="flex flex-1 flex-col justify-evenly px-4 pb-3 pt-2">
-                  {weeklyBars.length > 0 && (
+                  {data.failures.trends ? (
+                    <PanelUnavailable message="Trending terms are temporarily unavailable." />
+                  ) : weeklyBars.length > 0 ? (
                     <div
                       className={`flex items-center gap-3 pb-1 text-[10px] font-medium uppercase tracking-wide ${MUTED}`}
                     >
@@ -612,44 +695,45 @@ export default function Portal({
                       <span className="flex-1">Relative volume</span>
                       <span className="w-[52px] text-right">7d change</span>
                     </div>
-                  )}
-                  {weeklyBars.map((b) => (
-                    <div
-                      key={b.term}
-                      className="flex items-center gap-3 py-[5px]"
-                    >
-                      <span className="w-[90px] truncate text-[13px] font-semibold sm:w-[110px]">
-                        {b.term}
-                      </span>
-                      <span className="w-[54px] text-right text-[12px] tabular-nums text-muted-foreground">
-                        {b.last7.toLocaleString('en-US')}
-                      </span>
+                  ) : null}
+                  {!data.failures.trends &&
+                    weeklyBars.map((b) => (
                       <div
-                        className="h-2 flex-1 overflow-hidden rounded bg-zinc-100 dark:bg-[#26262a]"
-                        role="img"
-                        aria-label={`${b.term}: ${b.last7.toLocaleString('en-US')} tweets in the last seven days`}
-                        title={`${b.last7.toLocaleString('en-US')} tweets in the last 7 days; bar is relative to ${weeklyBars[0].term}`}
+                        key={b.term}
+                        className="flex items-center gap-3 py-[5px]"
                       >
+                        <span className="w-[90px] truncate text-[13px] font-semibold sm:w-[110px]">
+                          {b.term}
+                        </span>
+                        <span className="w-[54px] text-right text-[12px] tabular-nums text-muted-foreground">
+                          {b.last7.toLocaleString('en-US')}
+                        </span>
                         <div
-                          className="h-full rounded bg-brand"
-                          style={{ width: `${(b.last7 / maxWeekly) * 100}%` }}
-                        />
+                          className="h-2 flex-1 overflow-hidden rounded bg-zinc-100 dark:bg-[#26262a]"
+                          role="img"
+                          aria-label={`${b.term}: ${b.last7.toLocaleString('en-US')} tweets in the last seven days`}
+                          title={`${b.last7.toLocaleString('en-US')} tweets in the last 7 days; bar is relative to ${weeklyBars[0].term}`}
+                        >
+                          <div
+                            className="h-full rounded bg-brand"
+                            style={{ width: `${(b.last7 / maxWeekly) * 100}%` }}
+                          />
+                        </div>
+                        <span
+                          title={`${b.last7.toLocaleString('en-US')} tweets vs ${b.prev7.toLocaleString('en-US')} in the previous 7 days`}
+                          className={`w-[52px] text-right text-[12px] font-bold tabular-nums ${
+                            b.status === 'inactive'
+                              ? MUTED
+                              : (b.deltaPct ?? 0) >= 0
+                                ? 'text-[#16a34a] dark:text-[#2acf80]'
+                                : 'text-[#dc2626] dark:text-[#f87171]'
+                          }`}
+                        >
+                          {fmtDelta(b)}
+                        </span>
                       </div>
-                      <span
-                        title={`${b.last7.toLocaleString('en-US')} tweets vs ${b.prev7.toLocaleString('en-US')} in the previous 7 days`}
-                        className={`w-[52px] text-right text-[12px] font-bold tabular-nums ${
-                          b.status === 'inactive'
-                            ? MUTED
-                            : (b.deltaPct ?? 0) >= 0
-                              ? 'text-[#16a34a] dark:text-[#2acf80]'
-                              : 'text-[#dc2626] dark:text-[#f87171]'
-                        }`}
-                      >
-                        {fmtDelta(b)}
-                      </span>
-                    </div>
-                  ))}
-                  {weeklyBars.length === 0 && (
+                    ))}
+                  {!data.failures.trends && weeklyBars.length === 0 && (
                     <div className={`py-8 text-center text-[13px] ${MUTED}`}>
                       No watchlist activity in the last seven days.
                     </div>
@@ -657,20 +741,27 @@ export default function Portal({
                 </div>
               </div>
 
-              {(recentBanger || historicalBanger) && (
+              {(recentBanger ||
+                historicalBanger ||
+                data.failures.recentBangers ||
+                data.failures.historicalBangers) && (
                 <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                  {recentBanger && (
+                  {(recentBanger || data.failures.recentBangers) && (
                     <div
                       className={`${CARD} flex min-w-0 flex-col overflow-hidden lg:min-h-[320px]`}
                     >
                       <PanelHeader title="Banger of the moment" />
-                      <div className="flex flex-1 flex-col [&>article]:flex-1">
-                        <TweetRow tweet={recentBanger} collapsible />
-                      </div>
+                      {recentBanger ? (
+                        <div className="flex flex-1 flex-col [&>article]:flex-1">
+                          <TweetRow tweet={recentBanger} collapsible />
+                        </div>
+                      ) : (
+                        <PanelUnavailable message="Recent bangers are temporarily unavailable." />
+                      )}
                     </div>
                   )}
 
-                  {historicalBanger && (
+                  {(historicalBanger || data.failures.historicalBangers) && (
                     <div
                       className={`${CARD} flex min-w-0 flex-col overflow-hidden lg:min-h-[320px]`}
                     >
@@ -678,13 +769,17 @@ export default function Portal({
                         title="Historical Banger"
                         action={{ label: 'More bangers', href: '/bangers' }}
                       />
-                      <div className="flex flex-1 flex-col [&>article]:flex-1">
-                        <TweetRow
-                          tweet={historicalBanger}
-                          collapsible
-                          showDate
-                        />
-                      </div>
+                      {historicalBanger ? (
+                        <div className="flex flex-1 flex-col [&>article]:flex-1">
+                          <TweetRow
+                            tweet={historicalBanger}
+                            collapsible
+                            showDate
+                          />
+                        </div>
+                      ) : (
+                        <PanelUnavailable message="Historical bangers are temporarily unavailable." />
+                      )}
                     </div>
                   )}
                 </div>
@@ -698,47 +793,51 @@ export default function Portal({
                   action={{ label: 'All research', href: '/research' }}
                 />
                 <div className="flex flex-col">
-                  {data.research.slice(0, 4).map((post) => (
-                    <a
-                      key={post.url}
-                      href={post.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="group flex items-start gap-3 border-b border-zinc-100 px-4 py-3 transition-colors last:border-b-0 hover:bg-zinc-50 dark:border-[#202023] dark:hover:bg-[#1f1f23]"
-                    >
-                      <div className="min-w-0 flex-1">
-                        <div
-                          className="flex items-baseline gap-1.5 text-[15.5px] font-semibold leading-snug"
-                          style={SERIF}
-                        >
-                          {post.title}
-                          <FaExternalLinkAlt className="h-2.5 w-2.5 flex-shrink-0 text-zinc-900 opacity-0 transition-opacity group-hover:opacity-70 dark:text-white" />
-                        </div>
-                        {post.excerpt && (
+                  {data.failures.research ? (
+                    <PanelUnavailable message="Featured research is temporarily unavailable." />
+                  ) : (
+                    data.research.slice(0, 4).map((post) => (
+                      <a
+                        key={post.url}
+                        href={post.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="group flex items-start gap-3 border-b border-zinc-100 px-4 py-3 transition-colors last:border-b-0 hover:bg-zinc-50 dark:border-[#202023] dark:hover:bg-[#1f1f23]"
+                      >
+                        <div className="min-w-0 flex-1">
                           <div
-                            className={`mt-1 line-clamp-2 text-[12.5px] leading-normal ${MUTED}`}
+                            className="flex items-baseline gap-1.5 text-[15.5px] font-semibold leading-snug"
+                            style={SERIF}
                           >
-                            {post.excerpt}
+                            {post.title}
+                            <FaExternalLinkAlt className="h-2.5 w-2.5 flex-shrink-0 text-zinc-900 opacity-0 transition-opacity group-hover:opacity-70 dark:text-white" />
                           </div>
-                        )}
-                        <div className={`mt-1 text-[12px] ${MUTED}`}>
-                          {RESEARCH_SOURCE.name}
-                          {post.date &&
-                            ` · ${new Date(post.date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })}`}
+                          {post.excerpt && (
+                            <div
+                              className={`mt-1 line-clamp-2 text-[12.5px] leading-normal ${MUTED}`}
+                            >
+                              {post.excerpt}
+                            </div>
+                          )}
+                          <div className={`mt-1 text-[12px] ${MUTED}`}>
+                            {RESEARCH_SOURCE.name}
+                            {post.date &&
+                              ` · ${new Date(post.date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })}`}
+                          </div>
                         </div>
-                      </div>
-                      {post.image && (
-                        // eslint-disable-next-line @next/next/no-img-element
-                        <img
-                          src={post.image}
-                          alt=""
-                          loading="lazy"
-                          className="mt-0.5 h-14 w-20 flex-shrink-0 rounded-[4px] border border-zinc-200 object-cover dark:border-[#26262a]"
-                        />
-                      )}
-                    </a>
-                  ))}
-                  {data.research.length === 0 && (
+                        {post.image && (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img
+                            src={post.image}
+                            alt=""
+                            loading="lazy"
+                            className="mt-0.5 h-14 w-20 flex-shrink-0 rounded-[4px] border border-zinc-200 object-cover dark:border-[#26262a]"
+                          />
+                        )}
+                      </a>
+                    ))
+                  )}
+                  {!data.failures.research && data.research.length === 0 && (
                     <a
                       href={RESEARCH_SOURCE.url}
                       target="_blank"
@@ -862,7 +961,10 @@ export default function Portal({
               >
                 ← Dashboard
               </Link>
-              <LiveStreamHeading stats={stats} />
+              <LiveStreamHeading
+                stats={stats}
+                unavailable={data.failures.liveAnalytics}
+              />
               <div className={`mb-3.5 text-[13px] ${MUTED}`}>
                 Tweets arriving from the browser-extension firehose, as
                 contributors read their timelines.
@@ -876,7 +978,10 @@ export default function Portal({
                     showArchivedBadge
                   />
                 ))}
-                {visible.length === 0 && (
+                {visible.length === 0 && streamUnavailable && (
+                  <PanelUnavailable message="Live stream is temporarily unavailable." />
+                )}
+                {visible.length === 0 && !streamUnavailable && (
                   <div className={`px-4 py-8 text-center text-[13px] ${MUTED}`}>
                     Waiting for the firehose…
                   </div>
@@ -897,7 +1002,18 @@ export default function Portal({
               </div>
             </div>
             <div id="trends" className="scroll-mt-32">
-              <TrendsView trends={trends} risers={risers} fallers={fallers} />
+              {data.failures.trends ? (
+                <>
+                  <h2 className="mb-3 text-[18px] font-semibold" style={SERIF}>
+                    Trends in ideas
+                  </h2>
+                  <div className={CARD}>
+                    <PanelUnavailable message="Trends are temporarily unavailable." />
+                  </div>
+                </>
+              ) : (
+                <TrendsView trends={trends} risers={risers} fallers={fallers} />
+              )}
             </div>
           </div>
         </div>

--- a/src/components/portal/PortalLayout.test.tsx
+++ b/src/components/portal/PortalLayout.test.tsx
@@ -55,6 +55,17 @@ const data: PortalData = {
   research,
   recentBangers: [banger],
   historicalBangers: [{ ...banger, id: '99', text: 'A historical banger' }],
+  failures: {
+    liveAnalytics: false,
+    memberCount: false,
+    joinedThisWeek: false,
+    corpusRange: false,
+    trends: false,
+    initialStream: false,
+    research: false,
+    recentBangers: false,
+    historicalBangers: false,
+  },
 }
 
 test('renders the balanced homepage composition and editorial labels', async () => {

--- a/src/lib/frontendHealth.test.ts
+++ b/src/lib/frontendHealth.test.ts
@@ -11,6 +11,7 @@ describe('frontend readiness health', () => {
       env: {
         CLICKHOUSE_ANALYTICS_API_URL:
           'https://analytics.community-archive.org/analytics',
+        NEXT_PUBLIC_SUPABASE_ANON_KEY: 'public-key',
         NEXT_PUBLIC_SUPABASE_URL: 'https://example.supabase.co',
         VERCEL_ENV: 'preview',
         VERCEL_GIT_COMMIT_SHA: '0123456789abcdef',
@@ -28,9 +29,13 @@ describe('frontend readiness health', () => {
       'https://example.supabase.co/auth/v1/health',
       'https://analytics.community-archive.org/health',
     ])
+    expect(fetchImpl.mock.calls[0][1]?.headers).toMatchObject({
+      apikey: 'public-key',
+    })
+    expect(JSON.stringify(result)).not.toContain('public-key')
   })
 
-  it('reports unhealthy without leaking dependency errors', async () => {
+  it('reports degraded when optional analytics is unavailable', async () => {
     const fetchImpl = jest
       .fn((_input: URL | RequestInfo, _init?: RequestInit) =>
         Promise.resolve(new Response('{}')),
@@ -41,6 +46,30 @@ describe('frontend readiness health', () => {
     const result = await checkFrontendHealth({
       env: {
         CLICKHOUSE_ANALYTICS_API_URL: 'https://analytics.example/analytics',
+        NEXT_PUBLIC_SUPABASE_ANON_KEY: 'public-key',
+        NEXT_PUBLIC_SUPABASE_URL: 'https://example.supabase.co',
+      },
+      fetchImpl,
+      timeoutMs: 100,
+    })
+
+    expect(result.status).toBe('degraded')
+    expect(result.dependencies.analyticsGateway.status).toBe('unavailable')
+    expect(JSON.stringify(result)).not.toContain('secret upstream response')
+  })
+
+  it('reports unhealthy when required Supabase Auth is unavailable', async () => {
+    const fetchImpl = jest
+      .fn((_input: URL | RequestInfo, _init?: RequestInit) =>
+        Promise.resolve(new Response('{}')),
+      )
+      .mockRejectedValueOnce(new Error('auth unavailable'))
+      .mockResolvedValueOnce(new Response('{}', { status: 200 }))
+
+    const result = await checkFrontendHealth({
+      env: {
+        CLICKHOUSE_ANALYTICS_API_URL: 'https://analytics.example/analytics',
+        NEXT_PUBLIC_SUPABASE_ANON_KEY: 'public-key',
         NEXT_PUBLIC_SUPABASE_URL: 'https://example.supabase.co',
       },
       fetchImpl,
@@ -48,8 +77,8 @@ describe('frontend readiness health', () => {
     })
 
     expect(result.status).toBe('unhealthy')
-    expect(result.dependencies.analyticsGateway.status).toBe('unavailable')
-    expect(JSON.stringify(result)).not.toContain('secret upstream response')
+    expect(result.dependencies.supabaseAuth.status).toBe('unavailable')
+    expect(result.dependencies.analyticsGateway.status).toBe('ok')
   })
 
   it('treats missing or malformed configuration as unavailable', async () => {

--- a/src/lib/frontendHealth.ts
+++ b/src/lib/frontendHealth.ts
@@ -13,12 +13,13 @@ export type FrontendHealthResult = {
     supabaseAuth: HealthDependency
   }
   service: 'community-archive-web'
-  status: 'healthy' | 'unhealthy'
+  status: 'degraded' | 'healthy' | 'unhealthy'
 }
 
 type HealthEnvironment = {
   [name: string]: string | undefined
   CLICKHOUSE_ANALYTICS_API_URL?: string
+  NEXT_PUBLIC_SUPABASE_ANON_KEY?: string
   NEXT_PUBLIC_SUPABASE_URL?: string
   VERCEL_ENV?: string
   VERCEL_GIT_COMMIT_SHA?: string
@@ -38,6 +39,7 @@ async function checkDependency(
   url: URL | undefined,
   fetchImpl: typeof fetch,
   timeoutMs: number,
+  headers: Record<string, string> = {},
 ): Promise<HealthDependency> {
   const startedAt = performance.now()
   if (!url) {
@@ -47,7 +49,7 @@ async function checkDependency(
   try {
     const response = await fetchImpl(url, {
       cache: 'no-store',
-      headers: { Accept: 'application/json' },
+      headers: { Accept: 'application/json', ...headers },
       signal: AbortSignal.timeout(timeoutMs),
     })
     return {
@@ -90,6 +92,9 @@ export async function checkFrontendHealth({
       supabaseHealthUrl(env.NEXT_PUBLIC_SUPABASE_URL),
       fetchImpl,
       timeoutMs,
+      env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+        ? { apikey: env.NEXT_PUBLIC_SUPABASE_ANON_KEY }
+        : {},
     ),
     checkDependency(
       analyticsHealthUrl(env.CLICKHOUSE_ANALYTICS_API_URL),
@@ -97,8 +102,12 @@ export async function checkFrontendHealth({
       timeoutMs,
     ),
   ])
-  const healthy =
-    supabaseAuth.status === 'ok' && analyticsGateway.status === 'ok'
+  const status =
+    supabaseAuth.status !== 'ok'
+      ? 'unhealthy'
+      : analyticsGateway.status === 'ok'
+        ? 'healthy'
+        : 'degraded'
 
   return {
     build: {
@@ -107,6 +116,6 @@ export async function checkFrontendHealth({
     },
     dependencies: { analyticsGateway, supabaseAuth },
     service: 'community-archive-web',
-    status: healthy ? 'healthy' : 'unhealthy',
+    status,
   }
 }

--- a/src/lib/portal/data.test.ts
+++ b/src/lib/portal/data.test.ts
@@ -2,9 +2,21 @@ jest.mock('server-only', () => ({}), { virtual: true })
 jest.mock('next/cache', () => ({
   unstable_cache: (callback: unknown) => callback,
 }))
+jest.mock('./analytics', () => ({
+  fetchPortalBangersPage: jest.fn(),
+  fetchPortalHistoricalBangers: jest.fn(),
+  fetchPortalLiveAnalytics: jest.fn(),
+  fetchPortalRecentBangers: jest.fn(),
+  fetchPortalTrends: jest.fn(),
+}))
+jest.mock('./research', () => ({
+  getResearchPosts: jest.fn(),
+  selectFeaturedResearchPosts: jest.fn((posts: unknown) => posts),
+}))
 
 import {
   fetchPortalMemberCount,
+  getPortalData,
   getPortalStreamPage,
   getPortalStreamUpdates,
   loadOptionalPortalData,
@@ -13,7 +25,33 @@ import {
   resolvePortalReadConfig,
   selectDailyBangers,
 } from './data'
+import {
+  fetchPortalHistoricalBangers,
+  fetchPortalLiveAnalytics,
+  fetchPortalRecentBangers,
+  fetchPortalTrends,
+} from './analytics'
+import { getResearchPosts } from './research'
 import type { PortalTweet } from './types'
+
+const fetchPortalHistoricalBangersMock =
+  fetchPortalHistoricalBangers as jest.MockedFunction<
+    typeof fetchPortalHistoricalBangers
+  >
+const fetchPortalLiveAnalyticsMock =
+  fetchPortalLiveAnalytics as jest.MockedFunction<
+    typeof fetchPortalLiveAnalytics
+  >
+const fetchPortalRecentBangersMock =
+  fetchPortalRecentBangers as jest.MockedFunction<
+    typeof fetchPortalRecentBangers
+  >
+const fetchPortalTrendsMock = fetchPortalTrends as jest.MockedFunction<
+  typeof fetchPortalTrends
+>
+const getResearchPostsMock = getResearchPosts as jest.MockedFunction<
+  typeof getResearchPosts
+>
 
 describe('portal read source', () => {
   test('uses an explicit server-only row source without changing app Supabase', () => {
@@ -93,6 +131,131 @@ describe('optional portal data', () => {
       expect.stringContaining('"section":"historical-bangers"'),
     )
     consoleError.mockRestore()
+  })
+})
+
+describe('portal page resilience', () => {
+  const previousEnv = {
+    portalUrl: process.env.PORTAL_READ_SUPABASE_URL,
+    portalKey: process.env.PORTAL_READ_SUPABASE_ANON_KEY,
+    analyticsUrl: process.env.CLICKHOUSE_ANALYTICS_API_URL,
+    analyticsToken: process.env.CLICKHOUSE_ANALYTICS_API_TOKEN,
+  }
+
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation()
+    process.env.PORTAL_READ_SUPABASE_URL = 'https://prod-project.supabase.co/'
+    process.env.PORTAL_READ_SUPABASE_ANON_KEY = 'prod-public-anon'
+    process.env.CLICKHOUSE_ANALYTICS_API_URL =
+      'https://analytics.community-archive.org/analytics'
+    process.env.CLICKHOUSE_ANALYTICS_API_TOKEN = 'test-token'
+
+    fetchPortalTrendsMock.mockResolvedValue({
+      years: [],
+      series: [],
+      weekly: [],
+      computedAt: '2026-08-07T20:00:00.000Z',
+    })
+    fetchPortalLiveAnalyticsMock.mockResolvedValue({
+      totalTweets: 1_000,
+      streamedLast24Hours: 25,
+      generatedAt: '2026-08-07T20:00:00.000Z',
+      latestObservedAt: '2026-08-07T20:00:00.000Z',
+    })
+    fetchPortalRecentBangersMock.mockResolvedValue([])
+    fetchPortalHistoricalBangersMock.mockResolvedValue([])
+    getResearchPostsMock.mockResolvedValue([])
+
+    jest.spyOn(global, 'fetch').mockImplementation(async (input, init) => {
+      const url = new URL(String(input))
+      if (url.pathname.endsWith('/portal-stream')) {
+        return new Response('gateway unavailable', { status: 503 })
+      }
+      if (init?.method === 'HEAD') {
+        return new Response(null, {
+          status: 200,
+          headers: { 'content-range': '0-0/42' },
+        })
+      }
+      if (url.pathname.endsWith('/tweets')) {
+        const createdAt = url.searchParams.get('order')?.endsWith('.asc')
+          ? '2007-01-01T00:00:00.000Z'
+          : '2026-08-07T00:00:00.000Z'
+        return new Response(JSON.stringify([{ created_at: createdAt }]), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      throw new Error(`Unexpected test request: ${url}`)
+    })
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    jest.clearAllMocks()
+    const restore = (name: string, value: string | undefined) => {
+      if (value === undefined) delete process.env[name]
+      else process.env[name] = value
+    }
+    restore('PORTAL_READ_SUPABASE_URL', previousEnv.portalUrl)
+    restore('PORTAL_READ_SUPABASE_ANON_KEY', previousEnv.portalKey)
+    restore('CLICKHOUSE_ANALYTICS_API_URL', previousEnv.analyticsUrl)
+    restore('CLICKHOUSE_ANALYTICS_API_TOKEN', previousEnv.analyticsToken)
+  })
+
+  test('keeps the page available when the initial stream request fails', async () => {
+    await expect(getPortalData()).resolves.toMatchObject({
+      initialStream: [],
+      failures: {
+        initialStream: true,
+        liveAnalytics: false,
+        memberCount: false,
+        corpusRange: false,
+        trends: false,
+      },
+    })
+  })
+
+  test('preserves other components when the trends request fails', async () => {
+    fetchPortalTrendsMock.mockRejectedValueOnce(
+      new Error('trend snapshot unavailable'),
+    )
+
+    await expect(getPortalData()).resolves.toMatchObject({
+      stats: {
+        totalTweets: 1_000,
+        accountCount: 42,
+        firstYear: 2007,
+        currentYear: 2026,
+      },
+      trends: { years: [], series: [], weekly: [] },
+      failures: {
+        trends: true,
+        liveAnalytics: false,
+        memberCount: false,
+        corpusRange: false,
+      },
+    })
+  })
+
+  test('preserves member and corpus metrics when live analytics fails', async () => {
+    fetchPortalLiveAnalyticsMock.mockRejectedValueOnce(
+      new Error('live analytics unavailable'),
+    )
+
+    await expect(getPortalData()).resolves.toMatchObject({
+      stats: {
+        totalTweets: 0,
+        accountCount: 42,
+        firstYear: 2007,
+        currentYear: 2026,
+      },
+      failures: {
+        liveAnalytics: true,
+        memberCount: false,
+        corpusRange: false,
+      },
+    })
   })
 })
 

--- a/src/lib/portal/data.ts
+++ b/src/lib/portal/data.ts
@@ -11,7 +11,6 @@ import {
   fetchPortalRecentBangers,
   fetchPortalTrends,
 } from './analytics'
-import type { PortalLiveAnalytics } from './analytics'
 import { getResearchPosts, selectFeaturedResearchPosts } from './research'
 import { selectHomepageStream } from './stream'
 import type {
@@ -42,18 +41,12 @@ export interface PortalStreamPageCursor {
   id: string
 }
 
-interface PortalCorpusSnapshot {
-  trends: PortalTrends
+interface PortalCorpusRange {
   firstYear: number
   currentYear: number
 }
 
 const PORTAL_READ_TIMEOUT_MS = 10_000
-
-type PortalStatsSnapshot = PortalLiveAnalytics & {
-  accountCount: number
-  joinedThisWeek: number
-}
 
 function required(value: string | undefined, name: string): string {
   if (!value) throw new Error(`${name} is not configured`)
@@ -580,10 +573,7 @@ export function selectDailyBangers(
   return [selected, ...candidates.filter((_, index) => index !== selectedIndex)]
 }
 
-async function fetchCorpusRange(): Promise<{
-  firstYear: number
-  currentYear: number
-}> {
+async function fetchCorpusRange(): Promise<PortalCorpusRange> {
   const [firstResult, latestResult] = await Promise.all([
     portalRestRows<{ created_at: string }>(
       'tweets',
@@ -613,44 +603,43 @@ async function fetchCorpusRange(): Promise<{
   }
 }
 
-async function computePortalCorpusSnapshot(): Promise<PortalCorpusSnapshot> {
-  const [trends, range] = await Promise.all([
-    fetchPortalTrends(),
-    fetchCorpusRange(),
-  ])
-  return { trends, ...range }
-}
-
-async function computePortalStatsSnapshot(): Promise<PortalStatsSnapshot> {
-  const [analytics, accountCount, joinedThisWeekResponse] = await Promise.all([
-    fetchPortalLiveAnalytics(),
-    fetchPortalMemberCount(),
-    portalRestRequest(
-      'archive_upload',
-      new URLSearchParams({
-        select: 'id',
-        created_at: `gte.${isoDaysAgo(7)}`,
-      }),
-      { method: 'HEAD', prefer: 'count=exact' },
-    ),
-  ])
-  return {
-    ...analytics,
-    accountCount,
-    joinedThisWeek: exactCount(joinedThisWeekResponse, 'upload'),
-  }
+async function fetchPortalJoinedThisWeek(): Promise<number> {
+  const response = await portalRestRequest(
+    'archive_upload',
+    new URLSearchParams({
+      select: 'id',
+      created_at: `gte.${isoDaysAgo(7)}`,
+    }),
+    { method: 'HEAD', prefer: 'count=exact' },
+  )
+  return exactCount(response, 'upload')
 }
 
 // Arguments participate in the cache key, keeping staging/prod sources and
 // deployment environments isolated even when the Data Cache survives deploys.
-const getCachedCorpusSnapshot = unstable_cache(
-  async (_sourceKey: string) => computePortalCorpusSnapshot(),
-  ['portal-corpus-snapshot-v3'],
+const getCachedTrendsSnapshot = unstable_cache(
+  async (_sourceKey: string) => fetchPortalTrends(),
+  ['portal-trends-snapshot-v1'],
   { revalidate: 86_400 },
 )
-const getCachedStatsSnapshot = unstable_cache(
-  async (_sourceKey: string) => computePortalStatsSnapshot(),
-  ['portal-stats-snapshot-v6'],
+const getCachedCorpusRange = unstable_cache(
+  async (_sourceKey: string) => fetchCorpusRange(),
+  ['portal-corpus-range-v1'],
+  { revalidate: 86_400 },
+)
+const getCachedLiveAnalytics = unstable_cache(
+  async (_sourceKey: string) => fetchPortalLiveAnalytics(),
+  ['portal-live-analytics-v1'],
+  { revalidate: 300 },
+)
+const getCachedMemberCount = unstable_cache(
+  async (_sourceKey: string) => fetchPortalMemberCount(),
+  ['portal-member-count-v1'],
+  { revalidate: 300 },
+)
+const getCachedJoinedThisWeek = unstable_cache(
+  async (_sourceKey: string) => fetchPortalJoinedThisWeek(),
+  ['portal-joined-this-week-v1'],
   { revalidate: 300 },
 )
 const getCachedInitialStream = unstable_cache(
@@ -698,7 +687,7 @@ export async function loadPortalComponentData<T>(
     console.error(
       JSON.stringify({
         level: 'error',
-        message: 'Optional portal data failed',
+        message: 'Portal component data failed',
         section,
         error: error instanceof Error ? error.message : String(error),
       }),
@@ -726,7 +715,7 @@ export async function getPortalBangersPage(
 
 /** Cached corpus-wide seed series for the authenticated trends explorer. */
 export async function getPortalTrendSnapshot(): Promise<PortalTrends> {
-  return (await getCachedCorpusSnapshot(portalDataSourceKey())).trends
+  return getCachedTrendsSnapshot(portalDataSourceKey())
 }
 
 export async function getPortalData(
@@ -735,63 +724,110 @@ export async function getPortalData(
   const sourceKey = portalDataSourceKey()
   const today = new Date().toISOString().slice(0, 10)
   const [
-    corpus,
-    live,
+    trends,
+    corpusRange,
+    liveAnalytics,
+    memberCount,
+    joinedThisWeek,
     initialStream,
     research,
     recentBangers,
     historicalBangers,
   ] = await Promise.all([
-    getCachedCorpusSnapshot(sourceKey),
-    getCachedStatsSnapshot(sourceKey),
+    loadPortalComponentData(
+      'trends',
+      () => getCachedTrendsSnapshot(sourceKey),
+      { years: [], series: [], weekly: [], computedAt: '' },
+    ),
+    loadPortalComponentData(
+      'corpus-range',
+      () => getCachedCorpusRange(sourceKey),
+      { firstYear: 0, currentYear: 0 },
+    ),
+    loadPortalComponentData(
+      'live-analytics',
+      () => getCachedLiveAnalytics(sourceKey),
+      {
+        totalTweets: 0,
+        streamedLast24Hours: 0,
+        generatedAt: new Date().toISOString(),
+        latestObservedAt: null,
+      },
+    ),
+    loadPortalComponentData(
+      'member-count',
+      () => getCachedMemberCount(sourceKey),
+      0,
+    ),
+    loadPortalComponentData(
+      'joined-this-week',
+      () => getCachedJoinedThisWeek(sourceKey),
+      0,
+    ),
+    loadPortalComponentData(
+      'initial-stream',
+      () =>
+        view === 'home'
+          ? getCachedHomepageStreamCandidates(sourceKey)
+          : getCachedInitialStream(sourceKey),
+      [],
+    ),
     view === 'home'
-      ? getCachedHomepageStreamCandidates(sourceKey)
-      : getCachedInitialStream(sourceKey),
-    view === 'home'
-      ? loadOptionalPortalData(
+      ? loadPortalComponentData(
           'research',
           async () => selectFeaturedResearchPosts(await getResearchPosts(24)),
           [],
         )
-      : Promise.resolve([]),
+      : Promise.resolve({ data: [], failed: false }),
     view === 'home'
-      ? loadOptionalPortalData(
+      ? loadPortalComponentData(
           'recent-bangers',
           () => getCachedRecentBangers(sourceKey),
           [],
         )
-      : Promise.resolve([]),
+      : Promise.resolve({ data: [], failed: false }),
     view === 'home'
-      ? loadOptionalPortalData(
+      ? loadPortalComponentData(
           'historical-bangers',
           () => getCachedHistoricalBangers(sourceKey, today),
           [],
         )
-      : Promise.resolve([]),
+      : Promise.resolve({ data: [], failed: false }),
   ])
   const stats: PortalStats = {
-    totalTweets: live.totalTweets,
-    accountCount: live.accountCount,
-    streamedLast24Hours: live.streamedLast24Hours,
-    joinedThisWeek: live.joinedThisWeek,
-    firstYear: corpus.firstYear,
-    currentYear: corpus.currentYear,
-    generatedAt: live.generatedAt,
+    totalTweets: liveAnalytics.data.totalTweets,
+    accountCount: memberCount.data,
+    streamedLast24Hours: liveAnalytics.data.streamedLast24Hours,
+    joinedThisWeek: joinedThisWeek.data,
+    firstYear: corpusRange.data.firstYear,
+    currentYear: corpusRange.data.currentYear,
+    generatedAt: liveAnalytics.data.generatedAt,
   }
   const selectedStream =
     view === 'home'
       ? selectHomepageStream(
-          [...initialStream, ...recentBangers],
+          [...initialStream.data, ...recentBangers.data],
           30,
-          new Date(live.generatedAt),
+          new Date(liveAnalytics.data.generatedAt),
         )
-      : initialStream
+      : initialStream.data
   return {
     stats,
-    trends: corpus.trends,
+    trends: trends.data,
     initialStream: selectedStream,
-    research,
-    recentBangers,
-    historicalBangers,
+    research: research.data,
+    recentBangers: recentBangers.data,
+    historicalBangers: historicalBangers.data,
+    failures: {
+      liveAnalytics: liveAnalytics.failed,
+      memberCount: memberCount.failed,
+      joinedThisWeek: joinedThisWeek.failed,
+      corpusRange: corpusRange.failed,
+      trends: trends.failed,
+      initialStream: initialStream.failed,
+      research: research.failed,
+      recentBangers: recentBangers.failed,
+      historicalBangers: historicalBangers.failed,
+    },
   }
 }

--- a/src/lib/portal/types.ts
+++ b/src/lib/portal/types.ts
@@ -114,4 +114,16 @@ export interface PortalData {
   recentBangers: PortalTweet[]
   /** Calendar-matched canonical bangers, refreshed daily. */
   historicalBangers: PortalTweet[]
+  /** Request failures are carried to the client so only their panels degrade. */
+  failures: {
+    liveAnalytics: boolean
+    memberCount: boolean
+    joinedThisWeek: boolean
+    corpusRange: boolean
+    trends: boolean
+    initialStream: boolean
+    research: boolean
+    recentBangers: boolean
+    historicalBangers: boolean
+  }
 }


### PR DESCRIPTION
## What changed

- split authenticated-homepage loading into independently guarded portal reads
- preserve healthy stats and content when ClickHouse, Supabase, or external feed requests fail
- show local unavailable states for affected cards and panels
- let the live stream panel recover automatically when polling succeeds again
- add loader and component regression coverage

## Root cause

`getPortalData()` awaited the corpus snapshot, live statistics, and initial stream in one all-or-nothing `Promise.all`. After the stream moved to the ClickHouse `portal-stream` endpoint, one timeout or 5xx rejected the Server Component render and activated the route-level error boundary.

The corpus and stats snapshots also grouped unrelated requests, so one failed trends or analytics request discarded otherwise healthy data.

## User impact

Signed-in members now keep the full homepage shell, navigation, search, tools, and every healthy data panel. Only the panels backed by failed requests show a temporary unavailable state.

## Verification

- `pnpm type-check`
- `pnpm test -- --runInBand`: 47 suites, 195 tests passed
- production `next build`
- named Playwright run with ClickHouse deliberately unreachable: homepage returned 200, Supabase member/corpus cards remained populated, and ClickHouse panels rendered local fallbacks
