### PR TITLE
Show eight avatars in homepage social proof

### DIFF
--- a/src/components/home/ClassicHomepage.tsx
+++ b/src/components/home/ClassicHomepage.tsx
@@ -193,7 +193,7 @@ export default async function ClassicHomepage() {
   }
 
   const isOptedIn = canShowHomepageSearch(user?.id, optedInStatus)
-  const mostFollowed = mostFollowedAccounts.slice(0, 7)
+  const mostFollowed = mostFollowedAccounts.slice(0, 8)
 
   const totalAmountRaised = financialContributors.reduce(
     (sum, contributor) => sum + contributor.totalAmountDonated,


### PR DESCRIPTION
## What changed

Increase the homepage social-proof avatar selection from seven accounts to eight.

## Root cause

The homepage applied a hard-coded seven-account slice before rendering the avatar list.

## User impact

The homepage now displays the requested eight community avatars when enough account data is available.

## Validation

- `pnpm type-check`
- `pnpm exec next lint --file src/components/home/ClassicHomepage.tsx`
- `pnpm exec prettier --check src/components/home/ClassicHomepage.tsx`

Closes #497
