### PR TITLE
Implement approved Bangers UI feedback

### DIFF
--- a/src/app/bangers/page.tsx
+++ b/src/app/bangers/page.tsx
@@ -43,10 +43,9 @@ export default async function BangersPage({
     periodValue === 'week' ||
     periodValue === 'three-months'
       ? periodValue
-      : periodValue === 'all' || year !== undefined
-        ? undefined
-        : 'today'
-  const allTime = periodValue === 'all'
+      : undefined
+  const allTime =
+    periodValue === 'all' || (period === undefined && year === undefined)
   const query = paramValue(searchParams.q).trim().slice(0, 120)
   const initialPage = await getInitialPortalBangersPage({
     scope,
@@ -76,10 +75,10 @@ export default async function BangersPage({
             Bangers
           </h1>
           <p className={`text-[13.5px] leading-relaxed ${MUTED}`}>
-            The archive&apos;s most quoted tweets, ranked by distinct quote
-            tweets from archive uploaders and opted-in members. Quotes by the
-            original author do not count. Today&apos;s rolling 24-hour view is
-            selected by default, with longer ranges available below.
+            The archive&apos;s best tweets, ranked by distinct archived quotes
+            from archive uploaders and opted-in members. Quotes by the original
+            author do not count. Best of all time is selected by default, with
+            recent ranges available below.
           </p>
         </header>
         <BangersExplorer

--- a/src/components/HeaderNavigation.tsx
+++ b/src/components/HeaderNavigation.tsx
@@ -10,23 +10,23 @@ import {
   navigationMenuTriggerStyle,
 } from '@/components/ui/navigation-menu'
 import { cn } from '@/utils/tailwind'
-import { NavItem } from '@/lib/navigation'
+import { isNavItemActive, NavItem } from '@/lib/navigation'
 
 export default function HeaderNavigation({ items }: { items: NavItem[] }) {
   const pathname = usePathname()
 
   return (
-    <NavigationMenu className="hidden lg:flex">
+    <NavigationMenu className="hidden xl:flex">
       <NavigationMenuList>
         {items.map((item) => {
-          const isActive = !item.href.includes('#') && pathname === item.href
+          const isActive = isNavItemActive(pathname, item.href)
           return (
             <NavigationMenuItem key={item.href}>
               <Link href={item.href} legacyBehavior passHref>
                 <NavigationMenuLink
                   className={cn(
                     navigationMenuTriggerStyle(),
-                    'transition-colors duration-150 hover:bg-accent',
+                    'px-2.5 text-xs transition-colors duration-150 hover:bg-accent 2xl:px-4 2xl:text-sm',
                     isActive ? 'bg-muted font-semibold' : '',
                   )}
                 >

--- a/src/components/MobileNavigation.tsx
+++ b/src/components/MobileNavigation.tsx
@@ -12,7 +12,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 
-import { NavItem } from '@/lib/navigation'
+import { isNavItemActive, NavItem } from '@/lib/navigation'
 
 export default function MobileNavigation({ items }: { items: NavItem[] }) {
   const pathname = usePathname()
@@ -20,7 +20,7 @@ export default function MobileNavigation({ items }: { items: NavItem[] }) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="icon" className="lg:hidden">
+        <Button variant="outline" size="icon" className="xl:hidden">
           <Menu className="h-5 w-5" />
           <span className="sr-only">Open navigation menu</span>
         </Button>
@@ -28,16 +28,13 @@ export default function MobileNavigation({ items }: { items: NavItem[] }) {
       <DropdownMenuContent
         align="end"
         sideOffset={8}
-        className="w-56 rounded-lg p-2 lg:hidden"
+        className="w-56 rounded-lg p-2 xl:hidden"
       >
         <DropdownMenuLabel className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
           Navigation
         </DropdownMenuLabel>
         {items.map((item) => {
-          const isActive = item.href.includes('#')
-            ? false
-            : pathname === item.href ||
-              (item.href !== '/' && pathname.startsWith(`${item.href}/`))
+          const isActive = isNavItemActive(pathname, item.href)
 
           return (
             <DropdownMenuItem key={item.href} asChild>

--- a/src/components/portal/BangersExplorer.test.tsx
+++ b/src/components/portal/BangersExplorer.test.tsx
@@ -130,7 +130,7 @@ describe('BangersExplorer', () => {
     jest.restoreAllMocks()
   })
 
-  test('offers only banger-relevant ranking and author scopes', () => {
+  test('defaults to Best of all time and orders the controls by intent', () => {
     renderExplorer()
 
     const orderedMasonryItems = Array.from(
@@ -150,17 +150,33 @@ describe('BangersExplorer', () => {
         (item) => within(item).getByTestId('tweet-row').dataset.rank,
       ),
     ).toEqual(['1', '2', '3'])
-    expect(screen.getByRole('link', { name: 'Most quoted' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Best' })).toHaveAttribute(
       'aria-current',
       'page',
     )
-    expect(screen.getByRole('link', { name: 'Most recent' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Best' })).toHaveAttribute(
       'href',
-      '/bangers?sort=recent',
+      '/bangers?period=all',
+    )
+    expect(screen.getByRole('link', { name: 'Recent' })).toHaveAttribute(
+      'href',
+      '/bangers?sort=recent&period=all',
     )
     expect(
       screen.getByRole('link', { name: 'Archive members' }),
-    ).toHaveAttribute('href', '/bangers?scope=members')
+    ).toHaveAttribute('href', '/bangers?scope=members&period=all')
+    expect(
+      screen.getByRole('combobox', { name: 'Filter by time' }),
+    ).toHaveTextContent('All time')
+    const when = screen.getByText('When')
+    const rank = screen.getByText('Rank')
+    const tweetsBy = screen.getByText('Tweets by')
+    expect(
+      when.compareDocumentPosition(rank) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+    expect(
+      rank.compareDocumentPosition(tweetsBy) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
     expect(screen.queryByText('Likes')).not.toBeInTheDocument()
     expect(screen.queryByText('Reposts')).not.toBeInTheDocument()
     expect(screen.getByTestId('bangers-masonry')).toHaveClass(
@@ -189,7 +205,7 @@ describe('BangersExplorer', () => {
     expect(
       screen.getByRole('combobox', { name: 'Filter by time' }),
     ).toHaveTextContent('Today')
-    expect(screen.getByRole('link', { name: 'Most recent' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Recent' })).toHaveAttribute(
       'href',
       '/bangers?sort=recent&period=today',
     )
@@ -209,9 +225,25 @@ describe('BangersExplorer', () => {
     expect(options.slice(0, 4).map((option) => option.textContent)).toEqual([
       'All time',
       'Today',
-      'This week',
+      'Last 7 days',
       'Last 3 months',
     ])
+  })
+
+  test('explains the Best ranking on hover and keyboard focus', async () => {
+    const user = userEvent.setup()
+    renderExplorer()
+
+    const best = screen.getByRole('link', { name: 'Best' })
+    await user.hover(best)
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      /Best means most quoted by distinct archive uploaders/i,
+    )
+
+    await user.unhover(best)
+    best.focus()
+    expect(await screen.findByRole('tooltip')).toBeVisible()
   })
 
   test('searches names and text and can clear the result', () => {

--- a/src/components/portal/BangersExplorer.tsx
+++ b/src/components/portal/BangersExplorer.tsx
@@ -12,6 +12,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import type {
   PortalBangersPage,
   PortalBangersPeriod,
@@ -126,6 +132,7 @@ export function BangersExplorer({
   const requestControllerRef = useRef<AbortController | null>(null)
   const loadMoreRef = useRef<HTMLDivElement | null>(null)
   const columnLoadMoreRefs = useRef<Array<HTMLDivElement | null>>([])
+  const isAllTime = allTime || (period === undefined && year === undefined)
 
   const availableYears = useMemo(() => {
     const years = page.pagination.yearCounts.map(({ year }) => year)
@@ -284,21 +291,18 @@ export function BangersExplorer({
       sort,
       year,
       period,
-      allTime,
+      allTime: isAllTime,
     })
     window.history.replaceState(window.history.state, '', nextUrl)
-  }, [allTime, period, query, scope, sort, year])
+  }, [isAllTime, period, query, scope, sort, year])
 
   const hasFilters =
-    query.trim().length > 0 ||
-    year !== undefined ||
-    allTime ||
-    (period !== undefined && period !== 'today')
+    query.trim().length > 0 || year !== undefined || period !== undefined
   const selectedTime = period ?? (year === undefined ? 'all' : `year-${year}`)
   const clearFilters = () => {
     setQuery('')
-    if (year !== undefined || allTime || period !== 'today') {
-      router.push(bangersHref({ query: '', scope, sort, period: 'today' }))
+    if (year !== undefined || period !== undefined) {
+      router.push(bangersHref({ query: '', scope, sort, allTime: true }))
     }
   }
   const isSearching = query.trim() !== loadedQuery
@@ -310,7 +314,7 @@ export function BangersExplorer({
     sort,
     year,
     period,
-    allTime,
+    allTime: isAllTime,
   })
 
   return (
@@ -347,99 +351,7 @@ export function BangersExplorer({
           </span>
         </label>
 
-        <div className="mt-3 flex flex-wrap items-end gap-x-5 gap-y-3">
-          <div>
-            <span
-              className={`mb-1.5 block text-[11px] font-bold uppercase tracking-[0.08em] ${MUTED}`}
-            >
-              Tweets by
-            </span>
-            <div className="flex">
-              <Link
-                href={bangersHref({
-                  query,
-                  scope: 'all',
-                  sort,
-                  year,
-                  period,
-                  allTime,
-                })}
-                aria-current={scope === 'all' ? 'page' : undefined}
-                className={`${segmentClassName} rounded-l-[3px] ${
-                  scope === 'all'
-                    ? activeSegmentClassName
-                    : idleSegmentClassName
-                }`}
-              >
-                Anyone
-              </Link>
-              <Link
-                href={bangersHref({
-                  query,
-                  scope: 'members',
-                  sort,
-                  year,
-                  period,
-                  allTime,
-                })}
-                aria-current={scope === 'members' ? 'page' : undefined}
-                className={`${segmentClassName} -ml-px rounded-r-[3px] ${
-                  scope === 'members'
-                    ? activeSegmentClassName
-                    : idleSegmentClassName
-                }`}
-              >
-                Archive members
-              </Link>
-            </div>
-          </div>
-
-          <div>
-            <span
-              className={`mb-1.5 block text-[11px] font-bold uppercase tracking-[0.08em] ${MUTED}`}
-            >
-              Rank
-            </span>
-            <div className="flex">
-              <Link
-                href={bangersHref({
-                  query,
-                  scope,
-                  sort: 'quotes',
-                  year,
-                  period,
-                  allTime,
-                })}
-                aria-current={sort === 'quotes' ? 'page' : undefined}
-                className={`${segmentClassName} rounded-l-[3px] ${
-                  sort === 'quotes'
-                    ? activeSegmentClassName
-                    : idleSegmentClassName
-                }`}
-              >
-                Most quoted
-              </Link>
-              <Link
-                href={bangersHref({
-                  query,
-                  scope,
-                  sort: 'recent',
-                  year,
-                  period,
-                  allTime,
-                })}
-                aria-current={sort === 'recent' ? 'page' : undefined}
-                className={`${segmentClassName} -ml-px rounded-r-[3px] ${
-                  sort === 'recent'
-                    ? activeSegmentClassName
-                    : idleSegmentClassName
-                }`}
-              >
-                Most recent
-              </Link>
-            </div>
-          </div>
-
+        <div className="mt-3 flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
           <label>
             <span
               className={`mb-1.5 block text-[11px] font-bold uppercase tracking-[0.08em] ${MUTED}`}
@@ -479,7 +391,7 @@ export function BangersExplorer({
               <SelectContent className="rounded-[3px]">
                 <SelectItem value="all">All time</SelectItem>
                 <SelectItem value="today">Today</SelectItem>
-                <SelectItem value="week">This week</SelectItem>
+                <SelectItem value="week">Last 7 days</SelectItem>
                 <SelectItem value="three-months">Last 3 months</SelectItem>
                 {availableYears.map((availableYear) => (
                   <SelectItem
@@ -492,6 +404,111 @@ export function BangersExplorer({
               </SelectContent>
             </Select>
           </label>
+
+          <div className="flex flex-wrap items-end gap-x-5 gap-y-3 lg:justify-end">
+            <div>
+              <span
+                className={`mb-1.5 block text-[11px] font-bold uppercase tracking-[0.08em] ${MUTED}`}
+              >
+                Rank
+              </span>
+              <div className="flex">
+                <TooltipProvider delayDuration={150}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Link
+                        href={bangersHref({
+                          query,
+                          scope,
+                          sort: 'quotes',
+                          year,
+                          period,
+                          allTime: isAllTime,
+                        })}
+                        aria-current={sort === 'quotes' ? 'page' : undefined}
+                        className={`${segmentClassName} rounded-l-[3px] ${
+                          sort === 'quotes'
+                            ? activeSegmentClassName
+                            : idleSegmentClassName
+                        }`}
+                      >
+                        Best
+                      </Link>
+                    </TooltipTrigger>
+                    <TooltipContent side="top" className="max-w-xs text-xs">
+                      Best means most quoted by distinct archive uploaders and
+                      opted-in members. Quotes by the original author do not
+                      count.
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+                <Link
+                  href={bangersHref({
+                    query,
+                    scope,
+                    sort: 'recent',
+                    year,
+                    period,
+                    allTime: isAllTime,
+                  })}
+                  aria-current={sort === 'recent' ? 'page' : undefined}
+                  className={`${segmentClassName} -ml-px rounded-r-[3px] ${
+                    sort === 'recent'
+                      ? activeSegmentClassName
+                      : idleSegmentClassName
+                  }`}
+                >
+                  Recent
+                </Link>
+              </div>
+            </div>
+
+            <div>
+              <span
+                className={`mb-1.5 block text-[11px] font-bold uppercase tracking-[0.08em] ${MUTED}`}
+              >
+                Tweets by
+              </span>
+              <div className="flex">
+                <Link
+                  href={bangersHref({
+                    query,
+                    scope: 'all',
+                    sort,
+                    year,
+                    period,
+                    allTime: isAllTime,
+                  })}
+                  aria-current={scope === 'all' ? 'page' : undefined}
+                  className={`${segmentClassName} rounded-l-[3px] ${
+                    scope === 'all'
+                      ? activeSegmentClassName
+                      : idleSegmentClassName
+                  }`}
+                >
+                  Anyone
+                </Link>
+                <Link
+                  href={bangersHref({
+                    query,
+                    scope: 'members',
+                    sort,
+                    year,
+                    period,
+                    allTime: isAllTime,
+                  })}
+                  aria-current={scope === 'members' ? 'page' : undefined}
+                  className={`${segmentClassName} -ml-px rounded-r-[3px] ${
+                    scope === 'members'
+                      ? activeSegmentClassName
+                      : idleSegmentClassName
+                  }`}
+                >
+                  Archive members
+                </Link>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
 
@@ -501,7 +518,7 @@ export function BangersExplorer({
             ? 'Searching ranked bangers…'
             : `Showing ${loadedCount.toLocaleString()} of ${totalCount.toLocaleString()} ranked ${totalCount === 1 ? 'tweet' : 'tweets'}`}
           {!isSearching && period === 'today' ? ' from the last 24 hours' : ''}
-          {!isSearching && period === 'week' ? ' from this week' : ''}
+          {!isSearching && period === 'week' ? ' from the last 7 days' : ''}
           {!isSearching && period === 'three-months'
             ? ' from the last 3 months'
             : ''}

--- a/src/components/portal/Portal.test.tsx
+++ b/src/components/portal/Portal.test.tsx
@@ -179,9 +179,14 @@ describe.each<PortalView>(['home', 'stream'])(
       expect(screen.getByText('preview tweet 5')).toBeInTheDocument()
       expect(screen.getByText('preview tweet 12')).toBeInTheDocument()
       if (view === 'home') {
-        expect(
-          screen.getByRole('region', { name: 'Live tweet stream' }),
-        ).toHaveClass('max-h-[420px]', 'overflow-y-auto')
+        const preview = screen.getByRole('region', {
+          name: 'Live tweet stream',
+        })
+        expect(preview).toHaveClass('max-h-[420px]', 'overflow-y-auto')
+        expect(preview.parentElement).toHaveClass(
+          'lg:h-[420px]',
+          'lg:min-h-[420px]',
+        )
         expect(screen.queryByText('preview tweet 13')).not.toBeInTheDocument()
       } else {
         expect(

--- a/src/components/portal/Portal.tsx
+++ b/src/components/portal/Portal.tsx
@@ -28,6 +28,7 @@ import {
   comparePortalTweetChronology,
   selectHomepageStream,
 } from '@/lib/portal/stream'
+import { BANGERS_ALL_TIME_HREF, BANGERS_WEEK_HREF } from '@/lib/portal/bangers'
 
 export type PortalView = 'home' | 'stream'
 
@@ -649,7 +650,7 @@ export default function Portal({
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-[1.45fr_1fr]">
             <div className="flex h-full min-h-0 flex-col gap-4 lg:overflow-hidden">
               <div
-                className={`${CARD} flex min-h-[420px] flex-col lg:min-h-[240px] lg:flex-1 lg:overflow-hidden lg:[contain:size]`}
+                className={`${CARD} flex min-h-[420px] flex-col lg:h-[420px] lg:min-h-[420px] lg:flex-none lg:overflow-hidden lg:[contain:size]`}
               >
                 <PanelHeader
                   title="Live stream"
@@ -760,7 +761,10 @@ export default function Portal({
                     >
                       <PanelHeader
                         title="Banger of the moment"
-                        action={{ label: 'More bangers', href: '/bangers' }}
+                        action={{
+                          label: 'Recent bangers',
+                          href: BANGERS_WEEK_HREF,
+                        }}
                       />
                       {recentBanger ? (
                         <div className="flex flex-1 flex-col [&>article]:flex-1">
@@ -784,7 +788,10 @@ export default function Portal({
                     >
                       <PanelHeader
                         title="Historical Banger"
-                        action={{ label: 'More bangers', href: '/bangers' }}
+                        action={{
+                          label: 'All-time bangers',
+                          href: BANGERS_ALL_TIME_HREF,
+                        }}
                       />
                       {historicalBanger ? (
                         <div className="flex flex-1 flex-col [&>article]:flex-1">
@@ -816,7 +823,7 @@ export default function Portal({
                   {data.failures.research ? (
                     <PanelUnavailable message="Featured research is temporarily unavailable." />
                   ) : (
-                    data.research.slice(0, 3).map((post) => (
+                    data.research.slice(0, 4).map((post) => (
                       <a
                         key={post.url}
                         href={post.url}

--- a/src/components/portal/PortalLayout.test.tsx
+++ b/src/components/portal/PortalLayout.test.tsx
@@ -84,15 +84,16 @@ test('renders the balanced homepage composition and editorial labels', async () 
 
   expect(screen.getByText('Featured research')).toBeInTheDocument()
   expect(screen.getByText('Research post 3')).toBeInTheDocument()
-  expect(screen.queryByText('Research post 4')).not.toBeInTheDocument()
+  expect(screen.getByText('Research post 4')).toBeInTheDocument()
+  expect(screen.queryByText('Research post 5')).not.toBeInTheDocument()
   expect(screen.getByText('Historical Banger')).toBeInTheDocument()
-  const moreBangersLinks = screen.getAllByRole('link', {
-    name: /More bangers/i,
-  })
-  expect(moreBangersLinks).toHaveLength(2)
-  moreBangersLinks.forEach((link) => {
-    expect(link).toHaveAttribute('href', '/bangers')
-  })
+  expect(screen.getByRole('link', { name: /Recent bangers/i })).toHaveAttribute(
+    'href',
+    '/bangers?period=week',
+  )
+  expect(
+    screen.getByRole('link', { name: /All-time bangers/i }),
+  ).toHaveAttribute('href', '/bangers?period=all')
   expect(
     screen.getByRole('link', { name: /Export the archive/i }),
   ).toHaveAttribute(
@@ -104,6 +105,9 @@ test('renders the balanced homepage composition and editorial labels', async () 
     'lg:max-h-none',
     'overflow-y-auto',
   )
+  expect(
+    screen.getByRole('region', { name: 'Live tweet stream' }).parentElement,
+  ).toHaveClass('lg:h-[420px]', 'lg:min-h-[420px]')
 
   unmount()
   jest.clearAllTimers()

--- a/src/components/portal/TweetRow.tsx
+++ b/src/components/portal/TweetRow.tsx
@@ -9,6 +9,12 @@ import TweetAvatarImage from '@/components/TweetAvatarImage'
 import { tweetPermalinkHref, type TweetOrigin } from '@/lib/navigation'
 import { decodeTweetText } from '@/lib/tweetText'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { PortalMedia, PortalQuotedTweet, PortalTweet } from '@/lib/portal/types'
 
 const HUES = [262, 32, 145, 4, 155, 200, 217, 88, 240, 190, 340, 45, 280, 20]
@@ -202,6 +208,36 @@ export interface TweetCardProps {
   returnTo?: string
 }
 
+function ArchivedQuotesMetric({
+  count,
+  href,
+}: {
+  count: number
+  href: string
+}) {
+  return (
+    <TooltipProvider delayDuration={150}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Link
+            href={href}
+            aria-label={`${count} archived quotes. Open tweet to see them.`}
+            className="inline-flex items-center gap-1 rounded-sm text-zinc-500 transition-colors hover:text-zinc-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 dark:text-[#a7a7b4] dark:hover:text-zinc-200"
+          >
+            <span aria-hidden="true">✦</span>
+            <span>{formatCount(count)} archived quotes</span>
+          </Link>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-xs text-xs">
+          Archived quotes are distinct quote tweets from archive uploaders and
+          opted-in members. Bangers uses this count for its Best ranking. Open
+          the tweet to see who quoted it.
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+
 export function TweetRow({
   tweet,
   animate = false,
@@ -301,15 +337,7 @@ export function TweetRow({
       {!compact && (
         <div className="mt-1.5 flex flex-wrap gap-x-4 gap-y-1 text-[12px] tabular-nums text-zinc-500 dark:text-[#a7a7b4]">
           {tweet.quoteCount !== undefined && (
-            <span
-              className={`font-semibold text-brand ${
-                isFeatured
-                  ? 'border-brand/15 rounded-full border bg-brand/[0.07] px-2 py-0.5'
-                  : ''
-              }`}
-            >
-              ✦ {formatCount(tweet.quoteCount)} archive quotes
-            </span>
+            <ArchivedQuotesMetric count={tweet.quoteCount} href={href} />
           )}
           <span>♥ {formatCount(tweet.likes)}</span>
           <span>⇄ {formatCount(tweet.rts)}</span>

--- a/src/lib/navigation.test.ts
+++ b/src/lib/navigation.test.ts
@@ -2,19 +2,35 @@ import {
   getMobileNav,
   getPrimaryNav,
   getTweetBackLink,
+  isNavItemActive,
   tweetPermalinkHref,
 } from './navigation'
 
 describe('member navigation', () => {
-  it('includes the member directory in desktop and mobile navigation', () => {
+  it('uses explicit Users, Live stream, Bangers, and Search destinations', () => {
     expect(getPrimaryNav(true)).toContainEqual({
       href: '/user-dir',
-      label: 'Library',
+      label: 'Users',
     })
-    expect(getMobileNav(true)).toContainEqual({
-      href: '/user-dir',
-      label: 'Library',
+    expect(getPrimaryNav(true)).toContainEqual({
+      href: '/stream',
+      label: 'Live stream',
     })
+    expect(getPrimaryNav(true)).toContainEqual({
+      href: '/bangers?period=all',
+      label: 'Bangers',
+    })
+    expect(getMobileNav(true)).toEqual(
+      expect.arrayContaining([
+        { href: '/user-dir', label: 'Users' },
+        { href: '/stream', label: 'Live stream' },
+        { href: '/bangers?period=all', label: 'Bangers' },
+        { href: '/search', label: 'Search' },
+      ]),
+    )
+    expect(isNavItemActive('/bangers', '/bangers?period=all')).toBe(true)
+    expect(isNavItemActive('/stream', '/stream')).toBe(true)
+    expect(isNavItemActive('/search', '/bangers?period=all')).toBe(false)
   })
 })
 

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -1,3 +1,5 @@
+import { BANGERS_ALL_TIME_HREF } from './portal/bangers'
+
 export interface NavItem {
   href: string
   label: string
@@ -99,8 +101,9 @@ export const getPrimaryNav = (isMember: boolean): NavItem[] =>
   isMember
     ? [
         { href: '/', label: 'Home' },
-        { href: '/user-dir', label: 'Library' },
-        { href: '/stream', label: 'Stream' },
+        { href: '/user-dir', label: 'Users' },
+        { href: '/stream', label: 'Live stream' },
+        { href: BANGERS_ALL_TIME_HREF, label: 'Bangers' },
         { href: '/trends', label: 'Trends' },
         { href: '/research', label: 'Research' },
         { href: '/tools', label: 'Tools' },
@@ -122,3 +125,12 @@ export const getMobileNav = (isMember: boolean): NavItem[] => [
   ...getUtilityNav(isMember),
   { href: '/search', label: 'Search' },
 ]
+
+export function isNavItemActive(pathname: string, href: string): boolean {
+  if (href.includes('#')) return false
+  const itemPathname = href.split('?')[0]
+  return (
+    pathname === itemPathname ||
+    (itemPathname !== '/' && pathname.startsWith(`${itemPathname}/`))
+  )
+}

--- a/src/lib/portal/TweetRow.test.tsx
+++ b/src/lib/portal/TweetRow.test.tsx
@@ -3,6 +3,7 @@
 import React from 'react'
 import '@testing-library/jest-dom'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { TweetRow } from '@/components/portal/TweetRow'
 import type { PortalTweet } from '@/lib/portal/types'
 ;(globalThis as typeof globalThis & { React: typeof React }).React = React
@@ -21,15 +22,16 @@ jest.mock('next/image', () => ({
 
 jest.mock('next/link', () => ({
   __esModule: true,
-  default: ({
-    href,
-    children,
-    ...props
-  }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
-    <a href={String(href)} {...props}>
-      {children}
-    </a>
-  ),
+  default: React.forwardRef<
+    HTMLAnchorElement,
+    React.AnchorHTMLAttributes<HTMLAnchorElement>
+  >(function MockNextLink({ href, children, ...props }, ref) {
+    return (
+      <a ref={ref} href={String(href)} {...props}>
+        {children}
+      </a>
+    )
+  }),
 }))
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: jest.fn() }),
@@ -73,14 +75,24 @@ const tweet: PortalTweet = {
 }
 
 describe('portal TweetRow media', () => {
-  test('uses the same neutral card treatment for a top banger', () => {
+  test('uses a neutral card and explains its archived-quote evidence', async () => {
+    const user = userEvent.setup()
     const { container } = render(<TweetRow tweet={tweet} featuredRank={1} />)
     const card = container.querySelector('article')
 
     expect(screen.queryByLabelText('Rank 1')).not.toBeInTheDocument()
     expect(card).toHaveClass('border-zinc-200/75')
     expect(card?.className).not.toMatch(/amber|blue/)
-    expect(screen.getByText(/12 archive quotes/)).toHaveClass('rounded-full')
+    const archivedQuotes = screen.getByRole('link', {
+      name: '12 archived quotes. Open tweet to see them.',
+    })
+    expect(archivedQuotes).toHaveClass('text-zinc-500')
+    expect(archivedQuotes).not.toHaveClass('rounded-full', 'text-brand')
+
+    await user.hover(archivedQuotes)
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      /Bangers uses this count for its Best ranking/i,
+    )
   })
 
   test('renders quotes and closes an enlarged image when the backdrop is clicked', async () => {

--- a/src/lib/portal/bangers.ts
+++ b/src/lib/portal/bangers.ts
@@ -1,0 +1,2 @@
+export const BANGERS_ALL_TIME_HREF = '/bangers?period=all'
+export const BANGERS_WEEK_HREF = '/bangers?period=week'

--- a/src/lib/portal/data.test.ts
+++ b/src/lib/portal/data.test.ts
@@ -221,6 +221,12 @@ describe('portal page resilience', () => {
     })
   })
 
+  test('loads the homepage Banger of the moment from a rolling week', async () => {
+    await getPortalData()
+
+    expect(fetchPortalRecentBangersMock).toHaveBeenCalledWith(50, 168)
+  })
+
   test('preserves other components when the trends request fails', async () => {
     fetchPortalTrendsMock.mockRejectedValueOnce(
       new Error('trend snapshot unavailable'),
@@ -496,31 +502,31 @@ describe('portal reads', () => {
     }
   })
 
-  test('starts this week on Monday at midnight UTC', async () => {
+  test('uses an exact rolling seven-day window', async () => {
     jest.useFakeTimers()
     jest.setSystemTime(new Date('2026-08-12T14:00:00.000Z'))
     fetchPortalBangersPageMock.mockResolvedValueOnce({
       tweets: [
         {
-          id: 'monday',
+          id: 'boundary',
           username: 'alice',
           name: 'Alice',
           avatar: null,
-          text: 'Monday banger',
-          observedAt: '2026-08-10T00:00:00.000Z',
-          createdAt: '2026-08-10T00:00:00.000Z',
+          text: 'Exactly seven days ago',
+          observedAt: '2026-08-05T14:00:00.000Z',
+          createdAt: '2026-08-05T14:00:00.000Z',
           likes: 4,
           rts: 0,
           quoteCount: 2,
         },
         {
-          id: 'sunday',
+          id: 'outside-window',
           username: 'bob',
           name: 'Bob',
           avatar: null,
-          text: 'Sunday banger',
-          observedAt: '2026-08-09T23:59:59.000Z',
-          createdAt: '2026-08-09T23:59:59.000Z',
+          text: 'One second outside the week',
+          observedAt: '2026-08-05T13:59:59.000Z',
+          createdAt: '2026-08-05T13:59:59.000Z',
           likes: 8,
           rts: 0,
           quoteCount: 9,
@@ -541,7 +547,7 @@ describe('portal reads', () => {
       await expect(
         getPortalBangersPage({ period: 'week' }),
       ).resolves.toMatchObject({
-        tweets: [{ id: 'monday' }],
+        tweets: [{ id: 'boundary' }],
         pagination: { totalAvailable: 1 },
       })
     } finally {

--- a/src/lib/portal/data.ts
+++ b/src/lib/portal/data.ts
@@ -668,8 +668,8 @@ const getCachedHistoricalBangers = unstable_cache(
 )
 const getCachedRecentBangers = unstable_cache(
   async (_sourceKey: string) =>
-    enrichPortalTweets(await fetchPortalRecentBangers(50, 48)),
-  ['portal-recent-bangers-v2'],
+    enrichPortalTweets(await fetchPortalRecentBangers(50, 168)),
+  ['portal-recent-bangers-v3'],
   { revalidate: 1_800 },
 )
 
@@ -681,9 +681,7 @@ function portalBangersPeriodStart(
   if (period === 'today') {
     start.setUTCDate(start.getUTCDate() - 1)
   } else if (period === 'week') {
-    start.setUTCHours(0, 0, 0, 0)
-    const daysSinceMonday = (start.getUTCDay() + 6) % 7
-    start.setUTCDate(start.getUTCDate() - daysSinceMonday)
+    start.setUTCDate(start.getUTCDate() - 7)
   } else {
     start.setUTCMonth(start.getUTCMonth() - 3)
   }
@@ -695,7 +693,7 @@ function portalBangersSnapshotStart(
   now = new Date(),
 ): string {
   const start = new Date(portalBangersPeriodStart(period, now))
-  if (period === 'today') start.setUTCMinutes(0, 0, 0)
+  if (period === 'today' || period === 'week') start.setUTCMinutes(0, 0, 0)
   if (period === 'three-months') start.setUTCHours(0, 0, 0, 0)
   return start.toISOString()
 }


### PR DESCRIPTION
## Summary

- make Bangers default to Best / All time and expose it in the member navigation
- reorganize and rename Bangers controls, with clear tooltips for the Best ranking and archived-quote metric
- route homepage Banger cards to their matching all-time and last-7-days views
- show roughly four live-stream tweets and four research highlights on the homepage
- rename member navigation to Users and Live stream while keeping Search unchanged
- keep the expanded member navigation collision-free across tablet and desktop widths

## Validation

- `pnpm type-check`
- scoped `next lint` (no warnings)
- `pnpm test:ci` (56 suites, 236 tests)
- focused UI/data suite after final review (6 suites, 38 tests)
- GitHub pull-request workflow passed
- authenticated Vercel preview verified at 390px, 1024px, 1280px, and 1440px
- verified Best / All time defaults, ranking and archived-quote tooltips, card routes, four full stream rows, four research highlights, responsive navigation, no overflow, no error overlay, and clean fresh-request browser logs

Closes #532
Closes #539
Closes #540
Closes #541
Closes #542
Closes #543
Closes #544

Related: #519
