### PR TITLE
Secure archive storage ownership

### DIFF
--- a/src/lib/upload-archive/uploadArchiveToStorage.test.ts
+++ b/src/lib/upload-archive/uploadArchiveToStorage.test.ts
@@ -1,0 +1,102 @@
+import type { SupabaseClient, User } from '@supabase/supabase-js'
+import type { Archive } from '../types'
+import { refreshSession } from '../refreshSession'
+import { uploadArchiveToStorage } from './uploadArchiveToStorage'
+
+jest.mock('../refreshSession', () => ({
+  refreshSession: jest.fn(),
+}))
+
+const mockedRefreshSession = jest.mocked(refreshSession)
+
+const createArchive = (username: string) =>
+  ({
+    account: [{ account: { username } }],
+  }) as unknown as Archive
+
+const createTwitterUser = (username: string) =>
+  ({
+    id: 'auth-user-1',
+    app_metadata: { user_name: username.toLowerCase() },
+    user_metadata: {},
+    aud: 'authenticated',
+    created_at: '2026-08-10T00:00:00.000Z',
+    identities: [
+      {
+        id: 'twitter-123',
+        identity_id: 'twitter-identity-1',
+        user_id: 'auth-user-1',
+        identity_data: { user_name: username },
+        provider: 'twitter',
+        created_at: '2026-08-10T00:00:00.000Z',
+        updated_at: '2026-08-10T00:00:00.000Z',
+        last_sign_in_at: '2026-08-10T00:00:00.000Z',
+      },
+    ],
+  }) as User
+
+const createSupabase = (getUserResult: unknown) => {
+  const upload = jest.fn().mockResolvedValue({ data: {}, error: null })
+  const from = jest.fn().mockReturnValue({ upload })
+  const getUser = jest.fn().mockResolvedValue(getUserResult)
+  const supabase = {
+    auth: { getUser },
+    storage: { from },
+  } as unknown as SupabaseClient
+
+  return { supabase, getUser, from, upload }
+}
+
+describe('uploadArchiveToStorage', () => {
+  beforeEach(() => {
+    mockedRefreshSession.mockResolvedValue(undefined)
+  })
+
+  it('keys the object path from the verified Twitter identity', async () => {
+    const archive = createArchive('client_supplied_victim')
+    const { supabase, getUser, from, upload } = createSupabase({
+      data: { user: createTwitterUser('Verified_Owner') },
+      error: null,
+    })
+
+    await uploadArchiveToStorage(supabase, archive)
+
+    expect(getUser).toHaveBeenCalledTimes(1)
+    expect(from).toHaveBeenCalledWith('archives')
+    expect(upload).toHaveBeenCalledWith(
+      'verified_owner/archive.json',
+      JSON.stringify(archive),
+      { upsert: true },
+    )
+  })
+
+  it('rejects a session without a trusted identity username', async () => {
+    const user = {
+      ...createTwitterUser('verified_owner'),
+      app_metadata: {},
+      identities: [],
+      user_metadata: { user_name: 'client_supplied_victim' },
+    } as User
+    const { supabase, upload } = createSupabase({
+      data: { user },
+      error: null,
+    })
+
+    await expect(
+      uploadArchiveToStorage(supabase, createArchive('victim')),
+    ).rejects.toThrow('Unable to determine a trusted username')
+    expect(upload).not.toHaveBeenCalled()
+  })
+
+  it('does not upload when Supabase cannot verify the session', async () => {
+    const { supabase, upload } = createSupabase({
+      data: { user: null },
+      error: { message: 'invalid access token' },
+    })
+
+    await expect(
+      uploadArchiveToStorage(supabase, createArchive('victim')),
+    ).rejects.toThrow('Unable to verify the archive owner')
+    expect(upload).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/upload-archive/uploadArchiveToStorage.ts
+++ b/src/lib/upload-archive/uploadArchiveToStorage.ts
@@ -1,22 +1,18 @@
 import { SupabaseClient } from '@supabase/supabase-js'
 import { Archive } from '../types'
 import { devLog } from '../devLog'
-import { createAdminBrowserClient } from '@/utils/supabase'
 import { refreshSession } from '../refreshSession'
+import { getSessionTwitterUsername } from '@/lib/sessionTwitterUsername'
 
 export const uploadArchiveToStorage = async (
   supabase: SupabaseClient,
   archive: Archive,
 ): Promise<void> => {
-  // Upload archive objects to storage
-  const username = archive.account[0].account.username.toLowerCase()
-
-  const archiveSize = JSON.stringify(archive).length / (1024 * 1024)
+  const serializedArchive = JSON.stringify(archive)
+  const archiveSize = serializedArchive.length / (1024 * 1024)
   console.log(`Size of archive: ${archiveSize.toFixed(2)} MB`)
   const isDevelopment = process.env.NODE_ENV === 'development'
   const useRemoteDevDb = process.env.NEXT_PUBLIC_USE_REMOTE_DEV_DB === 'true'
-
-  console.log('Uploading archive to storage', { username })
 
   try {
     await refreshSession(supabase)
@@ -24,7 +20,24 @@ export const uploadArchiveToStorage = async (
     console.error('Error refreshing session:', error)
   }
 
-  // const supabaseAdmin = createAdminBrowserClient()
+  // getUser verifies the session with Supabase Auth. Never derive this path
+  // from the uploaded archive: its account metadata is controlled by the file.
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+  if (userError || !user) {
+    throw new Error(
+      `Unable to verify the archive owner: ${userError?.message ?? 'no authenticated user'}`,
+    )
+  }
+
+  const username = getSessionTwitterUsername(user)
+  if (!username) {
+    throw new Error('Unable to determine a trusted username for this session')
+  }
+
+  console.log('Uploading archive to storage', { username })
 
   devLog('storage - supabase config', {
     isDevelopment,
@@ -35,7 +48,7 @@ export const uploadArchiveToStorage = async (
   const bucketName = 'archives'
   const { data, error: uploadError } = await supabase.storage
     .from(bucketName)
-    .upload(`${username}/archive.json`, JSON.stringify(archive), {
+    .upload(`${username}/archive.json`, serializedArchive, {
       upsert: true,
     })
   if (uploadError && uploadError.message !== 'The resource already exists') {

--- a/supabase/migrations/20260811011637_restrict_archive_storage_to_authenticated_username.sql
+++ b/supabase/migrations/20260811011637_restrict_archive_storage_to_authenticated_username.sql
@@ -1,0 +1,70 @@
+-- #372(a): keep archive object paths bound to the authenticated account.
+--
+-- The browser now derives the folder from the Twitter identity returned by
+-- auth.getUser(). These policies independently enforce the same trusted
+-- app_metadata value, so a modified client cannot overwrite another user's
+-- archive. The filename restriction also keeps browser writes within the one
+-- object shape consumed by the archive worker.
+--
+-- Remove the legacy dashboard policies, including the trailing-space policy
+-- whose unscoped `using (true)` also exposed objects in private buckets.
+
+begin;
+
+drop policy if exists "Allow archive access " on storage.objects;
+drop policy if exists "Allow archive access generally" on storage.objects;
+drop policy if exists "Allow authenticated archive deletes" on storage.objects;
+drop policy if exists "Allow authenticated archive updates" on storage.objects;
+drop policy if exists "Allow authenticated uploads" on storage.objects;
+
+drop policy if exists "Archives are publicly readable" on storage.objects;
+drop policy if exists "Users can upload their own archive" on storage.objects;
+drop policy if exists "Users can update their own archive" on storage.objects;
+drop policy if exists "Users can delete their own archive" on storage.objects;
+
+create policy "Archives are publicly readable"
+on storage.objects
+for select
+to public
+using (bucket_id = 'archives');
+
+create policy "Users can upload their own archive"
+on storage.objects
+for insert
+to authenticated
+with check (
+  bucket_id = 'archives'
+  and storage.filename(name) = 'archive.json'
+  and lower((storage.foldername(name))[1]) =
+      lower((select auth.jwt() -> 'app_metadata' ->> 'user_name'))
+);
+
+create policy "Users can update their own archive"
+on storage.objects
+for update
+to authenticated
+using (
+  bucket_id = 'archives'
+  and storage.filename(name) = 'archive.json'
+  and lower((storage.foldername(name))[1]) =
+      lower((select auth.jwt() -> 'app_metadata' ->> 'user_name'))
+)
+with check (
+  bucket_id = 'archives'
+  and storage.filename(name) = 'archive.json'
+  and lower((storage.foldername(name))[1]) =
+      lower((select auth.jwt() -> 'app_metadata' ->> 'user_name'))
+);
+
+create policy "Users can delete their own archive"
+on storage.objects
+for delete
+to authenticated
+using (
+  bucket_id = 'archives'
+  and storage.filename(name) = 'archive.json'
+  and lower((storage.foldername(name))[1]) =
+      lower((select auth.jwt() -> 'app_metadata' ->> 'user_name'))
+);
+
+commit;

--- a/supabase/schemas/060_policies.sql
+++ b/supabase/schemas/060_policies.sql
@@ -1,5 +1,53 @@
 -- Row Level Security policies and enablement
 
+-- Storage policies for the public archives bucket. Writes are restricted to
+-- the folder named by trusted, server-controlled app_metadata; the upload
+-- client derives the same name from its verified Twitter identity (#372).
+CREATE POLICY "Archives are publicly readable" ON "storage"."objects"
+  FOR SELECT TO public
+  USING (("bucket_id" = 'archives'::"text"));
+
+CREATE POLICY "Users can upload their own archive" ON "storage"."objects"
+  FOR INSERT TO "authenticated"
+  WITH CHECK (
+    ("bucket_id" = 'archives'::"text")
+    AND ("storage"."filename"("name") = 'archive.json'::"text")
+    AND (
+      "lower"(("storage"."foldername"("name"))[1]) =
+      "lower"((SELECT (("auth"."jwt"() -> 'app_metadata'::"text") ->> 'user_name'::"text")))
+    )
+  );
+
+CREATE POLICY "Users can update their own archive" ON "storage"."objects"
+  FOR UPDATE TO "authenticated"
+  USING (
+    ("bucket_id" = 'archives'::"text")
+    AND ("storage"."filename"("name") = 'archive.json'::"text")
+    AND (
+      "lower"(("storage"."foldername"("name"))[1]) =
+      "lower"((SELECT (("auth"."jwt"() -> 'app_metadata'::"text") ->> 'user_name'::"text")))
+    )
+  )
+  WITH CHECK (
+    ("bucket_id" = 'archives'::"text")
+    AND ("storage"."filename"("name") = 'archive.json'::"text")
+    AND (
+      "lower"(("storage"."foldername"("name"))[1]) =
+      "lower"((SELECT (("auth"."jwt"() -> 'app_metadata'::"text") ->> 'user_name'::"text")))
+    )
+  );
+
+CREATE POLICY "Users can delete their own archive" ON "storage"."objects"
+  FOR DELETE TO "authenticated"
+  USING (
+    ("bucket_id" = 'archives'::"text")
+    AND ("storage"."filename"("name") = 'archive.json'::"text")
+    AND (
+      "lower"(("storage"."foldername"("name"))[1]) =
+      "lower"((SELECT (("auth"."jwt"() -> 'app_metadata'::"text") ->> 'user_name'::"text")))
+    )
+  );
+
 -- Modification policies for authenticated users
 CREATE POLICY "Data is modifiable by their users" ON "public"."all_account" TO "authenticated" USING (("account_id" = ((( SELECT "auth"."jwt"() AS "jwt") -> 'app_metadata'::"text") ->> 'provider_id'::"text"))) WITH CHECK (("account_id" = ((( SELECT "auth"."jwt"() AS "jwt") -> 'app_metadata'::"text") ->> 'provider_id'::"text")));
 CREATE POLICY "Data is modifiable by their users" ON "public"."all_profile" TO "authenticated" USING (("account_id" = ((( SELECT "auth"."jwt"() AS "jwt") -> 'app_metadata'::"text") ->> 'provider_id'::"text"))) WITH CHECK (("account_id" = ((( SELECT "auth"."jwt"() AS "jwt") -> 'app_metadata'::"text") ->> 'provider_id'::"text")));


### PR DESCRIPTION
## What changed

- derive the archive Storage key from the Twitter identity returned by `supabase.auth.getUser()`, never from account metadata inside the uploaded archive
- add regression tests for spoofed archive usernames, missing trusted identity data, and failed session verification
- version the `archives` bucket RLS policies in both the migration history and declarative schema
- restrict insert/update/delete to the authenticated user's trusted `app_metadata.user_name` folder and the expected `archive.json` filename
- remove the legacy trailing-space `SELECT USING (true)` policy, which was unintentionally readable across every Storage bucket

## Root cause and impact

The upload client constructed `<username>/archive.json` from the archive file itself. Production RLS already compared that folder with server-controlled app metadata, but the client still trusted attacker-controlled input and the dashboard-managed policies were not auditable in Git.

After this change, both the client and database independently bind writes to the authenticated identity. A modified archive or browser client cannot select another user's object key. Removing the unscoped legacy policy also restores the intended service-role-only access model for private buckets.

Part (b) of #372 was already shipped in #391; production confirms `anon` cannot execute either archive-delete function.

## Validation

- `pnpm exec jest --selectProjects server --runInBand` — 43 suites / 196 tests passed
- `pnpm type-check`
- `pnpm lint` — passed with one unrelated existing `<img>` warning
- migration and declarative policy SQL parsed and asserted successfully against the production Postgres engine inside rollback-only transactions
- production policy and bucket inventory inspected read-only
- Supabase security advisor run; reported pre-existing findings unrelated to this change

Local Supabase role-level testing was unavailable because Docker was not running, and the connector blocks role impersonation. No production schema changes were applied.

## Rollout

Deploy `20260811011637_restrict_archive_storage_to_authenticated_username.sql` and verify the canonical Storage policies before merging/deploying the frontend change.

Fixes #372

