### PR TITLE
Clarify nightly archive refresh messaging

### DIFF
--- a/src/components/UploadArchiveSection.tsx
+++ b/src/components/UploadArchiveSection.tsx
@@ -152,6 +152,10 @@ export default function UploadArchiveSection() {
           <br className="hidden sm:block" />
           to build on top of our data and access our tools.
         </p>
+        <p className="mx-auto mt-3 max-w-2xl text-sm text-muted-foreground">
+          The public archive is updated every night with new tweets, and your
+          upload helps backfill older posts.
+        </p>
       </div>
 
       <div className="mx-auto grid max-w-4xl grid-cols-1 gap-6 md:grid-cols-3">

--- a/src/components/home/ClassicHomepage.tsx
+++ b/src/components/home/ClassicHomepage.tsx
@@ -316,9 +316,9 @@ export default async function ClassicHomepage() {
               Fill the gaps in the public record
             </h2>
             <p className="mx-auto mb-8 mt-4 max-w-2xl text-base leading-7 text-muted-foreground">
-              We refresh recent tweets every day. Upload your X archive to
-              backfill older posts, then use the extension to contribute new
-              tweets in real time while you browse.
+              We update the public archive every night with recent tweets.
+              Upload your X archive to backfill older posts, then use the
+              extension to contribute new tweets in real time while you browse.
             </p>
             <DynamicHeroCTAButtons initialIsOptedIn />
             <div className="mt-10 md:mt-12">{socialProof}</div>


### PR DESCRIPTION
## Summary

- make the logged-out homepage explicitly say the public archive updates every night
- explain in the upload flow that uploads backfill older posts while the public archive continues to refresh nightly

## Issue

Closes #524

## Validation

- `pnpm type-check`
- `pnpm exec next lint --file src/components/home/ClassicHomepage.tsx --file src/components/UploadArchiveSection.tsx`
- `pnpm exec prettier --check src/components/home/ClassicHomepage.tsx src/components/UploadArchiveSection.tsx`
- `git diff --check`
