### PR TITLE
Make image lightboxes larger

### DIFF
--- a/src/components/ImageLightbox.tsx
+++ b/src/components/ImageLightbox.tsx
@@ -61,7 +61,7 @@ export default function ImageLightbox({
           width={width}
           height={height}
           sizes="96vw"
-          className="max-h-[92vh] w-auto max-w-[96vw] rounded-md object-contain"
+          className="h-auto max-h-[92vh] w-[min(96vw,1200px)] max-w-[96vw] rounded-md object-contain"
         />
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Summary

- allow image lightboxes to scale up to a responsive 1200px display width
- keep the existing viewport-height and mobile-width limits

## Issue

Closes #528

## Validation

- `pnpm type-check`
- `pnpm exec next lint --file src/components/ImageLightbox.tsx`
- `pnpm exec prettier --check src/components/ImageLightbox.tsx`
- `pnpm exec jest --selectProjects client --runInBand src/components/TweetCard.test.tsx src/components/portal/TweetRow.test.tsx`
- `git diff --check`
