### PR TITLE
Restore the member directory navigation link

### DIFF
--- a/src/lib/navigation.test.ts
+++ b/src/lib/navigation.test.ts
@@ -1,0 +1,14 @@
+import { getMobileNav, getPrimaryNav } from './navigation'
+
+describe('member navigation', () => {
+  it('includes the member directory in desktop and mobile navigation', () => {
+    expect(getPrimaryNav(true)).toContainEqual({
+      href: '/user-dir',
+      label: 'Library',
+    })
+    expect(getMobileNav(true)).toContainEqual({
+      href: '/user-dir',
+      label: 'Library',
+    })
+  })
+})

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -14,6 +14,7 @@ export const getPrimaryNav = (isMember: boolean): NavItem[] =>
   isMember
     ? [
         { href: '/', label: 'Home' },
+        { href: '/user-dir', label: 'Library' },
         { href: '/stream', label: 'Stream' },
         { href: '/trends', label: 'Trends' },
         { href: '/research', label: 'Research' },


### PR DESCRIPTION
## What changed

- restore the Library link to the signed-in primary navigation
- add regression coverage for desktop and mobile member navigation

## Root cause

The logged-out navigation still exposed `/user-dir`, but the member primary navigation omitted it when the portal navigation was introduced.

## User impact

Signed-in members can reach the user directory directly from both desktop and mobile navigation again.

## Validation

- `pnpm type-check`
- `pnpm exec next lint --file src/lib/navigation.ts --file src/lib/navigation.test.ts`
- `pnpm exec prettier --check src/lib/navigation.ts src/lib/navigation.test.ts`
- server Jest project: 42 suites, 193 tests passed

Closes #490
