### PR TITLE
Show three research highlights on the member dashboard

### DIFF
--- a/src/components/portal/Portal.tsx
+++ b/src/components/portal/Portal.tsx
@@ -796,7 +796,7 @@ export default function Portal({
                   {data.failures.research ? (
                     <PanelUnavailable message="Featured research is temporarily unavailable." />
                   ) : (
-                    data.research.slice(0, 4).map((post) => (
+                    data.research.slice(0, 3).map((post) => (
                       <a
                         key={post.url}
                         href={post.url}

--- a/src/components/portal/PortalLayout.test.tsx
+++ b/src/components/portal/PortalLayout.test.tsx
@@ -83,8 +83,8 @@ test('renders the balanced homepage composition and editorial labels', async () 
   })
 
   expect(screen.getByText('Featured research')).toBeInTheDocument()
-  expect(screen.getByText('Research post 4')).toBeInTheDocument()
-  expect(screen.queryByText('Research post 5')).not.toBeInTheDocument()
+  expect(screen.getByText('Research post 3')).toBeInTheDocument()
+  expect(screen.queryByText('Research post 4')).not.toBeInTheDocument()
   expect(screen.getByText('Historical Banger')).toBeInTheDocument()
   expect(screen.getByRole('link', { name: /More bangers/i })).toHaveAttribute(
     'href',


### PR DESCRIPTION
## What changed

- limit the member dashboard’s featured research panel to three posts
- update layout coverage to enforce the three-item boundary

## Root cause

The dashboard used a hard-coded four-post slice.

## User impact

The research panel now shows the requested three highlights and leaves the complete list available through “All research.”

## Validation

- `pnpm type-check`
- scoped Next.js lint
- scoped Prettier check
- client Jest project: 10 suites, 22 tests passed

Closes #500
