### PR TITLE
Make Trends Explorer evidence incremental

### DIFF
--- a/src/components/portal/TrendsExplorer.tsx
+++ b/src/components/portal/TrendsExplorer.tsx
@@ -5,16 +5,22 @@ import type { FormEvent, PointerEvent as ReactPointerEvent } from 'react'
 import Link from 'next/link'
 import TweetCard from '@/components/TweetCard'
 import { CHART_TERMS } from '@/lib/portal/trendConfig'
+import {
+  cachedTrendEvidence,
+  storeTrendEvidence,
+  trendEvidenceCacheKey,
+} from '@/lib/portal/trendEvidenceCache'
+import type {
+  TrendEvidenceCacheEntry,
+  TrendEvidenceRange,
+} from '@/lib/portal/trendEvidenceCache'
 import type { PortalTrends, PortalTweet, TermSeries } from '@/lib/portal/types'
 import { BODY, CARD, MUTED, SERIF } from './styles'
 
 type FeedFilter = 'include' | 'off'
 type TrendScale = 'raw' | 'normalized'
 
-interface SelectedYears {
-  start: number
-  end: number
-}
+type SelectedYears = TrendEvidenceRange
 
 interface SeriesResponse {
   years: number[]
@@ -29,6 +35,7 @@ interface FeedResponse {
 }
 
 const MAX_SERIES = 12
+const RANGE_QUERY_DEBOUNCE_MS = 1_200
 const compactAxisFormatter = new Intl.NumberFormat('en', {
   notation: 'compact',
   maximumFractionDigits: 1,
@@ -66,6 +73,36 @@ async function requestTrendSeries(terms: string[]): Promise<SeriesResponse> {
     throw new Error('The trends service returned an invalid response')
   }
   return body
+}
+
+async function requestTrendEvidence(
+  term: string,
+  selectedYears: SelectedYears | null,
+  signal: AbortSignal,
+): Promise<PortalTweet[]> {
+  const params = new URLSearchParams({ view: 'feed', include: term })
+  if (selectedYears) {
+    params.set('since', `${selectedYears.start}-01-01`)
+    params.set('until', `${selectedYears.end + 1}-01-01`)
+  }
+  const response = await fetch(`/api/portal/trends?${params.toString()}`, {
+    signal,
+  })
+  const body = (await response.json().catch(() => null)) as FeedResponse | null
+  if (!response.ok) {
+    throw new Error(body?.error || `Could not load tweets for ${term}`)
+  }
+  if (!body || !Array.isArray(body.tweets)) {
+    throw new Error('The tweet feed returned an invalid response')
+  }
+  return body.tweets
+}
+
+function sameYears(
+  left: SelectedYears | null,
+  right: SelectedYears | null,
+): boolean {
+  return left?.start === right?.start && left?.end === right?.end
 }
 
 function niceCeiling(value: number): number {
@@ -124,13 +161,27 @@ export default function TrendsExplorer({
   const [chartError, setChartError] = useState<string | null>(
     initialLoadFailed ? 'The default trends could not be loaded.' : null,
   )
-  const [evidence, setEvidence] = useState<PortalTweet[]>([])
   const [isLoadingEvidence, setIsLoadingEvidence] = useState(true)
   const [feedError, setFeedError] = useState<string | null>(null)
   const [refreshKey, setRefreshKey] = useState(0)
   const [selectedYears, setSelectedYears] = useState<SelectedYears | null>(null)
+  const [requestedYears, setRequestedYears] = useState<SelectedYears | null>(
+    null,
+  )
+  const [, setEvidenceCacheVersion] = useState(0)
   const [dragStartYear, setDragStartYear] = useState<number | null>(null)
   const chartRef = useRef<SVGSVGElement>(null)
+  const evidenceCacheRef = useRef<Map<string, TrendEvidenceCacheEntry>>(
+    new Map(),
+  )
+  const evidenceRequestsRef = useRef(
+    new Map<
+      string,
+      { controller: AbortController; promise: Promise<PortalTweet[]> }
+    >(),
+  )
+  const evidenceRequestSignatureRef = useRef('')
+  const handledRefreshKeyRef = useRef(0)
 
   const enabledSeries = useMemo(
     () => series.filter(({ term }) => chartEnabled[term]),
@@ -143,58 +194,121 @@ export default function TrendsExplorer({
         .filter((term) => feedFilters[term] === 'include'),
     [feedFilters, series],
   )
+  const evidence = cachedTrendEvidence(
+    evidenceCacheRef.current,
+    includeTerms,
+    selectedYears,
+  )
+
   useEffect(() => {
+    const requests = evidenceRequestsRef.current
+    return () => {
+      requests.forEach(({ controller }) => controller.abort())
+      requests.clear()
+    }
+  }, [])
+
+  useEffect(() => {
+    if (dragStartYear !== null || sameYears(selectedYears, requestedYears)) {
+      return
+    }
+    setFeedError(null)
+    const timeout = window.setTimeout(
+      () => setRequestedYears(selectedYears),
+      RANGE_QUERY_DEBOUNCE_MS,
+    )
+    return () => window.clearTimeout(timeout)
+  }, [dragStartYear, requestedYears, selectedYears])
+
+  useEffect(() => {
+    const signature = JSON.stringify({
+      includeTerms,
+      requestedYears,
+      refreshKey,
+    })
+    evidenceRequestSignatureRef.current = signature
     if (includeTerms.length === 0) {
-      setEvidence([])
       setFeedError(null)
       setIsLoadingEvidence(false)
       return
     }
 
-    const controller = new AbortController()
+    const forceRefresh = refreshKey !== handledRefreshKeyRef.current
+    handledRefreshKeyRef.current = refreshKey
+    const termsToLoad = includeTerms.filter(
+      (term) =>
+        forceRefresh ||
+        !evidenceCacheRef.current.has(
+          trendEvidenceCacheKey(term, requestedYears),
+        ),
+    )
+    if (termsToLoad.length === 0) {
+      setFeedError(null)
+      setIsLoadingEvidence(false)
+      return
+    }
+
     const loadEvidence = async () => {
       setIsLoadingEvidence(true)
       setFeedError(null)
-      const params = new URLSearchParams({ view: 'feed' })
-      includeTerms.forEach((term) => params.append('include', term))
-      if (selectedYears) {
-        params.set('since', `${selectedYears.start}-01-01`)
-        params.set('until', `${selectedYears.end + 1}-01-01`)
+      const results: PromiseSettledResult<PortalTweet[]>[] = []
+      for (const term of termsToLoad) {
+        const key = trendEvidenceCacheKey(term, requestedYears)
+        let request = evidenceRequestsRef.current.get(key)
+        if (!request) {
+          const controller = new AbortController()
+          let promise: Promise<PortalTweet[]>
+          promise = requestTrendEvidence(
+            term,
+            requestedYears,
+            controller.signal,
+          )
+            .then((tweets) => {
+              storeTrendEvidence(evidenceCacheRef.current, {
+                term,
+                range: requestedYears,
+                tweets,
+              })
+              setEvidenceCacheVersion((version) => version + 1)
+              return tweets
+            })
+            .finally(() => {
+              if (evidenceRequestsRef.current.get(key)?.promise === promise) {
+                evidenceRequestsRef.current.delete(key)
+              }
+            })
+          request = { controller, promise }
+          evidenceRequestsRef.current.set(key, request)
+        }
+        try {
+          results.push({ status: 'fulfilled', value: await request.promise })
+        } catch (reason) {
+          results.push({ status: 'rejected', reason })
+        }
       }
-
-      try {
-        const response = await fetch(
-          `/api/portal/trends?${params.toString()}`,
-          {
-            signal: controller.signal,
-          },
-        )
-        const body = (await response
-          .json()
-          .catch(() => null)) as FeedResponse | null
-        if (!response.ok) {
-          throw new Error(body?.error || 'Could not load matching tweets')
-        }
-        if (!body || !Array.isArray(body.tweets)) {
-          throw new Error('The tweet feed returned an invalid response')
-        }
-        setEvidence(body.tweets)
-      } catch (error) {
-        if (controller.signal.aborted) return
-        setEvidence([])
+      if (evidenceRequestSignatureRef.current !== signature) return
+      const failure = results.find(
+        (result): result is PromiseRejectedResult =>
+          result.status === 'rejected',
+      )
+      if (failure) {
         setFeedError(
-          error instanceof Error
-            ? error.message
+          failure.reason instanceof Error
+            ? failure.reason.message
             : 'Could not load matching tweets',
         )
-      } finally {
-        if (!controller.signal.aborted) setIsLoadingEvidence(false)
       }
+      setIsLoadingEvidence(
+        includeTerms.some((term) =>
+          evidenceRequestsRef.current.has(
+            trendEvidenceCacheKey(term, requestedYears),
+          ),
+        ),
+      )
     }
 
     void loadEvidence()
-    return () => controller.abort()
-  }, [includeTerms, refreshKey, selectedYears])
+  }, [includeTerms, refreshKey, requestedYears])
 
   const removeTerm = (term: string) => {
     setSeries((current) => current.filter((item) => item.term !== term))
@@ -344,6 +458,9 @@ export default function TrendsExplorer({
     ? years.indexOf(selectedYears.start)
     : -1
   const selectedEndIndex = selectedYears ? years.indexOf(selectedYears.end) : -1
+  const isUpdatingEvidence =
+    includeTerms.length > 0 &&
+    (isLoadingEvidence || !sameYears(selectedYears, requestedYears))
 
   const yearForPointer = (clientX: number): number | null => {
     const svg = chartRef.current
@@ -780,12 +897,17 @@ export default function TrendsExplorer({
                   Tweets counted
                 </h2>
                 <p className={`mt-0.5 text-[11.5px] ${MUTED}`}>
-                  Latest posts matching any included trend.
+                  {selectedYears
+                    ? `Posts from ${selectedYears.start}–${selectedYears.end} matching any included trend.`
+                    : 'Latest posts matching any included trend.'}
                 </p>
               </div>
               <button
                 type="button"
-                onClick={() => setRefreshKey((key) => key + 1)}
+                onClick={() => {
+                  setRequestedYears(selectedYears)
+                  setRefreshKey((key) => key + 1)
+                }}
                 disabled={isLoadingEvidence || includeTerms.length === 0}
                 className={`text-[11.5px] font-semibold ${MUTED} hover:text-brand disabled:opacity-40`}
               >
@@ -842,22 +964,29 @@ export default function TrendsExplorer({
               className={`${CARD} max-h-[760px] overflow-y-auto`}
               aria-live="polite"
             >
-              {isLoadingEvidence && (
+              {isUpdatingEvidence && evidence.length === 0 && (
                 <div className={`px-4 py-12 text-center text-[13px] ${MUTED}`}>
                   Finding matching tweets…
                 </div>
               )}
-              {!isLoadingEvidence && includeTerms.length === 0 && (
+              {isUpdatingEvidence && evidence.length > 0 && (
+                <div
+                  className={`sticky top-0 z-10 border-b border-zinc-200 bg-white/95 px-4 py-2 text-[11.5px] backdrop-blur dark:border-[#29292e] dark:bg-[#171719]/95 ${MUTED}`}
+                >
+                  Updating this period in the background…
+                </div>
+              )}
+              {includeTerms.length === 0 && (
                 <div className={`px-4 py-12 text-center text-[13px] ${MUTED}`}>
                   Include at least one term to inspect its tweets.
                 </div>
               )}
-              {!isLoadingEvidence && feedError && (
-                <div className="px-4 py-10 text-center text-[13px] text-red-600 dark:text-red-400">
+              {feedError && (
+                <div className="border-b border-red-200 px-4 py-3 text-center text-[12px] text-red-600 dark:border-red-900/60 dark:text-red-400">
                   {feedError}
                 </div>
               )}
-              {!isLoadingEvidence &&
+              {!isUpdatingEvidence &&
                 !feedError &&
                 includeTerms.length > 0 &&
                 evidence.length === 0 && (
@@ -867,18 +996,16 @@ export default function TrendsExplorer({
                     No matching tweets in this period.
                   </div>
                 )}
-              {!isLoadingEvidence &&
-                !feedError &&
-                evidence.map((tweet) => (
-                  <TweetCard
-                    key={tweet.id}
-                    tweet={tweet}
-                    collapsible
-                    clickable
-                    origin="trends"
-                    returnTo="/trends"
-                  />
-                ))}
+              {evidence.map((tweet) => (
+                <TweetCard
+                  key={tweet.id}
+                  tweet={tweet}
+                  collapsible
+                  clickable
+                  origin="trends"
+                  returnTo="/trends"
+                />
+              ))}
             </div>
           </aside>
         </div>

--- a/src/lib/portal/TrendsExplorerResilience.test.tsx
+++ b/src/lib/portal/TrendsExplorerResilience.test.tsx
@@ -2,12 +2,16 @@
 
 import '@testing-library/jest-dom'
 import React from 'react'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import TrendsExplorer from '@/components/portal/TrendsExplorer'
 import { emptyPortalTrends } from './trendConfig'
 import type { PortalTrends } from './types'
 ;(globalThis as typeof globalThis & { React: typeof React }).React = React
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}))
 
 const successfulTrends: PortalTrends = {
   years: [2025, 2026],
@@ -23,8 +27,37 @@ const successfulTrends: PortalTrends = {
   computedAt: '2026-08-07T12:00:00.000Z',
 }
 
+const twoTrends: PortalTrends = {
+  ...successfulTrends,
+  series: [
+    successfulTrends.series[0],
+    {
+      term: 'postrat',
+      color: '#f59e0b',
+      tweetsPerYear: [5, 8],
+      perYear: [50, 80],
+    },
+  ],
+}
+
+function feedTweet(id: string, year: number) {
+  const createdAt = `${year}-06-01T00:00:00.000Z`
+  return {
+    id,
+    username: 'alice',
+    name: 'Alice',
+    avatar: null,
+    text: `tweet-${year}-${id}`,
+    observedAt: createdAt,
+    createdAt,
+    likes: 0,
+    rts: 0,
+  }
+}
+
 describe('TrendsExplorer request isolation', () => {
   afterEach(() => {
+    jest.useRealTimers()
     jest.restoreAllMocks()
   })
 
@@ -136,17 +169,58 @@ describe('TrendsExplorer request isolation', () => {
     expect(screen.getByText('0/12 trends')).toBeVisible()
   })
 
-  test('filters evidence to the selected graph period', async () => {
+  test('loads only a newly included term when prior term evidence is cached', async () => {
     const user = userEvent.setup()
     const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue({
       ok: true,
       json: async () => ({ tweets: [] }),
     } as Response)
 
+    render(<TrendsExplorer initialTrends={twoTrends} />)
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    expect(String(fetchMock.mock.calls[0][0])).toContain('include=tpot')
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'postrat is off. Click to include it.',
+      }),
+    )
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    expect(String(fetchMock.mock.calls[1][0])).toContain('include=postrat')
+    expect(String(fetchMock.mock.calls[1][0])).not.toContain('include=tpot')
+  })
+
+  test('filters cached evidence immediately and debounces the range query', async () => {
+    jest.useFakeTimers()
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          tweets: [feedTweet('old', 2025), feedTweet('new', 2026)],
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tweets: [feedTweet('range', 2025)] }),
+      } as Response)
+
     render(<TrendsExplorer initialTrends={successfulTrends} />)
 
+    expect(await screen.findByText('tweet-2025-old')).toBeVisible()
+    expect(screen.getByText('tweet-2026-new')).toBeVisible()
     await user.selectOptions(screen.getByLabelText('Tweets from year'), '2025')
 
+    expect(screen.getByText('tweet-2025-old')).toBeVisible()
+    expect(screen.queryByText('tweet-2026-new')).not.toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    act(() => jest.advanceTimersByTime(1_199))
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    act(() => jest.advanceTimersByTime(1))
     await waitFor(() =>
       expect(
         fetchMock.mock.calls.some(([url]) =>
@@ -154,6 +228,7 @@ describe('TrendsExplorer request isolation', () => {
         ),
       ).toBe(true),
     )
+    expect(await screen.findByText('tweet-2025-range')).toBeVisible()
     expect(screen.getByRole('button', { name: 'Clear range' })).toBeVisible()
   })
 })

--- a/src/lib/portal/trendEvidenceCache.test.ts
+++ b/src/lib/portal/trendEvidenceCache.test.ts
@@ -1,0 +1,70 @@
+import {
+  MAX_TREND_EVIDENCE_CACHE_ENTRIES,
+  cachedTrendEvidence,
+  storeTrendEvidence,
+} from './trendEvidenceCache'
+import type { PortalTweet } from './types'
+
+function tweet(id: string, createdAt: string): PortalTweet {
+  return {
+    id,
+    username: 'alice',
+    name: 'Alice',
+    avatar: null,
+    text: id,
+    observedAt: createdAt,
+    createdAt,
+    likes: 0,
+    rts: 0,
+  }
+}
+
+describe('trend evidence cache', () => {
+  test('merges per-term and per-range results without duplicate tweets', () => {
+    const cache = new Map()
+    storeTrendEvidence(cache, {
+      term: 'tpot',
+      range: null,
+      tweets: [
+        tweet('3', '2026-01-01T00:00:00.000Z'),
+        tweet('1', '2024-01-01T00:00:00.000Z'),
+      ],
+    })
+    storeTrendEvidence(cache, {
+      term: 'tpot',
+      range: { start: 2024, end: 2024 },
+      tweets: [
+        tweet('2', '2024-12-01T00:00:00.000Z'),
+        tweet('1', '2024-01-01T00:00:00.000Z'),
+      ],
+    })
+    storeTrendEvidence(cache, {
+      term: 'postrat',
+      range: null,
+      tweets: [tweet('4', '2024-06-01T00:00:00.000Z')],
+    })
+
+    expect(
+      cachedTrendEvidence(cache, ['tpot'], { start: 2024, end: 2024 }).map(
+        ({ id }) => id,
+      ),
+    ).toEqual(['2', '1'])
+    expect(
+      cachedTrendEvidence(cache, ['tpot', 'postrat'], null).map(({ id }) => id),
+    ).toEqual(['3', '2', '4', '1'])
+  })
+
+  test('bounds stored combinations with least-recently-used insertion order', () => {
+    const cache = new Map()
+    for (let index = 0; index <= MAX_TREND_EVIDENCE_CACHE_ENTRIES; index += 1) {
+      storeTrendEvidence(cache, {
+        term: `term-${index}`,
+        range: null,
+        tweets: [],
+      })
+    }
+
+    expect(cache.size).toBe(MAX_TREND_EVIDENCE_CACHE_ENTRIES)
+    expect(Array.from(cache.values())[0].term).toBe('term-1')
+  })
+})

--- a/src/lib/portal/trendEvidenceCache.ts
+++ b/src/lib/portal/trendEvidenceCache.ts
@@ -1,0 +1,66 @@
+import type { PortalTweet } from './types'
+
+export interface TrendEvidenceRange {
+  start: number
+  end: number
+}
+
+export interface TrendEvidenceCacheEntry {
+  term: string
+  range: TrendEvidenceRange | null
+  tweets: PortalTweet[]
+}
+
+export const MAX_TREND_EVIDENCE_CACHE_ENTRIES = 96
+
+export function trendEvidenceCacheKey(
+  term: string,
+  range: TrendEvidenceRange | null,
+): string {
+  return `${term}\u0000${range ? `${range.start}-${range.end}` : 'any'}`
+}
+
+export function storeTrendEvidence(
+  cache: Map<string, TrendEvidenceCacheEntry>,
+  entry: TrendEvidenceCacheEntry,
+): void {
+  const key = trendEvidenceCacheKey(entry.term, entry.range)
+  cache.delete(key)
+  cache.set(key, entry)
+  while (cache.size > MAX_TREND_EVIDENCE_CACHE_ENTRIES) {
+    const oldestKey = cache.keys().next().value
+    if (oldestKey === undefined) return
+    cache.delete(oldestKey)
+  }
+}
+
+export function cachedTrendEvidence(
+  cache: ReadonlyMap<string, TrendEvidenceCacheEntry>,
+  includedTerms: string[],
+  range: TrendEvidenceRange | null,
+  limit = 30,
+): PortalTweet[] {
+  const included = new Set(includedTerms)
+  const rangeStart = range ? Date.UTC(range.start, 0, 1) : null
+  const rangeEnd = range ? Date.UTC(range.end + 1, 0, 1) : null
+  const unique = new Map<string, PortalTweet>()
+
+  cache.forEach((entry) => {
+    if (!included.has(entry.term)) return
+    for (const tweet of entry.tweets) {
+      const createdAt = new Date(tweet.createdAt).getTime()
+      if (!Number.isFinite(createdAt)) continue
+      if (rangeStart !== null && createdAt < rangeStart) continue
+      if (rangeEnd !== null && createdAt >= rangeEnd) continue
+      unique.set(tweet.id, tweet)
+    }
+  })
+
+  return Array.from(unique.values())
+    .sort(
+      (left, right) =>
+        new Date(right.createdAt).getTime() -
+          new Date(left.createdAt).getTime() || right.id.localeCompare(left.id),
+    )
+    .slice(0, Math.max(1, limit))
+}


### PR DESCRIPTION
## Summary

- cache tweet evidence by individual term and exact year range in the Trends Explorer
- fetch only missing or newly included terms, then merge and deduplicate cached tweets locally
- filter cached tweets immediately during range selection and debounce background range expansion by 1.2 seconds
- retain visible tweets and show a lightweight updating state while additional coverage loads
- bound the browser cache to 96 term/range combinations and serialize missing evidence requests

## Root cause

The feed request accepted every included term at once, so toggling one keyword repeated searches for all prior keywords. The selected range also updated on every pointer move, causing repeated aborted requests and eventually search-admission rejections.

## Backend dependency

The query gateway now caches current searches for 30 minutes and closed historical ranges for 24 hours. All seven default trend evidence searches warm after gateway startup; production verification completed 7/7 with zero failures.

## Verification

- 244 web tests across 58 suites
- TypeScript type-check
- Next.js production build
- focused interaction tests for incremental term loading and 1.2-second range debounce
- gateway: 54 tests, TypeScript check, Bun production bundle
- production gateway: warmed defaults in 7 ms; arbitrary historical search 1.83 s cold and 8 ms cached

Closes #573