### PR TITLE
Add recent Bangers filters and masonry layout

### DIFF
--- a/src/app/api/portal/bangers/route.ts
+++ b/src/app/api/portal/bangers/route.ts
@@ -4,7 +4,11 @@ import {
   getPortalBangersPage,
   PORTAL_BANGERS_PAGE_SIZE,
 } from '@/lib/portal/data'
-import type { PortalBangersScope, PortalBangersSort } from '@/lib/portal/types'
+import type {
+  PortalBangersPeriod,
+  PortalBangersScope,
+  PortalBangersSort,
+} from '@/lib/portal/types'
 
 export const dynamic = 'force-dynamic'
 export const maxDuration = 60
@@ -39,14 +43,23 @@ export async function GET(request: NextRequest) {
   try {
     const params = new URL(request.url).searchParams
     const offset = boundedInteger(params.get('offset'), 0, 0, 1_000_000)
-    const year = params.has('year')
-      ? boundedInteger(
-          params.get('year'),
-          new Date().getUTCFullYear(),
-          2006,
-          new Date().getUTCFullYear() + 1,
-        )
-      : undefined
+    const periodValue = params.get('period')
+    if (periodValue && periodValue !== 'today' && periodValue !== 'week') {
+      throw new Error('Invalid bangers period')
+    }
+    const period: PortalBangersPeriod | undefined =
+      periodValue === 'today' || periodValue === 'week'
+        ? periodValue
+        : undefined
+    const year =
+      !period && params.has('year')
+        ? boundedInteger(
+            params.get('year'),
+            new Date().getUTCFullYear(),
+            2006,
+            new Date().getUTCFullYear() + 1,
+          )
+        : undefined
     const scope: PortalBangersScope =
       params.get('scope') === 'members' ? 'members' : 'all'
     const sort: PortalBangersSort =
@@ -61,6 +74,7 @@ export async function GET(request: NextRequest) {
         scope,
         sort,
         year,
+        period,
         query,
       }),
     )

--- a/src/app/bangers/page.tsx
+++ b/src/app/bangers/page.tsx
@@ -4,7 +4,11 @@ import { BangersExplorer } from '@/components/portal/BangersExplorer'
 import { MUTED, SERIF } from '@/components/portal/styles'
 import { getIsMember } from '@/lib/portal/auth'
 import { getInitialPortalBangersPage } from '@/lib/portal/data'
-import type { PortalBangersScope, PortalBangersSort } from '@/lib/portal/types'
+import type {
+  PortalBangersPeriod,
+  PortalBangersScope,
+  PortalBangersSort,
+} from '@/lib/portal/types'
 
 export const metadata = { title: 'Bangers · Community Archive' }
 export const maxDuration = 60
@@ -25,6 +29,9 @@ export default async function BangersPage({
     paramValue(searchParams.sort) === 'recent' ? 'recent' : 'quotes'
   const scope: PortalBangersScope =
     paramValue(searchParams.scope) === 'members' ? 'members' : 'all'
+  const periodValue = paramValue(searchParams.period)
+  const period: PortalBangersPeriod | undefined =
+    periodValue === 'today' || periodValue === 'week' ? periodValue : undefined
   const requestedYear = Number(paramValue(searchParams.year))
   const currentYear = new Date().getUTCFullYear()
   const year =
@@ -37,7 +44,7 @@ export default async function BangersPage({
   const initialPage = await getInitialPortalBangersPage({
     scope,
     sort,
-    year,
+    ...(period ? { period } : { year }),
     query,
   })
 
@@ -69,11 +76,13 @@ export default async function BangersPage({
           </p>
         </header>
         <BangersExplorer
-          key={`${scope}:${sort}:${year ?? 'all'}:${query}`}
+          key={`${scope}:${sort}:${period ?? year ?? 'all'}:${query}`}
           initialPage={initialPage}
           scope={scope}
           sort={sort}
-          year={year}
+          currentYear={currentYear}
+          year={period ? undefined : year}
+          period={period}
           initialQuery={query}
           initialView={
             paramValue(searchParams.view) === 'years' ? 'years' : 'list'

--- a/src/components/portal/BangersExplorer.test.tsx
+++ b/src/components/portal/BangersExplorer.test.tsx
@@ -7,7 +7,11 @@ import {
   within,
 } from '@testing-library/react'
 import { BangersExplorer } from './BangersExplorer'
-import type { PortalBangersPage, PortalTweet } from '@/lib/portal/types'
+import type {
+  PortalBangersPage,
+  PortalBangersPeriod,
+  PortalTweet,
+} from '@/lib/portal/types'
 
 const push = jest.fn()
 jest.mock('next/navigation', () => ({ useRouter: () => ({ push }) }))
@@ -80,9 +84,15 @@ function page(
   }
 }
 
-function renderExplorer(initialPage = page()) {
+function renderExplorer(initialPage = page(), period?: PortalBangersPeriod) {
   return render(
-    <BangersExplorer initialPage={initialPage} scope="all" sort="quotes" />,
+    <BangersExplorer
+      initialPage={initialPage}
+      scope="all"
+      sort="quotes"
+      currentYear={2026}
+      period={period}
+    />,
   )
 }
 
@@ -123,6 +133,26 @@ describe('BangersExplorer', () => {
     ).toHaveAttribute('href', '/bangers?scope=members')
     expect(screen.queryByText('Likes')).not.toBeInTheDocument()
     expect(screen.queryByText('Reposts')).not.toBeInTheDocument()
+    expect(screen.getByTestId('bangers-masonry')).toHaveClass(
+      'columns-1',
+      'lg:columns-2',
+    )
+  })
+
+  test('keeps today selected across ranking and author links', () => {
+    renderExplorer(page(), 'today')
+
+    expect(
+      screen.getByRole('combobox', { name: 'Filter by time' }),
+    ).toHaveTextContent('Today')
+    expect(screen.getByRole('link', { name: 'Most recent' })).toHaveAttribute(
+      'href',
+      '/bangers?sort=recent&period=today',
+    )
+    expect(
+      screen.getByRole('link', { name: 'Archive members' }),
+    ).toHaveAttribute('href', '/bangers?scope=members&period=today')
+    expect(screen.getByText(/from today/)).toBeVisible()
   })
 
   test('searches names and text and can clear the result', () => {

--- a/src/components/portal/BangersExplorer.test.tsx
+++ b/src/components/portal/BangersExplorer.test.tsx
@@ -114,11 +114,22 @@ describe('BangersExplorer', () => {
   test('offers only banger-relevant ranking and author scopes', () => {
     renderExplorer()
 
+    const orderedMasonryItems = Array.from(
+      screen
+        .getByTestId('bangers-masonry')
+        .querySelectorAll<HTMLElement>('[data-masonry-order]'),
+    ).sort(
+      (left, right) => Number(left.style.order) - Number(right.style.order),
+    )
     expect(
-      screen.getAllByTestId('tweet-row').map((row) => row.textContent),
+      orderedMasonryItems.map(
+        (item) => within(item).getByTestId('tweet-row').textContent,
+      ),
     ).toEqual(['Another older thought', 'Older favorite', 'Newest thought'])
     expect(
-      screen.getAllByTestId('tweet-row').map((row) => row.dataset.rank),
+      orderedMasonryItems.map(
+        (item) => within(item).getByTestId('tweet-row').dataset.rank,
+      ),
     ).toEqual(['1', '2', '3'])
     expect(screen.getByRole('link', { name: 'Most quoted' })).toHaveAttribute(
       'aria-current',
@@ -134,9 +145,23 @@ describe('BangersExplorer', () => {
     expect(screen.queryByText('Likes')).not.toBeInTheDocument()
     expect(screen.queryByText('Reposts')).not.toBeInTheDocument()
     expect(screen.getByTestId('bangers-masonry')).toHaveClass(
-      'columns-1',
-      'lg:columns-2',
+      'flex',
+      'lg:grid',
+      'lg:grid-cols-2',
     )
+    expect(
+      within(screen.getByTestId('bangers-masonry-column-0'))
+        .getAllByTestId('tweet-row')
+        .map((row) => row.dataset.rank),
+    ).toEqual(['1', '3'])
+    expect(
+      within(screen.getByTestId('bangers-masonry-column-1'))
+        .getAllByTestId('tweet-row')
+        .map((row) => row.dataset.rank),
+    ).toEqual(['2'])
+    expect(
+      orderedMasonryItems.map((item) => item.dataset.masonryOrder),
+    ).toEqual(['1', '2', '3'])
   })
 
   test('keeps today selected across ranking and author links', () => {

--- a/src/components/portal/BangersExplorer.tsx
+++ b/src/components/portal/BangersExplorer.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/components/ui/select'
 import type {
   PortalBangersPage,
+  PortalBangersPeriod,
   PortalBangersScope,
   PortalBangersSort,
   PortalTweet,
@@ -26,7 +27,9 @@ interface BangersExplorerProps {
   initialPage: PortalBangersPage
   scope: PortalBangersScope
   sort: PortalBangersSort
+  currentYear: number
   year?: number
+  period?: PortalBangersPeriod
   initialQuery?: string
   initialView?: BangersView
 }
@@ -64,12 +67,14 @@ function bangersHref({
   scope,
   sort,
   year,
+  period,
   view,
 }: {
   query: string
   scope: PortalBangersScope
   sort: PortalBangersSort
   year?: number
+  period?: PortalBangersPeriod
   view: BangersView
 }): string {
   const params = new URLSearchParams()
@@ -77,7 +82,8 @@ function bangersHref({
   if (trimmedQuery) params.set('q', trimmedQuery)
   if (scope === 'members') params.set('scope', scope)
   if (sort === 'recent') params.set('sort', sort)
-  if (year !== undefined) params.set('year', String(year))
+  if (period) params.set('period', period)
+  else if (year !== undefined) params.set('year', String(year))
   if (view === 'years') params.set('view', view)
   const search = params.toString()
   return `/bangers${search ? `?${search}` : ''}`
@@ -89,12 +95,14 @@ function apiHref({
   scope,
   sort,
   year,
+  period,
 }: {
   offset: number
   query: string
   scope: PortalBangersScope
   sort: PortalBangersSort
   year?: number
+  period?: PortalBangersPeriod
 }): string {
   const params = new URLSearchParams({
     offset: String(offset),
@@ -103,7 +111,8 @@ function apiHref({
   })
   const trimmedQuery = query.trim()
   if (trimmedQuery) params.set('q', trimmedQuery)
-  if (year !== undefined) params.set('year', String(year))
+  if (period) params.set('period', period)
+  else if (year !== undefined) params.set('year', String(year))
   return `/api/portal/bangers?${params.toString()}`
 }
 
@@ -111,7 +120,9 @@ export function BangersExplorer({
   initialPage,
   scope,
   sort,
+  currentYear,
   year,
+  period,
   initialQuery = '',
   initialView = 'list',
 }: BangersExplorerProps) {
@@ -130,8 +141,17 @@ export function BangersExplorer({
   const availableYears = useMemo(() => {
     const years = page.pagination.yearCounts.map(({ year }) => year)
     if (year !== undefined && !years.includes(year)) years.push(year)
+    if (period) {
+      for (
+        let availableYear = currentYear;
+        availableYear >= 2006;
+        availableYear -= 1
+      ) {
+        if (!years.includes(availableYear)) years.push(availableYear)
+      }
+    }
     return years.sort((left, right) => right - left)
-  }, [page.pagination.yearCounts, year])
+  }, [currentYear, page.pagination.yearCounts, period, year])
   const yearTotals = useMemo(
     () =>
       new Map(
@@ -186,7 +206,7 @@ export function BangersExplorer({
 
       try {
         const response = await fetch(
-          apiHref({ offset, query: requestQuery, scope, sort, year }),
+          apiHref({ offset, query: requestQuery, scope, sort, year, period }),
           { signal: controller.signal },
         )
         const result = (await response.json()) as PortalBangersPage & {
@@ -220,7 +240,7 @@ export function BangersExplorer({
         }
       }
     },
-    [scope, sort, year],
+    [period, scope, sort, year],
   )
 
   const loadMore = useCallback(() => {
@@ -271,15 +291,16 @@ export function BangersExplorer({
   )
 
   useEffect(() => {
-    const nextUrl = bangersHref({ query, scope, sort, year, view })
+    const nextUrl = bangersHref({ query, scope, sort, year, period, view })
     window.history.replaceState(window.history.state, '', nextUrl)
-  }, [query, scope, sort, view, year])
+  }, [period, query, scope, sort, view, year])
 
-  const hasFilters = query.trim().length > 0 || year !== undefined
-  const selectedYear = year === undefined ? 'all' : String(year)
+  const hasFilters =
+    query.trim().length > 0 || year !== undefined || period !== undefined
+  const selectedTime = period ?? (year === undefined ? 'all' : `year-${year}`)
   const clearFilters = () => {
     setQuery('')
-    if (year !== undefined) {
+    if (year !== undefined || period !== undefined) {
       router.push(bangersHref({ query: '', scope, sort, view }))
     }
   }
@@ -330,7 +351,14 @@ export function BangersExplorer({
             </span>
             <div className="flex">
               <Link
-                href={bangersHref({ query, scope: 'all', sort, year, view })}
+                href={bangersHref({
+                  query,
+                  scope: 'all',
+                  sort,
+                  year,
+                  period,
+                  view,
+                })}
                 aria-current={scope === 'all' ? 'page' : undefined}
                 className={`${segmentClassName} rounded-l-[3px] ${
                   scope === 'all'
@@ -346,6 +374,7 @@ export function BangersExplorer({
                   scope: 'members',
                   sort,
                   year,
+                  period,
                   view,
                 })}
                 aria-current={scope === 'members' ? 'page' : undefined}
@@ -368,7 +397,14 @@ export function BangersExplorer({
             </span>
             <div className="flex">
               <Link
-                href={bangersHref({ query, scope, sort: 'quotes', year, view })}
+                href={bangersHref({
+                  query,
+                  scope,
+                  sort: 'quotes',
+                  year,
+                  period,
+                  view,
+                })}
                 aria-current={sort === 'quotes' ? 'page' : undefined}
                 className={`${segmentClassName} rounded-l-[3px] ${
                   sort === 'quotes'
@@ -379,7 +415,14 @@ export function BangersExplorer({
                 Most quoted
               </Link>
               <Link
-                href={bangersHref({ query, scope, sort: 'recent', year, view })}
+                href={bangersHref({
+                  query,
+                  scope,
+                  sort: 'recent',
+                  year,
+                  period,
+                  view,
+                })}
                 aria-current={sort === 'recent' ? 'page' : undefined}
                 className={`${segmentClassName} -ml-px rounded-r-[3px] ${
                   sort === 'recent'
@@ -396,32 +439,43 @@ export function BangersExplorer({
             <span
               className={`mb-1.5 block text-[11px] font-bold uppercase tracking-[0.08em] ${MUTED}`}
             >
-              Year
+              When
             </span>
             <Select
-              value={selectedYear}
-              onValueChange={(value) =>
+              value={selectedTime}
+              onValueChange={(value) => {
+                const nextPeriod =
+                  value === 'today' || value === 'week' ? value : undefined
+                const nextYear = value.startsWith('year-')
+                  ? Number(value.slice(5))
+                  : undefined
                 router.push(
                   bangersHref({
                     query,
                     scope,
                     sort,
-                    year: value === 'all' ? undefined : Number(value),
+                    year: nextYear,
+                    period: nextPeriod,
                     view,
                   }),
                 )
-              }
+              }}
             >
               <SelectTrigger
-                aria-label="Filter by year"
-                className="h-9 w-[122px] rounded-[3px] border-zinc-300 bg-transparent px-3 text-[12px] font-semibold shadow-none focus:ring-brand/30 focus:ring-offset-0 dark:border-[#3a3a40]"
+                aria-label="Filter by time"
+                className="h-9 w-[132px] rounded-[3px] border-zinc-300 bg-transparent px-3 text-[12px] font-semibold shadow-none focus:ring-brand/30 focus:ring-offset-0 dark:border-[#3a3a40]"
               >
                 <SelectValue />
               </SelectTrigger>
               <SelectContent className="rounded-[3px]">
-                <SelectItem value="all">All years</SelectItem>
+                <SelectItem value="today">Today</SelectItem>
+                <SelectItem value="week">This week</SelectItem>
+                <SelectItem value="all">All time</SelectItem>
                 {availableYears.map((availableYear) => (
-                  <SelectItem key={availableYear} value={String(availableYear)}>
+                  <SelectItem
+                    key={availableYear}
+                    value={`year-${availableYear}`}
+                  >
                     {availableYear}
                   </SelectItem>
                 ))}
@@ -472,7 +526,9 @@ export function BangersExplorer({
           {isSearching
             ? 'Searching ranked bangers…'
             : `Showing ${loadedCount.toLocaleString()} of ${totalCount.toLocaleString()} ranked ${totalCount === 1 ? 'tweet' : 'tweets'}`}
-          {!isSearching && year !== undefined ? ` from ${year}` : ''}
+          {!isSearching && period === 'today' ? ' from today' : ''}
+          {!isSearching && period === 'week' ? ' from this week' : ''}
+          {!isSearching && !period && year !== undefined ? ` from ${year}` : ''}
           {!isSearching && loadedQuery ? ` matching “${loadedQuery}”` : ''}
           {!isSearching && page.pagination.candidateRankingTruncated
             ? ` · top ${page.pagination.snapshotSize.toLocaleString()} candidate snapshot`
@@ -493,7 +549,7 @@ export function BangersExplorer({
         <div className={`${CARD} px-4 py-16 text-center`}>
           <p className="text-[14px] font-semibold">No bangers found</p>
           <p className={`mt-1 text-[13px] ${MUTED}`}>
-            Try another search, year, or author scope.
+            Try another search, time period, or author scope.
           </p>
           {hasFilters ? (
             <button
@@ -506,15 +562,19 @@ export function BangersExplorer({
           ) : null}
         </div>
       ) : view === 'list' ? (
-        <div className="grid grid-cols-1 items-start gap-x-5 gap-y-6 lg:grid-cols-2">
+        <div
+          data-testid="bangers-masonry"
+          className="columns-1 gap-5 lg:columns-2"
+        >
           {visibleTweets.map((tweet) => (
-            <TweetRow
-              key={tweet.id}
-              tweet={tweet}
-              featuredRank={tweetRanks.get(tweet.id)}
-              showDate
-              collapsible
-            />
+            <div key={tweet.id} className="mb-6 break-inside-avoid">
+              <TweetRow
+                tweet={tweet}
+                featuredRank={tweetRanks.get(tweet.id)}
+                showDate
+                collapsible
+              />
+            </div>
           ))}
         </div>
       ) : (

--- a/src/components/portal/BangersExplorer.tsx
+++ b/src/components/portal/BangersExplorer.tsx
@@ -163,6 +163,22 @@ export function BangersExplorer({
     () => page.tweets.filter((tweet) => matchesQuery(tweet, query)),
     [page.tweets, query],
   )
+  const masonryColumns = useMemo(
+    () =>
+      visibleTweets.reduce<
+        [
+          Array<{ tweet: PortalTweet; order: number }>,
+          Array<{ tweet: PortalTweet; order: number }>,
+        ]
+      >(
+        (columns, tweet, order) => {
+          columns[order % 2].push({ tweet, order })
+          return columns
+        },
+        [[], []],
+      ),
+    [visibleTweets],
+  )
   const tweetRanks = useMemo(
     () =>
       new Map(
@@ -564,16 +580,29 @@ export function BangersExplorer({
       ) : view === 'list' ? (
         <div
           data-testid="bangers-masonry"
-          className="columns-1 gap-5 lg:columns-2"
+          className="flex flex-col lg:grid lg:grid-cols-2 lg:items-start lg:gap-5"
         >
-          {visibleTweets.map((tweet) => (
-            <div key={tweet.id} className="mb-6 break-inside-avoid">
-              <TweetRow
-                tweet={tweet}
-                featuredRank={tweetRanks.get(tweet.id)}
-                showDate
-                collapsible
-              />
+          {masonryColumns.map((column, columnIndex) => (
+            <div
+              key={columnIndex}
+              data-testid={`bangers-masonry-column-${columnIndex}`}
+              className="contents lg:block lg:space-y-6"
+            >
+              {column.map(({ tweet, order }) => (
+                <div
+                  key={tweet.id}
+                  data-masonry-order={order + 1}
+                  className="mb-6 lg:mb-0"
+                  style={{ order }}
+                >
+                  <TweetRow
+                    tweet={tweet}
+                    featuredRank={tweetRanks.get(tweet.id)}
+                    showDate
+                    collapsible
+                  />
+                </div>
+              ))}
             </div>
           ))}
         </div>

--- a/src/components/portal/TweetRow.tsx
+++ b/src/components/portal/TweetRow.tsx
@@ -204,7 +204,7 @@ export function TweetRow({
   const isFeatured = featuredRank !== undefined
   const isTopThree = isFeatured && featuredRank <= 3
   const rowClassName = isFeatured
-    ? `relative mt-2 flex min-w-0 gap-3 rounded-lg border px-4 pb-4 pt-5 shadow-sm transition-[border-color,box-shadow,transform] hover:-translate-y-0.5 hover:border-brand/50 hover:shadow-md motion-reduce:transition-none motion-reduce:hover:translate-y-0 dark:hover:border-brand/60 sm:gap-3.5 sm:px-5 sm:pb-5 sm:pt-6 ${
+    ? `relative flex min-w-0 gap-3 rounded-lg border p-4 shadow-sm transition-[border-color,box-shadow,transform] hover:-translate-y-0.5 hover:border-brand/50 hover:shadow-md motion-reduce:transition-none motion-reduce:hover:translate-y-0 dark:hover:border-brand/60 sm:gap-3.5 sm:p-5 ${
         isTopThree
           ? 'border-amber-200/90 bg-gradient-to-br from-amber-50/80 via-white to-white dark:border-amber-400/25 dark:from-amber-400/[0.06] dark:via-[#1b1b1e] dark:to-[#1b1b1e]'
           : 'border-zinc-200 bg-white dark:border-[#303036] dark:bg-[#1b1b1e]'
@@ -287,18 +287,6 @@ export function TweetRow({
 
   return (
     <article className={rowClassName}>
-      {isFeatured ? (
-        <span
-          aria-label={`Rank ${featuredRank}`}
-          className={`absolute right-4 top-0 -translate-y-1/2 rounded-full border px-2.5 py-1 text-[10.5px] font-extrabold tabular-nums tracking-[0.06em] shadow-sm ${
-            isTopThree
-              ? 'border-amber-300 bg-amber-50 text-amber-800 dark:border-amber-400/40 dark:bg-[#2b2418] dark:text-amber-200'
-              : 'border-brand/25 bg-blue-50 text-brand dark:bg-[#20283a]'
-          }`}
-        >
-          #{featuredRank}
-        </span>
-      ) : null}
       <Link href={href} aria-label={`View tweet by @${tweet.username}`}>
         <TweetAvatar tweet={tweet} size={isFeatured ? 38 : 34} />
       </Link>

--- a/src/lib/portal/TweetRow.test.tsx
+++ b/src/lib/portal/TweetRow.test.tsx
@@ -70,10 +70,11 @@ const tweet: PortalTweet = {
 }
 
 describe('portal TweetRow media', () => {
-  test('can present a tweet as a ranked banger card', () => {
+  test('highlights a top banger without showing a corner rank badge', () => {
     render(<TweetRow tweet={tweet} featuredRank={1} />)
 
-    expect(screen.getByLabelText('Rank 1')).toHaveTextContent('#1')
+    expect(screen.queryByLabelText('Rank 1')).not.toBeInTheDocument()
+    expect(screen.getByRole('article')).toHaveClass('from-amber-50/80')
     expect(screen.getByText(/12 archive quotes/)).toHaveClass('rounded-full')
   })
 

--- a/src/lib/portal/data.test.ts
+++ b/src/lib/portal/data.test.ts
@@ -17,6 +17,7 @@ jest.mock('./research', () => ({
 import {
   fetchPortalMemberCount,
   getInitialPortalBangersPage,
+  getPortalBangersPage,
   getPortalData,
   getPortalStreamPage,
   getPortalStreamUpdates,
@@ -270,6 +271,7 @@ describe('portal reads', () => {
   const previousClickHouseToken = process.env.CLICKHOUSE_ANALYTICS_API_TOKEN
 
   beforeEach(() => {
+    fetchPortalBangersPageMock.mockReset()
     process.env.PORTAL_READ_SUPABASE_URL = 'https://prod-project.supabase.co/'
     process.env.PORTAL_READ_SUPABASE_ANON_KEY = 'prod-public-anon'
     process.env.CLICKHOUSE_ANALYTICS_API_URL =
@@ -403,6 +405,136 @@ describe('portal reads', () => {
       scope: 'all',
       sort: 'quotes',
     })
+  })
+
+  test('builds an exact ranked page from the recent prefix for today', async () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-08-10T14:00:00.000Z'))
+    fetchPortalBangersPageMock.mockResolvedValueOnce({
+      tweets: [
+        {
+          id: 'today-low',
+          username: 'alice',
+          name: 'Alice',
+          avatar: null,
+          text: 'Today with fewer quotes',
+          observedAt: '2026-08-10T13:00:00.000Z',
+          createdAt: '2026-08-10T13:00:00.000Z',
+          likes: 4,
+          rts: 0,
+          quoteCount: 2,
+        },
+        {
+          id: 'today-high',
+          username: 'bob',
+          name: 'Bob',
+          avatar: null,
+          text: 'Today with more quotes',
+          observedAt: '2026-08-10T12:00:00.000Z',
+          createdAt: '2026-08-10T12:00:00.000Z',
+          likes: 8,
+          rts: 0,
+          quoteCount: 9,
+        },
+        {
+          id: 'yesterday',
+          username: 'carol',
+          name: 'Carol',
+          avatar: null,
+          text: 'Yesterday',
+          observedAt: '2026-08-09T23:59:59.000Z',
+          createdAt: '2026-08-09T23:59:59.000Z',
+          likes: 20,
+          rts: 0,
+          quoteCount: 20,
+        },
+      ],
+      pagination: {
+        limit: 100,
+        offset: 0,
+        nextOffset: 100,
+        totalAvailable: 1_000,
+        snapshotSize: 1_000,
+        yearCounts: [{ year: 2026, count: 1_000 }],
+        candidateRankingTruncated: false,
+      },
+    })
+
+    try {
+      await expect(
+        getPortalBangersPage({ period: 'today', sort: 'quotes' }),
+      ).resolves.toMatchObject({
+        tweets: [{ id: 'today-high' }, { id: 'today-low' }],
+        pagination: {
+          nextOffset: null,
+          totalAvailable: 2,
+          snapshotSize: 2,
+          yearCounts: [{ year: 2026, count: 2 }],
+        },
+      })
+      expect(fetchPortalBangersPageMock).toHaveBeenCalledWith({
+        limit: 100,
+        offset: 0,
+        sort: 'recent',
+        scope: 'all',
+        query: '',
+      })
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
+  test('starts this week on Monday at midnight UTC', async () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-08-12T14:00:00.000Z'))
+    fetchPortalBangersPageMock.mockResolvedValueOnce({
+      tweets: [
+        {
+          id: 'monday',
+          username: 'alice',
+          name: 'Alice',
+          avatar: null,
+          text: 'Monday banger',
+          observedAt: '2026-08-10T00:00:00.000Z',
+          createdAt: '2026-08-10T00:00:00.000Z',
+          likes: 4,
+          rts: 0,
+          quoteCount: 2,
+        },
+        {
+          id: 'sunday',
+          username: 'bob',
+          name: 'Bob',
+          avatar: null,
+          text: 'Sunday banger',
+          observedAt: '2026-08-09T23:59:59.000Z',
+          createdAt: '2026-08-09T23:59:59.000Z',
+          likes: 8,
+          rts: 0,
+          quoteCount: 9,
+        },
+      ],
+      pagination: {
+        limit: 100,
+        offset: 0,
+        nextOffset: null,
+        totalAvailable: 1_000,
+        snapshotSize: 1_000,
+        yearCounts: [{ year: 2026, count: 1_000 }],
+        candidateRankingTruncated: false,
+      },
+    })
+
+    try {
+      await expect(
+        getPortalBangersPage({ period: 'week' }),
+      ).resolves.toMatchObject({
+        tweets: [{ id: 'monday' }],
+        pagination: { totalAvailable: 1 },
+      })
+    } finally {
+      jest.useRealTimers()
+    }
   })
 
   test('encodes the observation cursor for ClickHouse polling', async () => {

--- a/src/lib/portal/data.ts
+++ b/src/lib/portal/data.ts
@@ -15,6 +15,7 @@ import { getResearchPosts, selectFeaturedResearchPosts } from './research'
 import { selectHomepageStream } from './stream'
 import type {
   PortalBangersPage,
+  PortalBangersPeriod,
   PortalBangersScope,
   PortalBangersSort,
   PortalData,
@@ -48,6 +49,8 @@ interface PortalCorpusRange {
 
 const PORTAL_READ_TIMEOUT_MS = 10_000
 export const PORTAL_BANGERS_PAGE_SIZE = 30
+const PORTAL_BANGERS_PERIOD_SCAN_PAGE_SIZE = 100
+const PORTAL_BANGERS_PERIOD_SCAN_PAGE_LIMIT = 25
 
 function required(value: string | undefined, name: string): string {
   if (!value) throw new Error(`${name} is not configured`)
@@ -669,6 +672,100 @@ const getCachedRecentBangers = unstable_cache(
   ['portal-recent-bangers-v2'],
   { revalidate: 1_800 },
 )
+
+function portalBangersPeriodStart(
+  period: PortalBangersPeriod,
+  now = new Date(),
+): string {
+  const start = new Date(now)
+  start.setUTCHours(0, 0, 0, 0)
+  if (period === 'week') {
+    const daysSinceMonday = (start.getUTCDay() + 6) % 7
+    start.setUTCDate(start.getUTCDate() - daysSinceMonday)
+  }
+  return start.toISOString()
+}
+
+async function fetchPortalBangersPeriodSnapshot(
+  _sourceKey: string,
+  periodStart: string,
+  scope: PortalBangersScope,
+  query: string,
+): Promise<{ tweets: PortalTweet[]; candidateRankingTruncated: boolean }> {
+  const tweets: PortalTweet[] = []
+  let offset = 0
+  let candidateRankingTruncated = false
+
+  for (
+    let pageIndex = 0;
+    pageIndex < PORTAL_BANGERS_PERIOD_SCAN_PAGE_LIMIT;
+    pageIndex += 1
+  ) {
+    const page = await fetchPortalBangersPage({
+      limit: PORTAL_BANGERS_PERIOD_SCAN_PAGE_SIZE,
+      offset,
+      sort: 'recent',
+      scope,
+      query,
+    })
+    candidateRankingTruncated ||= page.pagination.candidateRankingTruncated
+
+    const firstOlderIndex = page.tweets.findIndex(
+      (tweet) => tweet.createdAt < periodStart,
+    )
+    tweets.push(
+      ...(firstOlderIndex === -1
+        ? page.tweets
+        : page.tweets.slice(0, firstOlderIndex)),
+    )
+
+    if (firstOlderIndex !== -1 || page.pagination.nextOffset === null) {
+      return {
+        tweets: dedupePortalTweets(tweets),
+        candidateRankingTruncated,
+      }
+    }
+    if (page.tweets.length === 0) break
+    offset = page.pagination.nextOffset
+  }
+
+  return {
+    tweets: dedupePortalTweets(tweets),
+    candidateRankingTruncated: true,
+  }
+}
+
+function dedupePortalTweets(tweets: PortalTweet[]): PortalTweet[] {
+  return Array.from(new Map(tweets.map((tweet) => [tweet.id, tweet])).values())
+}
+
+function sortPortalBangers(
+  tweets: PortalTweet[],
+  sort: PortalBangersSort,
+): PortalTweet[] {
+  return [...tweets].sort((left, right) => {
+    if (sort === 'recent') {
+      return (
+        Date.parse(right.createdAt) - Date.parse(left.createdAt) ||
+        (right.quoteCount ?? 0) - (left.quoteCount ?? 0) ||
+        right.id.localeCompare(left.id)
+      )
+    }
+    return (
+      (right.quoteCount ?? 0) - (left.quoteCount ?? 0) ||
+      right.likes - left.likes ||
+      Date.parse(right.createdAt) - Date.parse(left.createdAt) ||
+      right.id.localeCompare(left.id)
+    )
+  })
+}
+
+const getCachedPortalBangersPeriodSnapshot = unstable_cache(
+  fetchPortalBangersPeriodSnapshot,
+  ['portal-bangers-period-snapshot-v1'],
+  { revalidate: 300 },
+)
+
 const getCachedInitialBangersPage = unstable_cache(
   async (
     _sourceKey: string,
@@ -720,9 +817,56 @@ export async function getPortalBangersPage(
     sort?: PortalBangersSort
     scope?: PortalBangersScope
     year?: number
+    period?: PortalBangersPeriod
     query?: string
   } = {},
 ): Promise<PortalBangersPage> {
+  if (options.period) {
+    const limit = Math.max(
+      1,
+      Math.min(100, Math.trunc(options.limit ?? PORTAL_BANGERS_PAGE_SIZE)),
+    )
+    const offset = Math.max(
+      0,
+      Math.min(1_000_000, Math.trunc(options.offset ?? 0)),
+    )
+    const sort = options.sort ?? 'quotes'
+    const scope = options.scope ?? 'all'
+    const query = options.query?.trim().slice(0, 120) ?? ''
+    const periodStart = portalBangersPeriodStart(options.period)
+    const snapshot = await getCachedPortalBangersPeriodSnapshot(
+      portalDataSourceKey(),
+      periodStart,
+      scope,
+      query,
+    )
+    const ranked = sortPortalBangers(snapshot.tweets, sort)
+    const pageTweets = ranked.slice(offset, offset + limit)
+    const nextOffset = offset + pageTweets.length
+    const yearCounts = new Map<number, number>()
+    for (const tweet of ranked) {
+      const year = new Date(tweet.createdAt).getUTCFullYear()
+      if (Number.isFinite(year)) {
+        yearCounts.set(year, (yearCounts.get(year) ?? 0) + 1)
+      }
+    }
+    return {
+      tweets: await enrichPortalTweets(pageTweets),
+      pagination: {
+        limit,
+        offset,
+        nextOffset: nextOffset < ranked.length ? nextOffset : null,
+        totalAvailable: ranked.length,
+        snapshotSize: ranked.length,
+        yearCounts: Array.from(yearCounts, ([year, count]) => ({
+          year,
+          count,
+        })).sort((left, right) => right.year - left.year),
+        candidateRankingTruncated: snapshot.candidateRankingTruncated,
+      },
+    }
+  }
+
   const page = await fetchPortalBangersPage(options)
   return {
     ...page,
@@ -735,18 +879,19 @@ export async function getInitialPortalBangersPage(
     sort?: PortalBangersSort
     scope?: PortalBangersScope
     year?: number
+    period?: PortalBangersPeriod
     query?: string
   } = {},
 ): Promise<PortalBangersPage> {
   const scope = options.scope ?? 'all'
   const sort = options.sort ?? 'quotes'
   const query = options.query?.trim() ?? ''
-  if (query) {
+  if (query || options.period) {
     return getPortalBangersPage({
       limit: PORTAL_BANGERS_PAGE_SIZE,
       scope,
       sort,
-      year: options.year,
+      ...(options.period ? { period: options.period } : { year: options.year }),
       query,
     })
   }

--- a/src/lib/portal/types.ts
+++ b/src/lib/portal/types.ts
@@ -40,6 +40,7 @@ export interface PortalTweet {
 
 export type PortalBangersScope = 'all' | 'members'
 export type PortalBangersSort = 'quotes' | 'recent'
+export type PortalBangersPeriod = 'today' | 'week'
 
 export interface PortalBangersPagination {
   limit: number

--- a/src/lib/portalBangersRoute.test.ts
+++ b/src/lib/portalBangersRoute.test.ts
@@ -58,7 +58,27 @@ describe('portal bangers route', () => {
       scope: 'members',
       sort: 'recent',
       year: 2024,
+      period: undefined,
       query: 'agency',
+    })
+  })
+
+  test('forwards this-week filtering instead of a year', async () => {
+    const response = await GET(
+      new NextRequest(
+        'https://community-archive.org/api/portal/bangers?period=week&year=2024',
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    expect(getPortalBangersPageMock).toHaveBeenCalledWith({
+      limit: 30,
+      offset: 0,
+      scope: 'all',
+      sort: 'quotes',
+      year: undefined,
+      period: 'week',
+      query: '',
     })
   })
 
@@ -66,6 +86,17 @@ describe('portal bangers route', () => {
     const response = await GET(
       new NextRequest(
         'https://community-archive.org/api/portal/bangers?offset=-1',
+      ),
+    )
+
+    expect(response.status).toBe(400)
+    expect(getPortalBangersPageMock).not.toHaveBeenCalled()
+  })
+
+  test('rejects an unsupported time period', async () => {
+    const response = await GET(
+      new NextRequest(
+        'https://community-archive.org/api/portal/bangers?period=month',
       ),
     )
 


### PR DESCRIPTION
## Summary
- add Today and This week filters while preserving accurate quote ranking
- switch the two-column list to a Pinterest-style masonry flow
- remove visible corner rank numbers while retaining featured-card emphasis

## Validation
- pnpm test -- --runInBand src/lib/portal/data.test.ts src/lib/portalBangersRoute.test.ts src/components/portal/BangersExplorer.test.tsx src/lib/portal/TweetRow.test.tsx
- pnpm type-check
- scoped Next.js lint (6 changed source files)