### PR TITLE
Add production frontend readiness endpoint

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server'
+import { checkFrontendHealth } from '@/lib/frontendHealth'
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+export async function GET() {
+  const health = await checkFrontendHealth()
+  return NextResponse.json(health, {
+    status: health.status === 'healthy' ? 200 : 503,
+    headers: {
+      'Cache-Control': 'no-store',
+      'X-Robots-Tag': 'noindex, nofollow',
+    },
+  })
+}

--- a/src/lib/frontendHealth.test.ts
+++ b/src/lib/frontendHealth.test.ts
@@ -1,0 +1,71 @@
+import { checkFrontendHealth } from '@/lib/frontendHealth'
+
+describe('frontend readiness health', () => {
+  it('reports healthy when both bounded dependency probes succeed', async () => {
+    const fetchImpl = jest.fn(
+      async (_input: URL | RequestInfo, _init?: RequestInit) =>
+        new Response('{}', { status: 200 }),
+    )
+
+    const result = await checkFrontendHealth({
+      env: {
+        CLICKHOUSE_ANALYTICS_API_URL:
+          'https://analytics.community-archive.org/analytics',
+        NEXT_PUBLIC_SUPABASE_URL: 'https://example.supabase.co',
+        VERCEL_ENV: 'preview',
+        VERCEL_GIT_COMMIT_SHA: '0123456789abcdef',
+      },
+      fetchImpl,
+      timeoutMs: 100,
+    })
+
+    expect(result).toMatchObject({
+      build: { deploymentEnvironment: 'preview', gitSha: '0123456789ab' },
+      service: 'community-archive-web',
+      status: 'healthy',
+    })
+    expect(fetchImpl.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://example.supabase.co/auth/v1/health',
+      'https://analytics.community-archive.org/health',
+    ])
+  })
+
+  it('reports unhealthy without leaking dependency errors', async () => {
+    const fetchImpl = jest
+      .fn((_input: URL | RequestInfo, _init?: RequestInit) =>
+        Promise.resolve(new Response('{}')),
+      )
+      .mockResolvedValueOnce(new Response('{}', { status: 200 }))
+      .mockRejectedValueOnce(new Error('secret upstream response'))
+
+    const result = await checkFrontendHealth({
+      env: {
+        CLICKHOUSE_ANALYTICS_API_URL: 'https://analytics.example/analytics',
+        NEXT_PUBLIC_SUPABASE_URL: 'https://example.supabase.co',
+      },
+      fetchImpl,
+      timeoutMs: 100,
+    })
+
+    expect(result.status).toBe('unhealthy')
+    expect(result.dependencies.analyticsGateway.status).toBe('unavailable')
+    expect(JSON.stringify(result)).not.toContain('secret upstream response')
+  })
+
+  it('treats missing or malformed configuration as unavailable', async () => {
+    const fetchImpl = jest.fn(
+      (_input: URL | RequestInfo, _init?: RequestInit) =>
+        Promise.resolve(new Response('{}')),
+    )
+
+    const result = await checkFrontendHealth({
+      env: {
+        CLICKHOUSE_ANALYTICS_API_URL: 'not a url',
+      },
+      fetchImpl,
+    })
+
+    expect(result.status).toBe('unhealthy')
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/frontendHealth.ts
+++ b/src/lib/frontendHealth.ts
@@ -1,0 +1,112 @@
+type HealthDependency = {
+  latencyMs: number
+  status: 'ok' | 'unavailable'
+}
+
+export type FrontendHealthResult = {
+  build: {
+    deploymentEnvironment: string
+    gitSha: string
+  }
+  dependencies: {
+    analyticsGateway: HealthDependency
+    supabaseAuth: HealthDependency
+  }
+  service: 'community-archive-web'
+  status: 'healthy' | 'unhealthy'
+}
+
+type HealthEnvironment = {
+  [name: string]: string | undefined
+  CLICKHOUSE_ANALYTICS_API_URL?: string
+  NEXT_PUBLIC_SUPABASE_URL?: string
+  VERCEL_ENV?: string
+  VERCEL_GIT_COMMIT_SHA?: string
+}
+
+type CheckFrontendHealthOptions = {
+  env?: HealthEnvironment
+  fetchImpl?: typeof fetch
+  timeoutMs?: number
+}
+
+function elapsedMilliseconds(startedAt: number): number {
+  return Math.max(0, Math.round(performance.now() - startedAt))
+}
+
+async function checkDependency(
+  url: URL | undefined,
+  fetchImpl: typeof fetch,
+  timeoutMs: number,
+): Promise<HealthDependency> {
+  const startedAt = performance.now()
+  if (!url) {
+    return { latencyMs: elapsedMilliseconds(startedAt), status: 'unavailable' }
+  }
+
+  try {
+    const response = await fetchImpl(url, {
+      cache: 'no-store',
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(timeoutMs),
+    })
+    return {
+      latencyMs: elapsedMilliseconds(startedAt),
+      status: response.ok ? 'ok' : 'unavailable',
+    }
+  } catch {
+    return {
+      latencyMs: elapsedMilliseconds(startedAt),
+      status: 'unavailable',
+    }
+  }
+}
+
+function supabaseHealthUrl(value: string | undefined): URL | undefined {
+  if (!value) return undefined
+  try {
+    return new URL('/auth/v1/health', value)
+  } catch {
+    return undefined
+  }
+}
+
+function analyticsHealthUrl(value: string | undefined): URL | undefined {
+  if (!value) return undefined
+  try {
+    return new URL('/health', new URL(value).origin)
+  } catch {
+    return undefined
+  }
+}
+
+export async function checkFrontendHealth({
+  env = process.env,
+  fetchImpl = fetch,
+  timeoutMs = 2_500,
+}: CheckFrontendHealthOptions = {}): Promise<FrontendHealthResult> {
+  const [supabaseAuth, analyticsGateway] = await Promise.all([
+    checkDependency(
+      supabaseHealthUrl(env.NEXT_PUBLIC_SUPABASE_URL),
+      fetchImpl,
+      timeoutMs,
+    ),
+    checkDependency(
+      analyticsHealthUrl(env.CLICKHOUSE_ANALYTICS_API_URL),
+      fetchImpl,
+      timeoutMs,
+    ),
+  ])
+  const healthy =
+    supabaseAuth.status === 'ok' && analyticsGateway.status === 'ok'
+
+  return {
+    build: {
+      deploymentEnvironment: env.VERCEL_ENV || 'unknown',
+      gitSha: env.VERCEL_GIT_COMMIT_SHA?.slice(0, 12) || 'unknown',
+    },
+    dependencies: { analyticsGateway, supabaseAuth },
+    service: 'community-archive-web',
+    status: healthy ? 'healthy' : 'unhealthy',
+  }
+}

--- a/src/lib/monitoringHealthRoute.test.ts
+++ b/src/lib/monitoringHealthRoute.test.ts
@@ -1,0 +1,10 @@
+import { isMonitoringHealthRoute } from '@/lib/monitoringHealthRoute'
+
+describe('monitoring health route classification', () => {
+  it('allows only the exact readiness path', () => {
+    expect(isMonitoringHealthRoute('/api/health')).toBe(true)
+    expect(isMonitoringHealthRoute('/api/health/')).toBe(false)
+    expect(isMonitoringHealthRoute('/api/healthcheck')).toBe(false)
+    expect(isMonitoringHealthRoute('/api/search')).toBe(false)
+  })
+})

--- a/src/lib/monitoringHealthRoute.ts
+++ b/src/lib/monitoringHealthRoute.ts
@@ -1,0 +1,4 @@
+/** Exact machine-readable readiness route used by the production probe. */
+export function isMonitoringHealthRoute(pathname: string): boolean {
+  return pathname === '/api/health'
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,5 @@
 import { NextResponse, type NextRequest } from 'next/server'
+import { isMonitoringHealthRoute } from '@/lib/monitoringHealthRoute'
 import { createMiddlewareClient } from '@/utils/supabase'
 
 // ─── Constants ───────────────────────────────────────────────────────────────
@@ -240,6 +241,7 @@ export async function middleware(request: NextRequest) {
   const pageRoute = isPageRoute(pathname)
   const previewBot = isPreviewBot(ua)
   const publicDocumentationRoute = isPublicDocumentationRoute(pathname)
+  const monitoringHealthRoute = isMonitoringHealthRoute(pathname)
   // Server Action POSTs go to the page route URL (e.g. POST /admin) but with
   // `next-action` header and Accept: text/x-component — not text/html. The
   // browser-fingerprint check would otherwise 403 them and the client sees
@@ -248,7 +250,7 @@ export async function middleware(request: NextRequest) {
     request.method === 'POST' && request.headers.has('next-action')
 
   // ── Stage 1: Bot User-Agent Detection (all routes) ──────────────────────
-  if (!previewBot && !publicDocumentationRoute) {
+  if (!previewBot && !publicDocumentationRoute && !monitoringHealthRoute) {
     // Block empty or missing UA
     if (!ua || ua.trim().length === 0) {
       return blocked(403, 'Forbidden')
@@ -344,7 +346,11 @@ export async function middleware(request: NextRequest) {
   // endpoints don't fight with the cookie/challenge flow. But unprotected
   // /api routes are a cheap DoS target, so apply the in-memory IP bucket
   // (no cookie, no challenge) here. Tighter quota than page routes.
-  if (pathname.startsWith('/api/') && process.env.NODE_ENV !== 'development') {
+  if (
+    pathname.startsWith('/api/') &&
+    !monitoringHealthRoute &&
+    process.env.NODE_ENV !== 'development'
+  ) {
     const ip = getIp(request)
     const country = request.headers.get('x-vercel-ip-country') || ''
     const isSG = country === 'SG'


### PR DESCRIPTION
## Summary
- add an uncached `/api/health` readiness endpoint
- verify Supabase Auth and the ClickHouse analytics gateway concurrently with 2.5-second timeouts
- expose only bounded dependency status, latency, and build identity
- exempt only the exact health path from bot and API rate-limit middleware

## Validation
- `pnpm exec jest --selectProjects server --runInBand src/lib/frontendHealth.test.ts src/lib/monitoringHealthRoute.test.ts`
- `pnpm type-check`
- focused Prettier and diff checks

## Rollout
After the Vercel preview succeeds, merge/deploy this endpoint before switching the production blackbox probe from `robots.txt` to `/api/health`. A failed dependency returns 503 so Grafana can alert on real readiness.