### PR TITLE
[codex] Fix rolling 24-hour Bangers window

### DIFF
--- a/src/lib/portal/data.test.ts
+++ b/src/lib/portal/data.test.ts
@@ -407,9 +407,9 @@ describe('portal reads', () => {
     })
   })
 
-  test('builds an exact ranked page from the recent prefix for today', async () => {
+  test('uses a rolling 24-hour window for today', async () => {
     jest.useFakeTimers()
-    jest.setSystemTime(new Date('2026-08-10T14:00:00.000Z'))
+    jest.setSystemTime(new Date('2026-08-10T14:37:42.000Z'))
     fetchPortalBangersPageMock.mockResolvedValueOnce({
       tweets: [
         {
@@ -437,22 +437,34 @@ describe('portal reads', () => {
           quoteCount: 9,
         },
         {
-          id: 'yesterday',
+          id: 'window-boundary',
           username: 'carol',
           name: 'Carol',
           avatar: null,
-          text: 'Yesterday',
-          observedAt: '2026-08-09T23:59:59.000Z',
-          createdAt: '2026-08-09T23:59:59.000Z',
+          text: 'Exactly 24 hours ago',
+          observedAt: '2026-08-09T14:37:42.000Z',
+          createdAt: '2026-08-09T14:37:42.000Z',
           likes: 20,
           rts: 0,
           quoteCount: 20,
+        },
+        {
+          id: 'outside-window',
+          username: 'dave',
+          name: 'Dave',
+          avatar: null,
+          text: 'More than 24 hours ago',
+          observedAt: '2026-08-09T14:37:41.000Z',
+          createdAt: '2026-08-09T14:37:41.000Z',
+          likes: 30,
+          rts: 0,
+          quoteCount: 30,
         },
       ],
       pagination: {
         limit: 100,
         offset: 0,
-        nextOffset: 100,
+        nextOffset: null,
         totalAvailable: 1_000,
         snapshotSize: 1_000,
         yearCounts: [{ year: 2026, count: 1_000 }],
@@ -464,12 +476,16 @@ describe('portal reads', () => {
       await expect(
         getPortalBangersPage({ period: 'today', sort: 'quotes' }),
       ).resolves.toMatchObject({
-        tweets: [{ id: 'today-high' }, { id: 'today-low' }],
+        tweets: [
+          { id: 'window-boundary' },
+          { id: 'today-high' },
+          { id: 'today-low' },
+        ],
         pagination: {
           nextOffset: null,
-          totalAvailable: 2,
-          snapshotSize: 2,
-          yearCounts: [{ year: 2026, count: 2 }],
+          totalAvailable: 3,
+          snapshotSize: 3,
+          yearCounts: [{ year: 2026, count: 3 }],
         },
       })
       expect(fetchPortalBangersPageMock).toHaveBeenCalledWith({

--- a/src/lib/portal/data.ts
+++ b/src/lib/portal/data.ts
@@ -678,11 +678,22 @@ function portalBangersPeriodStart(
   now = new Date(),
 ): string {
   const start = new Date(now)
-  start.setUTCHours(0, 0, 0, 0)
-  if (period === 'week') {
+  if (period === 'today') {
+    start.setUTCDate(start.getUTCDate() - 1)
+  } else {
+    start.setUTCHours(0, 0, 0, 0)
     const daysSinceMonday = (start.getUTCDay() + 6) % 7
     start.setUTCDate(start.getUTCDate() - daysSinceMonday)
   }
+  return start.toISOString()
+}
+
+function portalBangersPeriodSnapshotStart(
+  period: PortalBangersPeriod,
+  now = new Date(),
+): string {
+  const start = new Date(portalBangersPeriodStart(period, now))
+  if (period === 'today') start.setUTCMinutes(0, 0, 0)
   return start.toISOString()
 }
 
@@ -833,14 +844,19 @@ export async function getPortalBangersPage(
     const sort = options.sort ?? 'quotes'
     const scope = options.scope ?? 'all'
     const query = options.query?.trim().slice(0, 120) ?? ''
-    const periodStart = portalBangersPeriodStart(options.period)
+    const now = new Date()
+    const periodStart = portalBangersPeriodStart(options.period, now)
+    const snapshotStart = portalBangersPeriodSnapshotStart(options.period, now)
     const snapshot = await getCachedPortalBangersPeriodSnapshot(
       portalDataSourceKey(),
-      periodStart,
+      snapshotStart,
       scope,
       query,
     )
-    const ranked = sortPortalBangers(snapshot.tweets, sort)
+    const ranked = sortPortalBangers(
+      snapshot.tweets.filter((tweet) => tweet.createdAt >= periodStart),
+      sort,
+    )
     const pageTweets = ranked.slice(offset, offset + limit)
     const nextOffset = offset + pageTweets.length
     const yearCounts = new Map<number, number>()


### PR DESCRIPTION
## Summary

- define the Bangers “Today” filter as the rolling 24 hours before each request
- keep the exact cutoff while reusing an hourly snapshot cache key
- cover the inclusive 24-hour boundary and exclude records one second older

## Root cause

`portalBangersPeriodStart()` truncated every period to UTC midnight before scanning recent Bangers. A tweet from the previous calendar day disappeared even when it was only a few hours old.

The snapshot scan now starts at the containing UTC hour for cache reuse, then the ranked result is filtered against the exact request-time cutoff.

## Validation

- `pnpm exec jest --selectProjects server --runInBand --runTestsByPath src/lib/portal/data.test.ts` (16 passed)
- `pnpm test:ci` (52 suites, 215 tests passed)
- `pnpm type-check`
- scoped Next.js lint
- Prettier check
- `git diff --check`

## Related work

#503 changes only the “This week” period to a rolling seven-day window. This PR leaves the weekly behavior unchanged, but both touch the period helper, so merge order may require a small rebase.

Fixes #514