### PR TITLE
Fix Twitter opt-in resumption and rate limits

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import ClassicHomepage from '@/components/home/ClassicHomepage'
 import Portal from '@/components/portal/Portal'
+import { hasPendingOptInAction } from '@/lib/homepageAccess'
 import { getIsMember } from '@/lib/portal/auth'
 import { getPortalData } from '@/lib/portal/data'
 
@@ -11,7 +12,21 @@ export const maxDuration = 60
 // classic marketing homepage. Auth comes from cookies, so this page renders
 // dynamically — the portal's data layer does its own caching (24h for heavy
 // aggregates, minutes for stats and the initial stream).
-export default async function Homepage() {
+interface HomepageProps {
+  searchParams?: {
+    action?: string | string[]
+  }
+}
+
+export default async function Homepage({ searchParams }: HomepageProps = {}) {
+  // OAuth returns to /?action=optin. Even though the new session makes this
+  // user eligible for the signed-in portal, keep this request on the classic
+  // homepage so HeroCTAButtons can consume and persist the pending consent
+  // action before the portal branch takes over.
+  if (hasPendingOptInAction(searchParams?.action)) {
+    return <ClassicHomepage />
+  }
+
   if (!(await getIsMember())) {
     return <ClassicHomepage />
   }

--- a/src/app/profile/ProfileContent.test.tsx
+++ b/src/app/profile/ProfileContent.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import ProfileContent from './ProfileContent'
+
+const mockFetch = jest.fn()
+const originalFetch = global.fetch
+const mockLogInsert = jest.fn().mockResolvedValue({ error: null })
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: jest.fn() }),
+}))
+
+jest.mock('@/hooks/useAuthAndArchive', () => ({
+  useAuthAndArchive: () => ({
+    userMetadata: { user_name: 'ExampleUser', provider_id: 'twitter-123' },
+  }),
+}))
+
+jest.mock('@/utils/supabase', () => ({
+  createBrowserClient: () => ({
+    from: () => ({ insert: mockLogInsert }),
+    storage: { from: jest.fn() },
+  }),
+}))
+
+jest.mock('@/lib/db_insert', () => ({
+  deleteArchive: jest.fn(),
+  deleteSingleArchive: jest.fn(),
+}))
+
+jest.mock('@/lib/posthog', () => ({
+  capturePostHogEvent: jest.fn(),
+}))
+
+const user = {
+  id: 'auth-user-123',
+  user_metadata: {
+    user_name: 'ExampleUser',
+    provider_id: 'twitter-123',
+  },
+  app_metadata: {},
+} as any
+
+describe('ProfileContent opt-in preference', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    global.fetch = mockFetch
+  })
+
+  afterAll(() => {
+    global.fetch = originalFetch
+  })
+
+  it('shows retry timing and preserves the prior state after a 429', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'Too Many Requests' }), {
+        status: 429,
+        headers: { 'Retry-After': '60' },
+      }),
+    )
+
+    render(<ProfileContent user={user} initialOptInData={null} archives={[]} />)
+
+    const optInSwitch = screen.getByRole('switch', {
+      name: /opt-in to tweet streaming/i,
+    })
+    fireEvent.click(optInSwitch)
+
+    expect(
+      await screen.findByText(
+        'Too many requests. Please wait 1 minute and try again.',
+      ),
+    ).toBeInTheDocument()
+    expect(optInSwitch).not.toBeChecked()
+    await waitFor(() => expect(optInSwitch).toBeEnabled())
+  })
+
+  it('allows only one opt-in mutation while the request is in flight', async () => {
+    let resolveRequest: (response: Response) => void = () => undefined
+    mockFetch.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveRequest = resolve
+        }),
+    )
+
+    render(<ProfileContent user={user} initialOptInData={null} archives={[]} />)
+
+    const optInSwitch = screen.getByRole('switch', {
+      name: /opt-in to tweet streaming/i,
+    })
+    fireEvent.click(optInSwitch)
+    fireEvent.click(optInSwitch)
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(optInSwitch).toBeDisabled()
+
+    resolveRequest(
+      new Response(JSON.stringify({ success: true }), { status: 200 }),
+    )
+
+    await waitFor(() => expect(optInSwitch).toBeChecked())
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/app/profile/ProfileContent.tsx
+++ b/src/app/profile/ProfileContent.tsx
@@ -1,13 +1,26 @@
 'use client'
 
-import { useState, useTransition } from 'react'
+import { useRef, useState } from 'react'
 import { User } from '@supabase/supabase-js'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
 import { Switch } from '@/components/ui/switch'
 import { Label } from '@/components/ui/label'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog'
 import { AlertCircle, Archive, Trash2, UserX, CheckCircle } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { createBrowserClient } from '@/utils/supabase'
@@ -18,6 +31,7 @@ import { deleteArchive, deleteSingleArchive } from '@/lib/db_insert'
 import { useAuthAndArchive } from '@/hooks/useAuthAndArchive'
 import { ArchiveUploadButton } from '@/components/ArchiveUploadButton'
 import { capturePostHogEvent } from '@/lib/posthog'
+import { updateOptIn } from '@/lib/optInApi'
 
 interface ProfileContentProps {
   user: User
@@ -28,13 +42,18 @@ interface ProfileContentProps {
 export default function ProfileContent({
   user,
   initialOptInData,
-  archives
+  archives,
 }: ProfileContentProps) {
   const router = useRouter()
   const { userMetadata } = useAuthAndArchive()
-  const [isPending, startTransition] = useTransition()
-  const [optInStatus, setOptInStatus] = useState(initialOptInData?.opted_in || false)
-  const [explicitOptOut, setExplicitOptOut] = useState(initialOptInData?.explicit_optout || false)
+  const preferenceMutationInFlight = useRef(false)
+  const [isPreferenceSaving, setIsPreferenceSaving] = useState(false)
+  const [optInStatus, setOptInStatus] = useState(
+    initialOptInData?.opted_in || false,
+  )
+  const [explicitOptOut, setExplicitOptOut] = useState(
+    initialOptInData?.explicit_optout || false,
+  )
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState<string | null>(null)
   const [deletingArchive, setDeletingArchive] = useState<string | null>(null)
@@ -49,56 +68,60 @@ export default function ProfileContent({
     user.user_metadata?.username ||
     user.app_metadata?.user_name
 
-  const twitterUserId =
-    userMetadata?.provider_id ||
-    user.user_metadata?.provider_id ||
-    user.app_metadata?.provider_id
+  const beginPreferenceMutation = () => {
+    if (preferenceMutationInFlight.current) return false
+
+    preferenceMutationInFlight.current = true
+    setIsPreferenceSaving(true)
+    return true
+  }
+
+  const endPreferenceMutation = () => {
+    preferenceMutationInFlight.current = false
+    setIsPreferenceSaving(false)
+  }
 
   const handleOptInToggle = async (checked: boolean) => {
+    if (!beginPreferenceMutation()) return
+
     setError(null)
     setSuccess(null)
 
-    startTransition(async () => {
-      try {
-        if (!twitterUsername) {
-          throw new Error(
-            'Twitter username not found. Please sign in with Twitter to manage opt-in settings.',
-          )
-        }
-
-        const response = await fetch('/api/opt-in', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            username: twitterUsername.toLowerCase(),
-            twitterUserId: twitterUserId || null,
-            optedIn: checked,
-            termsVersion: 'v1.0',
-          }),
-        })
-        const result = await response.json()
-
-        if (!response.ok) {
-          throw new Error(result.error || 'Failed to update opt-in status')
-        }
-
-        setOptInStatus(checked)
-        setExplicitOptOut(false)
-        setSuccess(checked ? 'Successfully opted in to tweet streaming' : 'Successfully opted out from tweet streaming')
-        capturePostHogEvent('tweet_streaming_preference_updated', {
-          opted_in: checked,
-        })
-
-        await logUserAction(checked ? 'opt_in' : 'opt_out_streaming')
-
-        // Skip router.refresh() — the only thing that changed is the optin row, and we
-        // already updated the local state above. Refreshing here re-mounts the whole
-        // server-rendered page, which the user perceives as a full reload.
-      } catch (err: any) {
-        setError(err.message || 'Failed to update opt-in status')
-        setOptInStatus(!checked) // Revert on error
+    try {
+      if (!twitterUsername) {
+        throw new Error(
+          'Twitter username not found. Please sign in with Twitter to manage opt-in settings.',
+        )
       }
-    })
+
+      await updateOptIn({
+        username: twitterUsername.toLowerCase(),
+        optedIn: checked,
+        termsVersion: 'v1.0',
+      })
+
+      setOptInStatus(checked)
+      setExplicitOptOut(false)
+      setSuccess(
+        checked
+          ? 'Successfully opted in to tweet streaming'
+          : 'Successfully opted out from tweet streaming',
+      )
+      capturePostHogEvent('tweet_streaming_preference_updated', {
+        opted_in: checked,
+      })
+
+      await logUserAction(checked ? 'opt_in' : 'opt_out_streaming')
+
+      // Skip router.refresh() — the only thing that changed is the optin row, and we
+      // already updated the local state above. Refreshing here re-mounts the whole
+      // server-rendered page, which the user perceives as a full reload.
+    } catch (err: any) {
+      setError(err.message || 'Failed to update opt-in status')
+      setOptInStatus(!checked) // Revert on error
+    } finally {
+      endPreferenceMutation()
+    }
   }
 
   // Best-effort append to the user action log. Never throws — logging failures
@@ -108,14 +131,16 @@ export default function ProfileContent({
     metadata?: Record<string, unknown>,
   ) => {
     try {
-      const { error: logError } = await supabase.from('user_action_log').insert({
-        account_id: userMetadata?.provider_id ?? null,
-        user_id: user.id,
-        action_type,
-        // Cast through unknown — Record<string, unknown> is structurally compatible
-        // with the recursive Json type Supabase generates but TS can't prove it.
-        metadata: (metadata ?? null) as unknown as never,
-      })
+      const { error: logError } = await supabase
+        .from('user_action_log')
+        .insert({
+          account_id: userMetadata?.provider_id ?? null,
+          user_id: user.id,
+          action_type,
+          // Cast through unknown — Record<string, unknown> is structurally compatible
+          // with the recursive Json type Supabase generates but TS can't prove it.
+          metadata: (metadata ?? null) as unknown as never,
+        })
       if (logError) console.warn('user_action_log insert failed:', logError)
     } catch (err) {
       console.warn('user_action_log insert threw:', err)
@@ -131,31 +156,21 @@ export default function ProfileContent({
       )
     }
 
-    const response = await fetch('/api/opt-in', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        username: twitterUsername.toLowerCase(),
-        twitterUserId: twitterUserId || null,
-        optedIn: false,
-        termsVersion: 'v1.0',
-        explicitOptOut: checked,
-        optOutReason: checked
-          ? 'User explicitly opted out via profile settings'
-          : null,
-      }),
+    await updateOptIn({
+      username: twitterUsername.toLowerCase(),
+      optedIn: false,
+      termsVersion: 'v1.0',
+      explicitOptOut: checked,
+      optOutReason: checked
+        ? 'User explicitly opted out via profile settings'
+        : null,
     })
-    const result = await response.json()
-
-    if (!response.ok) {
-      throw new Error(result.error || 'Failed to update opt-out status')
-    }
   }
 
   // Toggle-ON opens a confirmation dialog (opt-out also deletes all data, mirroring
   // the standalone "Delete All Your Data" flow). Toggle-OFF removes the user from the
   // opt-out list without touching data.
-  const handleExplicitOptOut = (checked: boolean) => {
+  const handleExplicitOptOut = async (checked: boolean) => {
     setError(null)
     setSuccess(null)
 
@@ -164,39 +179,44 @@ export default function ProfileContent({
       return
     }
 
-    startTransition(async () => {
-      try {
-        await persistOptOut(false)
-        setExplicitOptOut(false)
-        setSuccess('Removed from explicit opt-out list')
-        await logUserAction('opt_out_removed')
-        // No router.refresh — toggle state already updated locally.
-      } catch (err: any) {
-        setError(err.message || 'Failed to update opt-out status')
-      }
-    })
+    if (!beginPreferenceMutation()) return
+
+    try {
+      await persistOptOut(false)
+      setExplicitOptOut(false)
+      setSuccess('Removed from explicit opt-out list')
+      await logUserAction('opt_out_removed')
+      // No router.refresh — toggle state already updated locally.
+    } catch (err: any) {
+      setError(err.message || 'Failed to update opt-out status')
+    } finally {
+      endPreferenceMutation()
+    }
   }
 
   // Confirmed from the opt-out modal: only add to the opt-out list, no delete.
-  const confirmOptOutOnly = () => {
+  const confirmOptOutOnly = async () => {
+    if (!beginPreferenceMutation()) return
+
     setError(null)
     setSuccess(null)
-    startTransition(async () => {
-      try {
-        await persistOptOut(true)
-        setExplicitOptOut(true)
-        setOptInStatus(false)
-        setShowOptOutDialog(false)
-        setSuccess('Added to explicit opt-out list')
-        capturePostHogEvent('explicit_opt_out_confirmed', {
-          delete_archives: false,
-        })
-        await logUserAction('opt_out_only')
-        // No router.refresh — toggle state already updated locally.
-      } catch (err: any) {
-        setError(err.message || 'Failed to opt out')
-      }
-    })
+
+    try {
+      await persistOptOut(true)
+      setExplicitOptOut(true)
+      setOptInStatus(false)
+      setShowOptOutDialog(false)
+      setSuccess('Added to explicit opt-out list')
+      capturePostHogEvent('explicit_opt_out_confirmed', {
+        delete_archives: false,
+      })
+      await logUserAction('opt_out_only')
+      // No router.refresh — toggle state already updated locally.
+    } catch (err: any) {
+      setError(err.message || 'Failed to opt out')
+    } finally {
+      endPreferenceMutation()
+    }
   }
 
   // Confirmed from the opt-out modal: persist the hard opt-out before deletion
@@ -259,7 +279,11 @@ export default function ProfileContent({
   }
 
   const handleDeleteArchive = async (archiveId: number) => {
-    if (!confirm('Are you sure you want to delete this archive? This action cannot be undone.')) {
+    if (
+      !confirm(
+        'Are you sure you want to delete this archive? This action cannot be undone.',
+      )
+    ) {
       return
     }
 
@@ -359,7 +383,7 @@ export default function ProfileContent({
                   id="opt-in"
                   checked={optInStatus && !explicitOptOut}
                   onCheckedChange={handleOptInToggle}
-                  disabled={isPending || explicitOptOut}
+                  disabled={isPreferenceSaving || explicitOptOut}
                 />
               </div>
 
@@ -377,7 +401,7 @@ export default function ProfileContent({
                   id="opt-out"
                   checked={explicitOptOut}
                   onCheckedChange={handleExplicitOptOut}
-                  disabled={isPending}
+                  disabled={isPreferenceSaving}
                   className="data-[state=checked]:bg-destructive"
                 />
               </div>
@@ -386,8 +410,8 @@ export default function ProfileContent({
                 <Alert>
                   <AlertCircle className="h-4 w-4" />
                   <AlertDescription>
-                    You are on the explicit opt-out list. Your tweets will not be collected
-                    through any automated means.
+                    You are on the explicit opt-out list. Your tweets will not
+                    be collected through any automated means.
                   </AlertDescription>
                 </Alert>
               )}
@@ -396,8 +420,8 @@ export default function ProfileContent({
                 <Alert>
                   <CheckCircle className="h-4 w-4 text-green-600" />
                   <AlertDescription>
-                    You have opted in to tweet streaming. Your public tweets may be archived
-                    for historical and research purposes.
+                    You have opted in to tweet streaming. Your public tweets may
+                    be archived for historical and research purposes.
                   </AlertDescription>
                 </Alert>
               )}
@@ -426,13 +450,10 @@ export default function ProfileContent({
             </CardHeader>
             <CardContent>
               {archives.length === 0 ? (
-                <div className="text-center py-8 text-muted-foreground">
-                  <Archive className="h-12 w-12 mx-auto mb-3 opacity-50" />
+                <div className="py-8 text-center text-muted-foreground">
+                  <Archive className="mx-auto mb-3 h-12 w-12 opacity-50" />
                   <p>You haven&apos;t uploaded any archives yet</p>
-                  <ArchiveUploadButton
-                    variant="outline"
-                    className="mt-4 gap-2"
-                  >
+                  <ArchiveUploadButton variant="outline" className="mt-4 gap-2">
                     Upload Archive
                   </ArchiveUploadButton>
                 </div>
@@ -440,11 +461,13 @@ export default function ProfileContent({
                 <div className="space-y-4">
                   {archives.map((archive) => {
                     const account = archive.accounts
-                    const avatarUrl = account?.profile?.[0]?.avatar_media_url || account?.profile?.avatar_media_url
+                    const avatarUrl =
+                      account?.profile?.[0]?.avatar_media_url ||
+                      account?.profile?.avatar_media_url
                     return (
                       <div
                         key={archive.id}
-                        className="flex items-center justify-between p-4 border rounded-lg"
+                        className="flex items-center justify-between rounded-lg border p-4"
                       >
                         <div className="flex items-center space-x-4">
                           <Avatar>
@@ -462,9 +485,12 @@ export default function ProfileContent({
                             </p>
                             <p className="text-sm text-muted-foreground">
                               {account?.num_tweets || 0} tweets • Uploaded{' '}
-                              {formatDistanceToNow(new Date(archive.created_at), {
-                                addSuffix: true
-                              })}
+                              {formatDistanceToNow(
+                                new Date(archive.created_at),
+                                {
+                                  addSuffix: true,
+                                },
+                              )}
                             </p>
                             <p className="text-xs text-muted-foreground">
                               🌐 Public
@@ -477,8 +503,10 @@ export default function ProfileContent({
                           onClick={() => handleDeleteArchive(archive.id)}
                           disabled={deletingArchive !== null}
                         >
-                          <Trash2 className="h-4 w-4 mr-2" />
-                          {deletingArchive === String(archive.id) ? 'Deleting...' : 'Delete'}
+                          <Trash2 className="mr-2 h-4 w-4" />
+                          {deletingArchive === String(archive.id)
+                            ? 'Deleting...'
+                            : 'Delete'}
                         </Button>
                       </div>
                     )
@@ -486,21 +514,21 @@ export default function ProfileContent({
                 </div>
               )}
 
-              <div className="pt-4 border-t">
+              <div className="border-t pt-4">
                 <Button
                   variant="destructive"
                   size="sm"
                   onClick={() => setShowDeleteAllDialog(true)}
                   disabled={deletingArchive !== null}
                 >
-                  <Trash2 className="h-4 w-4 mr-2" />
+                  <Trash2 className="mr-2 h-4 w-4" />
                   Delete All Your Data
                 </Button>
-                <p className="text-xs text-muted-foreground mt-1">
-                  Remove all archives, tweets, likes, followers, and profile data — including data from the scraper/extension.
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Remove all archives, tweets, likes, followers, and profile
+                  data — including data from the scraper/extension.
                 </p>
               </div>
-
             </CardContent>
           </Card>
         </TabsContent>
@@ -514,10 +542,11 @@ export default function ProfileContent({
           <DialogHeader>
             <DialogTitle>Delete All Your Data</DialogTitle>
             <DialogDescription>
-              This will permanently delete <strong>all</strong> of your data from the Community Archive:
+              This will permanently delete <strong>all</strong> of your data
+              from the Community Archive:
             </DialogDescription>
           </DialogHeader>
-          <ul className="list-disc pl-6 text-sm text-muted-foreground space-y-1">
+          <ul className="list-disc space-y-1 pl-6 text-sm text-muted-foreground">
             <li>All uploaded archives</li>
             <li>All tweets, likes, followers, and following data</li>
             <li>Profile information</li>
@@ -527,7 +556,10 @@ export default function ProfileContent({
             This action is irreversible.
           </p>
           <DialogFooter className="gap-2 sm:gap-0">
-            <Button variant="outline" onClick={() => setShowDeleteAllDialog(false)}>
+            <Button
+              variant="outline"
+              onClick={() => setShowDeleteAllDialog(false)}
+            >
               Cancel
             </Button>
             <Button
@@ -546,36 +578,52 @@ export default function ProfileContent({
           <DialogHeader>
             <DialogTitle>Explicit Opt-Out</DialogTitle>
             <DialogDescription>
-              Opting out adds you to the explicit opt-out list so future collection (including scraper/extension data) is prevented. You can choose whether to also delete the data already on file.
+              Opting out adds you to the explicit opt-out list so future
+              collection (including scraper/extension data) is prevented. You
+              can choose whether to also delete the data already on file.
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-3 text-sm text-muted-foreground">
             <div>
               <p className="font-medium text-foreground">Opt out only</p>
-              <p>Add you to the opt-out list. Existing archives, tweets, and profile data stay where they are.</p>
+              <p>
+                Add you to the opt-out list. Existing archives, tweets, and
+                profile data stay where they are.
+              </p>
             </div>
             <div>
-              <p className="font-medium text-foreground">Opt out and delete everything</p>
-              <p>Also permanently delete all your archives, tweets, likes, followers/following, profile, and any scraper/extension data. This part is irreversible.</p>
+              <p className="font-medium text-foreground">
+                Opt out and delete everything
+              </p>
+              <p>
+                Also permanently delete all your archives, tweets, likes,
+                followers/following, profile, and any scraper/extension data.
+                This part is irreversible.
+              </p>
             </div>
           </div>
           <DialogFooter className="flex-col gap-2 sm:flex-row sm:justify-end">
-            <Button variant="outline" onClick={() => setShowOptOutDialog(false)}>
+            <Button
+              variant="outline"
+              onClick={() => setShowOptOutDialog(false)}
+            >
               Cancel
             </Button>
             <Button
               variant="secondary"
               onClick={confirmOptOutOnly}
-              disabled={isPending || deletingArchive === 'all'}
+              disabled={isPreferenceSaving || deletingArchive === 'all'}
             >
-              {isPending ? 'Opting out...' : 'Opt out only'}
+              {isPreferenceSaving ? 'Opting out...' : 'Opt out only'}
             </Button>
             <Button
               variant="destructive"
               onClick={confirmOptOutAndDelete}
               disabled={deletingArchive === 'all'}
             >
-              {deletingArchive === 'all' ? 'Deleting...' : 'Opt out and delete everything'}
+              {deletingArchive === 'all'
+                ? 'Deleting...'
+                : 'Opt out and delete everything'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/components/HeroCTAButtons.test.tsx
+++ b/src/components/HeroCTAButtons.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import HeroCTAButtons from './HeroCTAButtons'
 
 const mockReplace = jest.fn()
@@ -50,10 +50,9 @@ describe('HeroCTAButtons', () => {
       data: null,
       error: { code: 'PGRST116' },
     })
-    mockFetch.mockResolvedValue({
-      ok: true,
-      json: async () => ({ success: true }),
-    })
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), { status: 200 }),
+    )
     global.fetch = mockFetch
   })
 
@@ -70,9 +69,7 @@ describe('HeroCTAButtons', () => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        userId: 'auth-user-123',
         username: 'exampleuser',
-        twitterUserId: 'twitter-123',
         optedIn: true,
         termsVersion: 'v1.0',
       }),
@@ -94,5 +91,33 @@ describe('HeroCTAButtons', () => {
       expect(mockSingle).toHaveBeenCalledTimes(1)
     })
     expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('shows a retry action when the automatic opt-in is rate limited', async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 'Too Many Requests' }), {
+          status: 429,
+          headers: { 'Retry-After': '60' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ success: true }), { status: 200 }),
+      )
+
+    render(<HeroCTAButtons />)
+
+    expect(
+      await screen.findByText(
+        'Too many requests. Please wait 1 minute and try again.',
+      ),
+    ).toBeInTheDocument()
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(mockReplace).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: /retry opt in/i }))
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/'))
   })
 })

--- a/src/components/HeroCTAButtons.tsx
+++ b/src/components/HeroCTAButtons.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { Button } from '@/components/ui/button'
+import { Alert, AlertDescription } from '@/components/ui/alert'
 import {
   Tooltip,
   TooltipContent,
@@ -13,6 +14,7 @@ import { useAuthAndArchive } from '@/hooks/useAuthAndArchive'
 import { createBrowserClient } from '@/utils/supabase'
 import { Users, Puzzle, Upload } from 'lucide-react'
 import { devLog } from '@/lib/devLog'
+import { updateOptIn } from '@/lib/optInApi'
 
 const CHROME_EXTENSION_URL =
   'https://chromewebstore.google.com/detail/community-archive-stream/igclpobjpjlphgllncjcgaookmncegbk'
@@ -29,13 +31,14 @@ export default function HeroCTAButtons({
   const { userMetadata } = useAuthAndArchive()
   const supabase = useMemo(() => createBrowserClient(), [])
   const autoOptInStarted = useRef(false)
+  const optInInFlight = useRef(false)
 
   const [user, setUser] = useState<any>(null)
   const [isOptedIn, setIsOptedIn] = useState(initialIsOptedIn)
   const [isOptInLoading, setIsOptInLoading] = useState(false)
+  const [optInError, setOptInError] = useState<string | null>(null)
 
   const twitterUsername = userMetadata?.user_name
-  const twitterUserId = userMetadata?.provider_id
   const shouldAutoOptIn = searchParams.get('action') === 'optin'
 
   // Get current user session
@@ -126,40 +129,38 @@ export default function HeroCTAButtons({
   }
 
   const completeOptIn = useCallback(async () => {
-    if (!user?.id || !twitterUsername || isOptedIn) return false
+    if (!user?.id || !twitterUsername || isOptedIn || optInInFlight.current) {
+      return false
+    }
 
+    optInInFlight.current = true
     setIsOptInLoading(true)
+    setOptInError(null)
 
     try {
-      const response = await fetch('/api/opt-in', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          userId: user.id,
-          username: twitterUsername.toLowerCase(),
-          twitterUserId: twitterUserId || null,
-          optedIn: true,
-          termsVersion: 'v1.0',
-        }),
+      await updateOptIn({
+        username: twitterUsername.toLowerCase(),
+        optedIn: true,
+        termsVersion: 'v1.0',
       })
-
-      const data = await response.json()
-
-      if (!response.ok) {
-        throw new Error(data.error || 'Failed to opt in')
-      }
 
       setIsOptedIn(true)
       router.replace('/')
       router.refresh()
       return true
-    } catch (err: any) {
-      console.error('Opt-in error:', err.message)
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : 'Failed to opt in. Please try again.'
+      console.error('Opt-in error:', message)
+      setOptInError(message)
       return false
     } finally {
+      optInInFlight.current = false
       setIsOptInLoading(false)
     }
-  }, [isOptedIn, router, twitterUserId, twitterUsername, user?.id])
+  }, [isOptedIn, router, twitterUsername, user?.id])
 
   // Clicking Opt in before authentication records the intent in the OAuth
   // callback URL. Complete that intent as soon as the returning session and
@@ -204,6 +205,7 @@ export default function HeroCTAButtons({
 
   const getOptInButtonText = () => {
     if (isOptInLoading) return 'Processing...'
+    if (optInError) return 'Retry opt in'
     if (!user) return 'Opt in'
     return 'Opt in'
   }
@@ -282,6 +284,11 @@ export default function HeroCTAButtons({
             </TooltipContent>
           </Tooltip>
         </div>
+        {optInError ? (
+          <Alert variant="destructive" className="max-w-xl" aria-live="polite">
+            <AlertDescription>{optInError}</AlertDescription>
+          </Alert>
+        ) : null}
       </div>
     </TooltipProvider>
   )

--- a/src/lib/homepageAccess.test.ts
+++ b/src/lib/homepageAccess.test.ts
@@ -1,4 +1,4 @@
-import { canShowHomepageSearch } from './homepageAccess'
+import { canShowHomepageSearch, hasPendingOptInAction } from './homepageAccess'
 
 describe('canShowHomepageSearch', () => {
   it('hides search from logged-out visitors', () => {
@@ -11,5 +11,17 @@ describe('canShowHomepageSearch', () => {
 
   it('shows search only to signed-in opted-in members', () => {
     expect(canShowHomepageSearch('user-1', true)).toBe(true)
+  })
+})
+
+describe('hasPendingOptInAction', () => {
+  it('recognizes the OAuth return action', () => {
+    expect(hasPendingOptInAction('optin')).toBe(true)
+    expect(hasPendingOptInAction(['other', 'optin'])).toBe(true)
+  })
+
+  it('ignores unrelated homepage actions', () => {
+    expect(hasPendingOptInAction(undefined)).toBe(false)
+    expect(hasPendingOptInAction('upload')).toBe(false)
   })
 })

--- a/src/lib/homepageAccess.ts
+++ b/src/lib/homepageAccess.ts
@@ -2,3 +2,6 @@ export const canShowHomepageSearch = (
   userId: string | null | undefined,
   isOptedIn: boolean | null | undefined,
 ) => Boolean(userId && isOptedIn === true)
+
+export const hasPendingOptInAction = (action: string | string[] | undefined) =>
+  Array.isArray(action) ? action.includes('optin') : action === 'optin'

--- a/src/lib/homepageRoute.test.tsx
+++ b/src/lib/homepageRoute.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import Homepage from '@/app/page'
+import { getIsMember } from '@/lib/portal/auth'
+import { getPortalData } from '@/lib/portal/data'
+
+jest.mock('server-only', () => ({}), { virtual: true })
+jest.mock('@/components/home/ClassicHomepage', () => ({
+  __esModule: true,
+  default: () => <div>classic homepage</div>,
+}))
+jest.mock('@/components/portal/Portal', () => ({
+  __esModule: true,
+  default: () => <div>member portal</div>,
+}))
+jest.mock('@/lib/portal/auth', () => ({ getIsMember: jest.fn() }))
+jest.mock('@/lib/portal/data', () => ({ getPortalData: jest.fn() }))
+
+const getIsMemberMock = getIsMember as jest.MockedFunction<typeof getIsMember>
+const getPortalDataMock = getPortalData as jest.MockedFunction<
+  typeof getPortalData
+>
+
+describe('Homepage OAuth actions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    getIsMemberMock.mockResolvedValue(true)
+    getPortalDataMock.mockResolvedValue(
+      {} as Awaited<ReturnType<typeof getPortalData>>,
+    )
+  })
+
+  it('keeps an authenticated OAuth return on the opt-in completion surface', async () => {
+    const page = await Homepage({ searchParams: { action: 'optin' } })
+
+    expect(renderToStaticMarkup(page)).toContain('classic homepage')
+    expect(getIsMemberMock).not.toHaveBeenCalled()
+    expect(getPortalDataMock).not.toHaveBeenCalled()
+  })
+
+  it('renders the portal normally after the pending action is cleared', async () => {
+    const page = await Homepage({ searchParams: {} })
+
+    expect(renderToStaticMarkup(page)).toContain('member portal')
+    expect(getIsMemberMock).toHaveBeenCalledTimes(1)
+    expect(getPortalDataMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/lib/middlewareRateLimit.test.ts
+++ b/src/lib/middlewareRateLimit.test.ts
@@ -1,0 +1,59 @@
+import { NextRequest } from 'next/server'
+import { middleware } from '../../src/middleware'
+
+const browserUserAgent =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/140.0.0.0 Safari/537.36'
+
+const request = (
+  pathname: string,
+  ip: string,
+  method = 'GET',
+): Promise<Response> =>
+  middleware(
+    new NextRequest(`https://www.community-archive.org${pathname}`, {
+      method,
+      headers: {
+        'user-agent': browserUserAgent,
+        'x-forwarded-for': ip,
+      },
+    }),
+  )
+
+describe('API middleware rate limits', () => {
+  it('does not let unrelated API traffic block opt-in or OAuth completion', async () => {
+    const ip = '203.0.113.10'
+
+    for (let index = 0; index < 20; index += 1) {
+      await expect(request('/api/search', ip)).resolves.toMatchObject({
+        status: 200,
+      })
+    }
+
+    await expect(request('/api/search', ip)).resolves.toMatchObject({
+      status: 429,
+    })
+    await expect(request('/api/opt-in', ip, 'POST')).resolves.toMatchObject({
+      status: 200,
+    })
+    await expect(request('/api/auth/callback', ip)).resolves.toMatchObject({
+      status: 200,
+    })
+  })
+
+  it('still rate limits repeated opt-in mutations in their dedicated bucket', async () => {
+    const ip = '203.0.113.11'
+
+    for (let index = 0; index < 10; index += 1) {
+      await expect(request('/api/opt-in', ip, 'POST')).resolves.toMatchObject({
+        status: 200,
+      })
+    }
+
+    const response = await request('/api/opt-in', ip, 'POST')
+    expect(response.status).toBe(429)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Too Many Requests',
+    })
+    expect(response.headers.get('Retry-After')).toBe('60')
+  })
+})

--- a/src/lib/optInApi.test.ts
+++ b/src/lib/optInApi.test.ts
@@ -1,0 +1,56 @@
+import { OptInApiError, updateOptIn } from './optInApi'
+
+const mutation = {
+  username: 'exampleuser',
+  optedIn: true,
+  termsVersion: 'v1.0',
+}
+
+describe('updateOptIn', () => {
+  it('sends only the opt-in mutation fields', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    await expect(updateOptIn(mutation, fetchImpl)).resolves.toEqual({
+      success: true,
+    })
+    expect(fetchImpl).toHaveBeenCalledWith('/api/opt-in', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(mutation),
+    })
+  })
+
+  it('turns a rate limit response into retryable user-facing guidance', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Too Many Requests' }), {
+        status: 429,
+        headers: {
+          'Content-Type': 'application/json',
+          'Retry-After': '60',
+        },
+      }),
+    )
+
+    await expect(updateOptIn(mutation, fetchImpl)).rejects.toMatchObject({
+      name: 'OptInApiError',
+      message: 'Too many requests. Please wait 1 minute and try again.',
+      status: 429,
+      retryAfterSeconds: 60,
+    } satisfies Partial<OptInApiError>)
+  })
+
+  it('uses a stable fallback when an error response is not JSON', async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValue(new Response('upstream failure', { status: 502 }))
+
+    await expect(updateOptIn(mutation, fetchImpl)).rejects.toThrow(
+      'Failed to update opt-in status. Please try again.',
+    )
+  })
+})

--- a/src/lib/optInApi.ts
+++ b/src/lib/optInApi.ts
@@ -1,0 +1,86 @@
+export interface OptInMutation {
+  username: string
+  optedIn: boolean
+  termsVersion: string
+  explicitOptOut?: boolean
+  optOutReason?: string | null
+}
+
+export class OptInApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly retryAfterSeconds: number | null = null,
+  ) {
+    super(message)
+    this.name = 'OptInApiError'
+  }
+}
+
+const parseRetryAfter = (value: string | null): number | null => {
+  if (!value) return null
+
+  const seconds = Number(value)
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.ceil(seconds)
+  }
+
+  const retryAt = Date.parse(value)
+  if (Number.isNaN(retryAt)) return null
+
+  return Math.max(0, Math.ceil((retryAt - Date.now()) / 1000))
+}
+
+const formatRetryDelay = (seconds: number | null) => {
+  if (seconds === null) return 'a moment'
+  if (seconds < 60) return `${Math.max(1, seconds)} seconds`
+
+  const minutes = Math.ceil(seconds / 60)
+  return `${minutes} minute${minutes === 1 ? '' : 's'}`
+}
+
+const readJson = async (response: Response) => {
+  try {
+    return (await response.json()) as { error?: unknown } | null
+  } catch {
+    return null
+  }
+}
+
+export async function updateOptIn(
+  mutation: OptInMutation,
+  fetchImpl: typeof fetch = fetch,
+) {
+  const response = await fetchImpl('/api/opt-in', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(mutation),
+  })
+  const data = await readJson(response)
+
+  if (!response.ok) {
+    const retryAfterSeconds = parseRetryAfter(
+      response.headers.get('Retry-After'),
+    )
+    const serverError =
+      typeof data?.error === 'string' && data.error.trim()
+        ? data.error.trim()
+        : null
+
+    if (response.status === 429) {
+      throw new OptInApiError(
+        `Too many requests. Please wait ${formatRetryDelay(retryAfterSeconds)} and try again.`,
+        response.status,
+        retryAfterSeconds,
+      )
+    }
+
+    throw new OptInApiError(
+      serverError || 'Failed to update opt-in status. Please try again.',
+      response.status,
+      retryAfterSeconds,
+    )
+  }
+
+  return data
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -84,6 +84,12 @@ const IN_MEMORY_MAX_SG = 5
 // DoS target (no HTML rendering cost shifts the attacker's effort lower).
 const IN_MEMORY_MAX_API_DEFAULT = 20
 const IN_MEMORY_MAX_API_SG = 5
+// Critical signed-in flows have their own buckets so unrelated read traffic
+// cannot consume the request that completes OAuth or persists consent.
+const IN_MEMORY_MAX_OPT_IN_DEFAULT = 10
+const IN_MEMORY_MAX_OPT_IN_SG = 5
+const IN_MEMORY_MAX_AUTH_CALLBACK_DEFAULT = 30
+const IN_MEMORY_MAX_AUTH_CALLBACK_SG = 10
 const CLEANUP_INTERVAL_MS = 5 * 60_000
 
 let lastCleanup = Date.now()
@@ -115,6 +121,35 @@ function checkInMemoryRateLimit(ip: string, maxRequests: number): boolean {
   recent.push(now)
   rateLimitMap.set(ip, recent)
   return false
+}
+
+function getApiRateLimitPolicy(
+  pathname: string,
+  method: string,
+  isSG: boolean,
+) {
+  if (pathname === '/api/opt-in' && method === 'POST') {
+    return {
+      bucket: 'api:opt-in',
+      maxRequests: isSG
+        ? IN_MEMORY_MAX_OPT_IN_SG
+        : IN_MEMORY_MAX_OPT_IN_DEFAULT,
+    }
+  }
+
+  if (pathname === '/api/auth/callback' && method === 'GET') {
+    return {
+      bucket: 'api:auth-callback',
+      maxRequests: isSG
+        ? IN_MEMORY_MAX_AUTH_CALLBACK_SG
+        : IN_MEMORY_MAX_AUTH_CALLBACK_DEFAULT,
+    }
+  }
+
+  return {
+    bucket: 'api',
+    maxRequests: isSG ? IN_MEMORY_MAX_API_SG : IN_MEMORY_MAX_API_DEFAULT,
+  }
 }
 
 // ─── Cookie-based rate limiting ──────────────────────────────────────────────
@@ -378,11 +413,15 @@ export async function middleware(request: NextRequest) {
     const ip = getIp(request)
     const country = request.headers.get('x-vercel-ip-country') || ''
     const isSG = country === 'SG'
-    const maxRequests = isSG ? IN_MEMORY_MAX_API_SG : IN_MEMORY_MAX_API_DEFAULT
+    const { bucket, maxRequests } = getApiRateLimitPolicy(
+      pathname,
+      request.method,
+      isSG,
+    )
 
     cleanupStaleEntries()
 
-    if (checkInMemoryRateLimit(`api:${ip}`, maxRequests)) {
+    if (checkInMemoryRateLimit(`${bucket}:${ip}`, maxRequests)) {
       const resp = new NextResponse(
         JSON.stringify({ error: 'Too Many Requests' }),
         {


### PR DESCRIPTION
Closes #570

## What changed

- route authenticated `/?action=optin` OAuth returns to the classic opt-in completion surface before the normal signed-in portal branch
- isolate the OAuth callback and authenticated opt-in mutation from the shared read-API rate-limit bucket while retaining dedicated anti-abuse limits
- centralize opt-in mutation error handling and turn `429 Retry-After` responses into actionable UI copy
- preserve the post-OAuth opt-in intent on failure, expose a visible retry action, and guard against duplicate in-flight requests
- replace the profile preference toggle async `startTransition` usage with an explicit single-flight pending state
- stop sending ignored client-supplied user/Twitter IDs; the server continues to derive identity from the trusted OAuth session

## Root causes

There were two separate failures:

1. **Before rate limiting:** Twitter OAuth returned to `/?action=optin`, but the new authenticated session made the server render the portal. The client component responsible for consuming and persisting the pending action only mounts on the classic homepage, so no opt-in request was sent.
2. **Later profile failure:** all `/api/*` requests from one IP shared a 20/minute bucket (5/minute for SG). Unrelated reads could exhaust the request needed to write consent, producing the observed 429.

Production logs show the later profile `POST /api/opt-in 429` and no earlier mutation after the OAuth return, matching the routing failure.

## Validation

- `pnpm type-check`
- `pnpm lint` (passes; one pre-existing `<img>` warning in `UnifiedTweetList.test.tsx`)
- `pnpm test:ci` — 60 suites, 250 tests passed

The regressions cover authenticated post-OAuth routing, shared-bucket exhaustion followed by OAuth/opt-in, the dedicated mutation limit, post-OAuth failure and retry, profile state preservation after 429, and duplicate-click suppression.
