### PR TITLE
Increase Bangers hover lift and contrast

### DIFF
--- a/src/components/TweetCard.test.tsx
+++ b/src/components/TweetCard.test.tsx
@@ -109,9 +109,9 @@ describe('TweetCard', () => {
     expect(cards[0]).toHaveClass(
       'duration-100',
       'ease-out',
-      'hover:-translate-y-px',
-      'hover:border-[#dcdcdf]/75',
-      'dark:hover:border-[#38383e]/80',
+      'hover:-translate-y-0.5',
+      'hover:border-[#d4d4d7]/75',
+      'dark:hover:border-[#404046]/80',
       'motion-reduce:hover:translate-y-0',
     )
     expect(cards[0].className).not.toMatch(/blue/)

--- a/src/components/portal/TweetRow.tsx
+++ b/src/components/portal/TweetRow.tsx
@@ -19,7 +19,7 @@ import { PortalMedia, PortalQuotedTweet, PortalTweet } from '@/lib/portal/types'
 
 const HUES = [262, 32, 145, 4, 155, 200, 217, 88, 240, 190, 340, 45, 280, 20]
 const FEATURED_CARD_HOVER =
-  'transition-[transform,border-color,box-shadow] duration-100 ease-out hover:-translate-y-px hover:border-[#dcdcdf]/75 hover:shadow-[0_3px_9px_rgba(24,24,27,0.08)] motion-reduce:transition-none motion-reduce:hover:translate-y-0 dark:hover:border-[#38383e]/80 dark:hover:shadow-[0_3px_9px_rgba(0,0,0,0.22)]'
+  'transition-[transform,border-color,box-shadow] duration-100 ease-out hover:-translate-y-0.5 hover:border-[#d4d4d7]/75 hover:shadow-[0_3px_9px_rgba(24,24,27,0.08)] motion-reduce:transition-none motion-reduce:hover:translate-y-0 dark:hover:border-[#404046]/80 dark:hover:shadow-[0_3px_9px_rgba(0,0,0,0.22)]'
 
 export const avatarHue = (username: string) => {
   let h = 0

--- a/src/lib/portal/TweetRow.test.tsx
+++ b/src/lib/portal/TweetRow.test.tsx
@@ -84,8 +84,8 @@ describe('portal TweetRow media', () => {
     expect(card).toHaveClass('border-zinc-200/75')
     expect(card).toHaveClass(
       'duration-100',
-      'hover:-translate-y-px',
-      'hover:border-[#dcdcdf]/75',
+      'hover:-translate-y-0.5',
+      'hover:border-[#d4d4d7]/75',
     )
     expect(card?.className).not.toMatch(/amber|blue/)
     const archivedQuotes = screen.getByRole('link', {


### PR DESCRIPTION
## What changed\n\n- increases the Bangers card hover lift from 1px to 2px\n- increases neutral border contrast by one small lightness step in light and dark themes\n- keeps the existing 100ms transition, subtle shadow, and reduced-motion behavior\n\n## Validation\n\n- focused TweetCard and TweetRow tests\n- TypeScript type-check\n- Next.js lint\n- Prettier check