### PR TITLE
Speed up admin account loading

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -28,7 +28,7 @@ const customJestConfig = {
       testEnvironment: 'node',
       testMatch: [
         '<rootDir>/src/lib/**/*.test.{js,jsx,ts,tsx}',
-        '<rootDir>/tests/admin-search-sanitize.test.ts',
+        '<rootDir>/tests/admin-*.test.ts',
       ],
       setupFilesAfterEnv: ['<rootDir>/jest.setup.server.ts'],
     },

--- a/src/app/admin/AdminTable.tsx
+++ b/src/app/admin/AdminTable.tsx
@@ -173,7 +173,7 @@ export function AdminTable({
   const [activeSearch, setActiveSearch] = useState(initialSearch)
   const [rows, setRows] = useState<MergedRow[]>(initialRows)
   const [cursor, setCursor] = useState<AccountsCursor | null>(initialCursor)
-  // Derived from rows so adding/removing opt-in entries can't drift the count
+  // Derived from loaded rows so adding/removing opt-in entries can't drift the count
   // (and so we don't have to coordinate two setState calls across a
   // StrictMode-double-invoked updater — which doubled the count in dev).
   const optInCount = useMemo(
@@ -253,7 +253,7 @@ export function AdminTable({
         // The action created a brand-new opt-in row that wasn't yet shown
         // (manual opt-in for an unknown account, or for an account outside
         // the currently-loaded page). Prepend it; optInCount is derived
-        // from rows so the pinned-count display updates automatically.
+        // from rows so the loaded-count display updates automatically.
         return [
           {
             key: `optin:${updated.id}`,
@@ -277,9 +277,7 @@ export function AdminTable({
         ...row,
         optInRecord: updated,
         blockedFromScraping: result.blockedFromScraping,
-        account: result.archiveDeleted
-          ? null
-          : (result.account ?? row.account),
+        account: result.archiveDeleted ? null : (result.account ?? row.account),
         archiveUploadCount: result.archiveDeleted
           ? 0
           : (result.archiveUploadCount ?? row.archiveUploadCount),
@@ -306,7 +304,10 @@ export function AdminTable({
         setError('Failed to load more accounts (no data returned)')
         return
       }
-      setRows((prev) => [...prev, ...page.rows])
+      setRows((prev) => {
+        const loadedKeys = new Set(prev.map((row) => row.key))
+        return [...prev, ...page.rows.filter((row) => !loadedKeys.has(row.key))]
+      })
       setCursor(page.nextCursor)
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load more accounts')
@@ -401,7 +402,7 @@ export function AdminTable({
         </div>
         <p className="text-xs text-muted-foreground">
           {optInCount > 0
-            ? `${optInCount} opt-in row${optInCount === 1 ? '' : 's'} pinned at top · `
+            ? `${optInCount} opt-in row${optInCount === 1 ? '' : 's'} loaded first · `
             : ''}
           {rows.length} loaded
           {cursor ? ' · scroll for more' : ''}
@@ -450,9 +451,7 @@ export function AdminTable({
                         row.account.num_tweets !== row.archivedTweetCount ? (
                           <span className="text-muted-foreground">
                             {' '}
-                            (
-                            {compactNumber(row.account.num_tweets)} on
-                            Twitter)
+                            ({compactNumber(row.account.num_tweets)} on Twitter)
                           </span>
                         ) : null}
                       </div>

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -83,7 +83,7 @@ export type AdminActionResult =
   | { ok: false; error: string }
 
 const OPT_IN_SELECT =
-  'id, user_id, username, twitter_user_id, opted_in, explicit_optout, opt_out_reason, updated_at, opted_in_at, opted_out_at'
+  'id, user_id, username, twitter_user_id, opted_in, explicit_optout, opt_out_reason, created_at, updated_at, opted_in_at, opted_out_at'
 
 async function isBlocked(
   admin: Awaited<ReturnType<typeof getAdminClient>>,
@@ -126,7 +126,6 @@ async function upsertScrapeBlock(
   )
   if (error) throw error
 }
-
 
 export async function loadMoreAccountsAction(input: {
   search: string
@@ -442,4 +441,3 @@ export async function adminOptOutAccount(
     }
   }
 }
-

--- a/src/app/admin/data.ts
+++ b/src/app/admin/data.ts
@@ -1,16 +1,12 @@
-import {
-  createServerClient,
-  createServerServiceRoleClient,
-} from '@/utils/supabase'
+import { createServerServiceRoleClient } from '@/utils/supabase'
 import type { User } from '@supabase/supabase-js'
-import { cookies } from 'next/headers'
 import { notFound, redirect } from 'next/navigation'
 import { getCurrentUser } from '@/lib/portal/auth'
 
 export const ADMIN_USERNAME = 'exgenesis'
 const PRODUCTION_SUPABASE_HOST = 'fabxmporizzqflnftavs.supabase.co'
 
-export const ACCOUNTS_PAGE_SIZE = 50
+export const ACCOUNTS_PAGE_SIZE = 25
 
 export type OptInRecord = {
   id: string
@@ -20,6 +16,7 @@ export type OptInRecord = {
   opted_in: boolean
   explicit_optout: boolean | null
   opt_out_reason: string | null
+  created_at: string | null
   updated_at: string | null
   opted_in_at: string | null
   opted_out_at: string | null
@@ -61,15 +58,26 @@ export type AccountsPage = {
   warning: string | null
 }
 
-export type AccountsCursor = {
-  /** ISO timestamp of the last seen all_account row, or null when none seen yet. */
-  updatedAt: string | null
-  /** account_id tie-breaker for stable keyset pagination. */
-  accountId: string
-}
+export type AccountsCursor =
+  | {
+      source: 'accounts'
+      /** ISO timestamp of the last seen all_account row. */
+      updatedAt: string | null
+      /** null means the all_account scan has not started yet. */
+      accountId: string | null
+    }
+  | {
+      source: 'optin'
+      /** Immutable created_at + id position for stable keyset pagination. */
+      createdAt: string | null
+      id: string
+    }
+
+type AccountCursor = Extract<AccountsCursor, { source: 'accounts' }>
+type OptInCursor = Extract<AccountsCursor, { source: 'optin' }>
 
 const OPT_IN_SELECT =
-  'id, user_id, username, twitter_user_id, opted_in, explicit_optout, opt_out_reason, updated_at, opted_in_at, opted_out_at'
+  'id, user_id, username, twitter_user_id, opted_in, explicit_optout, opt_out_reason, created_at, updated_at, opted_in_at, opted_out_at'
 
 const ACCOUNT_SELECT =
   'account_id, username, account_display_name, num_tweets, created_via, updated_at'
@@ -184,14 +192,11 @@ export async function checkIsAdmin(): Promise<boolean> {
 }
 
 export async function requireAdmin() {
-  const cookieStore = await cookies()
-  const supabase = createServerClient(cookieStore)
-  const {
-    data: { user },
-    error,
-  } = await supabase.auth.getUser()
+  // getCurrentUser is request-cached, so the root layout, page, and streamed
+  // admin sections share one Supabase Auth round trip.
+  const user = await getCurrentUser()
 
-  if (error || !user) {
+  if (!user) {
     redirect('/login?redirect=/admin')
   }
 
@@ -201,7 +206,7 @@ export async function requireAdmin() {
     notFound()
   }
 
-  return { user, cookieStore }
+  return { user }
 }
 
 export async function getAdminClient() {
@@ -307,17 +312,19 @@ async function fetchArchivedTweetCounts(
   return result
 }
 
-async function fetchOptInRows(
+export async function fetchOptInPage(
   admin: AdminClient,
   search: string,
-): Promise<OptInRecord[]> {
+  cursor: OptInCursor | null,
+  limit: number,
+): Promise<{ rows: OptInRecord[]; nextCursor: OptInCursor | null }> {
   let query = admin
     .from('optin')
     .select(OPT_IN_SELECT)
-    .order('opted_in', { ascending: false })
-    .order('explicit_optout', { ascending: false })
-    .order('updated_at', { ascending: false, nullsFirst: false })
-    .limit(500)
+    // created_at is immutable, unlike the status and updated_at fields that
+    // admin actions change. That keeps later pages stable while edits happen.
+    .order('created_at', { ascending: false, nullsFirst: false })
+    .order('id', { ascending: true })
 
   // Defense in depth: callers already pass a normalized string, but we
   // re-sanitize at the chokepoint before building a PostgREST .or() filter.
@@ -329,15 +336,41 @@ async function fetchOptInRows(
     )
   }
 
-  const { data, error } = await query
+  if (cursor) {
+    if (cursor.createdAt !== null) {
+      query = query.or(
+        `created_at.lt.${cursor.createdAt},and(created_at.eq.${cursor.createdAt},id.gt.${cursor.id}),created_at.is.null`,
+      )
+    } else {
+      query = query.is('created_at', null).gt('id', cursor.id)
+    }
+  }
+
+  // Supabase ranges are inclusive, so requesting 0 through limit fetches one
+  // lookahead row. That detects another page without an exact COUNT query.
+  const { data, error } = await query.range(0, limit)
   if (error) throw error
-  return (data ?? []) as OptInRecord[]
+
+  const fetched = (data ?? []) as OptInRecord[]
+  const rows = fetched.slice(0, limit)
+  const last = rows[rows.length - 1]
+  return {
+    rows,
+    nextCursor:
+      fetched.length > limit && last
+        ? {
+            source: 'optin',
+            createdAt: last.created_at,
+            id: last.id,
+          }
+        : null,
+  }
 }
 
 async function fetchAccountsPage(
   admin: AdminClient,
   search: string,
-  cursor: AccountsCursor | null,
+  cursor: AccountCursor | null,
   excludeAccountIds: Set<string>,
   excludeUsernames: Set<string>,
   limit: number,
@@ -361,12 +394,12 @@ async function fetchAccountsPage(
     )
   }
 
-  if (cursor) {
+  if (cursor?.accountId) {
     // Keyset: (updated_at, account_id) strictly after the cursor under
     // (DESC NULLS LAST, ASC).
     if (cursor.updatedAt !== null) {
       query = query.or(
-        `updated_at.lt.${cursor.updatedAt},and(updated_at.eq.${cursor.updatedAt},account_id.gt.${cursor.accountId})`,
+        `updated_at.lt.${cursor.updatedAt},and(updated_at.eq.${cursor.updatedAt},account_id.gt.${cursor.accountId}),updated_at.is.null`,
       )
     } else {
       // Already in the NULL bucket — only ids strictly greater.
@@ -392,7 +425,11 @@ async function fetchAccountsPage(
   const reachedEnd = fetched.length < overscan
   const nextCursor: AccountsCursor | null =
     last && !reachedEnd
-      ? { updatedAt: last.updated_at, accountId: last.account_id }
+      ? {
+          source: 'accounts',
+          updatedAt: last.updated_at,
+          accountId: last.account_id,
+        }
       : null
 
   return { rows: filtered, nextCursor }
@@ -452,127 +489,90 @@ function buildAccountMergedRows(
   }))
 }
 
-export async function loadInitialAccounts(
-  search: string,
-): Promise<AccountsPage & { optInCount: number }> {
-  const admin = await getAdminClient()
+const mergeWarnings = (...warnings: Array<string | null>) =>
+  warnings.filter((warning): warning is string => Boolean(warning)).join(' ') ||
+  null
 
-  const optInRecords = await fetchOptInRows(admin, search)
-
-  const optInAccountIds = optInRecords
-    .map((r) => r.twitter_user_id)
+async function hydrateOptInRows(
+  admin: AdminClient,
+  records: OptInRecord[],
+): Promise<{
+  rows: MergedRow[]
+  excludeAccountIds: Set<string>
+  excludeUsernames: Set<string>
+  warning: string | null
+}> {
+  const optInAccountIds = records
+    .map((record) => record.twitter_user_id)
     .filter((id): id is string => Boolean(id))
-  const optInUsernames = optInRecords.map((r) => r.username.toLowerCase())
+  const optInUsernames = records.map((record) => record.username.toLowerCase())
 
-  const accountLookupSelect = ACCOUNT_SELECT
   const [byId, byUsername] = await Promise.all([
     optInAccountIds.length
       ? admin
           .from('all_account')
-          .select(accountLookupSelect)
+          .select(ACCOUNT_SELECT)
           .in('account_id', optInAccountIds)
       : Promise.resolve({ data: [], error: null }),
     optInUsernames.length
       ? admin
           .from('all_account')
-          .select(accountLookupSelect)
+          .select(ACCOUNT_SELECT)
           .in('username', optInUsernames)
       : Promise.resolve({ data: [], error: null }),
   ])
   if (byId.error) throw byId.error
   if (byUsername.error) throw byUsername.error
 
-  const optInAccountList = [
+  const accountList = [
     ...((byId.data ?? []) as AccountRecord[]),
     ...((byUsername.data ?? []) as AccountRecord[]),
   ]
-  const accountsByIdMap = new Map<string, AccountRecord>()
-  const accountsByUsernameMap = new Map<string, AccountRecord>()
-  for (const account of optInAccountList) {
-    accountsByIdMap.set(account.account_id, account)
-    accountsByUsernameMap.set(account.username.toLowerCase(), account)
+  const accountsById = new Map<string, AccountRecord>()
+  const accountsByUsername = new Map<string, AccountRecord>()
+  for (const account of accountList) {
+    accountsById.set(account.account_id, account)
+    accountsByUsername.set(account.username.toLowerCase(), account)
   }
-
-  const excludeAccountIds = new Set<string>(accountsByIdMap.keys())
-  const excludeUsernames = new Set<string>(accountsByUsernameMap.keys())
-
-  const { rows: firstAccounts, nextCursor } = await fetchAccountsPage(
-    admin,
-    search,
-    null,
-    excludeAccountIds,
-    excludeUsernames,
-    ACCOUNTS_PAGE_SIZE,
-  )
-
-  const candidateAccountIds = [
-    ...optInRecords.map((r) => r.twitter_user_id ?? ''),
-    ...optInAccountList.map((a) => a.account_id),
-    ...firstAccounts.map((a) => a.account_id),
-  ].filter(Boolean)
 
   const accountIdsForCounts = Array.from(
     new Set([
-      ...optInAccountList.map((a) => a.account_id),
-      ...firstAccounts.map((a) => a.account_id),
-      // Include opt-in rows' twitter_user_id even when no matching
-      // all_account exists, so the archived count can still resolve from
-      // tweets table (rare but possible for accounts the firehose touched
-      // before user_directory got refreshed).
-      ...optInRecords
-        .map((r) => r.twitter_user_id)
-        .filter((id): id is string => Boolean(id)),
+      ...accountList.map((account) => account.account_id),
+      // A tweet row can exist before all_account is refreshed, so preserve
+      // the direct opt-in id as a count and blocklist candidate too.
+      ...optInAccountIds,
     ]),
   )
-
   const [uploadCounts, archivedTweetCounts, scrapeBlocklist] =
     await Promise.all([
       fetchUploadCounts(admin, accountIdsForCounts),
       fetchArchivedTweetCounts(admin, accountIdsForCounts),
-      fetchScrapeBlocklist(admin, candidateAccountIds),
+      fetchScrapeBlocklist(admin, accountIdsForCounts),
     ])
 
-  const optInRows = buildOptInMergedRows(
-    optInRecords,
-    accountsByUsernameMap,
-    accountsByIdMap,
-    uploadCounts,
-    archivedTweetCounts,
-    scrapeBlocklist.blocked,
-  )
-  const accountRows = buildAccountMergedRows(
-    firstAccounts,
-    uploadCounts,
-    archivedTweetCounts,
-    scrapeBlocklist.blocked,
-  )
-
   return {
-    rows: [...optInRows, ...accountRows],
-    nextCursor,
+    rows: buildOptInMergedRows(
+      records,
+      accountsByUsername,
+      accountsById,
+      uploadCounts,
+      archivedTweetCounts,
+      scrapeBlocklist.blocked,
+    ),
+    excludeAccountIds: new Set([
+      ...accountList.map((account) => account.account_id),
+      ...optInAccountIds,
+    ]),
+    excludeUsernames: new Set(optInUsernames),
     warning: scrapeBlocklist.warning,
-    optInCount: optInRows.length,
   }
 }
 
-export async function loadMoreAccountsData(
-  search: string,
-  cursor: AccountsCursor,
-  excludeAccountIds: string[],
-  excludeUsernames: string[],
-): Promise<AccountsPage> {
-  const admin = await getAdminClient()
-
-  const { rows: accounts, nextCursor } = await fetchAccountsPage(
-    admin,
-    search,
-    cursor,
-    new Set(excludeAccountIds),
-    new Set(excludeUsernames.map((u) => u.toLowerCase())),
-    ACCOUNTS_PAGE_SIZE,
-  )
-
-  const accountIds = accounts.map((a) => a.account_id)
+async function hydrateAccountRows(
+  admin: AdminClient,
+  accounts: AccountRecord[],
+): Promise<{ rows: MergedRow[]; warning: string | null }> {
+  const accountIds = accounts.map((account) => account.account_id)
   const [uploadCounts, archivedTweetCounts, scrapeBlocklist] =
     await Promise.all([
       fetchUploadCounts(admin, accountIds),
@@ -587,8 +587,146 @@ export async function loadMoreAccountsData(
       archivedTweetCounts,
       scrapeBlocklist.blocked,
     ),
-    nextCursor,
     warning: scrapeBlocklist.warning,
+  }
+}
+
+async function loadAccountPage(
+  admin: AdminClient,
+  search: string,
+  cursor: AccountCursor | null,
+  excludeAccountIds: Set<string>,
+  excludeUsernames: Set<string>,
+  limit: number,
+): Promise<AccountsPage> {
+  const { rows: accounts, nextCursor } = await fetchAccountsPage(
+    admin,
+    search,
+    cursor?.accountId ? cursor : null,
+    excludeAccountIds,
+    excludeUsernames,
+    limit,
+  )
+  const hydrated = await hydrateAccountRows(admin, accounts)
+
+  return {
+    rows: hydrated.rows,
+    nextCursor,
+    warning: hydrated.warning,
+  }
+}
+
+export async function loadInitialAccounts(
+  search: string,
+): Promise<AccountsPage & { optInCount: number }> {
+  const admin = await getAdminClient()
+  const optInPage = await fetchOptInPage(
+    admin,
+    search,
+    null,
+    ACCOUNTS_PAGE_SIZE,
+  )
+  const optIn = await hydrateOptInRows(admin, optInPage.rows)
+
+  if (optInPage.nextCursor) {
+    return {
+      rows: optIn.rows,
+      nextCursor: optInPage.nextCursor,
+      warning: optIn.warning,
+      optInCount: optIn.rows.length,
+    }
+  }
+
+  const remaining = ACCOUNTS_PAGE_SIZE - optIn.rows.length
+  if (remaining === 0) {
+    return {
+      rows: optIn.rows,
+      nextCursor: { source: 'accounts', updatedAt: null, accountId: null },
+      warning: optIn.warning,
+      optInCount: optIn.rows.length,
+    }
+  }
+
+  const accounts = await loadAccountPage(
+    admin,
+    search,
+    null,
+    optIn.excludeAccountIds,
+    optIn.excludeUsernames,
+    remaining,
+  )
+
+  return {
+    rows: [...optIn.rows, ...accounts.rows],
+    nextCursor: accounts.nextCursor,
+    warning: mergeWarnings(optIn.warning, accounts.warning),
+    optInCount: optIn.rows.length,
+  }
+}
+
+export async function loadMoreAccountsData(
+  search: string,
+  cursor: AccountsCursor,
+  excludeAccountIds: string[],
+  excludeUsernames: string[],
+): Promise<AccountsPage> {
+  const admin = await getAdminClient()
+  const excludedIds = new Set(excludeAccountIds)
+  const excludedUsernames = new Set(
+    excludeUsernames.map((username) => username.toLowerCase()),
+  )
+
+  if (cursor.source === 'accounts') {
+    return loadAccountPage(
+      admin,
+      search,
+      cursor,
+      excludedIds,
+      excludedUsernames,
+      ACCOUNTS_PAGE_SIZE,
+    )
+  }
+
+  const optInPage = await fetchOptInPage(
+    admin,
+    search,
+    cursor,
+    ACCOUNTS_PAGE_SIZE,
+  )
+  const optIn = await hydrateOptInRows(admin, optInPage.rows)
+
+  if (optInPage.nextCursor) {
+    return {
+      rows: optIn.rows,
+      nextCursor: optInPage.nextCursor,
+      warning: optIn.warning,
+    }
+  }
+
+  const remaining = ACCOUNTS_PAGE_SIZE - optIn.rows.length
+  if (remaining === 0) {
+    return {
+      rows: optIn.rows,
+      nextCursor: { source: 'accounts', updatedAt: null, accountId: null },
+      warning: optIn.warning,
+    }
+  }
+
+  optIn.excludeAccountIds.forEach((id) => excludedIds.add(id))
+  optIn.excludeUsernames.forEach((username) => excludedUsernames.add(username))
+  const accounts = await loadAccountPage(
+    admin,
+    search,
+    null,
+    excludedIds,
+    excludedUsernames,
+    remaining,
+  )
+
+  return {
+    rows: [...optIn.rows, ...accounts.rows],
+    nextCursor: accounts.nextCursor,
+    warning: mergeWarnings(optIn.warning, accounts.warning),
   }
 }
 

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -6,6 +6,8 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Suspense } from 'react'
 import { AdminTable } from './AdminTable'
 import { RecentPrivacyActivity } from './RecentPrivacyActivity'
 import { loadRecentPrivacyActivity } from './activity'
@@ -26,6 +28,61 @@ export const dynamic = 'force-dynamic'
 // Has no effect on smaller actions; they return in milliseconds.
 export const maxDuration = 300
 
+async function RecentPrivacyActivitySection() {
+  const activity = await loadRecentPrivacyActivity()
+  return <RecentPrivacyActivity activity={activity} />
+}
+
+function SectionSkeleton({ label }: { label: string }) {
+  return (
+    <Card aria-label={label} aria-busy="true">
+      <CardHeader>
+        <Skeleton className="h-6 w-52" />
+        <Skeleton className="h-4 w-full max-w-2xl" />
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+      </CardContent>
+    </Card>
+  )
+}
+
+async function AccountsSection({ search }: { search: string }) {
+  const data = await loadInitialAccounts(search)
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Accounts</CardTitle>
+        <CardDescription>
+          Opt-in rows load first, followed by accounts with archive data sorted
+          by most recently updated. The manual opt-in input below creates an
+          opt-in row by Twitter username; if we already have an archive account
+          for that username the opt-in row is linked to it, otherwise it&apos;s
+          stored without a Twitter id and gets linked the next time that user
+          signs in or uploads an archive. Search runs against the full database;
+          the table updates in place.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {data.warning ? (
+          <div className="mb-4 rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-950 dark:border-red-700 dark:bg-red-950/30 dark:text-red-100">
+            {data.warning}
+          </div>
+        ) : null}
+        <AdminTable
+          key={search}
+          initialRows={data.rows}
+          initialCursor={data.nextCursor}
+          initialSearch={search}
+        />
+      </CardContent>
+    </Card>
+  )
+}
+
 export default async function AdminPage({
   searchParams,
 }: {
@@ -33,10 +90,6 @@ export default async function AdminPage({
 }) {
   const { user } = await requireAdmin()
   const search = normalizeUsername(searchParams?.q)
-  const [data, recentPrivacyActivity] = await Promise.all([
-    loadInitialAccounts(search),
-    loadRecentPrivacyActivity(),
-  ])
   const twitterUsername = getDisplayUsername(user)
 
   return (
@@ -59,38 +112,17 @@ export default async function AdminPage({
             </div>
             <Badge variant="secondary">@{twitterUsername}</Badge>
           </div>
-          {data.warning ? (
-            <div className="rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-950 dark:border-red-700 dark:bg-red-950/30 dark:text-red-100">
-              {data.warning}
-            </div>
-          ) : null}
         </section>
 
-        <RecentPrivacyActivity activity={recentPrivacyActivity} />
+        <Suspense
+          fallback={<SectionSkeleton label="Loading recent privacy activity" />}
+        >
+          <RecentPrivacyActivitySection />
+        </Suspense>
 
-        <Card>
-          <CardHeader>
-            <CardTitle>Accounts</CardTitle>
-            <CardDescription>
-              Every public.optin row is pinned at the top, followed by accounts
-              with archive data sorted by most recently updated. The manual
-              opt-in input below creates an opt-in row by Twitter username; if
-              we already have an archive account for that username the opt-in
-              row is linked to it, otherwise it&apos;s stored without a Twitter
-              id and gets linked the next time that user signs in or uploads an
-              archive. Search runs against the full database; the table updates
-              in place.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <AdminTable
-              key={search}
-              initialRows={data.rows}
-              initialCursor={data.nextCursor}
-              initialSearch={search}
-            />
-          </CardContent>
-        </Card>
+        <Suspense fallback={<SectionSkeleton label="Loading accounts" />}>
+          <AccountsSection search={search} />
+        </Suspense>
       </div>
     </main>
   )

--- a/tests/admin-pagination.test.ts
+++ b/tests/admin-pagination.test.ts
@@ -1,0 +1,98 @@
+import { fetchOptInPage, type OptInRecord } from '@/app/admin/data'
+
+const optInRecord = (index: number): OptInRecord => ({
+  id: `optin-${String(index).padStart(3, '0')}`,
+  user_id: null,
+  username: `user_${index}`,
+  twitter_user_id: String(index),
+  opted_in: true,
+  explicit_optout: false,
+  opt_out_reason: null,
+  created_at: '2026-08-11T00:00:00Z',
+  updated_at: '2026-08-11T00:00:00Z',
+  opted_in_at: '2026-08-11T00:00:00Z',
+  opted_out_at: null,
+})
+
+function mockAdmin(rows: OptInRecord[]) {
+  const query = {
+    select: jest.fn(),
+    order: jest.fn(),
+    or: jest.fn(),
+    is: jest.fn(),
+    gt: jest.fn(),
+    range: jest.fn(async (from: number, to: number) => ({
+      data: rows.slice(from, to + 1),
+      error: null,
+    })),
+  }
+  query.select.mockReturnValue(query)
+  query.order.mockReturnValue(query)
+  query.or.mockReturnValue(query)
+  query.is.mockReturnValue(query)
+  query.gt.mockReturnValue(query)
+
+  return {
+    admin: { from: jest.fn(() => query) },
+    query,
+  }
+}
+
+describe('admin opt-in pagination', () => {
+  it('loads one 25-row page plus a single lookahead row', async () => {
+    const { admin, query } = mockAdmin(
+      Array.from({ length: 30 }, (_, index) => optInRecord(index)),
+    )
+
+    const page = await fetchOptInPage(admin as never, '', null, 25)
+
+    expect(page.rows).toHaveLength(25)
+    expect(page.nextCursor).toEqual({
+      source: 'optin',
+      createdAt: '2026-08-11T00:00:00Z',
+      id: 'optin-024',
+    })
+    expect(query.range).toHaveBeenCalledWith(0, 25)
+    expect(query.order).toHaveBeenLastCalledWith('id', { ascending: true })
+  })
+
+  it('ends pagination when the lookahead row is absent', async () => {
+    const { admin, query } = mockAdmin(
+      Array.from({ length: 5 }, (_, index) => optInRecord(index + 25)),
+    )
+
+    const page = await fetchOptInPage(
+      admin as never,
+      '',
+      {
+        source: 'optin',
+        createdAt: '2026-08-11T00:00:00Z',
+        id: 'optin-024',
+      },
+      25,
+    )
+
+    expect(page.rows.map((row) => row.id)).toEqual([
+      'optin-025',
+      'optin-026',
+      'optin-027',
+      'optin-028',
+      'optin-029',
+    ])
+    expect(page.nextCursor).toBeNull()
+    expect(query.or).toHaveBeenCalledWith(
+      'created_at.lt.2026-08-11T00:00:00Z,and(created_at.eq.2026-08-11T00:00:00Z,id.gt.optin-024),created_at.is.null',
+    )
+    expect(query.range).toHaveBeenCalledWith(0, 25)
+  })
+
+  it('keeps full-database search on every page', async () => {
+    const { admin, query } = mockAdmin([])
+
+    await fetchOptInPage(admin as never, '@User_12', null, 25)
+
+    expect(query.or).toHaveBeenCalledWith(
+      'username.ilike.%user_12%,twitter_user_id.eq.user_12',
+    )
+  })
+})


### PR DESCRIPTION
## What changed

- paginate opt-in records as well as archive accounts, loading at most 25 enriched rows per request
- use stable keyset cursors and client-side row deduplication while scrolling
- stream recent privacy activity and account data behind independent Suspense boundaries
- reuse the request-cached authenticated user instead of repeating Supabase Auth calls
- add regression coverage for the inclusive Supabase range and cursor boundary

## Why

The admin route limited the archive-account query, but still fetched up to 500 opt-in records and calculated per-account tweet counts for all of them before the first render. The page therefore paid nearly the full profile enrichment cost up front.

The new path renders the authorized shell immediately, enriches only the first 25 rows, and loads subsequent opt-in/account pages on demand. Search still runs against the full database.

## Validation

- `tsc --noEmit`
- focused server and client Jest suites (13 tests)
- focused Next.js lint
- optimized production Next.js build
- read-only production Supabase pagination check: 25-row first and second pages, zero duplicate IDs
