### PR TITLE
Avoid redundant Trends range reloads

### DIFF
--- a/src/components/portal/TrendsExplorer.tsx
+++ b/src/components/portal/TrendsExplorer.tsx
@@ -7,6 +7,7 @@ import TweetCard from '@/components/TweetCard'
 import { CHART_TERMS } from '@/lib/portal/trendConfig'
 import {
   cachedTrendEvidence,
+  hasCompleteTrendEvidence,
   storeTrendEvidence,
   trendEvidenceCacheKey,
 } from '@/lib/portal/trendEvidenceCache'
@@ -35,6 +36,7 @@ interface FeedResponse {
 }
 
 const MAX_SERIES = 12
+const EVIDENCE_PAGE_SIZE = 30
 const RANGE_QUERY_DEBOUNCE_MS = 1_200
 const compactAxisFormatter = new Intl.NumberFormat('en', {
   notation: 'compact',
@@ -238,8 +240,11 @@ export default function TrendsExplorer({
     const termsToLoad = includeTerms.filter(
       (term) =>
         forceRefresh ||
-        !evidenceCacheRef.current.has(
-          trendEvidenceCacheKey(term, requestedYears),
+        !hasCompleteTrendEvidence(
+          evidenceCacheRef.current,
+          term,
+          requestedYears,
+          EVIDENCE_PAGE_SIZE,
         ),
     )
     if (termsToLoad.length === 0) {
@@ -460,7 +465,17 @@ export default function TrendsExplorer({
   const selectedEndIndex = selectedYears ? years.indexOf(selectedYears.end) : -1
   const isUpdatingEvidence =
     includeTerms.length > 0 &&
-    (isLoadingEvidence || !sameYears(selectedYears, requestedYears))
+    (isLoadingEvidence ||
+      (!sameYears(selectedYears, requestedYears) &&
+        includeTerms.some(
+          (term) =>
+            !hasCompleteTrendEvidence(
+              evidenceCacheRef.current,
+              term,
+              selectedYears,
+              EVIDENCE_PAGE_SIZE,
+            ),
+        )))
 
   const yearForPointer = (clientX: number): number | null => {
     const svg = chartRef.current

--- a/src/lib/portal/TrendsExplorerResilience.test.tsx
+++ b/src/lib/portal/TrendsExplorerResilience.test.tsx
@@ -2,7 +2,7 @@
 
 import '@testing-library/jest-dom'
 import React from 'react'
-import { act, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import TrendsExplorer from '@/components/portal/TrendsExplorer'
 import { emptyPortalTrends } from './trendConfig'
@@ -230,5 +230,87 @@ describe('TrendsExplorer request isolation', () => {
     )
     expect(await screen.findByText('tweet-2025-range')).toBeVisible()
     expect(screen.getByRole('button', { name: 'Clear range' })).toBeVisible()
+  })
+
+  test('skips a range top-up when a broader cache has a full page', async () => {
+    jest.useFakeTimers()
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+    const tweets = Array.from({ length: 30 }, (_, index) =>
+      feedTweet(String(index), 2026),
+    )
+    const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ tweets }),
+    } as Response)
+
+    render(<TrendsExplorer initialTrends={successfulTrends} />)
+
+    expect(await screen.findByText('tweet-2026-0')).toBeVisible()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    await user.selectOptions(screen.getByLabelText('Tweets from year'), '2026')
+
+    expect(screen.getByText('tweet-2026-0')).toBeVisible()
+    expect(
+      screen.queryByText('Updating this period in the background…'),
+    ).not.toBeInTheDocument()
+    act(() => jest.advanceTimersByTime(1_200))
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  test('does not query during a pointer drag and debounces after release', async () => {
+    jest.useFakeTimers()
+    const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ tweets: [] }),
+    } as Response)
+
+    render(<TrendsExplorer initialTrends={successfulTrends} />)
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+
+    const chart = screen.getByRole('img', {
+      name: /Yearly term trends shown as/,
+    })
+    Object.defineProperty(chart, 'getBoundingClientRect', {
+      value: () => ({ left: 0, width: 760 }),
+    })
+    const dragTarget = screen.getByLabelText(
+      'Drag horizontally to filter tweets by year',
+    ) as unknown as SVGRectElement & { setPointerCapture: jest.Mock }
+    dragTarget.setPointerCapture = jest.fn()
+    const dispatchPointer = (type: string, clientX: number) => {
+      const event = new Event(type, { bubbles: true })
+      Object.defineProperties(event, {
+        clientX: { value: clientX },
+        pointerId: { value: 1 },
+      })
+      fireEvent(dragTarget, event)
+    }
+
+    dispatchPointer('pointerdown', 62)
+    await waitFor(() =>
+      expect(screen.getByLabelText('Tweets from year')).toHaveValue('2025'),
+    )
+    dispatchPointer('pointermove', 732)
+    await waitFor(() =>
+      expect(screen.getByLabelText('Tweets through year')).toHaveValue('2026'),
+    )
+    act(() => jest.advanceTimersByTime(5_000))
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    dispatchPointer('pointerup', 732)
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Clear range' })).toBeVisible(),
+    )
+    act(() => jest.advanceTimersByTime(1_199))
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    await act(async () => {
+      jest.advanceTimersByTime(1)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    expect(
+      await screen.findByText('No matching tweets in this period.'),
+    ).toBeVisible()
   })
 })

--- a/src/lib/portal/trendEvidenceCache.test.ts
+++ b/src/lib/portal/trendEvidenceCache.test.ts
@@ -1,6 +1,7 @@
 import {
   MAX_TREND_EVIDENCE_CACHE_ENTRIES,
   cachedTrendEvidence,
+  hasCompleteTrendEvidence,
   storeTrendEvidence,
 } from './trendEvidenceCache'
 import type { PortalTweet } from './types'
@@ -66,5 +67,27 @@ describe('trend evidence cache', () => {
 
     expect(cache.size).toBe(MAX_TREND_EVIDENCE_CACHE_ENTRIES)
     expect(Array.from(cache.values())[0].term).toBe('term-1')
+  })
+
+  test('uses a full page from a broader range without an exact-range top-up', () => {
+    const cache = new Map()
+    storeTrendEvidence(cache, {
+      term: 'tpot',
+      range: null,
+      tweets: Array.from({ length: 30 }, (_, index) =>
+        tweet(
+          String(index),
+          `2026-06-${String(index + 1).padStart(2, '0')}T00:00:00.000Z`,
+        ),
+      ),
+    })
+
+    expect(
+      hasCompleteTrendEvidence(cache, 'tpot', { start: 2026, end: 2026 }),
+    ).toBe(true)
+    expect(
+      hasCompleteTrendEvidence(cache, 'tpot', { start: 2025, end: 2025 }),
+    ).toBe(false)
+    expect(hasCompleteTrendEvidence(cache, 'tpot', null)).toBe(true)
   })
 })

--- a/src/lib/portal/trendEvidenceCache.ts
+++ b/src/lib/portal/trendEvidenceCache.ts
@@ -13,6 +13,18 @@ export interface TrendEvidenceCacheEntry {
 
 export const MAX_TREND_EVIDENCE_CACHE_ENTRIES = 96
 
+function tweetFallsWithinRange(
+  tweet: PortalTweet,
+  range: TrendEvidenceRange,
+): boolean {
+  const createdAt = new Date(tweet.createdAt).getTime()
+  return (
+    Number.isFinite(createdAt) &&
+    createdAt >= Date.UTC(range.start, 0, 1) &&
+    createdAt < Date.UTC(range.end + 1, 0, 1)
+  )
+}
+
 export function trendEvidenceCacheKey(
   term: string,
   range: TrendEvidenceRange | null,
@@ -34,6 +46,35 @@ export function storeTrendEvidence(
   }
 }
 
+/**
+ * Whether the cache can answer this term/range without a top-up request.
+ * An exact response is complete even when empty. A broader response is only
+ * complete when a full page of its returned tweets survives local filtering.
+ */
+export function hasCompleteTrendEvidence(
+  cache: ReadonlyMap<string, TrendEvidenceCacheEntry>,
+  term: string,
+  range: TrendEvidenceRange | null,
+  limit = 30,
+): boolean {
+  if (cache.has(trendEvidenceCacheKey(term, range))) return true
+  if (!range) return false
+
+  return Array.from(cache.values()).some((entry) => {
+    if (entry.term !== term) return false
+    if (
+      entry.range &&
+      (entry.range.start > range.start || entry.range.end < range.end)
+    ) {
+      return false
+    }
+    return (
+      entry.tweets.filter((tweet) => tweetFallsWithinRange(tweet, range))
+        .length >= limit
+    )
+  })
+}
+
 export function cachedTrendEvidence(
   cache: ReadonlyMap<string, TrendEvidenceCacheEntry>,
   includedTerms: string[],
@@ -41,8 +82,6 @@ export function cachedTrendEvidence(
   limit = 30,
 ): PortalTweet[] {
   const included = new Set(includedTerms)
-  const rangeStart = range ? Date.UTC(range.start, 0, 1) : null
-  const rangeEnd = range ? Date.UTC(range.end + 1, 0, 1) : null
   const unique = new Map<string, PortalTweet>()
 
   cache.forEach((entry) => {
@@ -50,8 +89,7 @@ export function cachedTrendEvidence(
     for (const tweet of entry.tweets) {
       const createdAt = new Date(tweet.createdAt).getTime()
       if (!Number.isFinite(createdAt)) continue
-      if (rangeStart !== null && createdAt < rangeStart) continue
-      if (rangeEnd !== null && createdAt >= rangeEnd) continue
+      if (range && !tweetFallsWithinRange(tweet, range)) continue
       unique.set(tweet.id, tweet)
     }
   })


### PR DESCRIPTION
## What changed

- Reuse a full page of locally filtered evidence from any covering cached range instead of issuing an exact-range request.
- Only show the background update state when at least one included term actually needs a top-up.
- Preserve exact empty responses as complete cache entries.
- Add direct pointer-drag coverage proving no query runs during the drag and the 1.2-second debounce starts only after release.

## Root cause

The initial incremental implementation keyed completeness only by exact term/range combinations. It correctly retained and filtered cached cards, but always scheduled a new query for a previously unseen range. Because the unbounded cache is latest-first, historical selections often had no local overlap and looked like a full column reload.

## Validation

- `pnpm type-check`
- `pnpm test -- --runInBand` — 58 suites, 247 tests
- `pnpm build`
- Focused authenticated preview reproduction against the merged implementation

Closes #577