### PR TITLE
Link the featured banger to the Bangers explorer

### DIFF
--- a/src/components/portal/Portal.tsx
+++ b/src/components/portal/Portal.tsx
@@ -750,7 +750,10 @@ export default function Portal({
                     <div
                       className={`${CARD} flex min-w-0 flex-col overflow-hidden lg:min-h-[320px]`}
                     >
-                      <PanelHeader title="Banger of the moment" />
+                      <PanelHeader
+                        title="Banger of the moment"
+                        action={{ label: 'More bangers', href: '/bangers' }}
+                      />
                       {recentBanger ? (
                         <div className="flex flex-1 flex-col [&>article]:flex-1">
                           <TweetRow tweet={recentBanger} collapsible />

--- a/src/components/portal/PortalLayout.test.tsx
+++ b/src/components/portal/PortalLayout.test.tsx
@@ -86,10 +86,13 @@ test('renders the balanced homepage composition and editorial labels', async () 
   expect(screen.getByText('Research post 4')).toBeInTheDocument()
   expect(screen.queryByText('Research post 5')).not.toBeInTheDocument()
   expect(screen.getByText('Historical Banger')).toBeInTheDocument()
-  expect(screen.getByRole('link', { name: /More bangers/i })).toHaveAttribute(
-    'href',
-    '/bangers',
-  )
+  const moreBangersLinks = screen.getAllByRole('link', {
+    name: /More bangers/i,
+  })
+  expect(moreBangersLinks).toHaveLength(2)
+  moreBangersLinks.forEach((link) => {
+    expect(link).toHaveAttribute('href', '/bangers')
+  })
   expect(
     screen.getByRole('link', { name: /Export the archive/i }),
   ).toHaveAttribute(


### PR DESCRIPTION
## What changed

- add the existing “More bangers” action to the current featured-banger panel
- update layout coverage to require both banger cards to link to `/bangers`

## Root cause

The historical banger panel configured a Bangers explorer action, while the current featured-banger panel rendered the same header without one.

## User impact

Members can open the full Bangers explorer from either featured banger card.

## Validation

- `pnpm type-check`
- scoped Next.js lint
- scoped Prettier check
- client Jest project: 10 suites, 22 tests passed

Closes #491
