### PR TITLE
Use a rolling seven-day Bangers window

### DIFF
--- a/src/lib/portal/data.test.ts
+++ b/src/lib/portal/data.test.ts
@@ -484,31 +484,31 @@ describe('portal reads', () => {
     }
   })
 
-  test('starts this week on Monday at midnight UTC', async () => {
+  test('uses a rolling seven-day window instead of the calendar week', async () => {
     jest.useFakeTimers()
     jest.setSystemTime(new Date('2026-08-12T14:00:00.000Z'))
     fetchPortalBangersPageMock.mockResolvedValueOnce({
       tweets: [
         {
-          id: 'monday',
+          id: 'sunday',
           username: 'alice',
           name: 'Alice',
           avatar: null,
-          text: 'Monday banger',
-          observedAt: '2026-08-10T00:00:00.000Z',
-          createdAt: '2026-08-10T00:00:00.000Z',
+          text: 'Sunday banger',
+          observedAt: '2026-08-09T23:59:59.000Z',
+          createdAt: '2026-08-09T23:59:59.000Z',
           likes: 4,
           rts: 0,
           quoteCount: 2,
         },
         {
-          id: 'sunday',
+          id: 'eight-days-ago',
           username: 'bob',
           name: 'Bob',
           avatar: null,
-          text: 'Sunday banger',
-          observedAt: '2026-08-09T23:59:59.000Z',
-          createdAt: '2026-08-09T23:59:59.000Z',
+          text: 'Outside the rolling window',
+          observedAt: '2026-08-04T13:59:59.000Z',
+          createdAt: '2026-08-04T13:59:59.000Z',
           likes: 8,
           rts: 0,
           quoteCount: 9,
@@ -529,7 +529,7 @@ describe('portal reads', () => {
       await expect(
         getPortalBangersPage({ period: 'week' }),
       ).resolves.toMatchObject({
-        tweets: [{ id: 'monday' }],
+        tweets: [{ id: 'sunday' }],
         pagination: { totalAvailable: 1 },
       })
     } finally {

--- a/src/lib/portal/data.ts
+++ b/src/lib/portal/data.ts
@@ -678,11 +678,17 @@ function portalBangersPeriodStart(
   now = new Date(),
 ): string {
   const start = new Date(now)
-  start.setUTCHours(0, 0, 0, 0)
-  if (period === 'week') {
-    const daysSinceMonday = (start.getUTCDay() + 6) % 7
-    start.setUTCDate(start.getUTCDate() - daysSinceMonday)
-  }
+  if (period === 'today') start.setUTCHours(0, 0, 0, 0)
+  else start.setUTCDate(start.getUTCDate() - 7)
+  return start.toISOString()
+}
+
+function portalBangersPeriodSnapshotStart(
+  period: PortalBangersPeriod,
+  now = new Date(),
+): string {
+  const start = new Date(portalBangersPeriodStart(period, now))
+  if (period === 'week') start.setUTCMinutes(0, 0, 0)
   return start.toISOString()
 }
 
@@ -833,14 +839,19 @@ export async function getPortalBangersPage(
     const sort = options.sort ?? 'quotes'
     const scope = options.scope ?? 'all'
     const query = options.query?.trim().slice(0, 120) ?? ''
-    const periodStart = portalBangersPeriodStart(options.period)
+    const now = new Date()
+    const periodStart = portalBangersPeriodStart(options.period, now)
+    const snapshotStart = portalBangersPeriodSnapshotStart(options.period, now)
     const snapshot = await getCachedPortalBangersPeriodSnapshot(
       portalDataSourceKey(),
-      periodStart,
+      snapshotStart,
       scope,
       query,
     )
-    const ranked = sortPortalBangers(snapshot.tweets, sort)
+    const ranked = sortPortalBangers(
+      snapshot.tweets.filter((tweet) => tweet.createdAt >= periodStart),
+      sort,
+    )
     const pageTweets = ranked.slice(offset, offset + limit)
     const nextOffset = offset + pageTweets.length
     const yearCounts = new Map<number, number>()


### PR DESCRIPTION
## Summary
- change the Bangers “This week” filter from Monday-based dates to a rolling seven-day window
- keep exact time filtering while preserving hourly snapshot-cache reuse
- add regression coverage for the rolling boundary

## Validation
- 28 focused tests passed
- pnpm type-check
- scoped Next.js lint