### PR TITLE
Instrument portal actions in PostHog

### DIFF
--- a/memos/20260812-0930-posthog-portal-actions.md
+++ b/memos/20260812-0930-posthog-portal-actions.md
@@ -1,0 +1,57 @@
+# PostHog portal action instrumentation
+
+_12 August 2026, 09:30 PDT_
+
+## Outcome
+
+The signed-in Community Archive portal now emits semantic PostHog events for
+its main product interactions. These complement pageviews, autocapture, replay,
+errors, and Web Vitals; they do not replace them.
+
+The event catalog is intentionally compact so PostHog insights can break down a
+few stable event families by an `action`, `destination`, or `origin` property.
+
+## Event catalog
+
+| Event | Covers | Main breakdowns |
+| --- | --- | --- |
+| `archive_search_submitted` | Homepage and advanced archive searches | `surface`, `has_query`, `active_filter_count` |
+| `dashboard_destination_opened` | Dashboard panel links, research, tools, Best Strands, and the Parquet export | `destination`, `surface`, `external` |
+| `tweet_card_action` | Opening, expanding, collapsing, opening quoted tweets, and opening archived quotes | `action`, `origin`, media/quote/featured booleans |
+| `bangers_action` | Search, time/rank/author filters, clear, load more, and retry | `action`, `time_range`, `sort`, `scope`, `result_count` |
+| `trends_explorer_action` | Add/reactivate/remove terms, chart and evidence filters, year ranges, scale, refresh, and retry | `action`, series counts, `has_year_filter` |
+| `portal_stream_loaded_more` | Reaching and successfully loading another live-stream page | `loaded_tweet_count`, `has_more` |
+
+The stream now marks tweet links with `origin=stream`, so the tweet detail page
+can return readers to the live stream and PostHog can distinguish stream opens.
+
+## Data boundary
+
+Custom event properties use bounded enums, booleans, and aggregate counts. The
+new event fields do not include search phrases, trend terms, tweet text, tweet
+IDs, or outbound URLs. PostHog's existing SDK context, pageview, autocapture,
+and replay configuration remain unchanged.
+
+Signed-in users continue to be identified through the existing PostHog auth
+bridge, so these member actions can be associated with the existing public
+username, email, and display-name person properties.
+
+## Suggested PostHog insights
+
+Once production has collected events, the highest-value product panels are:
+
+1. Weekly unique members by event family.
+2. Dashboard destinations, broken down by `destination`.
+3. Tweet engagement, broken down by `action` and `origin`.
+4. Bangers usage, broken down by `action`, with `scope`, `sort`, and
+   `time_range` filters.
+5. Trends usage, broken down by `action`.
+6. Search submissions by `surface`.
+
+## Verification
+
+- `pnpm type-check`: passed.
+- `pnpm lint`: passed with one pre-existing `<img>` warning in
+  `src/components/UnifiedTweetList.test.tsx`.
+- Focused client tests: 2 suites, 10 tests passed.
+- Focused server/jsdom tests: 4 suites, 44 tests passed.

--- a/src/components/AdvancedSearchForm.tsx
+++ b/src/components/AdvancedSearchForm.tsx
@@ -80,6 +80,7 @@ export default function AdvancedSearchForm() {
     capturePostHogEvent('archive_search_submitted', {
       has_query: Boolean(query.trim()),
       active_filter_count: activeFilters.length,
+      surface: 'advanced',
     })
     router.push(params.size > 0 ? `/search?${params.toString()}` : '/search')
   }

--- a/src/components/HomepageSearch.test.tsx
+++ b/src/components/HomepageSearch.test.tsx
@@ -1,0 +1,63 @@
+/** @jest-environment jsdom */
+
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen } from '@testing-library/react'
+import HomepageSearch from './HomepageSearch'
+import { capturePostHogEvent } from '@/lib/posthog'
+
+const mockPush = jest.fn()
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}))
+
+jest.mock('@/lib/posthog', () => ({
+  capturePostHogEvent: jest.fn(),
+}))
+jest.mock('@/components/UserSearchInput', () => ({
+  __esModule: true,
+  default: ({
+    value,
+    onValueChange,
+    ...props
+  }: {
+    value: string
+    onValueChange: (value: string) => void
+    'aria-label': string
+  }) => (
+    <input
+      value={value}
+      aria-label={props['aria-label']}
+      onChange={(event) => onValueChange(event.target.value)}
+    />
+  ),
+}))
+
+const mockCapturePostHogEvent = capturePostHogEvent as jest.Mock
+
+describe('HomepageSearch analytics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('records the search surface without sending the query text', () => {
+    render(<HomepageSearch />)
+
+    fireEvent.change(screen.getByLabelText('Search Community Archive'), {
+      target: { value: 'a potentially sensitive phrase' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Search archive' }))
+
+    expect(mockCapturePostHogEvent).toHaveBeenCalledWith(
+      'archive_search_submitted',
+      {
+        has_query: true,
+        active_filter_count: 0,
+        surface: 'homepage',
+      },
+    )
+    expect(mockPush).toHaveBeenCalledWith(
+      '/search?q=a+potentially+sensitive+phrase',
+    )
+  })
+})

--- a/src/components/HomepageSearch.tsx
+++ b/src/components/HomepageSearch.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { Search } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import UserSearchInput from '@/components/UserSearchInput'
+import { capturePostHogEvent } from '@/lib/posthog'
 import { buildSearchParams } from '@/lib/searchParams'
 
 const exampleSearches = ['open source', 'AI alignment', 'from:vitalikbuterin']
@@ -18,6 +19,11 @@ export default function HomepageSearch() {
     if (!trimmedQuery) return
 
     const params = buildSearchParams(trimmedQuery)
+    capturePostHogEvent('archive_search_submitted', {
+      has_query: true,
+      active_filter_count: 0,
+      surface: 'homepage',
+    })
     router.push(`/search?${params.toString()}`)
   }
 

--- a/src/components/portal/BangersExplorer.test.tsx
+++ b/src/components/portal/BangersExplorer.test.tsx
@@ -14,9 +14,14 @@ import type {
   PortalBangersPeriod,
   PortalTweet,
 } from '@/lib/portal/types'
+import { capturePostHogEvent } from '@/lib/posthog'
 
 const push = jest.fn()
 jest.mock('next/navigation', () => ({ useRouter: () => ({ push }) }))
+jest.mock('@/lib/posthog', () => ({
+  capturePostHogEvent: jest.fn(),
+}))
+const mockCapturePostHogEvent = capturePostHogEvent as jest.Mock
 jest.mock('@/components/TweetCard', () => ({
   __esModule: true,
   default: ({
@@ -112,6 +117,7 @@ describe('BangersExplorer', () => {
   beforeEach(() => {
     window.history.replaceState({}, '', '/bangers')
     push.mockReset()
+    mockCapturePostHogEvent.mockReset()
     IntersectionObserverMock.instances = []
     Object.defineProperty(window, 'IntersectionObserver', {
       configurable: true,
@@ -213,6 +219,23 @@ describe('BangersExplorer', () => {
       screen.getByRole('link', { name: 'Archive members' }),
     ).toHaveAttribute('href', '/bangers?scope=members&period=today')
     expect(screen.getByText(/from the last 24 hours/)).toBeVisible()
+  })
+
+  test('records semantic filter actions without the query text', () => {
+    renderExplorer()
+
+    const recent = screen.getByRole('link', { name: 'Recent' })
+    recent.addEventListener('click', (event) => event.preventDefault())
+    fireEvent.click(recent)
+
+    expect(mockCapturePostHogEvent).toHaveBeenCalledWith('bangers_action', {
+      action: 'sort_changed',
+      has_query: false,
+      time_range: 'all',
+      sort: 'recent',
+      scope: 'all',
+      result_count: 3,
+    })
   })
 
   test('orders all time above today and offers the last three months', async () => {

--- a/src/components/portal/BangersExplorer.tsx
+++ b/src/components/portal/BangersExplorer.tsx
@@ -25,6 +25,7 @@ import type {
   PortalBangersSort,
   PortalTweet,
 } from '@/lib/portal/types'
+import { capturePostHogEvent } from '@/lib/posthog'
 import { CARD, MUTED } from './styles'
 
 interface BangersExplorerProps {
@@ -44,6 +45,45 @@ const activeSegmentClassName =
   'border-zinc-800 bg-zinc-900 text-white dark:border-zinc-100 dark:bg-zinc-100 dark:text-zinc-950'
 const idleSegmentClassName =
   'border-zinc-300 bg-transparent text-zinc-600 hover:border-zinc-500 hover:text-zinc-950 dark:border-[#3a3a40] dark:text-[#a7a7b4] dark:hover:border-zinc-500 dark:hover:text-white'
+
+type BangersAction =
+  | 'filters_cleared'
+  | 'load_more_clicked'
+  | 'retry_clicked'
+  | 'scope_changed'
+  | 'searched'
+  | 'sort_changed'
+  | 'time_filter_changed'
+
+function captureBangersAction({
+  action,
+  query,
+  scope,
+  sort,
+  year,
+  period,
+  resultCount,
+}: {
+  action: BangersAction
+  query: string
+  scope: PortalBangersScope
+  sort: PortalBangersSort
+  year?: number
+  period?: PortalBangersPeriod
+  resultCount: number
+}) {
+  capturePostHogEvent('bangers_action', {
+    action,
+    has_query: Boolean(query.trim()),
+    time_range:
+      period === 'three-months'
+        ? 'three_months'
+        : (period ?? (year === undefined ? 'all' : 'year')),
+    sort,
+    scope,
+    result_count: resultCount,
+  })
+}
 
 function matchesQuery(tweet: PortalTweet, query: string): boolean {
   const normalized = query.trim().toLocaleLowerCase()
@@ -216,6 +256,17 @@ export function BangersExplorer({
             ? result.tweets
             : dedupeTweets([...current.tweets, ...result.tweets]),
         }))
+        if (replace) {
+          captureBangersAction({
+            action: 'searched',
+            query: requestQuery,
+            scope,
+            sort,
+            year,
+            period,
+            resultCount: result.pagination.totalAvailable,
+          })
+        }
       } catch (error) {
         if (controller.signal.aborted) return
         if (requestVersion === requestVersionRef.current) {
@@ -300,6 +351,15 @@ export function BangersExplorer({
     query.trim().length > 0 || year !== undefined || period !== undefined
   const selectedTime = period ?? (year === undefined ? 'all' : `year-${year}`)
   const clearFilters = () => {
+    captureBangersAction({
+      action: 'filters_cleared',
+      query,
+      scope,
+      sort,
+      year,
+      period,
+      resultCount: page.pagination.totalAvailable,
+    })
     setQuery('')
     if (year !== undefined || period !== undefined) {
       router.push(bangersHref({ query: '', scope, sort, allTime: true }))
@@ -370,6 +430,15 @@ export function BangersExplorer({
                 const nextYear = value.startsWith('year-')
                   ? Number(value.slice(5))
                   : undefined
+                captureBangersAction({
+                  action: 'time_filter_changed',
+                  query,
+                  scope,
+                  sort,
+                  year: nextYear,
+                  period: nextPeriod,
+                  resultCount: page.pagination.totalAvailable,
+                })
                 router.push(
                   bangersHref({
                     query,
@@ -426,6 +495,18 @@ export function BangersExplorer({
                           allTime: isAllTime,
                         })}
                         aria-current={sort === 'quotes' ? 'page' : undefined}
+                        onClick={() => {
+                          if (sort === 'quotes') return
+                          captureBangersAction({
+                            action: 'sort_changed',
+                            query,
+                            scope,
+                            sort: 'quotes',
+                            year,
+                            period,
+                            resultCount: page.pagination.totalAvailable,
+                          })
+                        }}
                         className={`${segmentClassName} rounded-l-[3px] ${
                           sort === 'quotes'
                             ? activeSegmentClassName
@@ -452,6 +533,18 @@ export function BangersExplorer({
                     allTime: isAllTime,
                   })}
                   aria-current={sort === 'recent' ? 'page' : undefined}
+                  onClick={() => {
+                    if (sort === 'recent') return
+                    captureBangersAction({
+                      action: 'sort_changed',
+                      query,
+                      scope,
+                      sort: 'recent',
+                      year,
+                      period,
+                      resultCount: page.pagination.totalAvailable,
+                    })
+                  }}
                   className={`${segmentClassName} -ml-px rounded-r-[3px] ${
                     sort === 'recent'
                       ? activeSegmentClassName
@@ -480,6 +573,18 @@ export function BangersExplorer({
                     allTime: isAllTime,
                   })}
                   aria-current={scope === 'all' ? 'page' : undefined}
+                  onClick={() => {
+                    if (scope === 'all') return
+                    captureBangersAction({
+                      action: 'scope_changed',
+                      query,
+                      scope: 'all',
+                      sort,
+                      year,
+                      period,
+                      resultCount: page.pagination.totalAvailable,
+                    })
+                  }}
                   className={`${segmentClassName} rounded-l-[3px] ${
                     scope === 'all'
                       ? activeSegmentClassName
@@ -498,6 +603,18 @@ export function BangersExplorer({
                     allTime: isAllTime,
                   })}
                   aria-current={scope === 'members' ? 'page' : undefined}
+                  onClick={() => {
+                    if (scope === 'members') return
+                    captureBangersAction({
+                      action: 'scope_changed',
+                      query,
+                      scope: 'members',
+                      sort,
+                      year,
+                      period,
+                      resultCount: page.pagination.totalAvailable,
+                    })
+                  }}
                   className={`${segmentClassName} -ml-px rounded-r-[3px] ${
                     scope === 'members'
                       ? activeSegmentClassName
@@ -603,7 +720,18 @@ export function BangersExplorer({
           </p>
           <button
             type="button"
-            onClick={retryLoad}
+            onClick={() => {
+              captureBangersAction({
+                action: 'retry_clicked',
+                query,
+                scope,
+                sort,
+                year,
+                period,
+                resultCount: page.pagination.totalAvailable,
+              })
+              retryLoad()
+            }}
             className="mt-2 text-[12px] font-semibold text-brand hover:underline"
           >
             Try again
@@ -618,7 +746,18 @@ export function BangersExplorer({
         >
           <button
             type="button"
-            onClick={loadMore}
+            onClick={() => {
+              captureBangersAction({
+                action: 'load_more_clicked',
+                query,
+                scope,
+                sort,
+                year,
+                period,
+                resultCount: page.pagination.totalAvailable,
+              })
+              loadMore()
+            }}
             disabled={isLoading || query.trim() !== loadedQuery}
             className="inline-flex items-center gap-2 rounded-[3px] border border-zinc-300 bg-transparent px-4 py-2 text-[12.5px] font-semibold hover:border-brand hover:text-brand disabled:cursor-wait disabled:opacity-60 dark:border-[#3a3a40]"
           >

--- a/src/components/portal/Portal.tsx
+++ b/src/components/portal/Portal.tsx
@@ -29,12 +29,37 @@ import {
   selectHomepageStream,
 } from '@/lib/portal/stream'
 import { BANGERS_ALL_TIME_HREF, BANGERS_WEEK_HREF } from '@/lib/portal/bangers'
+import { capturePostHogEvent } from '@/lib/posthog'
 
 export type PortalView = 'home' | 'stream'
 
 const HOME_LIVE_STREAM_LIMIT = 12
 const ARCHIVE_EXPORT_URL =
   'https://github.com/TheExGenesis/community-archive/releases/tag/data_export'
+
+type DashboardDestination =
+  | 'all_time_bangers'
+  | 'best_strands'
+  | 'data_export'
+  | 'live_stream'
+  | 'recent_bangers'
+  | 'research'
+  | 'research_article'
+  | 'tool'
+  | 'tools'
+  | 'trends'
+
+function captureDashboardDestination(
+  destination: DashboardDestination,
+  surface: 'card' | 'list' | 'panel_header',
+  external: boolean,
+) {
+  capturePostHogEvent('dashboard_destination_opened', {
+    destination,
+    surface,
+    external,
+  })
+}
 
 const compact = (n: number) =>
   new Intl.NumberFormat('en', {
@@ -107,7 +132,12 @@ function PanelHeader({
   divider = true,
 }: {
   title: string
-  action?: { label: string; href: string; external?: boolean }
+  action?: {
+    label: string
+    href: string
+    analyticsDestination: DashboardDestination
+    external?: boolean
+  }
   live?: boolean
   divider?: boolean
 }) {
@@ -129,6 +159,13 @@ function PanelHeader({
             href={action.href}
             target="_blank"
             rel="noopener noreferrer"
+            onClick={() =>
+              captureDashboardDestination(
+                action.analyticsDestination,
+                'panel_header',
+                true,
+              )
+            }
             className="text-[12.5px] font-semibold text-brand hover:underline"
           >
             {action.label} →
@@ -136,6 +173,13 @@ function PanelHeader({
         ) : (
           <Link
             href={action.href}
+            onClick={() =>
+              captureDashboardDestination(
+                action.analyticsDestination,
+                'panel_header',
+                false,
+              )
+            }
             className="text-[12.5px] font-semibold text-brand hover:underline"
           >
             {action.label} →
@@ -445,7 +489,12 @@ export default function Portal({
         )
       }
       pageCursor.current = nextCursor
-      setHasMore(nextHasMore && nextCursor !== null)
+      const canLoadMore = nextHasMore && nextCursor !== null
+      setHasMore(canLoadMore)
+      capturePostHogEvent('portal_stream_loaded_more', {
+        loaded_tweet_count: older.length,
+        has_more: canLoadMore,
+      })
     } catch {
       // Keep the sentinel active so scrolling can retry after a network hiccup.
     } finally {
@@ -655,7 +704,11 @@ export default function Portal({
                 <PanelHeader
                   title="Live stream"
                   live
-                  action={{ label: 'Open firehose', href: '/stream' }}
+                  action={{
+                    label: 'Open firehose',
+                    href: '/stream',
+                    analyticsDestination: 'live_stream',
+                  }}
                 />
                 <div
                   role="region"
@@ -690,7 +743,11 @@ export default function Portal({
               <div className={`${CARD} flex flex-col`}>
                 <PanelHeader
                   title="Trending terms · 7 days"
-                  action={{ label: 'Trends explorer', href: '/trends' }}
+                  action={{
+                    label: 'Trends explorer',
+                    href: '/trends',
+                    analyticsDestination: 'trends',
+                  }}
                 />
                 <div className="flex flex-1 flex-col justify-evenly px-4 pb-3 pt-2">
                   {data.failures.trends ? (
@@ -764,6 +821,7 @@ export default function Portal({
                         action={{
                           label: 'Recent bangers',
                           href: BANGERS_WEEK_HREF,
+                          analyticsDestination: 'recent_bangers',
                         }}
                       />
                       {recentBanger ? (
@@ -791,6 +849,7 @@ export default function Portal({
                         action={{
                           label: 'All-time bangers',
                           href: BANGERS_ALL_TIME_HREF,
+                          analyticsDestination: 'all_time_bangers',
                         }}
                       />
                       {historicalBanger ? (
@@ -817,7 +876,11 @@ export default function Portal({
               <div className={CARD}>
                 <PanelHeader
                   title="Featured research"
-                  action={{ label: 'All research', href: '/research' }}
+                  action={{
+                    label: 'All research',
+                    href: '/research',
+                    analyticsDestination: 'research',
+                  }}
                 />
                 <div className="flex flex-col">
                   {data.failures.research ? (
@@ -829,6 +892,13 @@ export default function Portal({
                         href={post.url}
                         target="_blank"
                         rel="noopener noreferrer"
+                        onClick={() =>
+                          captureDashboardDestination(
+                            'research_article',
+                            'list',
+                            true,
+                          )
+                        }
                         className="group flex items-start gap-3 border-b border-zinc-100 px-4 py-3 transition-colors last:border-b-0 hover:bg-zinc-50 dark:border-[#202023] dark:hover:bg-[#1f1f23]"
                       >
                         <div className="min-w-0 flex-1">
@@ -869,6 +939,13 @@ export default function Portal({
                       href={RESEARCH_SOURCE.url}
                       target="_blank"
                       rel="noopener noreferrer"
+                      onClick={() =>
+                        captureDashboardDestination(
+                          'research_article',
+                          'list',
+                          true,
+                        )
+                      }
                       className={`px-4 py-6 text-center text-[13px] ${MUTED} hover:text-brand`}
                     >
                       Read the latest research at {RESEARCH_SOURCE.name} →
@@ -881,6 +958,9 @@ export default function Portal({
                   href={bestStrands.link}
                   target="_blank"
                   rel="noopener noreferrer"
+                  onClick={() =>
+                    captureDashboardDestination('best_strands', 'card', true)
+                  }
                   className={`${CARD} group overflow-hidden transition-colors hover:border-brand/60`}
                 >
                   {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -912,6 +992,9 @@ export default function Portal({
                 href={ARCHIVE_EXPORT_URL}
                 target="_blank"
                 rel="noopener noreferrer"
+                onClick={() =>
+                  captureDashboardDestination('data_export', 'card', true)
+                }
                 className={`${CARD} group flex items-center gap-3 px-4 py-4 transition-colors hover:border-brand/60`}
               >
                 <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-[4px] border border-zinc-200 bg-zinc-50 text-brand dark:border-[#2a2a2e] dark:bg-[#121214]">
@@ -938,7 +1021,11 @@ export default function Portal({
           <div id="products" className={`${CARD} mt-4 scroll-mt-32`}>
             <PanelHeader
               title="Explore the archive"
-              action={{ label: 'All tools', href: '/tools' }}
+              action={{
+                label: 'All tools',
+                href: '/tools',
+                analyticsDestination: 'tools',
+              }}
               divider={false}
             />
             <div className="grid grid-cols-1 gap-2.5 p-4 sm:grid-cols-2 lg:grid-cols-4">
@@ -952,6 +1039,9 @@ export default function Portal({
                   href={tool.link}
                   target="_blank"
                   rel="noopener noreferrer"
+                  onClick={() =>
+                    captureDashboardDestination('tool', 'card', true)
+                  }
                   className="group rounded-[4px] border border-zinc-200 bg-zinc-50 px-3 py-2.5 transition-colors hover:border-brand/60 dark:border-[#26262a] dark:bg-[#121214] dark:hover:border-brand/60"
                 >
                   <div className="flex items-start gap-2.5">
@@ -1003,6 +1093,8 @@ export default function Portal({
                     tweet={t}
                     animate={i === 0}
                     showArchivedBadge
+                    origin="stream"
+                    returnTo="/stream"
                   />
                 ))}
                 {visible.length === 0 && streamUnavailable && (

--- a/src/components/portal/TrendsExplorer.tsx
+++ b/src/components/portal/TrendsExplorer.tsx
@@ -16,6 +16,7 @@ import type {
   TrendEvidenceRange,
 } from '@/lib/portal/trendEvidenceCache'
 import type { PortalTrends, PortalTweet, TermSeries } from '@/lib/portal/types'
+import { capturePostHogEvent } from '@/lib/posthog'
 import { BODY, CARD, MUTED, SERIF } from './styles'
 
 type FeedFilter = 'include' | 'off'
@@ -60,6 +61,18 @@ const SERIES_COLORS = [
   '#84cc16',
 ]
 const DEFAULT_TREND_TERMS = CHART_TERMS.map(({ term }) => term)
+
+type TrendsExplorerAction =
+  | 'chart_series_toggled'
+  | 'evidence_filter_toggled'
+  | 'evidence_refreshed'
+  | 'retry_defaults'
+  | 'scale_changed'
+  | 'term_removed'
+  | 'terms_added'
+  | 'terms_reactivated'
+  | 'year_filter_applied'
+  | 'year_filter_cleared'
 
 async function requestTrendSeries(terms: string[]): Promise<SeriesResponse> {
   const params = new URLSearchParams({ view: 'series' })
@@ -201,6 +214,25 @@ export default function TrendsExplorer({
     includeTerms,
     selectedYears,
   )
+  const captureExplorerAction = (
+    action: TrendsExplorerAction,
+    overrides: Partial<{
+      seriesCount: number
+      enabledSeriesCount: number
+      includedSeriesCount: number
+      hasYearFilter: boolean
+    }> = {},
+  ) => {
+    capturePostHogEvent('trends_explorer_action', {
+      action,
+      series_count: overrides.seriesCount ?? series.length,
+      enabled_series_count:
+        overrides.enabledSeriesCount ?? enabledSeries.length,
+      included_series_count:
+        overrides.includedSeriesCount ?? includeTerms.length,
+      has_year_filter: overrides.hasYearFilter ?? selectedYears !== null,
+    })
+  }
 
   useEffect(() => {
     const requests = evidenceRequestsRef.current
@@ -316,6 +348,17 @@ export default function TrendsExplorer({
   }, [includeTerms, refreshKey, requestedYears])
 
   const removeTerm = (term: string) => {
+    captureExplorerAction('term_removed', {
+      seriesCount: Math.max(0, series.length - 1),
+      enabledSeriesCount: Math.max(
+        0,
+        enabledSeries.length - (chartEnabled[term] ? 1 : 0),
+      ),
+      includedSeriesCount: Math.max(
+        0,
+        includeTerms.length - (feedFilters[term] === 'include' ? 1 : 0),
+      ),
+    })
     setSeries((current) => current.filter((item) => item.term !== term))
     setChartEnabled((current) => {
       const next = { ...current }
@@ -361,6 +404,13 @@ export default function TrendsExplorer({
       }))
     }
     if (newTerms.length === 0) {
+      const nextEnabled = new Set([
+        ...enabledSeries.map(({ term }) => term),
+        ...alreadyPresent,
+      ])
+      captureExplorerAction('terms_reactivated', {
+        enabledSeriesCount: nextEnabled.size,
+      })
       setTermInput('')
       return
     }
@@ -386,6 +436,20 @@ export default function TrendsExplorer({
           additions.map(({ term }) => [term, 'include' as const]),
         ),
       }))
+      const nextEnabled = new Set([
+        ...enabledSeries.map(({ term }) => term),
+        ...alreadyPresent,
+        ...additions.map(({ term }) => term),
+      ])
+      const nextIncluded = new Set([
+        ...includeTerms,
+        ...additions.map(({ term }) => term),
+      ])
+      captureExplorerAction('terms_added', {
+        seriesCount: series.length + additions.length,
+        enabledSeriesCount: nextEnabled.size,
+        includedSeriesCount: nextIncluded.size,
+      })
       setChartError(null)
       setTermInput('')
     } catch (error) {
@@ -423,6 +487,11 @@ export default function TrendsExplorer({
           ]),
         ),
       )
+      captureExplorerAction('retry_defaults', {
+        seriesCount: defaults.length,
+        enabledSeriesCount: Math.min(defaults.length, 4),
+        includedSeriesCount: defaults.length > 0 ? 1 : 0,
+      })
       setChartError(null)
     } catch (error) {
       setChartError(
@@ -514,6 +583,7 @@ export default function TrendsExplorer({
     if (dragStartYear === null) return
     const year = yearForPointer(event.clientX)
     if (year !== null) updateDraggedYears(year)
+    captureExplorerAction('year_filter_applied', { hasYearFilter: true })
     setDragStartYear(null)
   }
 
@@ -603,7 +673,11 @@ export default function TrendsExplorer({
                       key={option}
                       type="button"
                       aria-pressed={scale === option}
-                      onClick={() => setScale(option)}
+                      onClick={() => {
+                        if (scale === option) return
+                        captureExplorerAction('scale_changed')
+                        setScale(option)
+                      }}
                       className={`rounded-[3px] px-2.5 py-1.5 text-[11.5px] font-semibold transition-colors ${
                         scale === option
                           ? 'bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900'
@@ -783,10 +857,16 @@ export default function TrendsExplorer({
                     value={selectedYears?.start ?? ''}
                     onChange={(event) => {
                       if (!event.target.value) {
+                        captureExplorerAction('year_filter_cleared', {
+                          hasYearFilter: false,
+                        })
                         setSelectedYears(null)
                         return
                       }
                       const start = Number(event.target.value)
+                      captureExplorerAction('year_filter_applied', {
+                        hasYearFilter: true,
+                      })
                       setSelectedYears((current) => ({
                         start,
                         end: Math.max(start, current?.end ?? start),
@@ -809,10 +889,16 @@ export default function TrendsExplorer({
                     value={selectedYears?.end ?? ''}
                     onChange={(event) => {
                       if (!event.target.value) {
+                        captureExplorerAction('year_filter_cleared', {
+                          hasYearFilter: false,
+                        })
                         setSelectedYears(null)
                         return
                       }
                       const end = Number(event.target.value)
+                      captureExplorerAction('year_filter_applied', {
+                        hasYearFilter: true,
+                      })
                       setSelectedYears((current) => ({
                         start: Math.min(current?.start ?? end, end),
                         end,
@@ -831,7 +917,12 @@ export default function TrendsExplorer({
                 {selectedYears && (
                   <button
                     type="button"
-                    onClick={() => setSelectedYears(null)}
+                    onClick={() => {
+                      captureExplorerAction('year_filter_cleared', {
+                        hasYearFilter: false,
+                      })
+                      setSelectedYears(null)
+                    }}
                     className={`rounded-[4px] px-2 py-1 text-[11px] font-semibold ${MUTED} hover:text-foreground`}
                   >
                     Clear range
@@ -861,12 +952,16 @@ export default function TrendsExplorer({
                           type="button"
                           aria-pressed={active}
                           aria-label={`${active ? 'Hide' : 'Show'} ${item.term} series`}
-                          onClick={() =>
+                          onClick={() => {
+                            captureExplorerAction('chart_series_toggled', {
+                              enabledSeriesCount:
+                                enabledSeries.length + (active ? -1 : 1),
+                            })
                             setChartEnabled((current) => ({
                               ...current,
                               [item.term]: !current[item.term],
                             }))
-                          }
+                          }}
                           className="inline-flex items-center gap-1.5 py-1.5 pl-2.5 pr-1.5"
                         >
                           <span
@@ -920,6 +1015,7 @@ export default function TrendsExplorer({
               <button
                 type="button"
                 onClick={() => {
+                  captureExplorerAction('evidence_refreshed')
                   setRequestedYears(selectedYears)
                   setRefreshKey((key) => key + 1)
                 }}
@@ -946,12 +1042,17 @@ export default function TrendsExplorer({
                       <button
                         type="button"
                         aria-label={filterLabel(term, filter)}
-                        onClick={() =>
+                        onClick={() => {
+                          captureExplorerAction('evidence_filter_toggled', {
+                            includedSeriesCount:
+                              includeTerms.length +
+                              (filter === 'include' ? -1 : 1),
+                          })
                           setFeedFilters((current) => ({
                             ...current,
                             [term]: nextFeedFilter(current[term] ?? 'off'),
                           }))
-                        }
+                        }}
                         className="py-1.5 pl-2.5 pr-1.5"
                       >
                         {filter === 'include' ? '+ ' : ''}

--- a/src/components/portal/TweetRow.tsx
+++ b/src/components/portal/TweetRow.tsx
@@ -16,6 +16,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { PortalMedia, PortalQuotedTweet, PortalTweet } from '@/lib/portal/types'
+import { capturePostHogEvent } from '@/lib/posthog'
 
 const HUES = [262, 32, 145, 4, 155, 200, 217, 88, 240, 190, 340, 45, 280, 20]
 const FEATURED_CARD_HOVER =
@@ -148,12 +149,14 @@ function QuotedTweet({
   summary,
   origin,
   returnTo,
+  onOpen,
 }: {
   tweet: PortalQuotedTweet
   compact: boolean
   summary: boolean
   origin?: TweetOrigin
   returnTo?: string
+  onOpen: () => void
 }) {
   if (tweet.isDeleted) {
     return (
@@ -169,6 +172,7 @@ function QuotedTweet({
     <div className="mt-2 rounded-[4px] border border-zinc-200 bg-white p-2.5 dark:border-[#303036] dark:bg-[#18181b]">
       <Link
         href={tweetPermalinkHref(tweet.id, origin, returnTo)}
+        onClick={onOpen}
         className="block rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
       >
         <div className="flex items-center gap-2">
@@ -220,9 +224,11 @@ export interface TweetCardProps {
 function ArchivedQuotesMetric({
   count,
   href,
+  onOpen,
 }: {
   count: number
   href: string
+  onOpen: () => void
 }) {
   return (
     <TooltipProvider delayDuration={150}>
@@ -230,6 +236,7 @@ function ArchivedQuotesMetric({
         <TooltipTrigger asChild>
           <Link
             href={href}
+            onClick={onOpen}
             aria-label={`${count} archived quotes. Open tweet to see them.`}
             className="inline-flex items-center gap-1 rounded-sm text-zinc-500 transition-colors hover:text-zinc-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 dark:text-[#a7a7b4] dark:hover:text-zinc-200"
           >
@@ -266,6 +273,22 @@ export function TweetRow({
   const href = tweetPermalinkHref(tweet.id, origin, returnTo)
   const isFeatured = featuredRank !== undefined
   const isClickable = clickable || isFeatured
+  const captureAction = (
+    action:
+      | 'collapse'
+      | 'expand'
+      | 'open'
+      | 'open_archived_quotes'
+      | 'open_quoted_tweet',
+  ) => {
+    capturePostHogEvent('tweet_card_action', {
+      action,
+      origin: origin ?? 'unknown',
+      has_media: imageMedia(tweet.media).length > 0,
+      has_quoted_tweet: Boolean(tweet.quotedTweet),
+      is_featured: isFeatured,
+    })
+  }
   const rowClassName = isFeatured
     ? `relative flex min-w-0 gap-3 rounded-lg border border-zinc-200/75 bg-white p-4 shadow-sm dark:border-[#303036]/80 dark:bg-[#1b1b1e] sm:gap-3.5 sm:p-5 ${FEATURED_CARD_HOVER} ${
         animate ? 'portal-slide-in' : ''
@@ -274,7 +297,10 @@ export function TweetRow({
         animate ? 'portal-slide-in' : ''
       }`
 
-  const activateCard = () => router.push(href)
+  const activateCard = () => {
+    captureAction('open')
+    router.push(href)
+  }
   const handleCardClick = (event: MouseEvent<HTMLElement>) => {
     if (!isClickable) return
     const target = event.target as HTMLElement
@@ -321,6 +347,7 @@ export function TweetRow({
     <div className="min-w-0 flex-1">
       <Link
         href={href}
+        onClick={() => captureAction('open')}
         className="block rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
       >
         {tweetContent}
@@ -329,7 +356,10 @@ export function TweetRow({
         <button
           type="button"
           aria-expanded={isExpanded}
-          onClick={() => setIsExpanded((expanded) => !expanded)}
+          onClick={() => {
+            captureAction(isExpanded ? 'collapse' : 'expand')
+            setIsExpanded((expanded) => !expanded)
+          }}
           className="mt-1 text-[12px] font-semibold text-brand hover:underline"
         >
           {isExpanded ? 'Show less' : 'Read more'}
@@ -343,12 +373,17 @@ export function TweetRow({
           summary={quotedTweetDisplay === 'summary'}
           origin={origin}
           returnTo={returnTo}
+          onOpen={() => captureAction('open_quoted_tweet')}
         />
       )}
       {!compact && (
         <div className="mt-1.5 flex flex-wrap gap-x-4 gap-y-1 text-[12px] tabular-nums text-zinc-500 dark:text-[#a7a7b4]">
           {tweet.quoteCount !== undefined && (
-            <ArchivedQuotesMetric count={tweet.quoteCount} href={href} />
+            <ArchivedQuotesMetric
+              count={tweet.quoteCount}
+              href={href}
+              onOpen={() => captureAction('open_archived_quotes')}
+            />
           )}
           <span>♥ {formatCount(tweet.likes)}</span>
           <span>⇄ {formatCount(tweet.rts)}</span>
@@ -371,7 +406,11 @@ export function TweetRow({
       tabIndex={isClickable ? 0 : undefined}
       aria-label={isClickable ? `View tweet by @${tweet.username}` : undefined}
     >
-      <Link href={href} aria-label={`View tweet by @${tweet.username}`}>
+      <Link
+        href={href}
+        onClick={() => captureAction('open')}
+        aria-label={`View tweet by @${tweet.username}`}
+      >
         <TweetAvatar tweet={tweet} size={isFeatured ? 38 : 34} />
       </Link>
       {details}

--- a/src/lib/navigation.test.ts
+++ b/src/lib/navigation.test.ts
@@ -52,10 +52,13 @@ describe('tweet detail navigation', () => {
     })
   })
 
-  it('maps homepage, Trends, and Search origins to honest labels', () => {
+  it('maps homepage, stream, Trends, and Search origins to honest labels', () => {
     expect(getTweetBackLink({ from: 'home', returnTo: '/' }).label).toBe(
       'Back to homepage',
     )
+    expect(
+      getTweetBackLink({ from: 'stream', returnTo: '/stream' }).label,
+    ).toBe('Back to live stream')
     expect(
       getTweetBackLink({ from: 'trends', returnTo: '/trends' }).label,
     ).toBe('Back to Trends')

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -5,7 +5,7 @@ export interface NavItem {
   label: string
 }
 
-export type TweetOrigin = 'home' | 'bangers' | 'trends' | 'search'
+export type TweetOrigin = 'home' | 'stream' | 'bangers' | 'trends' | 'search'
 
 export interface TweetBackLink {
   href: string
@@ -21,6 +21,11 @@ const TWEET_ORIGINS: Record<
     href: '/',
     label: 'Back to homepage',
     matches: (href) => href === '/' || href.startsWith('/?'),
+  },
+  stream: {
+    href: '/stream',
+    label: 'Back to live stream',
+    matches: (href) => href === '/stream' || href.startsWith('/stream?'),
   },
   bangers: {
     href: '/bangers',

--- a/src/lib/portal/TrendsExplorerResilience.test.tsx
+++ b/src/lib/portal/TrendsExplorerResilience.test.tsx
@@ -7,7 +7,13 @@ import userEvent from '@testing-library/user-event'
 import TrendsExplorer from '@/components/portal/TrendsExplorer'
 import { emptyPortalTrends } from './trendConfig'
 import type { PortalTrends } from './types'
+import { capturePostHogEvent } from '@/lib/posthog'
 ;(globalThis as typeof globalThis & { React: typeof React }).React = React
+
+jest.mock('@/lib/posthog', () => ({
+  capturePostHogEvent: jest.fn(),
+}))
+const mockCapturePostHogEvent = capturePostHogEvent as jest.Mock
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: jest.fn() }),
@@ -56,6 +62,10 @@ function feedTweet(id: string, year: number) {
 }
 
 describe('TrendsExplorer request isolation', () => {
+  beforeEach(() => {
+    mockCapturePostHogEvent.mockReset()
+  })
+
   afterEach(() => {
     jest.useRealTimers()
     jest.restoreAllMocks()
@@ -155,6 +165,16 @@ describe('TrendsExplorer request isolation', () => {
       name: 'tpot is included. Click to turn it off.',
     })
     await user.click(included)
+    expect(mockCapturePostHogEvent).toHaveBeenCalledWith(
+      'trends_explorer_action',
+      {
+        action: 'evidence_filter_toggled',
+        series_count: 1,
+        enabled_series_count: 1,
+        included_series_count: 0,
+        has_year_filter: false,
+      },
+    )
     expect(
       screen.getByRole('button', {
         name: 'tpot is off. Click to include it.',
@@ -163,6 +183,16 @@ describe('TrendsExplorer request isolation', () => {
     expect(screen.queryByText(/exclude/i)).not.toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: 'Remove tpot trend' }))
+    expect(mockCapturePostHogEvent).toHaveBeenLastCalledWith(
+      'trends_explorer_action',
+      {
+        action: 'term_removed',
+        series_count: 0,
+        enabled_series_count: 0,
+        included_series_count: 0,
+        has_year_filter: false,
+      },
+    )
     expect(
       screen.queryByRole('button', { name: 'Remove tpot trend' }),
     ).not.toBeInTheDocument()

--- a/src/lib/portal/TweetRow.test.tsx
+++ b/src/lib/portal/TweetRow.test.tsx
@@ -6,6 +6,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { TweetRow } from '@/components/portal/TweetRow'
 import type { PortalTweet } from '@/lib/portal/types'
+import { capturePostHogEvent } from '@/lib/posthog'
 ;(globalThis as typeof globalThis & { React: typeof React }).React = React
 
 jest.mock('next/image', () => ({
@@ -36,6 +37,10 @@ jest.mock('next/link', () => ({
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: jest.fn() }),
 }))
+jest.mock('@/lib/posthog', () => ({
+  capturePostHogEvent: jest.fn(),
+}))
+const mockCapturePostHogEvent = capturePostHogEvent as jest.Mock
 
 const tweet: PortalTweet = {
   id: '42',
@@ -75,6 +80,10 @@ const tweet: PortalTweet = {
 }
 
 describe('portal TweetRow media', () => {
+  beforeEach(() => {
+    mockCapturePostHogEvent.mockReset()
+  })
+
   test('uses a neutral card and explains its archived-quote evidence', async () => {
     const user = userEvent.setup()
     const { container } = render(<TweetRow tweet={tweet} featuredRank={1} />)
@@ -98,6 +107,16 @@ describe('portal TweetRow media', () => {
     expect(await screen.findByRole('tooltip')).toHaveTextContent(
       /Bangers uses this count for its Best ranking/i,
     )
+
+    archivedQuotes.addEventListener('click', (event) => event.preventDefault())
+    await user.click(archivedQuotes)
+    expect(mockCapturePostHogEvent).toHaveBeenCalledWith('tweet_card_action', {
+      action: 'open_archived_quotes',
+      origin: 'unknown',
+      has_media: true,
+      has_quoted_tweet: true,
+      is_featured: true,
+    })
   })
 
   test('renders quotes and closes an enlarged image when the backdrop is clicked', async () => {

--- a/src/lib/posthog.test.ts
+++ b/src/lib/posthog.test.ts
@@ -69,6 +69,7 @@ describe('sanitizePostHogEvent', () => {
       distinct_id: 'user-123',
       has_query: true,
       active_filter_count: 2,
+      surface: 'advanced',
       $current_url: 'https://example.com/search?q=private-words',
       $session_entry_url: 'https://example.com/search?q=private-words',
       utm_campaign: 'archive-launch',
@@ -85,6 +86,61 @@ describe('sanitizePostHogEvent', () => {
       utm_campaign: 'archive-launch',
       has_query: true,
       active_filter_count: 2,
+      surface: 'advanced',
+    })
+  })
+
+  it.each([
+    [
+      'dashboard_destination_opened',
+      {
+        destination: 'data_export',
+        surface: 'card',
+        external: true,
+      },
+    ],
+    [
+      'tweet_card_action',
+      {
+        action: 'expand',
+        origin: 'bangers',
+        has_media: true,
+        has_quoted_tweet: false,
+        is_featured: true,
+      },
+    ],
+    [
+      'bangers_action',
+      {
+        action: 'searched',
+        has_query: true,
+        time_range: 'three_months',
+        sort: 'quotes',
+        scope: 'members',
+        result_count: 42,
+      },
+    ],
+    [
+      'trends_explorer_action',
+      {
+        action: 'terms_added',
+        series_count: 6,
+        enabled_series_count: 5,
+        included_series_count: 2,
+        has_year_filter: false,
+      },
+    ],
+    ['portal_stream_loaded_more', { loaded_tweet_count: 30, has_more: true }],
+  ])('keeps aggregate properties for %s', (eventName, properties) => {
+    const event = captureResult(eventName, {
+      ...properties,
+      query: 'do not send this',
+      tweet_id: '1234567890',
+    })
+
+    expect(sanitizePostHogEvent(event)?.properties).toEqual({
+      $geoip_disable: true,
+      ...properties,
     })
   })
 
@@ -285,11 +341,13 @@ describe('capturePostHogEventWithClient', () => {
       capturePostHogEventWithClient(client, 'archive_search_submitted', {
         has_query: true,
         active_filter_count: 0,
+        surface: 'advanced',
       }),
     ).toBe(true)
     expect(client.capture).toHaveBeenCalledWith('archive_search_submitted', {
       has_query: true,
       active_filter_count: 0,
+      surface: 'advanced',
     })
   })
 

--- a/src/lib/posthog.ts
+++ b/src/lib/posthog.ts
@@ -39,6 +39,75 @@ const isTrendMatch: PropertyValidator = (value): value is string =>
   typeof value === 'string' && ['all', 'any'].includes(value)
 const isQuoteLimit: PropertyValidator = (value): value is number =>
   typeof value === 'number' && [10, 25, 50, 100].includes(value)
+const isOneOf =
+  (values: readonly string[]): PropertyValidator =>
+  (value): value is string =>
+    typeof value === 'string' && values.includes(value)
+const isPortalSeriesCount: PropertyValidator = (value): value is number =>
+  typeof value === 'number' &&
+  Number.isSafeInteger(value) &&
+  value >= 0 &&
+  value <= 12
+
+const isSearchSurface = isOneOf(['advanced', 'homepage'])
+const isDashboardDestination = isOneOf([
+  'all_time_bangers',
+  'best_strands',
+  'data_export',
+  'live_stream',
+  'recent_bangers',
+  'research',
+  'research_article',
+  'tool',
+  'tools',
+  'trends',
+])
+const isDashboardLinkSurface = isOneOf(['card', 'list', 'panel_header'])
+const isTweetCardAction = isOneOf([
+  'collapse',
+  'expand',
+  'open',
+  'open_archived_quotes',
+  'open_quoted_tweet',
+])
+const isTweetOrigin = isOneOf([
+  'bangers',
+  'home',
+  'search',
+  'stream',
+  'trends',
+  'unknown',
+])
+const isBangersAction = isOneOf([
+  'filters_cleared',
+  'load_more_clicked',
+  'retry_clicked',
+  'scope_changed',
+  'searched',
+  'sort_changed',
+  'time_filter_changed',
+])
+const isBangersTimeRange = isOneOf([
+  'all',
+  'three_months',
+  'today',
+  'week',
+  'year',
+])
+const isBangersSort = isOneOf(['quotes', 'recent'])
+const isBangersScope = isOneOf(['all', 'members'])
+const isTrendsExplorerAction = isOneOf([
+  'chart_series_toggled',
+  'evidence_filter_toggled',
+  'evidence_refreshed',
+  'retry_defaults',
+  'scale_changed',
+  'term_removed',
+  'terms_added',
+  'terms_reactivated',
+  'year_filter_applied',
+  'year_filter_cleared',
+])
 
 const allowedEventProperties: Record<
   string,
@@ -60,6 +129,38 @@ const allowedEventProperties: Record<
   archive_search_submitted: {
     has_query: isBoolean,
     active_filter_count: isActiveFilterCount,
+    surface: isSearchSurface,
+  },
+  dashboard_destination_opened: {
+    destination: isDashboardDestination,
+    surface: isDashboardLinkSurface,
+    external: isBoolean,
+  },
+  tweet_card_action: {
+    action: isTweetCardAction,
+    origin: isTweetOrigin,
+    has_media: isBoolean,
+    has_quoted_tweet: isBoolean,
+    is_featured: isBoolean,
+  },
+  bangers_action: {
+    action: isBangersAction,
+    has_query: isBoolean,
+    time_range: isBangersTimeRange,
+    sort: isBangersSort,
+    scope: isBangersScope,
+    result_count: isNonnegativeInteger,
+  },
+  trends_explorer_action: {
+    action: isTrendsExplorerAction,
+    series_count: isPortalSeriesCount,
+    enabled_series_count: isPortalSeriesCount,
+    included_series_count: isPortalSeriesCount,
+    has_year_filter: isBoolean,
+  },
+  portal_stream_loaded_more: {
+    loaded_tweet_count: isNonnegativeInteger,
+    has_more: isBoolean,
   },
   word_trend_requested: {
     bucket: isTrendBucket,


### PR DESCRIPTION
## What changed

- add semantic PostHog events for dashboard destinations, tweet-card engagement, Bangers controls, Trends controls, and deep live-stream reading
- label homepage vs advanced archive searches and preserve the stream origin on tweet detail navigation
- keep the new custom event properties aggregate and bounded (enums, counts, and booleans; no raw terms, tweet text, tweet IDs, or outbound URLs)
- document the event catalog and suggested PostHog insights

## Why

The signed-in portal now has several meaningful product interactions that pageviews and autocapture cannot describe cleanly. These events make member usage queryable without exploding the event taxonomy or adding arbitrary content to custom properties.

## Validation

- `pnpm type-check`
- `pnpm lint` (passes with one pre-existing `<img>` warning in `UnifiedTweetList.test.tsx`)
- focused client tests: 2 suites, 10 tests
- focused server/jsdom tests: 4 suites, 44 tests
