### PR TITLE
Confirm opt-in outcome after Twitter sign-in

### DIFF
--- a/src/components/HeroCTAButtons.test.tsx
+++ b/src/components/HeroCTAButtons.test.tsx
@@ -75,10 +75,16 @@ describe('HeroCTAButtons', () => {
       }),
     })
 
-    await waitFor(() => {
-      expect(mockReplace).toHaveBeenCalledWith('/')
-      expect(mockRefresh).toHaveBeenCalledTimes(1)
-    })
+    expect(
+      await screen.findByRole('heading', { name: 'You’re opted in' }),
+    ).toBeInTheDocument()
+    expect(mockReplace).not.toHaveBeenCalled()
+    expect(mockRefresh).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+    expect(mockReplace).toHaveBeenCalledWith('/')
+    expect(mockRefresh).toHaveBeenCalledTimes(1)
   })
 
   it('does not opt in automatically without the OAuth return action', async () => {
@@ -108,16 +114,44 @@ describe('HeroCTAButtons', () => {
     render(<HeroCTAButtons />)
 
     expect(
-      await screen.findByText(
+      await screen.findByRole('heading', {
+        name: 'We couldn’t complete your opt-in',
+      }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getAllByText(
         'Too many requests. Please wait 1 minute and try again.',
       ),
-    ).toBeInTheDocument()
+    ).toHaveLength(2)
     expect(mockFetch).toHaveBeenCalledTimes(1)
     expect(mockReplace).not.toHaveBeenCalled()
 
-    fireEvent.click(screen.getByRole('button', { name: /retry opt in/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
 
     await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2))
-    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/'))
+    expect(
+      await screen.findByRole('heading', { name: 'You’re opted in' }),
+    ).toBeInTheDocument()
+    expect(mockReplace).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+    expect(mockReplace).toHaveBeenCalledWith('/')
+    expect(mockRefresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('confirms an OAuth return when the user is already opted in', async () => {
+    render(<HeroCTAButtons initialIsOptedIn />)
+
+    expect(
+      await screen.findByRole('heading', { name: 'You’re opted in' }),
+    ).toBeInTheDocument()
+    expect(mockFetch).not.toHaveBeenCalled()
+    expect(mockReplace).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+    expect(mockReplace).toHaveBeenCalledWith('/')
+    expect(mockRefresh).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/components/HeroCTAButtons.tsx
+++ b/src/components/HeroCTAButtons.tsx
@@ -5,6 +5,14 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -23,6 +31,8 @@ interface HeroCTAButtonsProps {
   initialIsOptedIn?: boolean
 }
 
+type OptInOutcome = 'success' | 'error' | null
+
 export default function HeroCTAButtons({
   initialIsOptedIn = false,
 }: HeroCTAButtonsProps) {
@@ -37,6 +47,7 @@ export default function HeroCTAButtons({
   const [isOptedIn, setIsOptedIn] = useState(initialIsOptedIn)
   const [isOptInLoading, setIsOptInLoading] = useState(false)
   const [optInError, setOptInError] = useState<string | null>(null)
+  const [optInOutcome, setOptInOutcome] = useState<OptInOutcome>(null)
 
   const twitterUsername = userMetadata?.user_name
   const shouldAutoOptIn = searchParams.get('action') === 'optin'
@@ -128,39 +139,55 @@ export default function HeroCTAButtons({
     }
   }
 
-  const completeOptIn = useCallback(async () => {
-    if (!user?.id || !twitterUsername || isOptedIn || optInInFlight.current) {
-      return false
-    }
+  const finishOAuthReturn = useCallback(() => {
+    setOptInOutcome(null)
+    router.replace('/')
+    router.refresh()
+  }, [router])
 
-    optInInFlight.current = true
-    setIsOptInLoading(true)
-    setOptInError(null)
+  const completeOptIn = useCallback(
+    async ({ showConfirmation = false } = {}) => {
+      if (!user?.id || !twitterUsername || isOptedIn || optInInFlight.current) {
+        return false
+      }
 
-    try {
-      await updateOptIn({
-        username: twitterUsername.toLowerCase(),
-        optedIn: true,
-        termsVersion: 'v1.0',
-      })
+      optInInFlight.current = true
+      setIsOptInLoading(true)
+      setOptInError(null)
 
-      setIsOptedIn(true)
-      router.replace('/')
-      router.refresh()
-      return true
-    } catch (err) {
-      const message =
-        err instanceof Error
-          ? err.message
-          : 'Failed to opt in. Please try again.'
-      console.error('Opt-in error:', message)
-      setOptInError(message)
-      return false
-    } finally {
-      optInInFlight.current = false
-      setIsOptInLoading(false)
-    }
-  }, [isOptedIn, router, twitterUsername, user?.id])
+      try {
+        await updateOptIn({
+          username: twitterUsername.toLowerCase(),
+          optedIn: true,
+          termsVersion: 'v1.0',
+        })
+
+        setIsOptedIn(true)
+        if (showConfirmation) {
+          setOptInOutcome('success')
+        } else {
+          router.replace('/')
+          router.refresh()
+        }
+        return true
+      } catch (err) {
+        const message =
+          err instanceof Error
+            ? err.message
+            : 'Failed to opt in. Please try again.'
+        console.error('Opt-in error:', message)
+        setOptInError(message)
+        if (showConfirmation) {
+          setOptInOutcome('error')
+        }
+        return false
+      } finally {
+        optInInFlight.current = false
+        setIsOptInLoading(false)
+      }
+    },
+    [isOptedIn, router, twitterUsername, user?.id],
+  )
 
   // Clicking Opt in before authentication records the intent in the OAuth
   // callback URL. Complete that intent as soon as the returning session and
@@ -172,14 +199,14 @@ export default function HeroCTAButtons({
 
     if (isOptedIn) {
       autoOptInStarted.current = true
-      router.replace('/')
+      setOptInOutcome('success')
       return
     }
 
     if (!user?.id || !twitterUsername) return
 
     autoOptInStarted.current = true
-    void completeOptIn()
+    void completeOptIn({ showConfirmation: true })
   }, [
     completeOptIn,
     isOptedIn,
@@ -200,7 +227,7 @@ export default function HeroCTAButtons({
       return
     }
 
-    await completeOptIn()
+    await completeOptIn({ showConfirmation: shouldAutoOptIn })
   }
 
   const getOptInButtonText = () => {
@@ -290,6 +317,55 @@ export default function HeroCTAButtons({
           </Alert>
         ) : null}
       </div>
+      <Dialog
+        open={optInOutcome !== null}
+        onOpenChange={(open) => {
+          if (open) return
+
+          if (optInOutcome === 'success') {
+            finishOAuthReturn()
+          } else {
+            setOptInOutcome(null)
+          }
+        }}
+      >
+        <DialogContent>
+          {optInOutcome === 'success' ? (
+            <>
+              <DialogHeader>
+                <DialogTitle>You’re opted in</DialogTitle>
+                <DialogDescription>
+                  Your public tweets can now be included in the Community
+                  Archive.
+                </DialogDescription>
+              </DialogHeader>
+              <DialogFooter>
+                <Button onClick={finishOAuthReturn}>Continue</Button>
+              </DialogFooter>
+            </>
+          ) : (
+            <>
+              <DialogHeader>
+                <DialogTitle>We couldn’t complete your opt-in</DialogTitle>
+                <DialogDescription>
+                  {optInError || 'Please try again.'}
+                </DialogDescription>
+              </DialogHeader>
+              <DialogFooter>
+                <Button
+                  onClick={() => {
+                    setOptInOutcome(null)
+                    void completeOptIn({ showConfirmation: true })
+                  }}
+                  disabled={isOptInLoading}
+                >
+                  Try again
+                </Button>
+              </DialogFooter>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
     </TooltipProvider>
   )
 }


### PR DESCRIPTION
Follow-up to #570 and #571.

## What changed

- keep the pending `?action=optin` return state until the consent write has a confirmed outcome
- show a success modal only after `/api/opt-in` succeeds
- show a failure modal with the server error and an in-place retry action
- confirm already-opted-in OAuth returns without issuing a duplicate mutation

## Live-test finding

The reported preview retest returned through `https://www.community-archive.org/api/auth/callback`, according to Supabase auth logs. Its consent row retained the prior opt-out timestamp and had no later write. The test happened while the newly merged production deployment was still building, so it did not validate the completed #571 deployment.

## Retest

Allowlist this exact Supabase Auth Redirect URL:

`https://community-archive-git-codex-fix-op-d163fd-theexgenesis-projects.vercel.app/api/auth/callback`

Then start from the same stable preview hostname, opt out/sign out, click **Opt in**, finish Twitter sign-in, and verify that the return stays on the preview hostname and shows the success modal.

## Validation

- `pnpm type-check`
- `pnpm lint` (passes with one pre-existing `<img>` warning)
- `pnpm test -- --runInBand` — 60 suites, 251 tests
- `pnpm build`
- GitHub CI and Vercel preview checks pass
