### PR TITLE
Refine Bangers, Trends, and archived tweet rendering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,8 @@ Staging synchronization is automatic; production synchronization is not:
   attached media, and quoted-tweet payload (including the quoted tweet's media)
   before rendering. Do not introduce a surface-specific partial tweet renderer;
   make intentionally compact variants explicit through the canonical component.
+- Normalize archive text with `src/lib/tweetText.ts`; do not add another local
+  HTML-entity decoder to a tweet surface.
 
 Use Node 20 from `.nvmrc` and pnpm. Prefer the narrowest relevant check, then
 expand verification in proportion to risk.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,14 @@ Staging synchronization is automatic; production synchronization is not:
 
 ## Development And Verification
 
+### Tweet rendering
+
+- Use `src/components/TweetCard.tsx` as the canonical full-fidelity tweet card
+  for new product surfaces. Data adapters must preserve the complete text,
+  attached media, and quoted-tweet payload (including the quoted tweet's media)
+  before rendering. Do not introduce a surface-specific partial tweet renderer;
+  make intentionally compact variants explicit through the canonical component.
+
 Use Node 20 from `.nvmrc` and pnpm. Prefer the narrowest relevant check, then
 expand verification in proportion to risk.
 

--- a/src/app/api/portal/bangers/route.ts
+++ b/src/app/api/portal/bangers/route.ts
@@ -44,11 +44,19 @@ export async function GET(request: NextRequest) {
     const params = new URL(request.url).searchParams
     const offset = boundedInteger(params.get('offset'), 0, 0, 1_000_000)
     const periodValue = params.get('period')
-    if (periodValue && periodValue !== 'today' && periodValue !== 'week') {
+    if (
+      periodValue &&
+      periodValue !== 'all' &&
+      periodValue !== 'today' &&
+      periodValue !== 'week' &&
+      periodValue !== 'three-months'
+    ) {
       throw new Error('Invalid bangers period')
     }
     const period: PortalBangersPeriod | undefined =
-      periodValue === 'today' || periodValue === 'week'
+      periodValue === 'today' ||
+      periodValue === 'week' ||
+      periodValue === 'three-months'
         ? periodValue
         : undefined
     const year =

--- a/src/app/api/portal/trends/route.ts
+++ b/src/app/api/portal/trends/route.ts
@@ -40,6 +40,21 @@ function privateJson(body: unknown, status = 200) {
   })
 }
 
+function optionalDate(value: string | null, label: string): string | undefined {
+  if (value === null) return undefined
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    throw new Error(`Choose a valid ${label} date`)
+  }
+  const parsed = new Date(`${value}T00:00:00.000Z`)
+  if (
+    Number.isNaN(parsed.getTime()) ||
+    parsed.toISOString().slice(0, 10) !== value
+  ) {
+    throw new Error(`Choose a valid ${label} date`)
+  }
+  return value
+}
+
 export async function GET(request: NextRequest) {
   if (!(await getIsMember())) {
     return privateJson({ error: 'Sign in to explore trends' }, 401)
@@ -57,13 +72,21 @@ export async function GET(request: NextRequest) {
 
     if (view === 'feed') {
       const includeTerms = normalizedTerms(params.getAll('include'))
-      const excludeTerms = normalizedTerms(params.getAll('exclude'))
       if (includeTerms.length === 0) {
         throw new Error('Include at least one term to load matching tweets')
       }
+      const since = optionalDate(params.get('since'), 'start')
+      const until = optionalDate(params.get('until'), 'end')
+      if (since && until && since >= until) {
+        throw new Error('Choose an end date after the start date')
+      }
       return privateJson({
         tweets: await enrichPortalTweets(
-          await fetchPortalTrendEvidence(includeTerms, excludeTerms, 30),
+          await fetchPortalTrendEvidence(includeTerms, {
+            limit: 30,
+            since,
+            until,
+          }),
         ),
       })
     }

--- a/src/app/api/tweets/[tweet_id]/quotes/route.ts
+++ b/src/app/api/tweets/[tweet_id]/quotes/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getQuotingTweetsPage } from '@/lib/quotingTweets'
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 30
+
+function boundedInteger(
+  value: string | null,
+  fallback: number,
+  minimum: number,
+  maximum: number,
+): number {
+  if (value === null) return fallback
+  if (!/^\d+$/.test(value)) throw new Error('Invalid quote pagination')
+  const parsed = Number(value)
+  if (!Number.isSafeInteger(parsed) || parsed < minimum || parsed > maximum) {
+    throw new Error('Invalid quote pagination')
+  }
+  return parsed
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { tweet_id: string } },
+) {
+  try {
+    if (!/^\d{1,20}$/.test(params.tweet_id)) {
+      return NextResponse.json({ error: 'Tweet not found' }, { status: 404 })
+    }
+    const searchParams = new URL(request.url).searchParams
+    const offset = boundedInteger(searchParams.get('offset'), 0, 0, 5_000)
+    const limit = boundedInteger(searchParams.get('limit'), 12, 1, 50)
+    return NextResponse.json(
+      await getQuotingTweetsPage(params.tweet_id, offset, limit),
+      { headers: { 'Cache-Control': 'private, no-store' } },
+    )
+  } catch (error) {
+    const message = error instanceof Error ? error.message : ''
+    const invalid = message === 'Invalid quote pagination'
+    if (!invalid) console.error('Quote-post pagination failed:', error)
+    return NextResponse.json(
+      {
+        error: invalid
+          ? message
+          : 'Archived quotes are temporarily unavailable',
+      },
+      { status: invalid ? 400 : 502 },
+    )
+  }
+}

--- a/src/app/bangers/page.tsx
+++ b/src/app/bangers/page.tsx
@@ -30,8 +30,6 @@ export default async function BangersPage({
   const scope: PortalBangersScope =
     paramValue(searchParams.scope) === 'members' ? 'members' : 'all'
   const periodValue = paramValue(searchParams.period)
-  const period: PortalBangersPeriod | undefined =
-    periodValue === 'today' || periodValue === 'week' ? periodValue : undefined
   const requestedYear = Number(paramValue(searchParams.year))
   const currentYear = new Date().getUTCFullYear()
   const year =
@@ -40,6 +38,15 @@ export default async function BangersPage({
     requestedYear <= currentYear + 1
       ? requestedYear
       : undefined
+  const period: PortalBangersPeriod | undefined =
+    periodValue === 'today' ||
+    periodValue === 'week' ||
+    periodValue === 'three-months'
+      ? periodValue
+      : periodValue === 'all' || year !== undefined
+        ? undefined
+        : 'today'
+  const allTime = periodValue === 'all'
   const query = paramValue(searchParams.q).trim().slice(0, 120)
   const initialPage = await getInitialPortalBangersPage({
     scope,
@@ -60,7 +67,7 @@ export default async function BangersPage({
         <header className="mb-7 max-w-[760px]">
           <p className="mb-1.5 flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-[0.12em] text-brand">
             <span aria-hidden="true">✦</span>
-            The archive&apos;s all-time greats
+            The archive&apos;s standout posts
           </p>
           <h1
             className="mb-2 text-[34px] font-semibold leading-tight sm:text-[38px]"
@@ -71,8 +78,8 @@ export default async function BangersPage({
           <p className={`text-[13.5px] leading-relaxed ${MUTED}`}>
             The archive&apos;s most quoted tweets, ranked by distinct quote
             tweets from archive uploaders and opted-in members. Quotes by the
-            original author do not count. Browse the full ranked snapshot as it
-            loads.
+            original author do not count. Today&apos;s rolling 24-hour view is
+            selected by default, with longer ranges available below.
           </p>
         </header>
         <BangersExplorer
@@ -83,10 +90,8 @@ export default async function BangersPage({
           currentYear={currentYear}
           year={period ? undefined : year}
           period={period}
+          allTime={allTime}
           initialQuery={query}
-          initialView={
-            paramValue(searchParams.view) === 'years' ? 'years' : 'list'
-          }
         />
       </div>
     </main>

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -98,6 +98,8 @@ function SearchPageContent() {
               resultsDescription={searchDescription}
               collapseLongTweets
               compact
+              permalinkOrigin="search"
+              permalinkReturnTo={`/search?${tweetListKey}`}
             />
           ) : (
             <div className="rounded-xl border border-dashed border-border bg-card px-6 py-10 text-center sm:px-10">

--- a/src/app/tweets/[tweet_id]/page.tsx
+++ b/src/app/tweets/[tweet_id]/page.tsx
@@ -1,15 +1,22 @@
 import { getTweetPageData } from '@/lib/getTweetPageData'
 import { notFound } from 'next/navigation'
 import TweetComponent from '@/components/TweetComponent'
+import TweetBackLink from '@/components/TweetBackLink'
 import ThreadView from '@/components/ThreadView'
 import QuotingTweetsSidebar from '@/components/QuotingTweetsSidebar'
-import Link from 'next/link'
-import { ArrowLeft, Link2, MessagesSquare } from 'lucide-react'
+import { getTweetBackLink } from '@/lib/navigation'
+import { Link2, MessagesSquare } from 'lucide-react'
 
 // ISR: serve from CDN cache, revalidate at most once per hour
 export const revalidate = 3600
 
-export default async function TweetPage({ params }: any) {
+export default async function TweetPage({
+  params,
+  searchParams,
+}: {
+  params: { tweet_id: string }
+  searchParams?: Record<string, string | string[] | undefined>
+}) {
   const { tweet_id } = params
   const { tweet, threadTree, quotingTweets, quotingTweetCount } =
     await getTweetPageData(tweet_id)
@@ -19,17 +26,16 @@ export default async function TweetPage({ params }: any) {
   }
 
   const isThread = threadTree && Object.keys(threadTree.tweets).length > 1
+  const backLink = getTweetBackLink(searchParams)
 
   return (
     <main className="min-h-screen bg-background">
       <section className="mx-auto w-full max-w-7xl px-4 py-10 sm:px-6 sm:py-14 lg:px-8">
-        <Link
-          href="/search"
-          className="inline-flex items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Back to search
-        </Link>
+        <TweetBackLink
+          href={backLink.href}
+          label={backLink.label}
+          useHistory={backLink.hasKnownOrigin}
+        />
 
         <header className="mb-8 mt-8 border-b border-border pb-7">
           <div className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.16em] text-brand">
@@ -70,6 +76,7 @@ export default async function TweetPage({ params }: any) {
           <QuotingTweetsSidebar
             tweets={quotingTweets}
             totalCount={quotingTweetCount}
+            targetTweet={tweet}
           />
         </div>
       </section>

--- a/src/components/QuotingTweetsSidebar.test.tsx
+++ b/src/components/QuotingTweetsSidebar.test.tsx
@@ -9,6 +9,16 @@ jest.mock('@/components/TweetAvatarImage', () => ({
   __esModule: true,
   default: () => null,
 }))
+jest.mock('@/components/ImageLightbox', () => ({
+  __esModule: true,
+  default: ({ src, alt }: { src: string; alt: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src={src} alt={alt} />
+  ),
+}))
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}))
 
 const quotingTweet: TweetData = {
   tweet_id: 'quote-1',
@@ -23,28 +33,61 @@ const quotingTweet: TweetData = {
   avatar_media_url: 'https://example.com/avatar.jpg',
   username: 'quote_author',
   account_display_name: 'Quote Author',
-  media: [],
+  media: [
+    {
+      media_url: 'https://example.com/quote-image.jpg',
+      media_type: 'photo',
+    },
+  ],
   urls: [],
+}
+
+const targetTweet: TweetData = {
+  ...quotingTweet,
+  tweet_id: 'original-1',
+  account_id: 'account-2',
+  full_text: 'The complete original tweet being quoted.',
+  username: 'original_author',
+  account_display_name: 'Original Author',
+  quote_tweet_id: null,
+  media: [
+    {
+      media_url: 'https://example.com/original-image.jpg',
+      media_type: 'photo',
+    },
+  ],
 }
 
 describe('QuotingTweetsSidebar', () => {
   it('renders quoting tweets, engagement, and the complete result count', () => {
     const markup = renderToStaticMarkup(
-      <QuotingTweetsSidebar tweets={[quotingTweet]} totalCount={15} />,
+      <QuotingTweetsSidebar
+        tweets={[quotingTweet]}
+        totalCount={15}
+        targetTweet={targetTweet}
+      />,
     )
 
     expect(markup).toContain('aria-labelledby="quoting-tweets-heading"')
     expect(markup).toContain('Tweets quoting this')
     expect(markup).toContain('Quote Author')
     expect(markup).toContain('A useful perspective &amp; a second thought.')
+    expect(markup).toContain('quote-image.jpg')
+    expect(markup).toContain('The complete original tweet being quoted.')
+    expect(markup).toContain('original-image.jpg')
     expect(markup).toContain('href="/tweets/quote-1"')
     expect(markup).toContain('aria-label="15 quotes"')
-    expect(markup).toContain('Showing 1 of 15')
+    expect(markup).not.toContain('Open quote')
+    expect(markup).toContain('Load more quotes')
   })
 
   it('shows an archive-specific empty state', () => {
     const markup = renderToStaticMarkup(
-      <QuotingTweetsSidebar tweets={[]} totalCount={0} />,
+      <QuotingTweetsSidebar
+        tweets={[]}
+        totalCount={0}
+        targetTweet={targetTweet}
+      />,
     )
 
     expect(markup).toContain('No archived quotes yet')

--- a/src/components/QuotingTweetsSidebar.test.tsx
+++ b/src/components/QuotingTweetsSidebar.test.tsx
@@ -24,7 +24,7 @@ const quotingTweet: TweetData = {
   tweet_id: 'quote-1',
   account_id: 'account-1',
   created_at: '2026-08-01T12:00:00Z',
-  full_text: 'A useful perspective &amp; a second thought.',
+  full_text: 'A useful perspective &amp;amp; a second thought.',
   retweet_count: 4,
   favorite_count: 21,
   reply_to_tweet_id: null,

--- a/src/components/QuotingTweetsSidebar.tsx
+++ b/src/components/QuotingTweetsSidebar.tsx
@@ -1,155 +1,263 @@
-import React from 'react'
-import Link from 'next/link'
-import { FaHeart, FaRetweet } from 'react-icons/fa'
-import { Quote } from 'lucide-react'
-import { Avatar, AvatarFallback } from '@/components/ui/avatar'
-import TweetAvatarImage from '@/components/TweetAvatarImage'
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Loader2, Quote } from 'lucide-react'
+import TweetCard from '@/components/TweetCard'
 import type { TweetData } from '@/components/TweetComponent'
 import { formatNumber } from '@/lib/formatNumber'
+import type {
+  PortalMedia,
+  PortalQuotedTweet,
+  PortalTweet,
+} from '@/lib/portal/types'
 
 interface QuotingTweetsSidebarProps {
   tweets: TweetData[]
   totalCount: number
+  targetTweet: TweetData
 }
 
-const dateFormatter = new Intl.DateTimeFormat('en', {
-  month: 'short',
-  day: 'numeric',
-  year: 'numeric',
-  timeZone: 'UTC',
-})
-
-function decodeTweetText(text: string) {
-  return text
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#039;|&#x27;/g, "'")
+interface QuotesPageResponse {
+  tweets: TweetData[]
+  totalCount: number
+  nextOffset: number | null
+  error?: string
 }
 
-function getAvatarInitial(...values: Array<string | undefined>) {
-  for (const value of values) {
-    const initial = Array.from(value?.trim() ?? '')[0]
-    if (initial) return initial
+const PAGE_SIZE = 12
+
+function portalMedia(media: TweetData['media']): PortalMedia[] {
+  return (media ?? []).map((item) => ({
+    url: item.media_url,
+    type: item.media_type,
+    width: item.width,
+    height: item.height,
+  }))
+}
+
+function quotedTweet(tweet: TweetData): PortalQuotedTweet {
+  return {
+    id: tweet.tweet_id,
+    username: tweet.username,
+    name: tweet.account_display_name,
+    avatar: tweet.avatar_media_url,
+    text: tweet.full_text,
+    createdAt: tweet.created_at,
+    likes: tweet.favorite_count,
+    rts: tweet.retweet_count ?? 0,
+    media: portalMedia(tweet.media),
   }
-  return 'U'
+}
+
+function portalTweet(tweet: TweetData, target: TweetData): PortalTweet {
+  return {
+    id: tweet.tweet_id,
+    username: tweet.username,
+    name: tweet.account_display_name,
+    avatar: tweet.avatar_media_url,
+    text: tweet.full_text,
+    observedAt: tweet.created_at,
+    createdAt: tweet.created_at,
+    likes: tweet.favorite_count,
+    rts: tweet.retweet_count ?? 0,
+    media: portalMedia(tweet.media),
+    quotedTweet: quotedTweet(target),
+  }
+}
+
+function dedupeTweets(tweets: TweetData[]): TweetData[] {
+  return Array.from(
+    new Map(tweets.map((tweet) => [tweet.tweet_id, tweet])).values(),
+  )
 }
 
 export default function QuotingTweetsSidebar({
-  tweets,
-  totalCount,
+  tweets: initialTweets,
+  totalCount: initialTotalCount,
+  targetTweet,
 }: QuotingTweetsSidebarProps) {
+  const [tweets, setTweets] = useState(initialTweets)
+  const [totalCount, setTotalCount] = useState(initialTotalCount)
+  const [nextOffset, setNextOffset] = useState<number | null>(
+    initialTweets.length < initialTotalCount ? initialTweets.length : null,
+  )
+  const [isLoading, setIsLoading] = useState(false)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [isDesktop, setIsDesktop] = useState(false)
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null)
+  const loadMoreRef = useRef<HTMLDivElement | null>(null)
+  const loadingRef = useRef(false)
+  const requestControllerRef = useRef<AbortController | null>(null)
+
+  const renderedTweets = useMemo(
+    () => tweets.map((tweet) => portalTweet(tweet, targetTweet)),
+    [targetTweet, tweets],
+  )
+
+  const loadMore = useCallback(async () => {
+    if (nextOffset === null || loadingRef.current) return
+
+    const controller = new AbortController()
+    requestControllerRef.current = controller
+    loadingRef.current = true
+    setIsLoading(true)
+    setLoadError(null)
+
+    try {
+      const response = await fetch(
+        `/api/tweets/${encodeURIComponent(targetTweet.tweet_id)}/quotes?offset=${nextOffset}&limit=${PAGE_SIZE}`,
+        { signal: controller.signal },
+      )
+      const body = (await response
+        .json()
+        .catch(() => null)) as QuotesPageResponse | null
+      if (!response.ok || !body || !Array.isArray(body.tweets)) {
+        throw new Error(body?.error || 'Could not load more archived quotes')
+      }
+
+      setTweets((current) => dedupeTweets([...current, ...body.tweets]))
+      setTotalCount(body.totalCount)
+      setNextOffset(body.nextOffset)
+    } catch (error) {
+      if (controller.signal.aborted) return
+      setLoadError(
+        error instanceof Error
+          ? error.message
+          : 'Could not load more archived quotes',
+      )
+    } finally {
+      if (!controller.signal.aborted) {
+        loadingRef.current = false
+        setIsLoading(false)
+      }
+    }
+  }, [nextOffset, targetTweet.tweet_id])
+
+  useEffect(() => {
+    const media = window.matchMedia('(min-width: 1024px)')
+    const update = () => setIsDesktop(media.matches)
+    update()
+    media.addEventListener('change', update)
+    return () => media.removeEventListener('change', update)
+  }, [])
+
+  useEffect(() => {
+    const target = loadMoreRef.current
+    if (!target || nextOffset === null) return
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) void loadMore()
+      },
+      {
+        root: isDesktop ? scrollContainerRef.current : null,
+        rootMargin: '240px 0px',
+      },
+    )
+    observer.observe(target)
+    return () => observer.disconnect()
+  }, [isDesktop, loadMore, nextOffset])
+
+  useEffect(
+    () => () => {
+      requestControllerRef.current?.abort()
+    },
+    [],
+  )
+
   return (
     <aside
       aria-labelledby="quoting-tweets-heading"
-      className="lg:sticky lg:top-24"
+      className="lg:sticky lg:top-24 lg:h-[calc(100vh-7rem)] lg:min-h-0"
     >
-      <div className="overflow-hidden rounded-xl border border-border bg-card shadow-sm">
-        <div className="flex items-center justify-between gap-3 border-b border-border px-5 py-4">
-          <div className="flex items-center gap-2">
-            <Quote className="h-4 w-4 text-brand" aria-hidden="true" />
-            <h2
-              id="quoting-tweets-heading"
-              className="font-semibold text-foreground"
+      <div className="flex overflow-hidden rounded-xl border border-border bg-card shadow-sm lg:h-full lg:min-h-0 lg:flex-col">
+        <div className="flex min-w-0 flex-1 flex-col lg:min-h-0">
+          <div className="flex flex-none items-center justify-between gap-3 border-b border-border px-5 py-4">
+            <div className="flex items-center gap-2">
+              <Quote className="h-4 w-4 text-brand" aria-hidden="true" />
+              <h2
+                id="quoting-tweets-heading"
+                className="font-semibold text-foreground"
+              >
+                Tweets quoting this
+              </h2>
+            </div>
+            <span
+              className="rounded-full bg-muted px-2.5 py-1 text-xs font-semibold tabular-nums text-muted-foreground"
+              aria-label={`${totalCount} ${totalCount === 1 ? 'quote' : 'quotes'}`}
             >
-              Tweets quoting this
-            </h2>
+              {formatNumber(totalCount)}
+            </span>
           </div>
-          <span
-            className="rounded-full bg-muted px-2.5 py-1 text-xs font-semibold tabular-nums text-muted-foreground"
-            aria-label={`${totalCount} ${totalCount === 1 ? 'quote' : 'quotes'}`}
-          >
-            {formatNumber(totalCount)}
-          </span>
-        </div>
 
-        {tweets.length === 0 ? (
-          <div className="px-5 py-8 text-center">
-            <Quote
-              className="mx-auto h-7 w-7 text-muted-foreground/60"
-              aria-hidden="true"
-            />
-            <p className="mt-3 text-sm font-medium text-foreground">
-              No archived quotes yet
-            </p>
-            <p className="mt-1 text-xs leading-5 text-muted-foreground">
-              Tweets in Community Archive that quote this post will appear here.
-            </p>
-          </div>
-        ) : (
-          <div className="divide-y divide-border">
-            {tweets.map((tweet) => (
-              <article key={tweet.tweet_id} className="px-5 py-4">
-                <div className="flex items-start gap-3">
-                  <Avatar className="h-9 w-9 flex-shrink-0">
-                    <TweetAvatarImage
-                      src={tweet.avatar_media_url}
-                      alt={`${tweet.account_display_name}'s profile picture`}
-                      username={tweet.username}
-                      tweetId={tweet.tweet_id}
-                    />
-                    <AvatarFallback className="text-xs">
-                      {getAvatarInitial(
-                        tweet.account_display_name,
-                        tweet.username,
-                      )}
-                    </AvatarFallback>
-                  </Avatar>
+          {tweets.length === 0 ? (
+            <div className="px-5 py-8 text-center">
+              <Quote
+                className="mx-auto h-7 w-7 text-muted-foreground/60"
+                aria-hidden="true"
+              />
+              <p className="mt-3 text-sm font-medium text-foreground">
+                No archived quotes yet
+              </p>
+              <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                Tweets in Community Archive that quote this post will appear
+                here.
+              </p>
+            </div>
+          ) : (
+            <div
+              ref={scrollContainerRef}
+              role="region"
+              aria-label="Archived tweets quoting this post"
+              tabIndex={0}
+              className="min-h-0 divide-y divide-border overscroll-contain focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand/50 lg:flex-1 lg:overflow-y-auto"
+            >
+              {renderedTweets.map((tweet) => (
+                <TweetCard key={tweet.id} tweet={tweet} clickable showDate />
+              ))}
 
-                  <div className="min-w-0 flex-1">
-                    <div className="flex min-w-0 items-baseline gap-1.5">
-                      <span className="truncate text-sm font-semibold text-foreground">
-                        {tweet.account_display_name}
-                      </span>
-                      <span className="truncate text-xs text-muted-foreground">
-                        @{tweet.username}
-                      </span>
-                    </div>
-                    <time
-                      dateTime={tweet.created_at}
-                      className="text-xs text-muted-foreground"
-                    >
-                      {dateFormatter.format(new Date(tweet.created_at))}
-                    </time>
-                  </div>
-                </div>
-
-                <p className="mt-3 line-clamp-4 whitespace-pre-wrap break-words text-sm leading-5 text-foreground">
-                  {decodeTweetText(tweet.full_text)}
-                </p>
-
-                <div className="mt-3 flex items-center justify-between gap-3 text-xs text-muted-foreground">
-                  <div className="flex items-center gap-3">
-                    <span className="inline-flex items-center gap-1">
-                      <FaHeart aria-hidden="true" />
-                      {formatNumber(tweet.favorite_count)}
-                      <span className="sr-only">likes</span>
-                    </span>
-                    <span className="inline-flex items-center gap-1">
-                      <FaRetweet aria-hidden="true" />
-                      {formatNumber(tweet.retweet_count ?? 0)}
-                      <span className="sr-only">reposts</span>
-                    </span>
-                  </div>
-                  <Link
-                    href={`/tweets/${tweet.tweet_id}`}
-                    className="font-medium text-brand underline-offset-2 hover:underline"
+              {loadError ? (
+                <div className="px-5 py-4 text-center">
+                  <p className="text-xs text-red-600 dark:text-red-400">
+                    {loadError}
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => void loadMore()}
+                    className="mt-2 text-xs font-semibold text-brand hover:underline"
                   >
-                    Open quote
-                  </Link>
+                    Try again
+                  </button>
                 </div>
-              </article>
-            ))}
-          </div>
-        )}
+              ) : null}
 
-        {totalCount > tweets.length && (
-          <p className="border-t border-border bg-muted/40 px-5 py-3 text-center text-xs text-muted-foreground">
-            Showing {tweets.length} of {formatNumber(totalCount)} archived
-            quotes
-          </p>
-        )}
+              {nextOffset !== null ? (
+                <div
+                  ref={loadMoreRef}
+                  className="min-h-16 flex items-center justify-center px-5 py-3"
+                >
+                  <button
+                    type="button"
+                    onClick={() => void loadMore()}
+                    disabled={isLoading}
+                    className="inline-flex items-center gap-2 text-xs font-semibold text-brand disabled:cursor-wait disabled:opacity-60"
+                  >
+                    {isLoading ? (
+                      <Loader2
+                        aria-hidden="true"
+                        className="h-3.5 w-3.5 animate-spin"
+                      />
+                    ) : null}
+                    {isLoading ? 'Loading quotes…' : 'Load more quotes'}
+                  </button>
+                </div>
+              ) : (
+                <p className="px-5 py-3 text-center text-xs text-muted-foreground">
+                  All {formatNumber(totalCount)} archived quotes loaded
+                </p>
+              )}
+            </div>
+          )}
+        </div>
       </div>
     </aside>
   )

--- a/src/components/TweetBackLink.tsx
+++ b/src/components/TweetBackLink.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { ArrowLeft } from 'lucide-react'
+
+export default function TweetBackLink({
+  href,
+  label,
+  useHistory,
+}: {
+  href: string
+  label: string
+  useHistory: boolean
+}) {
+  const router = useRouter()
+
+  return (
+    <Link
+      href={href}
+      onClick={(event) => {
+        if (!useHistory || window.history.length <= 1) return
+        event.preventDefault()
+        router.back()
+      }}
+      className="inline-flex items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+    >
+      <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+      {label}
+    </Link>
+  )
+}

--- a/src/components/TweetCard.test.tsx
+++ b/src/components/TweetCard.test.tsx
@@ -23,7 +23,7 @@ const tweet: PortalTweet = {
   username: 'alice',
   name: 'Alice',
   avatar: null,
-  text: 'A complete tweet with media and a quote.',
+  text: 'A complete tweet &amp;amp; media with &amp;gt; one encoding layer.',
   observedAt: '2026-08-10T12:00:00.000Z',
   createdAt: '2026-08-10T12:00:00.000Z',
   likes: 12,
@@ -34,7 +34,7 @@ const tweet: PortalTweet = {
     username: 'bob',
     name: 'Bob',
     avatar: null,
-    text: 'The complete quoted tweet.',
+    text: 'The complete &amp;quot;quoted&amp;quot; tweet.',
     createdAt: '2026-08-09T12:00:00.000Z',
     likes: 8,
     rts: 2,
@@ -49,9 +49,9 @@ describe('TweetCard', () => {
     render(<TweetCard tweet={tweet} />)
 
     expect(
-      screen.getByText('A complete tweet with media and a quote.'),
+      screen.getByText('A complete tweet & media with > one encoding layer.'),
     ).toBeVisible()
-    expect(screen.getByText('The complete quoted tweet.')).toBeVisible()
+    expect(screen.getByText('The complete "quoted" tweet.')).toBeVisible()
     expect(
       screen.getAllByTestId('tweet-image').map((image) => image.dataset.src),
     ).toEqual([

--- a/src/components/TweetCard.test.tsx
+++ b/src/components/TweetCard.test.tsx
@@ -1,0 +1,99 @@
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen } from '@testing-library/react'
+import TweetCard from './TweetCard'
+import type { PortalTweet } from '@/lib/portal/types'
+
+const push = jest.fn()
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push }),
+}))
+jest.mock('@/components/TweetAvatarImage', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+jest.mock('@/components/ImageLightbox', () => ({
+  __esModule: true,
+  default: ({ src, alt }: { src: string; alt: string }) => (
+    <span data-testid="tweet-image" data-src={src} aria-label={alt} />
+  ),
+}))
+
+const tweet: PortalTweet = {
+  id: '123',
+  username: 'alice',
+  name: 'Alice',
+  avatar: null,
+  text: 'A complete tweet with media and a quote.',
+  observedAt: '2026-08-10T12:00:00.000Z',
+  createdAt: '2026-08-10T12:00:00.000Z',
+  likes: 12,
+  rts: 3,
+  media: [{ url: 'https://example.com/tweet.jpg', type: 'photo' }],
+  quotedTweet: {
+    id: '122',
+    username: 'bob',
+    name: 'Bob',
+    avatar: null,
+    text: 'The complete quoted tweet.',
+    createdAt: '2026-08-09T12:00:00.000Z',
+    likes: 8,
+    rts: 2,
+    media: [{ url: 'https://example.com/quoted.jpg', type: 'photo' }],
+  },
+}
+
+describe('TweetCard', () => {
+  beforeEach(() => push.mockReset())
+
+  test('renders tweet media and the complete quoted tweet', () => {
+    render(<TweetCard tweet={tweet} />)
+
+    expect(
+      screen.getByText('A complete tweet with media and a quote.'),
+    ).toBeVisible()
+    expect(screen.getByText('The complete quoted tweet.')).toBeVisible()
+    expect(
+      screen.getAllByTestId('tweet-image').map((image) => image.dataset.src),
+    ).toEqual([
+      'https://example.com/tweet.jpg',
+      'https://example.com/quoted.jpg',
+    ])
+  })
+
+  test('makes the card clickable while preserving its origin', () => {
+    const { container } = render(
+      <TweetCard
+        tweet={tweet}
+        clickable
+        origin="bangers"
+        returnTo="/bangers?period=today"
+      />,
+    )
+
+    const card = container.querySelector('article')
+    expect(card).not.toBeNull()
+    if (!card) return
+    fireEvent.click(card)
+    expect(push).toHaveBeenCalledWith(
+      '/tweets/123?from=bangers&returnTo=%2Fbangers%3Fperiod%3Dtoday',
+    )
+
+    fireEvent.keyDown(card, { key: 'Enter' })
+    expect(push).toHaveBeenCalledTimes(2)
+  })
+
+  test('uses the same light neutral outline for every featured rank', () => {
+    const { container } = render(
+      <>
+        <TweetCard tweet={tweet} featuredRank={1} />
+        <TweetCard tweet={{ ...tweet, id: '124' }} featuredRank={4} />
+      </>,
+    )
+    const cards = Array.from(container.querySelectorAll('article'))
+
+    expect(cards).toHaveLength(2)
+    expect(cards[0].className).toBe(cards[1].className)
+    expect(cards[0]).toHaveClass('border-zinc-200/75')
+    expect(cards[0].className).not.toMatch(/blue|translate|hover:border/)
+  })
+})

--- a/src/components/TweetCard.tsx
+++ b/src/components/TweetCard.tsx
@@ -1,0 +1,11 @@
+/**
+ * Canonical full-fidelity tweet card entrypoint for product surfaces.
+ *
+ * Adapters must populate `media` and `quotedTweet`; do not replace this with a
+ * surface-specific partial tweet renderer.
+ */
+export {
+  TweetRow as TweetCard,
+  TweetRow as default,
+  type TweetCardProps,
+} from './portal/TweetRow'

--- a/src/components/TweetComponent.tsx
+++ b/src/components/TweetComponent.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React from 'react'
+import { tweetPermalinkHref, type TweetOrigin } from '@/lib/navigation'
 import { formatDistanceToNow } from 'date-fns'
 import {
   FaHeart,
@@ -92,6 +93,8 @@ interface TweetComponentProps {
   className?: string
   collapseLongText?: boolean
   compact?: boolean
+  permalinkOrigin?: TweetOrigin
+  permalinkReturnTo?: string
 }
 
 export const compactTweetGridClass =
@@ -124,6 +127,8 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
   className = '',
   collapseLongText = false,
   compact = false,
+  permalinkOrigin,
+  permalinkReturnTo,
 }) => {
   const [isTextExpanded, setIsTextExpanded] = React.useState(false)
   // Support both interface formats for backwards compatibility
@@ -411,7 +416,11 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
               </div>
               <div className="flex items-center space-x-3">
                 <a
-                  href={`/tweets/${quotedTweet.tweet_id}`}
+                  href={tweetPermalinkHref(
+                    quotedTweet.tweet_id,
+                    permalinkOrigin,
+                    permalinkReturnTo,
+                  )}
                   className="transition-colors hover:text-foreground"
                   title="Permalink to quoted tweet"
                 >
@@ -441,7 +450,11 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
       aria-label="Tweet links"
     >
       <a
-        href={`/tweets/${tweet.tweet_id}`}
+        href={tweetPermalinkHref(
+          tweet.tweet_id,
+          permalinkOrigin,
+          permalinkReturnTo,
+        )}
         className={`${compactActionClass} border-brand/30 bg-brand/10 text-brand hover:bg-brand/20`}
         aria-label="View tweet in Community Archive"
         title="View tweet in Community Archive"
@@ -663,7 +676,11 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
         <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
           <span>{new Date(tweet.created_at).toLocaleDateString()}</span>
           <a
-            href={`/tweets/${tweet.tweet_id}`}
+            href={tweetPermalinkHref(
+              tweet.tweet_id,
+              permalinkOrigin,
+              permalinkReturnTo,
+            )}
             className="inline-flex items-center gap-1 transition-colors hover:text-foreground"
             title="Permalink"
           >

--- a/src/components/TweetComponent.tsx
+++ b/src/components/TweetComponent.tsx
@@ -13,6 +13,7 @@ import {
 import { Archive } from 'lucide-react'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { formatNumber } from '@/lib/formatNumber'
+import { decodeTweetText } from '@/lib/tweetText'
 import TweetAvatarImage from '@/components/TweetAvatarImage'
 import ImageLightbox from '@/components/ImageLightbox'
 
@@ -103,25 +104,6 @@ export const compactTweetGridClass =
 const compactActionClass =
   'inline-flex h-7 items-center gap-1.5 rounded-md border px-2 text-[11px] font-semibold leading-none transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
 
-// Helper function to decode HTML entities
-const decodeHtmlEntities = (text: string): string => {
-  if (typeof window === 'undefined') {
-    // Server-side fallback
-    return text
-      .replace(/&amp;/g, '&')
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-      .replace(/&quot;/g, '"')
-      .replace(/&#039;/g, "'")
-      .replace(/&#x27;/g, "'")
-      .replace(/&#x2F;/g, '/')
-  }
-  // Client-side: use DOM parser
-  const textarea = document.createElement('textarea')
-  textarea.innerHTML = text
-  return textarea.value
-}
-
 export const TweetComponent: React.FC<TweetComponentProps> = ({
   tweet,
   className = '',
@@ -187,7 +169,7 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
 
   const formatText = (text: string) => {
     // First decode HTML entities
-    let formattedText = decodeHtmlEntities(text)
+    let formattedText = decodeTweetText(text)
 
     // Replace t.co URLs with their expanded versions or display URLs
     if (tweet.urls) {
@@ -363,7 +345,7 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
                 compact ? 'line-clamp-3 text-xs leading-4' : 'text-sm leading-6'
               }`}
             >
-              {decodeHtmlEntities(quotedTweet.full_text)}
+              {decodeTweetText(quotedTweet.full_text)}
             </p>
             {quotedTweet.media && quotedTweet.media.length > 0 && (
               <div

--- a/src/components/TweetList.tsx
+++ b/src/components/TweetList.tsx
@@ -10,6 +10,7 @@ import { SupabaseClient } from '@supabase/supabase-js'
 import { TimelineTweet } from '@/lib/types'
 import { FilterCriteria, fetchTweets } from '@/lib/queries/tweetQueries'
 import { AlertCircle } from 'lucide-react'
+import type { TweetOrigin } from '@/lib/navigation'
 
 interface TweetListProps {
   filterCriteria: FilterCriteria
@@ -20,6 +21,8 @@ interface TweetListProps {
   resultsDescription?: string
   collapseLongTweets?: boolean
   compact?: boolean
+  permalinkOrigin?: TweetOrigin
+  permalinkReturnTo?: string
 }
 
 const DEFAULT_ITEMS_PER_PAGE = 20
@@ -33,6 +36,8 @@ export default function TweetList({
   resultsDescription,
   collapseLongTweets = false,
   compact = false,
+  permalinkOrigin,
+  permalinkReturnTo,
 }: TweetListProps) {
   const [tweets, setTweets] = useState<TimelineTweet[]>([])
   const [isLoading, setIsLoading] = useState(true)
@@ -200,6 +205,8 @@ export default function TweetList({
         headerDescription={resultsDescription}
         collapseLongTweets={collapseLongTweets}
         compact={compact}
+        permalinkOrigin={permalinkOrigin}
+        permalinkReturnTo={permalinkReturnTo}
       />
 
       {error && tweets.length > 0 && (

--- a/src/components/UnifiedTweetList.tsx
+++ b/src/components/UnifiedTweetList.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import TweetComponent, { compactTweetGridClass } from './TweetComponent'
 import { Button } from '@/components/ui/button'
 import { Download, SearchX } from 'lucide-react'
+import type { TweetOrigin } from '@/lib/navigation'
 
 interface UnifiedTweetListProps {
   tweets: any[]
@@ -16,6 +17,8 @@ interface UnifiedTweetListProps {
   headerDescription?: string
   collapseLongTweets?: boolean
   compact?: boolean
+  permalinkOrigin?: TweetOrigin
+  permalinkReturnTo?: string
 }
 
 /**
@@ -34,6 +37,8 @@ export default function UnifiedTweetList({
   headerDescription,
   collapseLongTweets = false,
   compact = false,
+  permalinkOrigin,
+  permalinkReturnTo,
 }: UnifiedTweetListProps) {
   const handleExportCsv = () => {
     if (tweets.length === 0) {
@@ -175,6 +180,8 @@ export default function UnifiedTweetList({
                   tweet={tweet}
                   collapseLongText={collapseLongTweets}
                   compact
+                  permalinkOrigin={permalinkOrigin}
+                  permalinkReturnTo={permalinkReturnTo}
                 />
               </div>
             ))}
@@ -190,6 +197,8 @@ export default function UnifiedTweetList({
               <TweetComponent
                 tweet={tweet}
                 collapseLongText={collapseLongTweets}
+                permalinkOrigin={permalinkOrigin}
+                permalinkReturnTo={permalinkReturnTo}
               />
             </div>
           ))}

--- a/src/components/portal/BangersExplorer.test.tsx
+++ b/src/components/portal/BangersExplorer.test.tsx
@@ -1,11 +1,13 @@
 import '@testing-library/jest-dom'
 import {
+  act,
   fireEvent,
   render,
   screen,
   waitFor,
   within,
 } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { BangersExplorer } from './BangersExplorer'
 import type {
   PortalBangersPage,
@@ -15,8 +17,9 @@ import type {
 
 const push = jest.fn()
 jest.mock('next/navigation', () => ({ useRouter: () => ({ push }) }))
-jest.mock('./TweetRow', () => ({
-  TweetRow: ({
+jest.mock('@/components/TweetCard', () => ({
+  __esModule: true,
+  default: ({
     tweet,
     featuredRank,
   }: {
@@ -30,7 +33,16 @@ jest.mock('./TweetRow', () => ({
 }))
 
 class IntersectionObserverMock {
-  observe() {}
+  static instances: IntersectionObserverMock[] = []
+  readonly observed: Element[] = []
+
+  constructor(readonly callback: IntersectionObserverCallback) {
+    IntersectionObserverMock.instances.push(this)
+  }
+
+  observe(target: Element) {
+    this.observed.push(target)
+  }
   disconnect() {}
   unobserve() {}
 }
@@ -100,10 +112,17 @@ describe('BangersExplorer', () => {
   beforeEach(() => {
     window.history.replaceState({}, '', '/bangers')
     push.mockReset()
+    IntersectionObserverMock.instances = []
     Object.defineProperty(window, 'IntersectionObserver', {
       configurable: true,
       writable: true,
       value: IntersectionObserverMock,
+    })
+    Object.defineProperties(Element.prototype, {
+      hasPointerCapture: { configurable: true, value: () => false },
+      setPointerCapture: { configurable: true, value: () => undefined },
+      releasePointerCapture: { configurable: true, value: () => undefined },
+      scrollIntoView: { configurable: true, value: () => undefined },
     })
   })
 
@@ -177,7 +196,22 @@ describe('BangersExplorer', () => {
     expect(
       screen.getByRole('link', { name: 'Archive members' }),
     ).toHaveAttribute('href', '/bangers?scope=members&period=today')
-    expect(screen.getByText(/from today/)).toBeVisible()
+    expect(screen.getByText(/from the last 24 hours/)).toBeVisible()
+  })
+
+  test('orders all time above today and offers the last three months', async () => {
+    const user = userEvent.setup()
+    renderExplorer(page(), 'today')
+
+    await user.click(screen.getByRole('combobox', { name: 'Filter by time' }))
+
+    const options = screen.getAllByRole('option')
+    expect(options.slice(0, 4).map((option) => option.textContent)).toEqual([
+      'All time',
+      'Today',
+      'This week',
+      'Last 3 months',
+    ])
   })
 
   test('searches names and text and can clear the result', () => {
@@ -196,17 +230,13 @@ describe('BangersExplorer', () => {
     expect(screen.getAllByTestId('tweet-row')).toHaveLength(3)
   })
 
-  test('groups the all-years view into year columns with full totals', () => {
+  test('removes the by-year view control', () => {
     renderExplorer(page(tweets, 3, 4))
 
-    fireEvent.click(screen.getByRole('button', { name: 'By year' }))
-
-    const year2026 = screen.getByRole('region', { name: '2026' })
-    const year2025 = screen.getByRole('region', { name: '2025' })
-    expect(within(year2026).getAllByTestId('tweet-row')).toHaveLength(1)
-    expect(within(year2026).getByText('1 of 2 loaded')).toBeVisible()
-    expect(within(year2025).getAllByTestId('tweet-row')).toHaveLength(2)
-    expect(window.location.search).toBe('?view=years')
+    expect(
+      screen.queryByRole('button', { name: 'By year' }),
+    ).not.toBeInTheDocument()
+    expect(screen.getByTestId('bangers-masonry')).toBeVisible()
   })
 
   test('loads and appends the next ranked page', async () => {
@@ -227,5 +257,33 @@ describe('BangersExplorer', () => {
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     )
     expect(screen.getByText('All 4 matching bangers loaded.')).toBeVisible()
+  })
+
+  test('loads more when either masonry column reaches its end', async () => {
+    const nextTweet = tweet('4', 'Loaded from the short column', 2026, 2, 8)
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => page([nextTweet], null, 4),
+    } as Response)
+    renderExplorer(page(tweets, 3, 4))
+
+    const observer = IntersectionObserverMock.instances.at(-1)
+    const shortColumnSentinel = screen.getByTestId('bangers-column-sentinel-1')
+    expect(observer?.observed).toContain(shortColumnSentinel)
+    act(() => {
+      observer?.callback(
+        [
+          {
+            target: shortColumnSentinel,
+            isIntersecting: true,
+          } as unknown as IntersectionObserverEntry,
+        ],
+        observer as unknown as IntersectionObserver,
+      )
+    })
+
+    await waitFor(() =>
+      expect(screen.getByText('Loaded from the short column')).toBeVisible(),
+    )
   })
 })

--- a/src/components/portal/BangersExplorer.tsx
+++ b/src/components/portal/BangersExplorer.tsx
@@ -3,7 +3,8 @@
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Columns3, Grid2X2, Loader2, Search, X } from 'lucide-react'
+import { Loader2, Search, X } from 'lucide-react'
+import TweetCard from '@/components/TweetCard'
 import {
   Select,
   SelectContent,
@@ -18,10 +19,7 @@ import type {
   PortalBangersSort,
   PortalTweet,
 } from '@/lib/portal/types'
-import { TweetRow } from './TweetRow'
-import { CARD, MUTED, SERIF } from './styles'
-
-type BangersView = 'list' | 'years'
+import { CARD, MUTED } from './styles'
 
 interface BangersExplorerProps {
   initialPage: PortalBangersPage
@@ -30,8 +28,8 @@ interface BangersExplorerProps {
   currentYear: number
   year?: number
   period?: PortalBangersPeriod
+  allTime?: boolean
   initialQuery?: string
-  initialView?: BangersView
 }
 
 const segmentClassName =
@@ -41,21 +39,12 @@ const activeSegmentClassName =
 const idleSegmentClassName =
   'border-zinc-300 bg-transparent text-zinc-600 hover:border-zinc-500 hover:text-zinc-950 dark:border-[#3a3a40] dark:text-[#a7a7b4] dark:hover:border-zinc-500 dark:hover:text-white'
 
-function tweetYear(tweet: PortalTweet): number | null {
-  const year = new Date(tweet.createdAt).getUTCFullYear()
-  return Number.isFinite(year) ? year : null
-}
-
 function matchesQuery(tweet: PortalTweet, query: string): boolean {
   const normalized = query.trim().toLocaleLowerCase()
   if (!normalized) return true
   return `${tweet.name} ${tweet.username} ${tweet.text}`
     .toLocaleLowerCase()
     .includes(normalized)
-}
-
-function pluralizeTweets(count: number): string {
-  return `${count} ${count === 1 ? 'tweet' : 'tweets'}`
 }
 
 function dedupeTweets(tweets: PortalTweet[]): PortalTweet[] {
@@ -68,14 +57,14 @@ function bangersHref({
   sort,
   year,
   period,
-  view,
+  allTime,
 }: {
   query: string
   scope: PortalBangersScope
   sort: PortalBangersSort
   year?: number
   period?: PortalBangersPeriod
-  view: BangersView
+  allTime?: boolean
 }): string {
   const params = new URLSearchParams()
   const trimmedQuery = query.trim()
@@ -84,7 +73,7 @@ function bangersHref({
   if (sort === 'recent') params.set('sort', sort)
   if (period) params.set('period', period)
   else if (year !== undefined) params.set('year', String(year))
-  if (view === 'years') params.set('view', view)
+  else if (allTime) params.set('period', 'all')
   const search = params.toString()
   return `/bangers${search ? `?${search}` : ''}`
 }
@@ -123,13 +112,12 @@ export function BangersExplorer({
   currentYear,
   year,
   period,
+  allTime = false,
   initialQuery = '',
-  initialView = 'list',
 }: BangersExplorerProps) {
   const router = useRouter()
   const [query, setQuery] = useState(initialQuery)
   const [loadedQuery, setLoadedQuery] = useState(initialQuery.trim())
-  const [view, setView] = useState<BangersView>(initialView)
   const [page, setPage] = useState(initialPage)
   const [isLoading, setIsLoading] = useState(false)
   const [loadError, setLoadError] = useState<string | null>(null)
@@ -137,6 +125,7 @@ export function BangersExplorer({
   const requestVersionRef = useRef(0)
   const requestControllerRef = useRef<AbortController | null>(null)
   const loadMoreRef = useRef<HTMLDivElement | null>(null)
+  const columnLoadMoreRefs = useRef<Array<HTMLDivElement | null>>([])
 
   const availableYears = useMemo(() => {
     const years = page.pagination.yearCounts.map(({ year }) => year)
@@ -152,13 +141,6 @@ export function BangersExplorer({
     }
     return years.sort((left, right) => right - left)
   }, [currentYear, page.pagination.yearCounts, period, year])
-  const yearTotals = useMemo(
-    () =>
-      new Map(
-        page.pagination.yearCounts.map(({ year, count }) => [year, count]),
-      ),
-    [page.pagination.yearCounts],
-  )
   const visibleTweets = useMemo(
     () => page.tweets.filter((tweet) => matchesQuery(tweet, query)),
     [page.tweets, query],
@@ -186,19 +168,6 @@ export function BangersExplorer({
       ),
     [page.tweets],
   )
-  const groupedTweets = useMemo(() => {
-    const groups = new Map<number, PortalTweet[]>()
-    for (const tweet of visibleTweets) {
-      const groupYear = tweetYear(tweet)
-      if (groupYear === null) continue
-      const group = groups.get(groupYear) ?? []
-      group.push(tweet)
-      groups.set(groupYear, group)
-    }
-    return Array.from(groups.entries()).sort(
-      ([leftYear], [rightYear]) => rightYear - leftYear,
-    )
-  }, [visibleTweets])
 
   const requestPage = useCallback(
     async ({
@@ -287,15 +256,17 @@ export function BangersExplorer({
   }, [loadedQuery, query, requestPage])
 
   useEffect(() => {
-    const target = loadMoreRef.current
-    if (!target || page.pagination.nextOffset === null) return
+    const targets = [loadMoreRef.current, ...columnLoadMoreRefs.current].filter(
+      (target): target is HTMLDivElement => Boolean(target),
+    )
+    if (targets.length === 0 || page.pagination.nextOffset === null) return
     const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) loadMore()
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) loadMore()
       },
       { rootMargin: '700px 0px' },
     )
-    observer.observe(target)
+    targets.forEach((target) => observer.observe(target))
     return () => observer.disconnect()
   }, [loadMore, page.pagination.nextOffset])
 
@@ -307,22 +278,40 @@ export function BangersExplorer({
   )
 
   useEffect(() => {
-    const nextUrl = bangersHref({ query, scope, sort, year, period, view })
+    const nextUrl = bangersHref({
+      query,
+      scope,
+      sort,
+      year,
+      period,
+      allTime,
+    })
     window.history.replaceState(window.history.state, '', nextUrl)
-  }, [period, query, scope, sort, view, year])
+  }, [allTime, period, query, scope, sort, year])
 
   const hasFilters =
-    query.trim().length > 0 || year !== undefined || period !== undefined
+    query.trim().length > 0 ||
+    year !== undefined ||
+    allTime ||
+    (period !== undefined && period !== 'today')
   const selectedTime = period ?? (year === undefined ? 'all' : `year-${year}`)
   const clearFilters = () => {
     setQuery('')
-    if (year !== undefined || period !== undefined) {
-      router.push(bangersHref({ query: '', scope, sort, view }))
+    if (year !== undefined || allTime || period !== 'today') {
+      router.push(bangersHref({ query: '', scope, sort, period: 'today' }))
     }
   }
   const isSearching = query.trim() !== loadedQuery
   const loadedCount = page.tweets.length
   const totalCount = page.pagination.totalAvailable
+  const currentReturnTo = bangersHref({
+    query,
+    scope,
+    sort,
+    year,
+    period,
+    allTime,
+  })
 
   return (
     <section aria-label="Browse bangers">
@@ -373,7 +362,7 @@ export function BangersExplorer({
                   sort,
                   year,
                   period,
-                  view,
+                  allTime,
                 })}
                 aria-current={scope === 'all' ? 'page' : undefined}
                 className={`${segmentClassName} rounded-l-[3px] ${
@@ -391,7 +380,7 @@ export function BangersExplorer({
                   sort,
                   year,
                   period,
-                  view,
+                  allTime,
                 })}
                 aria-current={scope === 'members' ? 'page' : undefined}
                 className={`${segmentClassName} -ml-px rounded-r-[3px] ${
@@ -419,7 +408,7 @@ export function BangersExplorer({
                   sort: 'quotes',
                   year,
                   period,
-                  view,
+                  allTime,
                 })}
                 aria-current={sort === 'quotes' ? 'page' : undefined}
                 className={`${segmentClassName} rounded-l-[3px] ${
@@ -437,7 +426,7 @@ export function BangersExplorer({
                   sort: 'recent',
                   year,
                   period,
-                  view,
+                  allTime,
                 })}
                 aria-current={sort === 'recent' ? 'page' : undefined}
                 className={`${segmentClassName} -ml-px rounded-r-[3px] ${
@@ -461,7 +450,11 @@ export function BangersExplorer({
               value={selectedTime}
               onValueChange={(value) => {
                 const nextPeriod =
-                  value === 'today' || value === 'week' ? value : undefined
+                  value === 'today' ||
+                  value === 'week' ||
+                  value === 'three-months'
+                    ? value
+                    : undefined
                 const nextYear = value.startsWith('year-')
                   ? Number(value.slice(5))
                   : undefined
@@ -472,7 +465,7 @@ export function BangersExplorer({
                     sort,
                     year: nextYear,
                     period: nextPeriod,
-                    view,
+                    allTime: value === 'all',
                   }),
                 )
               }}
@@ -484,9 +477,10 @@ export function BangersExplorer({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent className="rounded-[3px]">
+                <SelectItem value="all">All time</SelectItem>
                 <SelectItem value="today">Today</SelectItem>
                 <SelectItem value="week">This week</SelectItem>
-                <SelectItem value="all">All time</SelectItem>
+                <SelectItem value="three-months">Last 3 months</SelectItem>
                 {availableYears.map((availableYear) => (
                   <SelectItem
                     key={availableYear}
@@ -498,42 +492,6 @@ export function BangersExplorer({
               </SelectContent>
             </Select>
           </label>
-
-          <div>
-            <span
-              className={`mb-1.5 block text-[11px] font-bold uppercase tracking-[0.08em] ${MUTED}`}
-            >
-              View
-            </span>
-            <div className="flex">
-              <button
-                type="button"
-                aria-pressed={view === 'list'}
-                onClick={() => setView('list')}
-                className={`${segmentClassName} rounded-l-[3px] ${
-                  view === 'list'
-                    ? activeSegmentClassName
-                    : idleSegmentClassName
-                }`}
-              >
-                <Grid2X2 aria-hidden="true" className="h-3.5 w-3.5" />
-                Cards
-              </button>
-              <button
-                type="button"
-                aria-pressed={view === 'years'}
-                onClick={() => setView('years')}
-                className={`${segmentClassName} -ml-px rounded-r-[3px] ${
-                  view === 'years'
-                    ? activeSegmentClassName
-                    : idleSegmentClassName
-                }`}
-              >
-                <Columns3 aria-hidden="true" className="h-3.5 w-3.5" />
-                By year
-              </button>
-            </div>
-          </div>
         </div>
       </div>
 
@@ -542,8 +500,11 @@ export function BangersExplorer({
           {isSearching
             ? 'Searching ranked bangers…'
             : `Showing ${loadedCount.toLocaleString()} of ${totalCount.toLocaleString()} ranked ${totalCount === 1 ? 'tweet' : 'tweets'}`}
-          {!isSearching && period === 'today' ? ' from today' : ''}
+          {!isSearching && period === 'today' ? ' from the last 24 hours' : ''}
           {!isSearching && period === 'week' ? ' from this week' : ''}
+          {!isSearching && period === 'three-months'
+            ? ' from the last 3 months'
+            : ''}
           {!isSearching && !period && year !== undefined ? ` from ${year}` : ''}
           {!isSearching && loadedQuery ? ` matching “${loadedQuery}”` : ''}
           {!isSearching && page.pagination.candidateRankingTruncated
@@ -577,7 +538,7 @@ export function BangersExplorer({
             </button>
           ) : null}
         </div>
-      ) : view === 'list' ? (
+      ) : (
         <div
           data-testid="bangers-masonry"
           className="flex flex-col lg:grid lg:grid-cols-2 lg:items-start lg:gap-5"
@@ -595,62 +556,26 @@ export function BangersExplorer({
                   className="mb-6 lg:mb-0"
                   style={{ order }}
                 >
-                  <TweetRow
+                  <TweetCard
                     tweet={tweet}
                     featuredRank={tweetRanks.get(tweet.id)}
                     showDate
                     collapsible
+                    origin="bangers"
+                    returnTo={currentReturnTo}
                   />
                 </div>
               ))}
+              <div
+                ref={(element) => {
+                  columnLoadMoreRefs.current[columnIndex] = element
+                }}
+                data-testid={`bangers-column-sentinel-${columnIndex}`}
+                aria-hidden="true"
+                className="hidden h-px lg:block"
+              />
             </div>
           ))}
-        </div>
-      ) : (
-        <div>
-          {groupedTweets.length > 1 ? (
-            <p className={`mb-2 text-[11.5px] ${MUTED}`}>
-              Scroll sideways to browse every year.
-            </p>
-          ) : null}
-          <div className="grid auto-cols-[minmax(290px,1fr)] grid-flow-col gap-4 overflow-x-auto pb-4">
-            {groupedTweets.map(([groupYear, yearTweets]) => {
-              const yearTotal = yearTotals.get(groupYear) ?? yearTweets.length
-              return (
-                <section
-                  key={groupYear}
-                  aria-labelledby={`bangers-year-${groupYear}`}
-                  className="min-w-0"
-                >
-                  <div className="mb-2 flex items-baseline justify-between border-b-2 border-zinc-800 pb-2 dark:border-zinc-200">
-                    <h2
-                      id={`bangers-year-${groupYear}`}
-                      className="text-[22px] font-semibold"
-                      style={SERIF}
-                    >
-                      {groupYear}
-                    </h2>
-                    <span className={`text-[11.5px] tabular-nums ${MUTED}`}>
-                      {yearTweets.length < yearTotal
-                        ? `${yearTweets.length} of ${yearTotal} loaded`
-                        : pluralizeTweets(yearTotal)}
-                    </span>
-                  </div>
-                  <div className="space-y-5">
-                    {yearTweets.map((tweet) => (
-                      <TweetRow
-                        key={tweet.id}
-                        tweet={tweet}
-                        featuredRank={tweetRanks.get(tweet.id)}
-                        showDate
-                        collapsible
-                      />
-                    ))}
-                  </div>
-                </section>
-              )
-            })}
-          </div>
         </div>
       )}
 

--- a/src/components/portal/Portal.tsx
+++ b/src/components/portal/Portal.tsx
@@ -12,7 +12,7 @@ import {
 import { PORTAL_ARTICLES } from './articles'
 import { PORTAL_TOOLS } from './tools'
 import { CARD, MUTED, FAINT, BODY, SERIF } from './styles'
-import { TweetRow } from './TweetRow'
+import TweetCard from '@/components/TweetCard'
 import {
   estimateLiveTweetGain,
   interpolateLiveTweetCount,
@@ -663,7 +663,15 @@ export default function Portal({
                   className="flex max-h-[420px] flex-col overflow-y-auto overscroll-contain [-ms-overflow-style:none] [scrollbar-width:none] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand/60 lg:max-h-none lg:min-h-0 lg:flex-1 [&::-webkit-scrollbar]:hidden"
                 >
                   {visible.slice(0, HOME_LIVE_STREAM_LIMIT).map((t, i) => (
-                    <TweetRow key={t.id} tweet={t} compact animate={i === 0} />
+                    <TweetCard
+                      key={t.id}
+                      tweet={t}
+                      compact
+                      animate={i === 0}
+                      clickable
+                      origin="home"
+                      returnTo="/"
+                    />
                   ))}
                   {visible.length === 0 && streamUnavailable && (
                     <PanelUnavailable message="Live stream is temporarily unavailable." />
@@ -756,7 +764,13 @@ export default function Portal({
                       />
                       {recentBanger ? (
                         <div className="flex flex-1 flex-col [&>article]:flex-1">
-                          <TweetRow tweet={recentBanger} collapsible />
+                          <TweetCard
+                            tweet={recentBanger}
+                            collapsible
+                            clickable
+                            origin="home"
+                            returnTo="/"
+                          />
                         </div>
                       ) : (
                         <PanelUnavailable message="Recent bangers are temporarily unavailable." />
@@ -774,10 +788,13 @@ export default function Portal({
                       />
                       {historicalBanger ? (
                         <div className="flex flex-1 flex-col [&>article]:flex-1">
-                          <TweetRow
+                          <TweetCard
                             tweet={historicalBanger}
                             collapsible
                             showDate
+                            clickable
+                            origin="home"
+                            returnTo="/"
                           />
                         </div>
                       ) : (
@@ -974,7 +991,7 @@ export default function Portal({
               </div>
               <div className={`${CARD} overflow-hidden`}>
                 {visible.map((t, i) => (
-                  <TweetRow
+                  <TweetCard
                     key={t.id}
                     tweet={t}
                     animate={i === 0}

--- a/src/components/portal/TrendsExplorer.tsx
+++ b/src/components/portal/TrendsExplorer.tsx
@@ -1,15 +1,20 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
-import type { FormEvent } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import type { FormEvent, PointerEvent as ReactPointerEvent } from 'react'
 import Link from 'next/link'
+import TweetCard from '@/components/TweetCard'
 import { CHART_TERMS } from '@/lib/portal/trendConfig'
 import type { PortalTrends, PortalTweet, TermSeries } from '@/lib/portal/types'
-import { TweetRow } from './TweetRow'
 import { BODY, CARD, MUTED, SERIF } from './styles'
 
-type FeedFilter = 'include' | 'exclude' | 'off'
+type FeedFilter = 'include' | 'off'
 type TrendScale = 'raw' | 'normalized'
+
+interface SelectedYears {
+  start: number
+  end: number
+}
 
 interface SeriesResponse {
   years: number[]
@@ -79,14 +84,11 @@ function compactAxis(value: number): string {
 }
 
 function nextFeedFilter(filter: FeedFilter): FeedFilter {
-  if (filter === 'off') return 'include'
-  if (filter === 'include') return 'exclude'
-  return 'off'
+  return filter === 'off' ? 'include' : 'off'
 }
 
 function filterLabel(term: string, filter: FeedFilter): string {
-  if (filter === 'include') return `${term} is included. Click to exclude it.`
-  if (filter === 'exclude') return `${term} is excluded. Click to turn it off.`
+  if (filter === 'include') return `${term} is included. Click to turn it off.`
   return `${term} is off. Click to include it.`
 }
 
@@ -126,6 +128,9 @@ export default function TrendsExplorer({
   const [isLoadingEvidence, setIsLoadingEvidence] = useState(true)
   const [feedError, setFeedError] = useState<string | null>(null)
   const [refreshKey, setRefreshKey] = useState(0)
+  const [selectedYears, setSelectedYears] = useState<SelectedYears | null>(null)
+  const [dragStartYear, setDragStartYear] = useState<number | null>(null)
+  const chartRef = useRef<SVGSVGElement>(null)
 
   const enabledSeries = useMemo(
     () => series.filter(({ term }) => chartEnabled[term]),
@@ -138,14 +143,6 @@ export default function TrendsExplorer({
         .filter((term) => feedFilters[term] === 'include'),
     [feedFilters, series],
   )
-  const excludeTerms = useMemo(
-    () =>
-      series
-        .map(({ term }) => term)
-        .filter((term) => feedFilters[term] === 'exclude'),
-    [feedFilters, series],
-  )
-
   useEffect(() => {
     if (includeTerms.length === 0) {
       setEvidence([])
@@ -160,7 +157,10 @@ export default function TrendsExplorer({
       setFeedError(null)
       const params = new URLSearchParams({ view: 'feed' })
       includeTerms.forEach((term) => params.append('include', term))
-      excludeTerms.forEach((term) => params.append('exclude', term))
+      if (selectedYears) {
+        params.set('since', `${selectedYears.start}-01-01`)
+        params.set('until', `${selectedYears.end + 1}-01-01`)
+      }
 
       try {
         const response = await fetch(
@@ -194,7 +194,21 @@ export default function TrendsExplorer({
 
     void loadEvidence()
     return () => controller.abort()
-  }, [excludeTerms, includeTerms, refreshKey])
+  }, [includeTerms, refreshKey, selectedYears])
+
+  const removeTerm = (term: string) => {
+    setSeries((current) => current.filter((item) => item.term !== term))
+    setChartEnabled((current) => {
+      const next = { ...current }
+      delete next[term]
+      return next
+    })
+    setFeedFilters((current) => {
+      const next = { ...current }
+      delete next[term]
+      return next
+    })
+  }
 
   const addTerms = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -326,6 +340,50 @@ export default function TrendsExplorer({
     (_, index) => X0 + (index * (X1 - X0)) / Math.max(years.length - 1, 1),
   )
   const yPosition = (value: number) => Y0 - (value / chartMax) * (Y0 - Y1)
+  const selectedStartIndex = selectedYears
+    ? years.indexOf(selectedYears.start)
+    : -1
+  const selectedEndIndex = selectedYears ? years.indexOf(selectedYears.end) : -1
+
+  const yearForPointer = (clientX: number): number | null => {
+    const svg = chartRef.current
+    if (!svg || years.length === 0) return null
+    const rect = svg.getBoundingClientRect()
+    if (rect.width === 0) return null
+    const svgX = ((clientX - rect.left) / rect.width) * W
+    const ratio = Math.max(0, Math.min(1, (svgX - X0) / (X1 - X0)))
+    const index = Math.round(ratio * Math.max(years.length - 1, 0))
+    return years[index] ?? null
+  }
+
+  const updateDraggedYears = (year: number, anchor = dragStartYear) => {
+    if (anchor === null) return
+    setSelectedYears({
+      start: Math.min(anchor, year),
+      end: Math.max(anchor, year),
+    })
+  }
+
+  const beginRangeSelection = (event: ReactPointerEvent<SVGRectElement>) => {
+    const year = yearForPointer(event.clientX)
+    if (year === null) return
+    event.currentTarget.setPointerCapture(event.pointerId)
+    setDragStartYear(year)
+    setSelectedYears({ start: year, end: year })
+  }
+
+  const continueRangeSelection = (event: ReactPointerEvent<SVGRectElement>) => {
+    if (dragStartYear === null) return
+    const year = yearForPointer(event.clientX)
+    if (year !== null) updateDraggedYears(year)
+  }
+
+  const finishRangeSelection = (event: ReactPointerEvent<SVGRectElement>) => {
+    if (dragStartYear === null) return
+    const year = yearForPointer(event.clientX)
+    if (year !== null) updateDraggedYears(year)
+    setDragStartYear(null)
+  }
 
   return (
     <main className="min-h-screen bg-zinc-100/80 dark:bg-transparent">
@@ -451,8 +509,9 @@ export default function TrendsExplorer({
 
               <div className="px-2 pb-1 pt-3 sm:px-4">
                 <svg
+                  ref={chartRef}
                   viewBox={`0 0 ${W} ${H}`}
-                  className="block w-full"
+                  className="block w-full touch-none select-none"
                   role="img"
                   aria-label={`Yearly term trends shown as ${scale === 'normalized' ? 'occurrences per 100,000 tweets' : 'raw tweet counts'}`}
                 >
@@ -538,7 +597,114 @@ export default function TrendsExplorer({
                         : 'Select a trend below to draw it.'}
                     </text>
                   )}
+                  {selectedYears &&
+                    selectedStartIndex >= 0 &&
+                    selectedEndIndex >= 0 && (
+                      <rect
+                        x={Math.max(
+                          X0,
+                          xPositions[selectedStartIndex] -
+                            (xPositions[1] - xPositions[0] || 16) / 2,
+                        )}
+                        y={Y1}
+                        width={
+                          Math.min(
+                            X1,
+                            xPositions[selectedEndIndex] +
+                              (xPositions[1] - xPositions[0] || 16) / 2,
+                          ) -
+                          Math.max(
+                            X0,
+                            xPositions[selectedStartIndex] -
+                              (xPositions[1] - xPositions[0] || 16) / 2,
+                          )
+                        }
+                        height={Y0 - Y1}
+                        className="pointer-events-none fill-blue-500/10 stroke-blue-500/60"
+                        strokeWidth={1}
+                      />
+                    )}
+                  <rect
+                    x={X0}
+                    y={Y1}
+                    width={X1 - X0}
+                    height={Y0 - Y1}
+                    fill="transparent"
+                    className="cursor-crosshair"
+                    aria-label="Drag horizontally to filter tweets by year"
+                    onPointerDown={beginRangeSelection}
+                    onPointerMove={continueRangeSelection}
+                    onPointerUp={finishRangeSelection}
+                    onPointerCancel={() => setDragStartYear(null)}
+                  />
                 </svg>
+              </div>
+
+              <div className="flex flex-wrap items-end gap-2 border-t border-zinc-100 px-4 py-3 dark:border-[#202023] sm:px-5">
+                <span className={`mr-auto text-[11.5px] ${MUTED}`}>
+                  Drag across the chart to filter the tweets by year.
+                </span>
+                <label className={`text-[11px] font-semibold ${MUTED}`}>
+                  From
+                  <select
+                    aria-label="Tweets from year"
+                    value={selectedYears?.start ?? ''}
+                    onChange={(event) => {
+                      if (!event.target.value) {
+                        setSelectedYears(null)
+                        return
+                      }
+                      const start = Number(event.target.value)
+                      setSelectedYears((current) => ({
+                        start,
+                        end: Math.max(start, current?.end ?? start),
+                      }))
+                    }}
+                    className="ml-1 rounded-[4px] border border-zinc-300 bg-white px-2 py-1 text-foreground dark:border-[#34343a] dark:bg-[#121214]"
+                  >
+                    <option value="">Any</option>
+                    {years.map((year) => (
+                      <option key={year} value={year}>
+                        {year}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className={`text-[11px] font-semibold ${MUTED}`}>
+                  To
+                  <select
+                    aria-label="Tweets through year"
+                    value={selectedYears?.end ?? ''}
+                    onChange={(event) => {
+                      if (!event.target.value) {
+                        setSelectedYears(null)
+                        return
+                      }
+                      const end = Number(event.target.value)
+                      setSelectedYears((current) => ({
+                        start: Math.min(current?.start ?? end, end),
+                        end,
+                      }))
+                    }}
+                    className="ml-1 rounded-[4px] border border-zinc-300 bg-white px-2 py-1 text-foreground dark:border-[#34343a] dark:bg-[#121214]"
+                  >
+                    <option value="">Any</option>
+                    {years.map((year) => (
+                      <option key={year} value={year}>
+                        {year}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                {selectedYears && (
+                  <button
+                    type="button"
+                    onClick={() => setSelectedYears(null)}
+                    className={`rounded-[4px] px-2 py-1 text-[11px] font-semibold ${MUTED} hover:text-foreground`}
+                  >
+                    Clear range
+                  </button>
+                )}
               </div>
 
               <div className="border-t border-zinc-100 px-4 py-3 dark:border-[#202023] sm:px-5">
@@ -551,31 +717,44 @@ export default function TrendsExplorer({
                   {series.map((item) => {
                     const active = !!chartEnabled[item.term]
                     return (
-                      <button
+                      <span
                         key={item.term}
-                        type="button"
-                        aria-pressed={active}
-                        onClick={() =>
-                          setChartEnabled((current) => ({
-                            ...current,
-                            [item.term]: !current[item.term],
-                          }))
-                        }
-                        className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1.5 text-[12px] font-semibold transition-colors ${
+                        className={`inline-flex items-center overflow-hidden rounded-full border text-[12px] font-semibold transition-colors ${
                           active
                             ? 'border-zinc-400 bg-zinc-50 text-foreground dark:border-[#45454c] dark:bg-[#202024]'
                             : `border-zinc-200 bg-white dark:border-[#29292e] dark:bg-[#171719] ${MUTED}`
                         }`}
                       >
-                        <span
-                          className="h-2 w-2 rounded-full"
-                          style={{
-                            backgroundColor: item.color,
-                            opacity: active ? 1 : 0.3,
-                          }}
-                        />
-                        {item.term}
-                      </button>
+                        <button
+                          type="button"
+                          aria-pressed={active}
+                          aria-label={`${active ? 'Hide' : 'Show'} ${item.term} series`}
+                          onClick={() =>
+                            setChartEnabled((current) => ({
+                              ...current,
+                              [item.term]: !current[item.term],
+                            }))
+                          }
+                          className="inline-flex items-center gap-1.5 py-1.5 pl-2.5 pr-1.5"
+                        >
+                          <span
+                            className="h-2 w-2 rounded-full"
+                            style={{
+                              backgroundColor: item.color,
+                              opacity: active ? 1 : 0.3,
+                            }}
+                          />
+                          {item.term}
+                        </button>
+                        <button
+                          type="button"
+                          aria-label={`Remove ${item.term} trend`}
+                          onClick={() => removeTerm(item.term)}
+                          className="px-2 py-1.5 text-[14px] leading-none opacity-60 hover:opacity-100"
+                        >
+                          ×
+                        </button>
+                      </span>
                     )
                   })}
                   {series.length === 0 && (
@@ -619,37 +798,43 @@ export default function TrendsExplorer({
                 {series.map(({ term }) => {
                   const filter = feedFilters[term] ?? 'off'
                   return (
-                    <button
+                    <span
                       key={term}
-                      type="button"
-                      aria-label={filterLabel(term, filter)}
-                      onClick={() =>
-                        setFeedFilters((current) => ({
-                          ...current,
-                          [term]: nextFeedFilter(current[term] ?? 'off'),
-                        }))
-                      }
-                      className={`rounded-full border px-2.5 py-1.5 text-[11.5px] font-bold transition-colors ${
+                      className={`inline-flex items-center overflow-hidden rounded-full border text-[11.5px] font-bold transition-colors ${
                         filter === 'include'
                           ? 'border-brand bg-brand/10 text-blue-700 dark:text-blue-300'
-                          : filter === 'exclude'
-                            ? 'border-red-400 bg-red-50 text-red-700 dark:border-red-500/70 dark:bg-red-950/30 dark:text-red-300'
-                            : `border-zinc-200 bg-white dark:border-[#29292e] dark:bg-[#171719] ${MUTED}`
+                          : `border-zinc-200 bg-white dark:border-[#29292e] dark:bg-[#171719] ${MUTED}`
                       }`}
                     >
-                      {filter === 'include'
-                        ? '+ '
-                        : filter === 'exclude'
-                          ? '− '
-                          : ''}
-                      {term}
-                    </button>
+                      <button
+                        type="button"
+                        aria-label={filterLabel(term, filter)}
+                        onClick={() =>
+                          setFeedFilters((current) => ({
+                            ...current,
+                            [term]: nextFeedFilter(current[term] ?? 'off'),
+                          }))
+                        }
+                        className="py-1.5 pl-2.5 pr-1.5"
+                      >
+                        {filter === 'include' ? '+ ' : ''}
+                        {term}
+                      </button>
+                      <button
+                        type="button"
+                        aria-label={`Remove ${term} trend from explorer`}
+                        onClick={() => removeTerm(term)}
+                        className="px-2 py-1.5 text-[14px] leading-none opacity-60 hover:opacity-100"
+                      >
+                        ×
+                      </button>
+                    </span>
                   )
                 })}
               </div>
               <div className={`mt-2.5 text-[10.5px] leading-normal ${MUTED}`}>
-                Click a pill to cycle: include → exclude → off. Includes are OR;
-                exclusions remove matching posts.
+                Click a pill to include it or turn it off. Included terms are
+                OR.
               </div>
             </div>
 
@@ -679,13 +864,20 @@ export default function TrendsExplorer({
                   <div
                     className={`px-4 py-12 text-center text-[13px] ${MUTED}`}
                   >
-                    No matching tweets after exclusions.
+                    No matching tweets in this period.
                   </div>
                 )}
               {!isLoadingEvidence &&
                 !feedError &&
                 evidence.map((tweet) => (
-                  <TweetRow key={tweet.id} tweet={tweet} collapsible />
+                  <TweetCard
+                    key={tweet.id}
+                    tweet={tweet}
+                    collapsible
+                    clickable
+                    origin="trends"
+                    returnTo="/trends"
+                  />
                 ))}
             </div>
           </aside>

--- a/src/components/portal/TweetRow.tsx
+++ b/src/components/portal/TweetRow.tsx
@@ -7,6 +7,7 @@ import type { KeyboardEvent, MouseEvent } from 'react'
 import ImageLightbox from '@/components/ImageLightbox'
 import TweetAvatarImage from '@/components/TweetAvatarImage'
 import { tweetPermalinkHref, type TweetOrigin } from '@/lib/navigation'
+import { decodeTweetText } from '@/lib/tweetText'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { PortalMedia, PortalQuotedTweet, PortalTweet } from '@/lib/portal/types'
 
@@ -45,15 +46,6 @@ export const shortDate = (iso: string) =>
     month: 'short',
     year: 'numeric',
   })
-
-export function decodeTweetText(text: string): string {
-  return text
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#0?39;|&#x0?27;/gi, "'")
-}
 
 export function TweetAvatar({
   tweet,

--- a/src/components/portal/TweetRow.tsx
+++ b/src/components/portal/TweetRow.tsx
@@ -1,9 +1,12 @@
 'use client'
 
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import { useState } from 'react'
+import type { KeyboardEvent, MouseEvent } from 'react'
 import ImageLightbox from '@/components/ImageLightbox'
 import TweetAvatarImage from '@/components/TweetAvatarImage'
+import { tweetPermalinkHref, type TweetOrigin } from '@/lib/navigation'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { PortalMedia, PortalQuotedTweet, PortalTweet } from '@/lib/portal/types'
 
@@ -42,6 +45,15 @@ export const shortDate = (iso: string) =>
     month: 'short',
     year: 'numeric',
   })
+
+export function decodeTweetText(text: string): string {
+  return text
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#0?39;|&#x0?27;/gi, "'")
+}
 
 export function TweetAvatar({
   tweet,
@@ -133,9 +145,13 @@ function TweetImages({
 function QuotedTweet({
   tweet,
   compact,
+  origin,
+  returnTo,
 }: {
   tweet: PortalQuotedTweet
   compact: boolean
+  origin?: TweetOrigin
+  returnTo?: string
 }) {
   if (tweet.isDeleted) {
     return (
@@ -148,7 +164,7 @@ function QuotedTweet({
   return (
     <div className="mt-2 rounded-[4px] border border-zinc-200 bg-white p-2.5 dark:border-[#303036] dark:bg-[#18181b]">
       <Link
-        href={`/tweets/${tweet.id}`}
+        href={tweetPermalinkHref(tweet.id, origin, returnTo)}
         className="block rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
       >
         <div className="flex items-center gap-2">
@@ -163,7 +179,7 @@ function QuotedTweet({
         <div
           className={`${compact ? 'line-clamp-3' : ''} mt-1.5 whitespace-pre-wrap break-words text-[13px] leading-relaxed text-zinc-700 dark:text-[#d9d9de]`}
         >
-          {tweet.text}
+          {decodeTweetText(tweet.text)}
         </div>
       </Link>
       <TweetImages
@@ -181,6 +197,19 @@ function QuotedTweet({
   )
 }
 
+export interface TweetCardProps {
+  tweet: PortalTweet
+  animate?: boolean
+  compact?: boolean
+  collapsible?: boolean
+  featuredRank?: number
+  showDate?: boolean
+  showArchivedBadge?: boolean
+  clickable?: boolean
+  origin?: TweetOrigin
+  returnTo?: string
+}
+
 export function TweetRow({
   tweet,
   animate = false,
@@ -189,29 +218,37 @@ export function TweetRow({
   featuredRank,
   showDate = false,
   showArchivedBadge = false,
-}: {
-  tweet: PortalTweet
-  animate?: boolean
-  compact?: boolean
-  collapsible?: boolean
-  featuredRank?: number
-  showDate?: boolean
-  showArchivedBadge?: boolean
-}) {
+  clickable = false,
+  origin,
+  returnTo,
+}: TweetCardProps) {
+  const router = useRouter()
   const [isExpanded, setIsExpanded] = useState(false)
   const canExpand = collapsible && tweet.text.length > 280
-  const href = `/tweets/${tweet.id}`
+  const href = tweetPermalinkHref(tweet.id, origin, returnTo)
   const isFeatured = featuredRank !== undefined
-  const isTopThree = isFeatured && featuredRank <= 3
+  const isClickable = clickable || isFeatured
   const rowClassName = isFeatured
-    ? `relative flex min-w-0 gap-3 rounded-lg border p-4 shadow-sm transition-[border-color,box-shadow,transform] hover:-translate-y-0.5 hover:border-brand/50 hover:shadow-md motion-reduce:transition-none motion-reduce:hover:translate-y-0 dark:hover:border-brand/60 sm:gap-3.5 sm:p-5 ${
-        isTopThree
-          ? 'border-amber-200/90 bg-gradient-to-br from-amber-50/80 via-white to-white dark:border-amber-400/25 dark:from-amber-400/[0.06] dark:via-[#1b1b1e] dark:to-[#1b1b1e]'
-          : 'border-zinc-200 bg-white dark:border-[#303036] dark:bg-[#1b1b1e]'
-      } ${animate ? 'portal-slide-in' : ''}`
+    ? `relative flex min-w-0 gap-3 rounded-lg border border-zinc-200/75 bg-white p-4 shadow-sm dark:border-[#303036]/80 dark:bg-[#1b1b1e] sm:gap-3.5 sm:p-5 ${
+        animate ? 'portal-slide-in' : ''
+      }`
     : `flex gap-3 border-b border-zinc-100 px-4 py-3 transition-colors last:border-b-0 hover:bg-zinc-50 dark:border-[#202023] dark:hover:bg-[#1f1f23] ${
         animate ? 'portal-slide-in' : ''
       }`
+
+  const activateCard = () => router.push(href)
+  const handleCardClick = (event: MouseEvent<HTMLElement>) => {
+    if (!isClickable) return
+    const target = event.target as HTMLElement
+    if (target.closest('a, button, [role="button"]')) return
+    activateCard()
+  }
+  const handleCardKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+    if (!isClickable || event.target !== event.currentTarget) return
+    if (event.key !== 'Enter' && event.key !== ' ') return
+    event.preventDefault()
+    activateCard()
+  }
 
   const tweetContent = (
     <>
@@ -237,7 +274,7 @@ export function TweetRow({
               }`
         }`}
       >
-        {tweet.text}
+        {decodeTweetText(tweet.text)}
       </div>
     </>
   )
@@ -262,7 +299,12 @@ export function TweetRow({
       )}
       <TweetImages media={tweet.media} compact={compact} label="Tweet image" />
       {tweet.quotedTweet && (
-        <QuotedTweet tweet={tweet.quotedTweet} compact={compact} />
+        <QuotedTweet
+          tweet={tweet.quotedTweet}
+          compact={compact}
+          origin={origin}
+          returnTo={returnTo}
+        />
       )}
       {!compact && (
         <div className="mt-1.5 flex flex-wrap gap-x-4 gap-y-1 text-[12px] tabular-nums text-zinc-500 dark:text-[#a7a7b4]">
@@ -286,7 +328,18 @@ export function TweetRow({
   )
 
   return (
-    <article className={rowClassName}>
+    <article
+      className={`${rowClassName} ${
+        isClickable
+          ? 'cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 focus-visible:ring-offset-2'
+          : ''
+      }`}
+      onClick={handleCardClick}
+      onKeyDown={handleCardKeyDown}
+      role={isClickable ? 'link' : undefined}
+      tabIndex={isClickable ? 0 : undefined}
+      aria-label={isClickable ? `View tweet by @${tweet.username}` : undefined}
+    >
       <Link href={href} aria-label={`View tweet by @${tweet.username}`}>
         <TweetAvatar tweet={tweet} size={isFeatured ? 38 : 34} />
       </Link>

--- a/src/lib/clickhouseQuotePosts.test.ts
+++ b/src/lib/clickhouseQuotePosts.test.ts
@@ -14,6 +14,14 @@ describe('fetchClickHouseQuotePosts', () => {
           fullText: 'Quoted commentary',
           favoriteCount: '13',
           retweetCount: '3',
+          media: [
+            {
+              mediaUrl: 'https://pbs.twimg.com/media/quote.jpg',
+              mediaType: 'photo',
+              width: 1200,
+              height: 800,
+            },
+          ],
         },
       ],
       query: { total: '7' },
@@ -22,6 +30,7 @@ describe('fetchClickHouseQuotePosts', () => {
     const result = await fetchClickHouseQuotePosts(
       '2085375983708692599',
       12,
+      24,
       fetcher,
     )
 
@@ -29,7 +38,7 @@ describe('fetchClickHouseQuotePosts', () => {
       ['quote-posts', '2085375983708692599'],
       new URLSearchParams({
         limit: '12',
-        offset: '0',
+        offset: '24',
         exclude_self: 'true',
         quote_ca_users_only: 'true',
       }),
@@ -46,7 +55,14 @@ describe('fetchClickHouseQuotePosts', () => {
           account_display_name: 'Puheenjohtaja',
           favorite_count: 13,
           retweet_count: 3,
-          media: [],
+          media: [
+            {
+              media_url: 'https://pbs.twimg.com/media/quote.jpg',
+              media_type: 'photo',
+              width: 1200,
+              height: 800,
+            },
+          ],
         }),
       ],
     })
@@ -56,7 +72,7 @@ describe('fetchClickHouseQuotePosts', () => {
     const fetcher = jest.fn()
 
     await expect(
-      fetchClickHouseQuotePosts('not-a-tweet', 12, fetcher),
+      fetchClickHouseQuotePosts('not-a-tweet', 12, 0, fetcher),
     ).resolves.toEqual({ tweets: [], totalCount: 0 })
     expect(fetcher).not.toHaveBeenCalled()
   })

--- a/src/lib/clickhouseQuotePosts.ts
+++ b/src/lib/clickhouseQuotePosts.ts
@@ -11,6 +11,12 @@ interface ClickHouseQuotePost {
   fullText: string
   favoriteCount: string | number
   retweetCount: string | number
+  media?: Array<{
+    mediaUrl: string
+    mediaType: string
+    width: number | null
+    height: number | null
+  }>
 }
 
 interface ClickHouseQuotePostsResponse {
@@ -68,7 +74,12 @@ function quotePost(
     avatar_media_url: tweet.avatarUrl,
     username,
     account_display_name: displayName,
-    media: [],
+    media: (tweet.media ?? []).map((item) => ({
+      media_url: item.mediaUrl,
+      media_type: item.mediaType,
+      width: item.width ?? undefined,
+      height: item.height ?? undefined,
+    })),
     urls: [],
     account: {
       username,
@@ -83,16 +94,18 @@ function quotePost(
 export async function fetchClickHouseQuotePosts(
   tweetId: string,
   limit = 12,
+  offset = 0,
   fetcher = fetchAnalyticsGatewayJson,
 ): Promise<ClickHouseQuotePostsData> {
   if (!/^\d{1,20}$/.test(tweetId)) return EMPTY_QUOTE_POSTS
 
   const safeLimit = Math.max(1, Math.min(100, Math.trunc(limit)))
+  const safeOffset = Math.max(0, Math.min(5_000, Math.trunc(offset)))
   const response = await fetcher<ClickHouseQuotePostsResponse>(
     ['quote-posts', tweetId],
     new URLSearchParams({
       limit: String(safeLimit),
-      offset: '0',
+      offset: String(safeOffset),
       exclude_self: 'true',
       quote_ca_users_only: 'true',
     }),

--- a/src/lib/navigation.test.ts
+++ b/src/lib/navigation.test.ts
@@ -1,4 +1,9 @@
-import { getMobileNav, getPrimaryNav } from './navigation'
+import {
+  getMobileNav,
+  getPrimaryNav,
+  getTweetBackLink,
+  tweetPermalinkHref,
+} from './navigation'
 
 describe('member navigation', () => {
   it('includes the member directory in desktop and mobile navigation', () => {
@@ -9,6 +14,51 @@ describe('member navigation', () => {
     expect(getMobileNav(true)).toContainEqual({
       href: '/user-dir',
       label: 'Library',
+    })
+  })
+})
+
+describe('tweet detail navigation', () => {
+  it('encodes and restores a filtered Bangers origin', () => {
+    const href = tweetPermalinkHref(
+      '123',
+      'bangers',
+      '/bangers?period=today&sort=recent',
+    )
+    const url = new URL(href, 'https://community-archive.org')
+
+    expect(url.pathname).toBe('/tweets/123')
+    expect(url.searchParams.get('from')).toBe('bangers')
+    expect(getTweetBackLink(Object.fromEntries(url.searchParams))).toEqual({
+      href: '/bangers?period=today&sort=recent',
+      label: 'Back to Bangers',
+      hasKnownOrigin: true,
+    })
+  })
+
+  it('maps homepage, Trends, and Search origins to honest labels', () => {
+    expect(getTweetBackLink({ from: 'home', returnTo: '/' }).label).toBe(
+      'Back to homepage',
+    )
+    expect(
+      getTweetBackLink({ from: 'trends', returnTo: '/trends' }).label,
+    ).toBe('Back to Trends')
+    expect(
+      getTweetBackLink({ from: 'search', returnTo: '/search?q=archive' }).label,
+    ).toBe('Back to search')
+  })
+
+  it('rejects mismatched and external return targets', () => {
+    expect(
+      getTweetBackLink({ from: 'bangers', returnTo: '/search?q=wrong' }).href,
+    ).toBe('/bangers')
+    expect(
+      getTweetBackLink({ from: 'search', returnTo: '//example.com' }).href,
+    ).toBe('/search')
+    expect(getTweetBackLink()).toEqual({
+      href: '/',
+      label: 'Back to Community Archive',
+      hasKnownOrigin: false,
     })
   })
 })

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -3,6 +3,91 @@ export interface NavItem {
   label: string
 }
 
+export type TweetOrigin = 'home' | 'bangers' | 'trends' | 'search'
+
+export interface TweetBackLink {
+  href: string
+  label: string
+  hasKnownOrigin: boolean
+}
+
+const TWEET_ORIGINS: Record<
+  TweetOrigin,
+  { href: string; label: string; matches: (href: string) => boolean }
+> = {
+  home: {
+    href: '/',
+    label: 'Back to homepage',
+    matches: (href) => href === '/' || href.startsWith('/?'),
+  },
+  bangers: {
+    href: '/bangers',
+    label: 'Back to Bangers',
+    matches: (href) => href === '/bangers' || href.startsWith('/bangers?'),
+  },
+  trends: {
+    href: '/trends',
+    label: 'Back to Trends',
+    matches: (href) => href === '/trends' || href.startsWith('/trends?'),
+  },
+  search: {
+    href: '/search',
+    label: 'Back to search',
+    matches: (href) => href === '/search' || href.startsWith('/search?'),
+  },
+}
+
+function isTweetOrigin(value: string | undefined): value is TweetOrigin {
+  return Boolean(value && value in TWEET_ORIGINS)
+}
+
+function safeReturnTo(origin: TweetOrigin, value: string | undefined): string {
+  if (!value || !value.startsWith('/') || value.startsWith('//')) {
+    return TWEET_ORIGINS[origin].href
+  }
+  return TWEET_ORIGINS[origin].matches(value)
+    ? value
+    : TWEET_ORIGINS[origin].href
+}
+
+export function tweetPermalinkHref(
+  tweetId: string,
+  origin?: TweetOrigin,
+  returnTo?: string,
+): string {
+  const pathname = `/tweets/${encodeURIComponent(tweetId)}`
+  if (!origin) return pathname
+  const params = new URLSearchParams({
+    from: origin,
+    returnTo: safeReturnTo(origin, returnTo),
+  })
+  return `${pathname}?${params.toString()}`
+}
+
+export function getTweetBackLink(searchParams?: {
+  from?: string | string[]
+  returnTo?: string | string[]
+}): TweetBackLink {
+  const from = Array.isArray(searchParams?.from)
+    ? searchParams?.from[0]
+    : searchParams?.from
+  if (!isTweetOrigin(from)) {
+    return {
+      href: '/',
+      label: 'Back to Community Archive',
+      hasKnownOrigin: false,
+    }
+  }
+  const requestedReturnTo = Array.isArray(searchParams?.returnTo)
+    ? searchParams?.returnTo[0]
+    : searchParams?.returnTo
+  return {
+    href: safeReturnTo(from, requestedReturnTo),
+    label: TWEET_ORIGINS[from].label,
+    hasKnownOrigin: true,
+  }
+}
+
 /**
  * Single source of truth for site navigation, keyed by audience.
  *

--- a/src/lib/portal/TrendsExplorerResilience.test.tsx
+++ b/src/lib/portal/TrendsExplorerResilience.test.tsx
@@ -108,4 +108,52 @@ describe('TrendsExplorer request isolation', () => {
     expect(screen.getByText('1/12 trends')).toBeVisible()
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
+
+  test('removes terms and uses a binary include filter', async () => {
+    const user = userEvent.setup()
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ tweets: [] }),
+    } as Response)
+
+    render(<TrendsExplorer initialTrends={successfulTrends} />)
+
+    const included = await screen.findByRole('button', {
+      name: 'tpot is included. Click to turn it off.',
+    })
+    await user.click(included)
+    expect(
+      screen.getByRole('button', {
+        name: 'tpot is off. Click to include it.',
+      }),
+    ).toBeVisible()
+    expect(screen.queryByText(/exclude/i)).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Remove tpot trend' }))
+    expect(
+      screen.queryByRole('button', { name: 'Remove tpot trend' }),
+    ).not.toBeInTheDocument()
+    expect(screen.getByText('0/12 trends')).toBeVisible()
+  })
+
+  test('filters evidence to the selected graph period', async () => {
+    const user = userEvent.setup()
+    const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ tweets: [] }),
+    } as Response)
+
+    render(<TrendsExplorer initialTrends={successfulTrends} />)
+
+    await user.selectOptions(screen.getByLabelText('Tweets from year'), '2025')
+
+    await waitFor(() =>
+      expect(
+        fetchMock.mock.calls.some(([url]) =>
+          String(url).includes('since=2025-01-01&until=2026-01-01'),
+        ),
+      ).toBe(true),
+    )
+    expect(screen.getByRole('button', { name: 'Clear range' })).toBeVisible()
+  })
 })

--- a/src/lib/portal/TweetRow.test.tsx
+++ b/src/lib/portal/TweetRow.test.tsx
@@ -31,6 +31,9 @@ jest.mock('next/link', () => ({
     </a>
   ),
 }))
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}))
 
 const tweet: PortalTweet = {
   id: '42',
@@ -70,11 +73,13 @@ const tweet: PortalTweet = {
 }
 
 describe('portal TweetRow media', () => {
-  test('highlights a top banger without showing a corner rank badge', () => {
-    render(<TweetRow tweet={tweet} featuredRank={1} />)
+  test('uses the same neutral card treatment for a top banger', () => {
+    const { container } = render(<TweetRow tweet={tweet} featuredRank={1} />)
+    const card = container.querySelector('article')
 
     expect(screen.queryByLabelText('Rank 1')).not.toBeInTheDocument()
-    expect(screen.getByRole('article')).toHaveClass('from-amber-50/80')
+    expect(card).toHaveClass('border-zinc-200/75')
+    expect(card?.className).not.toMatch(/amber|blue/)
     expect(screen.getByText(/12 archive quotes/)).toHaveClass('rounded-full')
   })
 

--- a/src/lib/portal/analytics.test.ts
+++ b/src/lib/portal/analytics.test.ts
@@ -143,7 +143,7 @@ describe('ClickHouse-backed portal analytics', () => {
   })
 
   test('fetches several user-selected trend series concurrently', async () => {
-    const fetcher = jest.fn(
+    const fetcherMock = jest.fn(
       async (_path: string[], params: URLSearchParams) => ({
         data: [
           {
@@ -154,7 +154,8 @@ describe('ClickHouse-backed portal analytics', () => {
           },
         ],
       }),
-    ) as unknown as AnalyticsFetcher
+    )
+    const fetcher = fetcherMock as unknown as AnalyticsFetcher
 
     const result = await fetchPortalTrendSeries(
       ['alpha', 'beta'],
@@ -177,7 +178,7 @@ describe('ClickHouse-backed portal analytics', () => {
     ])
   })
 
-  test('merges included evidence and removes tweets matching excluded terms', async () => {
+  test('merges included evidence and forwards a selected date range', async () => {
     const tweet = (tweetId: string, fullText: string, createdAt: string) => ({
       tweetId,
       accountId: '42',
@@ -189,7 +190,7 @@ describe('ClickHouse-backed portal analytics', () => {
       accountDisplayName: 'Alice',
       avatarMediaUrl: null,
     })
-    const fetcher = jest.fn(
+    const fetcherMock = jest.fn(
       async (_path: string[], params: URLSearchParams) => ({
         data: {
           tweets:
@@ -200,11 +201,7 @@ describe('ClickHouse-backed portal analytics', () => {
                     'alpha without the excluded idea',
                     '2026-08-07 10:00:00.000',
                   ),
-                  tweet(
-                    '101',
-                    'alpha and moloch together',
-                    '2026-08-07 11:00:00.000',
-                  ),
+                  tweet('101', 'alpha joins in', '2026-08-07 11:00:00.000'),
                 ]
               : [
                   tweet('102', 'beta arrives later', '2026-08-07 12:00:00.000'),
@@ -217,17 +214,20 @@ describe('ClickHouse-backed portal analytics', () => {
           nextOffset: null,
         },
       }),
-    ) as unknown as AnalyticsFetcher
+    )
+    const fetcher = fetcherMock as unknown as AnalyticsFetcher
 
     const result = await fetchPortalTrendEvidence(
       ['alpha', 'beta'],
-      ['moloch'],
-      30,
+      { limit: 30, since: '2024-01-01', until: '2026-01-01' },
       fetcher,
     )
 
     expect(fetcher).toHaveBeenCalledTimes(2)
-    expect(result.map(({ id }) => id)).toEqual(['102', '100'])
+    expect(result.map(({ id }) => id)).toEqual(['102', '101', '100'])
+    expect(fetcherMock.mock.calls[0]?.[1]?.toString()).toContain(
+      'since=2024-01-01&until=2026-01-01',
+    )
     expect(result[0]).toMatchObject({
       username: 'alice',
       createdAt: '2026-08-07T12:00:00.000Z',

--- a/src/lib/portal/analytics.ts
+++ b/src/lib/portal/analytics.ts
@@ -243,11 +243,6 @@ function stableTrendColor(term: string): string {
   return TREND_COLORS[hash % TREND_COLORS.length]
 }
 
-function textMatchesTrend(text: string, term: string): boolean {
-  const textTokens = new Set(normalizedTextTokens(text))
-  return portalTrendTokens(term).every((token) => textTokens.has(token))
-}
-
 /** Fetch one or more user-selected yearly series in parallel. */
 export async function fetchPortalTrendSeries(
   terms: string[],
@@ -298,14 +293,16 @@ export async function fetchPortalTrendSeries(
   return { years, series, computedAt: now.toISOString() }
 }
 
-/**
- * Latest posts counted by at least one included trend, minus posts matching an
- * excluded trend. Each query uses the same all-token semantics as word-trend.
- */
+interface PortalTrendEvidenceOptions {
+  limit?: number
+  since?: string
+  until?: string
+}
+
+/** Latest posts counted by at least one included trend in an optional period. */
 export async function fetchPortalTrendEvidence(
   includeTerms: string[],
-  excludeTerms: string[],
-  limit = 30,
+  { limit = 30, since, until }: PortalTrendEvidenceOptions = {},
   fetcher: AnalyticsFetcher = fetchAnalyticsGatewayJson,
 ): Promise<PortalTweet[]> {
   const safeLimit = Math.max(1, Math.min(50, Math.trunc(limit)))
@@ -315,12 +312,17 @@ export async function fetchPortalTrendEvidence(
       (term) => () =>
         fetcher<ClickHouseSearchResponse>(
           ['search'],
-          new URLSearchParams({
-            q: term,
-            mode: 'all',
-            limit: String(candidateLimit),
-            offset: '0',
-          }),
+          (() => {
+            const params = new URLSearchParams({
+              q: term,
+              mode: 'all',
+              limit: String(candidateLimit),
+              offset: '0',
+            })
+            if (since) params.set('since', since)
+            if (until) params.set('until', until)
+            return params
+          })(),
           { timeoutMs: 30_000 },
         ),
     ),
@@ -341,9 +343,6 @@ export async function fetchPortalTrendEvidence(
         typeof row.fullText !== 'string'
       ) {
         throw new Error('ClickHouse search returned an invalid tweet')
-      }
-      if (excludeTerms.some((term) => textMatchesTrend(row.fullText, term))) {
-        continue
       }
       const username = row.username || 'unknown'
       const createdAt = safeTimestamp(row.createdAt, 'trend tweet timestamp')

--- a/src/lib/portal/data.test.ts
+++ b/src/lib/portal/data.test.ts
@@ -407,7 +407,7 @@ describe('portal reads', () => {
     })
   })
 
-  test('builds an exact ranked page from the recent prefix for today', async () => {
+  test('builds an exact ranked page from the rolling 24-hour prefix', async () => {
     jest.useFakeTimers()
     jest.setSystemTime(new Date('2026-08-10T14:00:00.000Z'))
     fetchPortalBangersPageMock.mockResolvedValueOnce({
@@ -437,16 +437,28 @@ describe('portal reads', () => {
           quoteCount: 9,
         },
         {
-          id: 'yesterday',
+          id: 'boundary',
           username: 'carol',
           name: 'Carol',
           avatar: null,
-          text: 'Yesterday',
-          observedAt: '2026-08-09T23:59:59.000Z',
-          createdAt: '2026-08-09T23:59:59.000Z',
+          text: 'Exactly 24 hours ago',
+          observedAt: '2026-08-09T14:00:00.000Z',
+          createdAt: '2026-08-09T14:00:00.000Z',
           likes: 20,
           rts: 0,
           quoteCount: 20,
+        },
+        {
+          id: 'outside-window',
+          username: 'dave',
+          name: 'Dave',
+          avatar: null,
+          text: 'One second outside the window',
+          observedAt: '2026-08-09T13:59:59.000Z',
+          createdAt: '2026-08-09T13:59:59.000Z',
+          likes: 40,
+          rts: 0,
+          quoteCount: 40,
         },
       ],
       pagination: {
@@ -464,12 +476,12 @@ describe('portal reads', () => {
       await expect(
         getPortalBangersPage({ period: 'today', sort: 'quotes' }),
       ).resolves.toMatchObject({
-        tweets: [{ id: 'today-high' }, { id: 'today-low' }],
+        tweets: [{ id: 'boundary' }, { id: 'today-high' }, { id: 'today-low' }],
         pagination: {
           nextOffset: null,
-          totalAvailable: 2,
-          snapshotSize: 2,
-          yearCounts: [{ year: 2026, count: 2 }],
+          totalAvailable: 3,
+          snapshotSize: 3,
+          yearCounts: [{ year: 2026, count: 3 }],
         },
       })
       expect(fetchPortalBangersPageMock).toHaveBeenCalledWith({
@@ -530,6 +542,59 @@ describe('portal reads', () => {
         getPortalBangersPage({ period: 'week' }),
       ).resolves.toMatchObject({
         tweets: [{ id: 'monday' }],
+        pagination: { totalAvailable: 1 },
+      })
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
+  test('uses a rolling three-calendar-month window', async () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-08-10T14:00:00.000Z'))
+    fetchPortalBangersPageMock.mockResolvedValueOnce({
+      tweets: [
+        {
+          id: 'inside-quarter',
+          username: 'alice',
+          name: 'Alice',
+          avatar: null,
+          text: 'Inside the quarter',
+          observedAt: '2026-05-10T14:00:00.000Z',
+          createdAt: '2026-05-10T14:00:00.000Z',
+          likes: 4,
+          rts: 0,
+          quoteCount: 2,
+        },
+        {
+          id: 'outside-quarter',
+          username: 'bob',
+          name: 'Bob',
+          avatar: null,
+          text: 'Outside the quarter',
+          observedAt: '2026-05-10T13:59:59.000Z',
+          createdAt: '2026-05-10T13:59:59.000Z',
+          likes: 8,
+          rts: 0,
+          quoteCount: 9,
+        },
+      ],
+      pagination: {
+        limit: 100,
+        offset: 0,
+        nextOffset: null,
+        totalAvailable: 2,
+        snapshotSize: 2,
+        yearCounts: [{ year: 2026, count: 2 }],
+        candidateRankingTruncated: false,
+      },
+    })
+
+    try {
+      await expect(
+        getPortalBangersPage({ period: 'three-months' }),
+      ).resolves.toMatchObject({
+        tweets: [{ id: 'inside-quarter' }],
         pagination: { totalAvailable: 1 },
       })
     } finally {

--- a/src/lib/portal/data.ts
+++ b/src/lib/portal/data.ts
@@ -678,11 +678,25 @@ function portalBangersPeriodStart(
   now = new Date(),
 ): string {
   const start = new Date(now)
-  start.setUTCHours(0, 0, 0, 0)
-  if (period === 'week') {
+  if (period === 'today') {
+    start.setUTCDate(start.getUTCDate() - 1)
+  } else if (period === 'week') {
+    start.setUTCHours(0, 0, 0, 0)
     const daysSinceMonday = (start.getUTCDay() + 6) % 7
     start.setUTCDate(start.getUTCDate() - daysSinceMonday)
+  } else {
+    start.setUTCMonth(start.getUTCMonth() - 3)
   }
+  return start.toISOString()
+}
+
+function portalBangersSnapshotStart(
+  period: PortalBangersPeriod,
+  now = new Date(),
+): string {
+  const start = new Date(portalBangersPeriodStart(period, now))
+  if (period === 'today') start.setUTCMinutes(0, 0, 0)
+  if (period === 'three-months') start.setUTCHours(0, 0, 0, 0)
   return start.toISOString()
 }
 
@@ -833,14 +847,19 @@ export async function getPortalBangersPage(
     const sort = options.sort ?? 'quotes'
     const scope = options.scope ?? 'all'
     const query = options.query?.trim().slice(0, 120) ?? ''
-    const periodStart = portalBangersPeriodStart(options.period)
+    const now = new Date()
+    const periodStart = portalBangersPeriodStart(options.period, now)
+    const snapshotStart = portalBangersSnapshotStart(options.period, now)
     const snapshot = await getCachedPortalBangersPeriodSnapshot(
       portalDataSourceKey(),
-      periodStart,
+      snapshotStart,
       scope,
       query,
     )
-    const ranked = sortPortalBangers(snapshot.tweets, sort)
+    const ranked = sortPortalBangers(
+      snapshot.tweets.filter((tweet) => tweet.createdAt >= periodStart),
+      sort,
+    )
     const pageTweets = ranked.slice(offset, offset + limit)
     const nextOffset = offset + pageTweets.length
     const yearCounts = new Map<number, number>()

--- a/src/lib/portal/types.ts
+++ b/src/lib/portal/types.ts
@@ -40,7 +40,7 @@ export interface PortalTweet {
 
 export type PortalBangersScope = 'all' | 'members'
 export type PortalBangersSort = 'quotes' | 'recent'
-export type PortalBangersPeriod = 'today' | 'week'
+export type PortalBangersPeriod = 'today' | 'week' | 'three-months'
 
 export interface PortalBangersPagination {
   limit: number

--- a/src/lib/portalTrendsRoute.test.ts
+++ b/src/lib/portalTrendsRoute.test.ts
@@ -74,27 +74,41 @@ describe('portal trends route', () => {
     ])
   })
 
-  test('forwards include and exclude filters to the evidence search', async () => {
+  test('forwards included terms and a selected date range to evidence search', async () => {
     fetchPortalTrendEvidenceMock.mockResolvedValue([])
 
     const response = await GET(
       new NextRequest(
-        'https://community-archive.org/api/portal/trends?view=feed&include=Alpha&include=Beta&exclude=Moloch',
+        'https://community-archive.org/api/portal/trends?view=feed&include=Alpha&include=Beta&since=2022-01-01&until=2025-01-01',
       ),
     )
 
     expect(response.status).toBe(200)
     expect(fetchPortalTrendEvidenceMock).toHaveBeenCalledWith(
       ['alpha', 'beta'],
-      ['moloch'],
-      30,
+      {
+        limit: 30,
+        since: '2022-01-01',
+        until: '2025-01-01',
+      },
     )
   })
 
   test('rejects an evidence query without an included term', async () => {
     const response = await GET(
       new NextRequest(
-        'https://community-archive.org/api/portal/trends?view=feed&exclude=moloch',
+        'https://community-archive.org/api/portal/trends?view=feed',
+      ),
+    )
+
+    expect(response.status).toBe(400)
+    expect(fetchPortalTrendEvidenceMock).not.toHaveBeenCalled()
+  })
+
+  test('rejects an inverted evidence date range', async () => {
+    const response = await GET(
+      new NextRequest(
+        'https://community-archive.org/api/portal/trends?view=feed&include=tpot&since=2026-01-01&until=2025-01-01',
       ),
     )
 

--- a/src/lib/quotingTweets.test.ts
+++ b/src/lib/quotingTweets.test.ts
@@ -1,0 +1,68 @@
+jest.mock('server-only', () => ({}), { virtual: true })
+
+import { getQuotingTweetsPage } from './quotingTweets'
+import { fetchClickHouseQuotePosts } from './clickhouseQuotePosts'
+import { isClickHouseReadsEnabled } from './clickhouseGateway'
+
+jest.mock('./clickhouseQuotePosts', () => ({
+  fetchClickHouseQuotePosts: jest.fn(),
+}))
+jest.mock('./clickhouseGateway', () => ({
+  isClickHouseReadsEnabled: jest.fn(),
+}))
+
+const fetchQuotePostsMock = fetchClickHouseQuotePosts as jest.MockedFunction<
+  typeof fetchClickHouseQuotePosts
+>
+const isClickHouseReadsEnabledMock =
+  isClickHouseReadsEnabled as jest.MockedFunction<
+    typeof isClickHouseReadsEnabled
+  >
+
+describe('getQuotingTweetsPage', () => {
+  beforeEach(() => {
+    fetchQuotePostsMock.mockReset()
+    isClickHouseReadsEnabledMock.mockReset().mockReturnValue(true)
+  })
+
+  test('pages ClickHouse quote posts and returns the next offset', async () => {
+    fetchQuotePostsMock.mockResolvedValue({
+      tweets: [
+        {
+          tweet_id: '202',
+          account_id: '20',
+          created_at: '2026-08-08T12:00:00.000Z',
+          full_text: 'Complete quote post',
+          retweet_count: 3,
+          favorite_count: 12,
+          reply_to_tweet_id: null,
+          quote_tweet_id: '101',
+          retweeted_tweet_id: null,
+          avatar_media_url: null,
+          username: 'bob',
+          account_display_name: 'Bob',
+          media: [
+            {
+              media_url: 'https://example.com/quote.jpg',
+              media_type: 'photo',
+            },
+          ],
+          urls: [],
+        },
+      ],
+      totalCount: 20,
+    })
+
+    await expect(getQuotingTweetsPage('101', 12, 12)).resolves.toMatchObject({
+      totalCount: 20,
+      nextOffset: 13,
+      tweets: [
+        {
+          tweet_id: '202',
+          media: [{ media_url: 'https://example.com/quote.jpg' }],
+        },
+      ],
+    })
+    expect(fetchQuotePostsMock).toHaveBeenCalledWith('101', 12, 12)
+  })
+})

--- a/src/lib/quotingTweets.ts
+++ b/src/lib/quotingTweets.ts
@@ -1,0 +1,129 @@
+import 'server-only'
+
+import type { TweetData, TweetMedia } from '@/components/TweetComponent'
+import { fetchClickHouseQuotePosts } from '@/lib/clickhouseQuotePosts'
+import { isClickHouseReadsEnabled } from '@/lib/clickhouseGateway'
+import { createServerClient } from '@/utils/supabase'
+import { cookies } from 'next/headers'
+
+export interface QuotingTweetsPage {
+  tweets: TweetData[]
+  totalCount: number
+  nextOffset: number | null
+}
+
+function nextOffset(
+  offset: number,
+  loaded: number,
+  totalCount: number,
+): number | null {
+  const next = offset + loaded
+  return loaded > 0 && next < totalCount ? next : null
+}
+
+async function getSupabaseQuotingTweetsPage(
+  tweetId: string,
+  offset: number,
+  limit: number,
+): Promise<QuotingTweetsPage> {
+  const cookieStore = await cookies()
+  const supabase = createServerClient(cookieStore)
+  const {
+    data: relations,
+    count,
+    error: relationError,
+  } = await supabase
+    .from('quote_tweets')
+    .select('tweet_id', { count: 'exact' })
+    .eq('quoted_tweet_id', tweetId)
+    .order('tweet_id', { ascending: false })
+    .range(offset, offset + limit - 1)
+
+  if (relationError) throw relationError
+  const tweetIds = (relations ?? []).map(({ tweet_id }) => tweet_id)
+  const totalCount = count ?? tweetIds.length
+  if (tweetIds.length === 0) {
+    return { tweets: [], totalCount, nextOffset: null }
+  }
+
+  const [
+    { data: rows, error: tweetsError },
+    { data: mediaRows, error: mediaError },
+  ] = await Promise.all([
+    supabase.from('enriched_tweets').select('*').in('tweet_id', tweetIds),
+    supabase.from('tweet_media').select('*').in('tweet_id', tweetIds),
+  ])
+  if (tweetsError) throw tweetsError
+  if (mediaError) throw mediaError
+
+  const mediaByTweet = new Map<string, TweetMedia[]>()
+  for (const media of mediaRows ?? []) {
+    const current = mediaByTweet.get(media.tweet_id) ?? []
+    current.push({
+      media_url: media.media_url,
+      media_type: media.media_type,
+      width: media.width ?? undefined,
+      height: media.height ?? undefined,
+    })
+    mediaByTweet.set(media.tweet_id, current)
+  }
+  const rowById = new Map(
+    (rows ?? []).flatMap((row) =>
+      row.tweet_id ? ([[row.tweet_id, row]] as const) : [],
+    ),
+  )
+  const tweets = tweetIds.flatMap((id): TweetData[] => {
+    const row = rowById.get(id)
+    if (
+      !row?.tweet_id ||
+      !row.account_id ||
+      !row.created_at ||
+      row.full_text === null
+    ) {
+      return []
+    }
+    const username = row.username || 'unknown_user'
+    return [
+      {
+        tweet_id: row.tweet_id,
+        account_id: row.account_id,
+        created_at: row.created_at,
+        full_text: row.full_text,
+        retweet_count: row.retweet_count,
+        favorite_count: row.favorite_count ?? 0,
+        reply_to_tweet_id: row.reply_to_tweet_id,
+        reply_to_username: row.reply_to_username ?? undefined,
+        quote_tweet_id: tweetId,
+        retweeted_tweet_id: null,
+        avatar_media_url: row.avatar_media_url,
+        username,
+        account_display_name: row.account_display_name || username,
+        media: mediaByTweet.get(row.tweet_id) ?? [],
+        urls: [],
+      },
+    ]
+  })
+
+  return {
+    tweets,
+    totalCount,
+    nextOffset: nextOffset(offset, tweetIds.length, totalCount),
+  }
+}
+
+export async function getQuotingTweetsPage(
+  tweetId: string,
+  offset = 0,
+  limit = 12,
+): Promise<QuotingTweetsPage> {
+  const safeOffset = Math.max(0, Math.min(5_000, Math.trunc(offset)))
+  const safeLimit = Math.max(1, Math.min(50, Math.trunc(limit)))
+  if (isClickHouseReadsEnabled()) {
+    const page = await fetchClickHouseQuotePosts(tweetId, safeLimit, safeOffset)
+    return {
+      ...page,
+      nextOffset: nextOffset(safeOffset, page.tweets.length, page.totalCount),
+    }
+  }
+  return getSupabaseQuotingTweetsPage(tweetId, safeOffset, safeLimit)
+}

--- a/src/lib/tweetText.test.ts
+++ b/src/lib/tweetText.test.ts
@@ -1,0 +1,27 @@
+import { decodeTweetText } from './tweetText'
+
+describe('decodeTweetText', () => {
+  test('decodes the HTML entities used by Twitter archives', () => {
+    expect(
+      decodeTweetText(
+        'bread &amp; butter &lt;3 &gt;2 &quot;yes&quot; it&#39;s it&#x27;s',
+      ),
+    ).toBe('bread & butter <3 >2 "yes" it\'s it\'s')
+  })
+
+  test('fully decodes text that has been encoded more than once', () => {
+    expect(
+      decodeTweetText(
+        'New paper &amp;amp; result; if &amp;gt; 50%, say &amp;quot;yes&amp;quot;',
+      ),
+    ).toBe('New paper & result; if > 50%, say "yes"')
+    expect(decodeTweetText('&amp;lt;name&amp;gt;')).toBe('<name>')
+  })
+
+  test('decodes valid numeric Unicode entities and preserves invalid input', () => {
+    expect(decodeTweetText('thread &#x1F9F5;')).toBe('thread 🧵')
+    expect(decodeTweetText('&copy; &#0; &#xD800; &madeup;')).toBe(
+      '&copy; &#0; &#xD800; &madeup;',
+    )
+  })
+})

--- a/src/lib/tweetText.ts
+++ b/src/lib/tweetText.ts
@@ -1,0 +1,51 @@
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: '&',
+  apos: "'",
+  gt: '>',
+  lt: '<',
+  quot: '"',
+}
+
+const HTML_ENTITY = /&(?:#\d{1,7}|#x[\da-f]{1,6}|amp|apos|gt|lt|quot);/gi
+const MAX_DECODE_PASSES = 5
+
+function decodeEntity(entity: string): string {
+  const body = entity.slice(1, -1)
+  if (!body.startsWith('#')) {
+    return NAMED_ENTITIES[body.toLowerCase()] ?? entity
+  }
+
+  const isHex = body[1]?.toLowerCase() === 'x'
+  const digits = body.slice(isHex ? 2 : 1)
+  const codePoint = Number.parseInt(digits, isHex ? 16 : 10)
+  if (
+    !Number.isInteger(codePoint) ||
+    codePoint <= 0 ||
+    codePoint > 0x10ffff ||
+    (codePoint >= 0xd800 && codePoint <= 0xdfff)
+  ) {
+    return entity
+  }
+
+  return String.fromCodePoint(codePoint)
+}
+
+/**
+ * Normalize encoded text from Twitter archives before rendering it.
+ *
+ * Archive sources are inconsistent: some contain ordinary HTML entities while
+ * others have been encoded more than once. Decode a small, deterministic HTML
+ * subset repeatedly so server and client renders agree. React still escapes the
+ * resulting text when it is inserted into the DOM.
+ */
+export function decodeTweetText(text: string): string {
+  let decoded = text
+
+  for (let pass = 0; pass < MAX_DECODE_PASSES; pass += 1) {
+    const next = decoded.replace(HTML_ENTITY, decodeEntity)
+    if (next === decoded) return decoded
+    decoded = next
+  }
+
+  return decoded
+}


### PR DESCRIPTION
## Summary
- introduce a canonical full-fidelity `TweetCard` and use it across Home, Bangers, Trends, and quote-post results, including media and nested quoted tweets
- normalize singly and multiply encoded archive text through one deterministic decoder shared by the canonical and legacy tweet renderers
- make the quote sidebar independently scrollable and infinitely paginated, and preserve source-aware back navigation for Home, Bangers, Trends, and search
- simplify Bangers card styling and hover behavior; default to a rolling 24-hour Today view; add Last 3 months; reorder the menu; and load from each masonry column sentinel
- make Trends terms removable and binary include/off controls, add horizontal year-range selection, and filter the evidence feed to the selected period
- record the canonical tweet-rendering rule in `AGENTS.md`

## Issues
Closes #509
Closes #510
Closes #511
Closes #512
Closes #513
Closes #514
Closes #515
Closes #517
Closes #518
Closes #519
Closes #537

#516 was already completed by merged PR #507; the logged-in Library navigation was reverified here.

## Verification
- `pnpm test` — 55 suites, 231 tests passed
- `pnpm type-check`
- `pnpm lint` — passes with one existing test-only `<img>` warning
- changed-file Prettier check — passed
- authenticated local browser walkthrough against the configured remote services: verified Library navigation, Bangers defaults/menu/cards, Trends term removal and 2025 range filtering, source-aware Back to Bangers, independent quote scrolling, and infinite quote loading from 12 to 24 cards; no browser console errors

The repository-wide `pnpm format-check` remains red on 102 pre-existing files; every file changed by this PR passes Prettier.

## Backend dependency
Depends on TheExGenesis/community-archive-control-panel#32. That gateway PR must be deployed and smoke-tested before this frontend PR is made ready to merge so quote-post media is available remotely. No merge or deployment is included here.