### PR TITLE
Make Bangers hover subtle and snappy

### DIFF
--- a/src/components/TweetCard.test.tsx
+++ b/src/components/TweetCard.test.tsx
@@ -82,7 +82,7 @@ describe('TweetCard', () => {
     expect(push).toHaveBeenCalledTimes(2)
   })
 
-  test('uses the same light neutral outline for every featured rank', () => {
+  test('uses the same subtle neutral hover for every featured rank', () => {
     const { container } = render(
       <>
         <TweetCard tweet={tweet} featuredRank={1} />
@@ -94,6 +94,14 @@ describe('TweetCard', () => {
     expect(cards).toHaveLength(2)
     expect(cards[0].className).toBe(cards[1].className)
     expect(cards[0]).toHaveClass('border-zinc-200/75')
-    expect(cards[0].className).not.toMatch(/blue|translate|hover:border/)
+    expect(cards[0]).toHaveClass(
+      'duration-100',
+      'ease-out',
+      'hover:-translate-y-px',
+      'hover:border-[#dcdcdf]/75',
+      'dark:hover:border-[#38383e]/80',
+      'motion-reduce:hover:translate-y-0',
+    )
+    expect(cards[0].className).not.toMatch(/blue/)
   })
 })

--- a/src/components/portal/TweetRow.tsx
+++ b/src/components/portal/TweetRow.tsx
@@ -12,6 +12,8 @@ import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { PortalMedia, PortalQuotedTweet, PortalTweet } from '@/lib/portal/types'
 
 const HUES = [262, 32, 145, 4, 155, 200, 217, 88, 240, 190, 340, 45, 280, 20]
+const FEATURED_CARD_HOVER =
+  'transition-[transform,border-color,box-shadow] duration-100 ease-out hover:-translate-y-px hover:border-[#dcdcdf]/75 hover:shadow-[0_3px_9px_rgba(24,24,27,0.08)] motion-reduce:transition-none motion-reduce:hover:translate-y-0 dark:hover:border-[#38383e]/80 dark:hover:shadow-[0_3px_9px_rgba(0,0,0,0.22)]'
 
 export const avatarHue = (username: string) => {
   let h = 0
@@ -221,7 +223,7 @@ export function TweetRow({
   const isFeatured = featuredRank !== undefined
   const isClickable = clickable || isFeatured
   const rowClassName = isFeatured
-    ? `relative flex min-w-0 gap-3 rounded-lg border border-zinc-200/75 bg-white p-4 shadow-sm dark:border-[#303036]/80 dark:bg-[#1b1b1e] sm:gap-3.5 sm:p-5 ${
+    ? `relative flex min-w-0 gap-3 rounded-lg border border-zinc-200/75 bg-white p-4 shadow-sm dark:border-[#303036]/80 dark:bg-[#1b1b1e] sm:gap-3.5 sm:p-5 ${FEATURED_CARD_HOVER} ${
         animate ? 'portal-slide-in' : ''
       }`
     : `flex gap-3 border-b border-zinc-100 px-4 py-3 transition-colors last:border-b-0 hover:bg-zinc-50 dark:border-[#202023] dark:hover:bg-[#1f1f23] ${

--- a/src/lib/portal/TweetRow.test.tsx
+++ b/src/lib/portal/TweetRow.test.tsx
@@ -79,6 +79,11 @@ describe('portal TweetRow media', () => {
 
     expect(screen.queryByLabelText('Rank 1')).not.toBeInTheDocument()
     expect(card).toHaveClass('border-zinc-200/75')
+    expect(card).toHaveClass(
+      'duration-100',
+      'hover:-translate-y-px',
+      'hover:border-[#dcdcdf]/75',
+    )
     expect(card?.className).not.toMatch(/amber|blue/)
     expect(screen.getByText(/12 archive quotes/)).toHaveClass('rounded-full')
   })


### PR DESCRIPTION
## Summary

- restore a restrained hover treatment for Bangers cards
- use a 1px lift with a snappy 100ms ease-out transition and a subtle shadow
- adjust only the neutral border lightness by eight RGB points in light and dark themes while preserving opacity
- suppress the lift for reduced-motion users while retaining the non-motion cue

## User impact

Bangers feel interactive again without returning to the prominent blue outline or larger raise from the earlier treatment.

## Verification

- focused TweetCard and TweetRow suites: 5 tests passed
- `pnpm type-check`
- `pnpm lint` (passes with one pre-existing test-only image warning)
- changed-file Prettier check
- Vercel preview browser verification after deployment
