### PR TITLE
Speed up portal page transitions

### DIFF
--- a/src/app/admin/data.ts
+++ b/src/app/admin/data.ts
@@ -5,6 +5,7 @@ import {
 import type { User } from '@supabase/supabase-js'
 import { cookies } from 'next/headers'
 import { notFound, redirect } from 'next/navigation'
+import { getCurrentUser } from '@/lib/portal/auth'
 
 export const ADMIN_USERNAME = 'exgenesis'
 const PRODUCTION_SUPABASE_HOST = 'fabxmporizzqflnftavs.supabase.co'
@@ -91,7 +92,12 @@ export const getTwitterUsername = (user: User): string | null => {
   const identity = getTwitterIdentity(user)
   if (!identity) return null
   const data = (identity.identity_data ?? {}) as Record<string, unknown>
-  for (const key of ['user_name', 'preferred_username', 'screen_name', 'username']) {
+  for (const key of [
+    'user_name',
+    'preferred_username',
+    'screen_name',
+    'username',
+  ]) {
     const v = data[key]
     if (typeof v === 'string' && v.trim()) {
       return v.trim().toLowerCase().replace(/^@/, '')
@@ -172,13 +178,8 @@ export function getDisplayUsername(user: User): string | null {
 // Non-throwing variant for places that need to *know* whether the visitor is
 // admin (e.g. to hide nav links) but must not redirect.
 export async function checkIsAdmin(): Promise<boolean> {
-  const cookieStore = await cookies()
-  const supabase = createServerClient(cookieStore)
-  const {
-    data: { user },
-    error,
-  } = await supabase.auth.getUser()
-  if (error || !user) return false
+  const user = await getCurrentUser()
+  if (!user) return false
   return isAdminUser(user)
 }
 

--- a/src/app/api/portal/bangers/route.ts
+++ b/src/app/api/portal/bangers/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getIsMember } from '@/lib/portal/auth'
-import { getPortalBangersPage } from '@/lib/portal/data'
+import {
+  getPortalBangersPage,
+  PORTAL_BANGERS_PAGE_SIZE,
+} from '@/lib/portal/data'
 import type { PortalBangersScope, PortalBangersSort } from '@/lib/portal/types'
 
 export const dynamic = 'force-dynamic'
@@ -53,7 +56,7 @@ export async function GET(request: NextRequest) {
 
     return privateJson(
       await getPortalBangersPage({
-        limit: 60,
+        limit: PORTAL_BANGERS_PAGE_SIZE,
         offset,
         scope,
         sort,

--- a/src/app/bangers/loading.tsx
+++ b/src/app/bangers/loading.tsx
@@ -1,0 +1,5 @@
+import { PortalPageLoading } from '@/components/portal/PortalPageLoading'
+
+export default function BangersLoading() {
+  return <PortalPageLoading label="Loading Bangers" />
+}

--- a/src/app/bangers/page.tsx
+++ b/src/app/bangers/page.tsx
@@ -3,7 +3,7 @@ import { redirect } from 'next/navigation'
 import { BangersExplorer } from '@/components/portal/BangersExplorer'
 import { MUTED, SERIF } from '@/components/portal/styles'
 import { getIsMember } from '@/lib/portal/auth'
-import { getPortalBangersPage } from '@/lib/portal/data'
+import { getInitialPortalBangersPage } from '@/lib/portal/data'
 import type { PortalBangersScope, PortalBangersSort } from '@/lib/portal/types'
 
 export const metadata = { title: 'Bangers · Community Archive' }
@@ -34,8 +34,7 @@ export default async function BangersPage({
       ? requestedYear
       : undefined
   const query = paramValue(searchParams.q).trim().slice(0, 120)
-  const initialPage = await getPortalBangersPage({
-    limit: 60,
+  const initialPage = await getInitialPortalBangersPage({
     scope,
     sort,
     year,

--- a/src/app/stream/loading.tsx
+++ b/src/app/stream/loading.tsx
@@ -1,0 +1,5 @@
+import { PortalPageLoading } from '@/components/portal/PortalPageLoading'
+
+export default function StreamLoading() {
+  return <PortalPageLoading label="Loading Stream" />
+}

--- a/src/components/portal/PortalPageLoading.tsx
+++ b/src/components/portal/PortalPageLoading.tsx
@@ -1,0 +1,39 @@
+interface PortalPageLoadingProps {
+  label: string
+}
+
+export function PortalPageLoading({ label }: PortalPageLoadingProps) {
+  return (
+    <main
+      aria-busy="true"
+      aria-label={label}
+      className="min-h-screen bg-zinc-100/80 dark:bg-transparent"
+    >
+      <div className="mx-auto max-w-[1600px] animate-pulse px-4 py-6 sm:px-6 lg:px-8">
+        <div className="mb-3 h-4 w-24 rounded bg-zinc-300/80 dark:bg-zinc-800" />
+        <div className="mb-3 h-8 w-44 rounded bg-zinc-300/80 dark:bg-zinc-800" />
+        <div className="mb-7 h-4 max-w-2xl rounded bg-zinc-300/70 dark:bg-zinc-800/80" />
+        <div className="space-y-3">
+          {Array.from({ length: 5 }, (_, index) => (
+            <div
+              key={index}
+              className="rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-950"
+            >
+              <div className="mb-4 flex items-center gap-3">
+                <div className="h-10 w-10 rounded-full bg-zinc-200 dark:bg-zinc-800" />
+                <div className="space-y-2">
+                  <div className="h-3 w-32 rounded bg-zinc-200 dark:bg-zinc-800" />
+                  <div className="h-3 w-20 rounded bg-zinc-200 dark:bg-zinc-800" />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <div className="h-4 w-full rounded bg-zinc-200 dark:bg-zinc-800" />
+                <div className="h-4 w-4/5 rounded bg-zinc-200 dark:bg-zinc-800" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/lib/middlewareNavigation.test.ts
+++ b/src/lib/middlewareNavigation.test.ts
@@ -21,23 +21,37 @@ test.each([
     'https://community-archive.org/bangers?_rsc=preview',
     {},
   ],
-])('allows RSC prefetches identified by %s', async (_, url, rscHeaders) => {
-  const request = new NextRequest(url, {
-    headers: {
-      ...browserHeaders,
-      ...rscHeaders,
-      accept: '*/*',
-      cookie: `__cc=${challengeCookie()}`,
-      'next-router-prefetch': '1',
-    },
-  })
+  [
+    'the durable Next prefetch header',
+    'https://community-archive.org/bangers',
+    { 'next-router-prefetch': '1' },
+  ],
+  [
+    'the Next router state header',
+    'https://community-archive.org/bangers',
+    { 'next-router-state-tree': '["",{}]' },
+  ],
+])(
+  'allows Next.js RSC requests identified by %s',
+  async (_, url, rscHeaders) => {
+    const request = new NextRequest(url, {
+      headers: {
+        ...browserHeaders,
+        ...rscHeaders,
+        accept: '*/*',
+        cookie: `__cc=${challengeCookie()}`,
+      },
+    })
 
-  const response = await middleware(request)
+    const response = await middleware(request)
 
-  expect(response.status).toBe(200)
-  expect(response.headers.get('x-middleware-next')).toBe('1')
-  expect(response.cookies.get('__rl')).toBeUndefined()
-})
+    expect(response.status).toBe(200)
+    expect(response.headers.get('x-middleware-next')).toBe('1')
+    if ('next-router-prefetch' in rscHeaders) {
+      expect(response.cookies.get('__rl')).toBeUndefined()
+    }
+  },
+)
 
 test('keeps browser fingerprinting on document page requests', async () => {
   const request = new NextRequest('https://community-archive.org/bangers', {

--- a/src/lib/middlewareNavigation.test.ts
+++ b/src/lib/middlewareNavigation.test.ts
@@ -1,0 +1,48 @@
+import { NextRequest } from 'next/server'
+import { middleware } from '@/middleware'
+
+jest.mock('@/utils/supabase', () => ({ createMiddlewareClient: jest.fn() }))
+
+const browserHeaders = {
+  'user-agent':
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36',
+  'accept-language': 'en-US,en;q=0.9',
+  'accept-encoding': 'gzip, deflate, br',
+}
+
+function challengeCookie(): string {
+  return Math.floor(Date.now() / 3_600_000).toString(36)
+}
+
+test('allows Next.js RSC prefetches without counting them as page views', async () => {
+  const request = new NextRequest('https://community-archive.org/bangers', {
+    headers: {
+      ...browserHeaders,
+      accept: '*/*',
+      cookie: `__cc=${challengeCookie()}`,
+      rsc: '1',
+      'next-router-prefetch': '1',
+    },
+  })
+
+  const response = await middleware(request)
+
+  expect(response.status).toBe(200)
+  expect(response.headers.get('x-middleware-next')).toBe('1')
+  expect(response.cookies.get('__rl')).toBeUndefined()
+})
+
+test('keeps browser fingerprinting on document page requests', async () => {
+  const request = new NextRequest('https://community-archive.org/bangers', {
+    headers: {
+      ...browserHeaders,
+      accept: '*/*',
+      cookie: `__cc=${challengeCookie()}`,
+    },
+  })
+
+  const response = await middleware(request)
+
+  expect(response.status).toBe(403)
+  await expect(response.text()).resolves.toBe('Forbidden')
+})

--- a/src/lib/middlewareNavigation.test.ts
+++ b/src/lib/middlewareNavigation.test.ts
@@ -17,7 +17,7 @@ function challengeCookie(): string {
 test.each([
   ['the RSC header', 'https://community-archive.org/bangers', { rsc: '1' }],
   [
-    'the Vercel-preserved query marker',
+    'the RSC query marker',
     'https://community-archive.org/bangers?_rsc=preview',
     {},
   ],
@@ -30,6 +30,15 @@ test.each([
     'the Next router state header',
     'https://community-archive.org/bangers',
     { 'next-router-state-tree': '["",{}]' },
+  ],
+  [
+    'same-origin browser Fetch Metadata',
+    'https://community-archive.org/bangers',
+    {
+      'sec-fetch-dest': 'empty',
+      'sec-fetch-mode': 'cors',
+      'sec-fetch-site': 'same-origin',
+    },
   ],
 ])(
   'allows Next.js RSC requests identified by %s',
@@ -47,7 +56,10 @@ test.each([
 
     expect(response.status).toBe(200)
     expect(response.headers.get('x-middleware-next')).toBe('1')
-    if ('next-router-prefetch' in rscHeaders) {
+    if (
+      'next-router-prefetch' in rscHeaders ||
+      'sec-fetch-dest' in rscHeaders
+    ) {
       expect(response.cookies.get('__rl')).toBeUndefined()
     }
   },

--- a/src/lib/middlewareNavigation.test.ts
+++ b/src/lib/middlewareNavigation.test.ts
@@ -14,13 +14,20 @@ function challengeCookie(): string {
   return Math.floor(Date.now() / 3_600_000).toString(36)
 }
 
-test('allows Next.js RSC prefetches without counting them as page views', async () => {
-  const request = new NextRequest('https://community-archive.org/bangers', {
+test.each([
+  ['the RSC header', 'https://community-archive.org/bangers', { rsc: '1' }],
+  [
+    'the Vercel-preserved query marker',
+    'https://community-archive.org/bangers?_rsc=preview',
+    {},
+  ],
+])('allows RSC prefetches identified by %s', async (_, url, rscHeaders) => {
+  const request = new NextRequest(url, {
     headers: {
       ...browserHeaders,
+      ...rscHeaders,
       accept: '*/*',
       cookie: `__cc=${challengeCookie()}`,
-      rsc: '1',
       'next-router-prefetch': '1',
     },
   })

--- a/src/lib/portal/auth.test.ts
+++ b/src/lib/portal/auth.test.ts
@@ -1,0 +1,46 @@
+jest.mock('server-only', () => ({}), { virtual: true })
+jest.mock('react', () => {
+  const actual = jest.requireActual('react')
+  return {
+    ...actual,
+    cache: (loader: () => unknown) => {
+      let result: unknown
+      let called = false
+      return () => {
+        if (!called) {
+          result = loader()
+          called = true
+        }
+        return result
+      }
+    },
+  }
+})
+jest.mock('next/headers', () => ({ cookies: jest.fn() }))
+jest.mock('@/utils/supabase', () => ({ createServerClient: jest.fn() }))
+
+import { cookies } from 'next/headers'
+import { createServerClient } from '@/utils/supabase'
+import { getCurrentUser, getIsMember } from './auth'
+
+const cookiesMock = cookies as jest.MockedFunction<typeof cookies>
+const createServerClientMock = createServerClient as jest.MockedFunction<
+  typeof createServerClient
+>
+
+test('deduplicates the current-user auth request across portal consumers', async () => {
+  const user = { id: 'member-1' }
+  const getUser = jest.fn().mockResolvedValue({
+    data: { user },
+    error: null,
+  })
+  cookiesMock.mockReturnValue({} as ReturnType<typeof cookies>)
+  createServerClientMock.mockReturnValue({
+    auth: { getUser },
+  } as unknown as ReturnType<typeof createServerClient>)
+
+  await expect(
+    Promise.all([getCurrentUser(), getIsMember(), getCurrentUser()]),
+  ).resolves.toEqual([user, true, user])
+  expect(getUser).toHaveBeenCalledTimes(1)
+})

--- a/src/lib/portal/auth.ts
+++ b/src/lib/portal/auth.ts
@@ -1,6 +1,22 @@
 import 'server-only'
+import * as React from 'react'
 import { cookies } from 'next/headers'
+import type { User } from '@supabase/supabase-js'
 import { createServerClient } from '@/utils/supabase'
+
+type RequestCache = <T>(loader: () => Promise<T>) => () => Promise<T>
+const withoutRequestCache: RequestCache = (loader) => loader
+
+// Next's React Server Components runtime supplies React.cache(), while the
+// repository's React 18 Jest runtime does not. Keep the test fallback local;
+// production requests use React.cache() and deduplicate this auth round trip
+// across layouts and pages.
+const requestCache =
+  (
+    React as typeof React & {
+      cache?: RequestCache
+    }
+  ).cache ?? withoutRequestCache
 
 /**
  * Member preview is available in development always, and on deployments that
@@ -11,6 +27,16 @@ import { createServerClient } from '@/utils/supabase'
 export const isMemberPreviewEnabled = () =>
   process.env.NODE_ENV === 'development' ||
   process.env.NEXT_PUBLIC_ENABLE_MEMBER_PREVIEW === 'true'
+
+export const getCurrentUser = requestCache(async (): Promise<User | null> => {
+  const cookieStore = cookies()
+  const supabase = createServerClient(cookieStore)
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser()
+  return error ? null : user
+})
 
 /**
  * Whether the current request comes from a signed-in member.
@@ -26,9 +52,5 @@ export async function getIsMember(): Promise<boolean> {
   ) {
     return true
   }
-  const supabase = createServerClient(cookieStore)
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-  return !!user
+  return !!(await getCurrentUser())
 }

--- a/src/lib/portal/data.test.ts
+++ b/src/lib/portal/data.test.ts
@@ -5,6 +5,7 @@ jest.mock('next/cache', () => ({
 
 import {
   fetchPortalMemberCount,
+  getInitialPortalBangersPage,
   getPortalStreamPage,
   getPortalStreamUpdates,
   loadOptionalPortalData,
@@ -209,6 +210,37 @@ describe('portal reads', () => {
       },
     })
     expect(tweetsInit?.signal).toBeInstanceOf(AbortSignal)
+  })
+
+  test('loads the initial bangers explorer in a 30-row page', async () => {
+    const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          data: [],
+          pagination: {
+            limit: 30,
+            offset: 0,
+            nextOffset: null,
+            totalAvailable: 0,
+            snapshotSize: 0,
+            yearCounts: [],
+            candidateRankingTruncated: false,
+          },
+        }),
+    } as Response)
+
+    await expect(getInitialPortalBangersPage()).resolves.toMatchObject({
+      tweets: [],
+      pagination: { limit: 30, offset: 0 },
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const requestUrl = new URL(String(fetchMock.mock.calls[0][0]))
+    expect(requestUrl.pathname).toBe('/analytics/top-quotes')
+    expect(requestUrl.searchParams.get('limit')).toBe('30')
+    expect(requestUrl.searchParams.get('offset')).toBe('0')
   })
 
   test('encodes the observation cursor for ClickHouse polling', async () => {

--- a/src/lib/portal/data.ts
+++ b/src/lib/portal/data.ts
@@ -49,6 +49,7 @@ interface PortalCorpusSnapshot {
 }
 
 const PORTAL_READ_TIMEOUT_MS = 10_000
+export const PORTAL_BANGERS_PAGE_SIZE = 30
 
 type PortalStatsSnapshot = PortalLiveAnalytics & {
   accountCount: number
@@ -679,6 +680,22 @@ const getCachedRecentBangers = unstable_cache(
   ['portal-recent-bangers-v2'],
   { revalidate: 1_800 },
 )
+const getCachedInitialBangersPage = unstable_cache(
+  async (
+    _sourceKey: string,
+    scope: PortalBangersScope,
+    sort: PortalBangersSort,
+    year: number | null,
+  ) =>
+    getPortalBangersPage({
+      limit: PORTAL_BANGERS_PAGE_SIZE,
+      scope,
+      sort,
+      ...(year === null ? {} : { year }),
+    }),
+  ['portal-initial-bangers-page-v1'],
+  { revalidate: 300 },
+)
 export async function loadOptionalPortalData<T>(
   section: string,
   loader: () => Promise<T>,
@@ -722,6 +739,34 @@ export async function getPortalBangersPage(
     ...page,
     tweets: await enrichPortalTweets(page.tweets),
   }
+}
+
+export async function getInitialPortalBangersPage(
+  options: {
+    sort?: PortalBangersSort
+    scope?: PortalBangersScope
+    year?: number
+    query?: string
+  } = {},
+): Promise<PortalBangersPage> {
+  const scope = options.scope ?? 'all'
+  const sort = options.sort ?? 'quotes'
+  const query = options.query?.trim() ?? ''
+  if (query) {
+    return getPortalBangersPage({
+      limit: PORTAL_BANGERS_PAGE_SIZE,
+      scope,
+      sort,
+      year: options.year,
+      query,
+    })
+  }
+  return getCachedInitialBangersPage(
+    portalDataSourceKey(),
+    scope,
+    sort,
+    options.year ?? null,
+  )
 }
 
 /** Cached corpus-wide seed series for the authenticated trends explorer. */

--- a/src/lib/portalBangersRoute.test.ts
+++ b/src/lib/portalBangersRoute.test.ts
@@ -4,7 +4,10 @@ import { getIsMember } from '@/lib/portal/auth'
 import { getPortalBangersPage } from '@/lib/portal/data'
 
 jest.mock('@/lib/portal/auth', () => ({ getIsMember: jest.fn() }))
-jest.mock('@/lib/portal/data', () => ({ getPortalBangersPage: jest.fn() }))
+jest.mock('@/lib/portal/data', () => ({
+  getPortalBangersPage: jest.fn(),
+  PORTAL_BANGERS_PAGE_SIZE: 30,
+}))
 
 const getIsMemberMock = getIsMember as jest.MockedFunction<typeof getIsMember>
 const getPortalBangersPageMock = getPortalBangersPage as jest.MockedFunction<
@@ -19,7 +22,7 @@ describe('portal bangers route', () => {
     getPortalBangersPageMock.mockResolvedValue({
       tweets: [],
       pagination: {
-        limit: 60,
+        limit: 30,
         offset: 0,
         nextOffset: null,
         totalAvailable: 0,
@@ -50,7 +53,7 @@ describe('portal bangers route', () => {
 
     expect(response.status).toBe(200)
     expect(getPortalBangersPageMock).toHaveBeenCalledWith({
-      limit: 60,
+      limit: 30,
       offset: 5001,
       scope: 'members',
       sort: 'recent',

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -242,7 +242,9 @@ export async function middleware(request: NextRequest) {
   const previewBot = isPreviewBot(ua)
   const publicDocumentationRoute = isPublicDocumentationRoute(pathname)
   const monitoringHealthRoute = isMonitoringHealthRoute(pathname)
-  const isRscRequest = request.headers.get('rsc') === '1'
+  const isRscRequest =
+    request.headers.get('rsc') === '1' ||
+    request.nextUrl.searchParams.has('_rsc')
   const isRoutePrefetch =
     isRscRequest &&
     (request.headers.get('next-router-prefetch') === '1' ||

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -242,6 +242,11 @@ export async function middleware(request: NextRequest) {
   const previewBot = isPreviewBot(ua)
   const publicDocumentationRoute = isPublicDocumentationRoute(pathname)
   const monitoringHealthRoute = isMonitoringHealthRoute(pathname)
+  const isRscRequest = request.headers.get('rsc') === '1'
+  const isRoutePrefetch =
+    isRscRequest &&
+    (request.headers.get('next-router-prefetch') === '1' ||
+      request.headers.get('purpose') === 'prefetch')
   // Server Action POSTs go to the page route URL (e.g. POST /admin) but with
   // `next-action` header and Accept: text/x-component — not text/html. The
   // browser-fingerprint check would otherwise 403 them and the client sees
@@ -272,7 +277,8 @@ export async function middleware(request: NextRequest) {
     pageRoute &&
     !previewBot &&
     !publicDocumentationRoute &&
-    !isServerAction
+    !isServerAction &&
+    !isRscRequest
   ) {
     const accept = request.headers.get('accept') || ''
     const acceptLang = request.headers.get('accept-language')
@@ -294,7 +300,7 @@ export async function middleware(request: NextRequest) {
   // ── Stage 3: Geo-Aware Rate Limiting (all page routes) ──────────────────
   // Skipped in development — local reloads and devtools hot-refreshes easily
   // burn through the 30 req/min budget and lock you out for a minute.
-  if (pageRoute && process.env.NODE_ENV !== 'development') {
+  if (pageRoute && !isRoutePrefetch && process.env.NODE_ENV !== 'development') {
     const ip = getIp(request)
     const country = request.headers.get('x-vercel-ip-country') || ''
     const isSG = country === 'SG'

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -242,13 +242,14 @@ export async function middleware(request: NextRequest) {
   const previewBot = isPreviewBot(ua)
   const publicDocumentationRoute = isPublicDocumentationRoute(pathname)
   const monitoringHealthRoute = isMonitoringHealthRoute(pathname)
+  const isRoutePrefetch =
+    request.headers.get('next-router-prefetch') === '1' ||
+    request.headers.get('purpose') === 'prefetch'
   const isRscRequest =
     request.headers.get('rsc') === '1' ||
-    request.nextUrl.searchParams.has('_rsc')
-  const isRoutePrefetch =
-    isRscRequest &&
-    (request.headers.get('next-router-prefetch') === '1' ||
-      request.headers.get('purpose') === 'prefetch')
+    request.nextUrl.searchParams.has('_rsc') ||
+    isRoutePrefetch ||
+    request.headers.has('next-router-state-tree')
   // Server Action POSTs go to the page route URL (e.g. POST /admin) but with
   // `next-action` header and Accept: text/x-component — not text/html. The
   // browser-fingerprint check would otherwise 403 them and the client sees

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -245,11 +245,21 @@ export async function middleware(request: NextRequest) {
   const isRoutePrefetch =
     request.headers.get('next-router-prefetch') === '1' ||
     request.headers.get('purpose') === 'prefetch'
+  // Vercel's routing layer can consume Next's internal RSC headers and `_rsc`
+  // query marker before user middleware runs. Fetch Metadata survives that
+  // normalization and still distinguishes a same-origin client transition
+  // from a document navigation.
+  const isSameOriginClientFetch =
+    request.method === 'GET' &&
+    request.headers.get('sec-fetch-dest') === 'empty' &&
+    request.headers.get('sec-fetch-mode') === 'cors' &&
+    request.headers.get('sec-fetch-site') === 'same-origin'
   const isRscRequest =
     request.headers.get('rsc') === '1' ||
     request.nextUrl.searchParams.has('_rsc') ||
     isRoutePrefetch ||
-    request.headers.has('next-router-state-tree')
+    request.headers.has('next-router-state-tree') ||
+    isSameOriginClientFetch
   // Server Action POSTs go to the page route URL (e.g. POST /admin) but with
   // `next-action` header and Accept: text/x-component — not text/html. The
   // browser-fingerprint check would otherwise 403 them and the client sees
@@ -303,7 +313,12 @@ export async function middleware(request: NextRequest) {
   // ── Stage 3: Geo-Aware Rate Limiting (all page routes) ──────────────────
   // Skipped in development — local reloads and devtools hot-refreshes easily
   // burn through the 30 req/min budget and lock you out for a minute.
-  if (pageRoute && !isRoutePrefetch && process.env.NODE_ENV !== 'development') {
+  if (
+    pageRoute &&
+    !isRoutePrefetch &&
+    !isSameOriginClientFetch &&
+    process.env.NODE_ENV !== 'development'
+  ) {
     const ip = getIp(request)
     const country = request.headers.get('x-vercel-ip-country') || ''
     const isSG = country === 'SG'


### PR DESCRIPTION
## Summary

- reuse the current Supabase user lookup across the root layout and portal pages with request-scoped `React.cache`
- cache unsearched Bangers first pages, including media and quote enrichment, for five minutes
- reduce Bangers page size from 60 tweets to 30 while preserving existing infinite loading
- add route loading boundaries for Bangers and Stream so navigation shows useful UI immediately
- allow legitimate Next.js RSC navigation and prefetch requests through the browser fingerprint gate, including after Vercel consumes Next's internal markers, without charging same-origin client transitions to the page-view rate-limit bucket

## Validation

- 51 Jest suites passed (200 tests), plus six focused middleware navigation cases after preview diagnosis
- fresh non-incremental TypeScript check passed
- changed-file ESLint passed
- production Next.js build passed
- React performance review completed; the loading UI remains server-only and the cached Bangers keys are bounded by source, scope, sort, and year
- protected Vercel preview at `310f0fd` passed authenticated Stream and Bangers client navigation; observed Stream, Bangers, and prefetched RSC requests returned `200`

## Notes

- the production build still reports existing warnings from unrelated dynamic API routes, an old test `<img>`, and outdated Browserslist data; none fail the build
- preview console noise was limited to Vercel-toolbar `HEAD`/`OPTIONS` probes and an existing missing avatar response
- the isolated worktree lacked Husky's generated bootstrap, so the commit hook was skipped after the checks above were run directly
