### PR TITLE
Cap Trends Explorer query concurrency

### DIFF
--- a/src/lib/portal/analytics.test.ts
+++ b/src/lib/portal/analytics.test.ts
@@ -178,6 +178,27 @@ describe('ClickHouse-backed portal analytics', () => {
     ])
   })
 
+  test('caps concurrent trend scans at the two-query gateway budget', async () => {
+    let active = 0
+    let maxActive = 0
+    const fetcher = jest.fn(async () => {
+      active += 1
+      maxActive = Math.max(maxActive, active)
+      await new Promise((resolve) => setTimeout(resolve, 2))
+      active -= 1
+      return { data: [] }
+    }) as unknown as AnalyticsFetcher
+
+    await fetchPortalTrendSeries(
+      ['alpha', 'beta', 'gamma', 'delta', 'epsilon'],
+      new Date('2026-08-07T12:00:00.000Z'),
+      fetcher,
+    )
+
+    expect(fetcher).toHaveBeenCalledTimes(5)
+    expect(maxActive).toBe(2)
+  })
+
   test('merges included evidence and forwards a selected date range', async () => {
     const tweet = (tweetId: string, fullText: string, createdAt: string) => ({
       tweetId,

--- a/src/lib/portal/analytics.ts
+++ b/src/lib/portal/analytics.ts
@@ -27,6 +27,8 @@ export const WATCHLIST = [
 ]
 
 type AnalyticsFetcher = typeof fetchAnalyticsGatewayJson
+// Keep corpus-scan fan-out aligned with the two-query production capacity.
+const DEFAULT_ANALYTICS_CONCURRENCY = 2
 
 interface ClickHouseSummaryResponse {
   data: {
@@ -163,7 +165,7 @@ function utcDateParam(date: Date): string {
 
 async function runBatched<T>(
   jobs: Array<() => Promise<T>>,
-  concurrency = 6,
+  concurrency = DEFAULT_ANALYTICS_CONCURRENCY,
 ): Promise<T[]> {
   const results: T[] = new Array(jobs.length)
   let next = 0


### PR DESCRIPTION
## Summary

- reduce shared analytics fan-out from six concurrent requests to two
- keep trend evidence searches serialized at one
- add a regression test proving five trend jobs never exceed two active gateway calls

Closes #550
Closes #547

## Why

The production ClickHouse host has two query CPUs. A cold Trends load requests 19 series; running six corpus scans at once amplified tail latency. The already-deployed gateway now also deduplicates the two shared denominator windows, so this client cap targets the remaining matched-term contention.

## Validation

- `src/lib/portal/analytics.test.ts`: 9/9 passed
- `src/lib/portalTrendsRoute.test.ts`: 5/5 passed
- full TypeScript check passed
- Prettier check passed

## Dependency

Gateway build `88015f112022` is already live with denominator single-flight caching, bounded search admission, and the new metrics. No frontend merge should precede that dependency; the production gate is satisfied.

Rollback: restore `DEFAULT_ANALYTICS_CONCURRENCY` to 6 and redeploy the prior frontend build.