### PR TITLE
Fix homepage tweet text, profile avatars, and deep threads

### DIFF
--- a/src/app/user/[account_id]/page.tsx
+++ b/src/app/user/[account_id]/page.tsx
@@ -16,6 +16,7 @@ import Image from 'next/image'
 import TweetList from '@/components/TweetList'
 import { FilterCriteria } from '@/lib/queries/tweetQueries'
 import { Archive, Radio } from 'lucide-react'
+import { getHighResolutionAvatarUrl } from '@/lib/avatar'
 
 // Style constants (glows removed)
 const unifiedDeepBlueBase = 'bg-card dark:bg-background'
@@ -31,7 +32,10 @@ const UserProfile = ({ userData }: { userData: FormattedUser }) => {
       <div className="flex flex-col items-center space-y-4 sm:flex-row sm:items-start sm:space-x-6 sm:space-y-0">
         <Avatar className="h-24 w-24 ring-2 ring-brand ring-offset-2 dark:ring-offset-background sm:h-28 sm:w-28">
           <AvatarImage
-            src={account.avatar_media_url || '/placeholder.jpg'}
+            src={
+              getHighResolutionAvatarUrl(account.avatar_media_url) ||
+              '/placeholder.jpg'
+            }
             alt={`${account.account_display_name}'s avatar`}
           />
           <AvatarFallback className="text-3xl">

--- a/src/components/ThreadView.test.tsx
+++ b/src/components/ThreadView.test.tsx
@@ -1,0 +1,56 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import ThreadView from './ThreadView'
+import type { ConversationTree, ThreadTweet } from '@/lib/threadUtils'
+
+jest.mock('./TweetComponent', () => ({
+  __esModule: true,
+  default: ({ tweet }: { tweet: { full_text: string } }) => (
+    <div>{tweet.full_text}</div>
+  ),
+}))
+
+const tweet = (
+  tweetId: string,
+  replyToTweetId: string | null,
+): ThreadTweet => ({
+  tweet_id: tweetId,
+  account_id: '1',
+  created_at: `2026-08-10T12:0${tweetId}:00.000Z`,
+  full_text: `tweet ${tweetId}`,
+  retweet_count: 0,
+  favorite_count: 0,
+  reply_to_tweet_id: replyToTweetId,
+  reply_to_user_id: replyToTweetId ? '1' : null,
+  reply_to_username: replyToTweetId ? 'alice' : null,
+  username: 'alice',
+  account_display_name: 'Alice',
+})
+
+describe('ThreadView', () => {
+  test('uses one fixed reply rail instead of progressively narrowing deep threads', () => {
+    const tree: ConversationTree = {
+      root: '1',
+      roots: ['1'],
+      tweets: {
+        '1': tweet('1', null),
+        '2': tweet('2', '1'),
+        '3': tweet('3', '2'),
+        '4': tweet('4', '3'),
+      },
+      children: { '1': ['2'], '2': ['3'], '3': ['4'], '4': [] },
+      parents: { '2': '1', '3': '2', '4': '3' },
+      paths: { '4': ['1', '2', '3', '4'] },
+    }
+
+    const { container } = render(<ThreadView tree={tree} />)
+    const containers = container.querySelectorAll('.thread-tweet-container')
+
+    expect(screen.getByText('tweet 4')).toBeVisible()
+    expect(containers).toHaveLength(4)
+    expect(containers[0]).not.toHaveClass('border-l-2', 'pl-3')
+    expect(containers[1]).toHaveClass('border-l-2', 'pl-3')
+    expect(containers[2]).not.toHaveClass('border-l-2', 'pl-3')
+    expect(containers[3]).not.toHaveClass('border-l-2', 'pl-3')
+  })
+})

--- a/src/components/ThreadView.tsx
+++ b/src/components/ThreadView.tsx
@@ -41,12 +41,12 @@ export const ThreadView: React.FC<ThreadViewProps> = ({
     const tweet = tree.tweets[tweetId]
     const children = tree.children[tweetId] || []
     const isHighlighted = highlightTweetId === tweetId
+    // Descendants inherit this first reply wrapper, keeping the rail visible
+    // without consuming more horizontal space at every level.
+    const replyRail = depth === 1 ? 'border-l-2 border-border pl-3 sm:pl-4' : ''
 
     return (
-      <div
-        key={tweetId}
-        className={`thread-tweet-container ${depth > 0 ? 'ml-3 border-l-2 border-border pl-3 sm:ml-8 sm:pl-4' : ''}`}
-      >
+      <div key={tweetId} className={`thread-tweet-container ${replyRail}`}>
         {tweet.is_deleted_placeholder ? (
           // Tombstone — deleted from the archive AND syndication couldn't find it.
           <div className="mb-4 rounded-lg border border-dashed border-border bg-muted p-4 text-sm italic text-muted-foreground dark:bg-card">

--- a/src/components/TweetCard.test.tsx
+++ b/src/components/TweetCard.test.tsx
@@ -72,6 +72,17 @@ describe('TweetCard', () => {
     expect(screen.queryByText('♥ 8')).not.toBeInTheDocument()
   })
 
+  test('can disable text clamping independently of the card layout', () => {
+    render(<TweetCard tweet={tweet} compact noClamp />)
+
+    expect(
+      screen.getByText('A complete tweet & media with > one encoding layer.'),
+    ).not.toHaveClass('line-clamp-2')
+    expect(screen.getByText('The complete "quoted" tweet.')).not.toHaveClass(
+      'line-clamp-3',
+    )
+  })
+
   test('makes the card clickable while preserving its origin', () => {
     const { container } = render(
       <TweetCard

--- a/src/components/portal/Portal.test.tsx
+++ b/src/components/portal/Portal.test.tsx
@@ -8,7 +8,9 @@ jest.mock('@/components/HomepageSearch', () => ({
 }))
 
 jest.mock('./TweetRow', () => ({
-  TweetRow: ({ tweet }: { tweet: PortalTweet }) => <div>{tweet.text}</div>,
+  TweetRow: ({ tweet, noClamp }: { tweet: PortalTweet; noClamp?: boolean }) => (
+    <div data-no-clamp={String(Boolean(noClamp))}>{tweet.text}</div>
+  ),
 }))
 
 const seedTweet: PortalTweet = {
@@ -179,6 +181,10 @@ describe.each<PortalView>(['home', 'stream'])(
       expect(screen.getByText('preview tweet 5')).toBeInTheDocument()
       expect(screen.getByText('preview tweet 12')).toBeInTheDocument()
       if (view === 'home') {
+        expect(screen.getByText('preview tweet 1')).toHaveAttribute(
+          'data-no-clamp',
+          'true',
+        )
         const preview = screen.getByRole('region', {
           name: 'Live tweet stream',
         })
@@ -189,6 +195,10 @@ describe.each<PortalView>(['home', 'stream'])(
         )
         expect(screen.queryByText('preview tweet 13')).not.toBeInTheDocument()
       } else {
+        expect(screen.getByText('preview tweet 1')).toHaveAttribute(
+          'data-no-clamp',
+          'false',
+        )
         expect(
           screen.queryByRole('region', { name: 'Live tweet stream' }),
         ).not.toBeInTheDocument()

--- a/src/components/portal/Portal.tsx
+++ b/src/components/portal/Portal.tsx
@@ -668,6 +668,7 @@ export default function Portal({
                       key={t.id}
                       tweet={t}
                       compact
+                      noClamp
                       animate={i === 0}
                       clickable
                       origin="home"

--- a/src/components/portal/TweetRow.tsx
+++ b/src/components/portal/TweetRow.tsx
@@ -146,12 +146,14 @@ function QuotedTweet({
   tweet,
   compact,
   summary,
+  noClamp,
   origin,
   returnTo,
 }: {
   tweet: PortalQuotedTweet
   compact: boolean
   summary: boolean
+  noClamp: boolean
   origin?: TweetOrigin
   returnTo?: string
 }) {
@@ -181,7 +183,7 @@ function QuotedTweet({
           </div>
         </div>
         <div
-          className={`${condensed ? 'line-clamp-3' : ''} mt-1.5 whitespace-pre-wrap break-words text-[13px] leading-relaxed text-zinc-700 dark:text-[#d9d9de]`}
+          className={`${condensed && !noClamp ? 'line-clamp-3' : ''} mt-1.5 whitespace-pre-wrap break-words text-[13px] leading-relaxed text-zinc-700 dark:text-[#d9d9de]`}
         >
           {decodeTweetText(tweet.text)}
         </div>
@@ -208,6 +210,7 @@ export interface TweetCardProps {
   animate?: boolean
   compact?: boolean
   collapsible?: boolean
+  noClamp?: boolean
   featuredRank?: number
   showDate?: boolean
   showArchivedBadge?: boolean
@@ -252,6 +255,7 @@ export function TweetRow({
   animate = false,
   compact = false,
   collapsible = false,
+  noClamp = false,
   featuredRank,
   showDate = false,
   showArchivedBadge = false,
@@ -262,7 +266,7 @@ export function TweetRow({
 }: TweetCardProps) {
   const router = useRouter()
   const [isExpanded, setIsExpanded] = useState(false)
-  const canExpand = collapsible && tweet.text.length > 280
+  const canExpand = collapsible && !noClamp && tweet.text.length > 280
   const href = tweetPermalinkHref(tweet.id, origin, returnTo)
   const isFeatured = featuredRank !== undefined
   const isClickable = clickable || isFeatured
@@ -306,10 +310,18 @@ export function TweetRow({
       <div
         className={`mt-0.5 leading-relaxed text-zinc-700 dark:text-[#d9d9de] ${
           compact
-            ? 'line-clamp-2 text-[13.5px]'
-            : `${isFeatured ? 'text-[14.5px]' : 'text-[14px]'} ${
-                canExpand && !isExpanded ? 'line-clamp-5' : ''
-              }`
+            ? 'text-[13.5px]'
+            : isFeatured
+              ? 'text-[14.5px]'
+              : 'text-[14px]'
+        } ${
+          noClamp
+            ? ''
+            : compact
+              ? 'line-clamp-2'
+              : canExpand && !isExpanded
+                ? 'line-clamp-5'
+                : ''
         }`}
       >
         {decodeTweetText(tweet.text)}
@@ -341,6 +353,7 @@ export function TweetRow({
           tweet={tweet.quotedTweet}
           compact={compact}
           summary={quotedTweetDisplay === 'summary'}
+          noClamp={noClamp}
           origin={origin}
           returnTo={returnTo}
         />

--- a/src/lib/avatar.test.ts
+++ b/src/lib/avatar.test.ts
@@ -1,4 +1,34 @@
-import { getLatestAvatarMediaUrl } from './avatar'
+import { getHighResolutionAvatarUrl, getLatestAvatarMediaUrl } from './avatar'
+
+describe('getHighResolutionAvatarUrl', () => {
+  it('upgrades stored Twitter thumbnail suffixes', () => {
+    expect(
+      getHighResolutionAvatarUrl(
+        'https://pbs.twimg.com/profile_images/123/avatar_normal.jpg',
+      ),
+    ).toBe('https://pbs.twimg.com/profile_images/123/avatar_400x400.jpg')
+    expect(
+      getHighResolutionAvatarUrl(
+        'https://pbs.twimg.com/profile_images/123/avatar_200x200.png',
+      ),
+    ).toBe('https://pbs.twimg.com/profile_images/123/avatar_400x400.png')
+  })
+
+  it('upgrades a pbs.twimg.com query-size request', () => {
+    expect(
+      getHighResolutionAvatarUrl(
+        'https://pbs.twimg.com/profile_images/123/avatar.jpg?name=small',
+      ),
+    ).toBe('https://pbs.twimg.com/profile_images/123/avatar.jpg?name=400x400')
+  })
+
+  it('leaves URLs without a known thumbnail marker unchanged', () => {
+    expect(getHighResolutionAvatarUrl('https://example.com/avatar.jpg')).toBe(
+      'https://example.com/avatar.jpg',
+    )
+    expect(getHighResolutionAvatarUrl(null)).toBeUndefined()
+  })
+})
 
 describe('getLatestAvatarMediaUrl', () => {
   it('reads an embedded one-to-one profile object', () => {

--- a/src/lib/avatar.ts
+++ b/src/lib/avatar.ts
@@ -3,6 +3,43 @@ export type AvatarProfile = {
   archive_upload_id?: number | null
 }
 
+const TWITTER_AVATAR_SIZE_SUFFIX =
+  /_(?:normal|bigger|mini|200x200)(?=\.[a-z0-9]+(?:[?#]|$))/i
+
+/**
+ * Requests Twitter's larger profile image variant when the stored URL points
+ * at one of its thumbnail variants. URLs without a known size marker are
+ * already the best available source and are returned unchanged.
+ */
+export function getHighResolutionAvatarUrl(
+  avatarMediaUrl: string | null | undefined,
+): string | undefined {
+  if (!avatarMediaUrl) return undefined
+
+  const upgradedSuffix = avatarMediaUrl.replace(
+    TWITTER_AVATAR_SIZE_SUFFIX,
+    '_400x400',
+  )
+  if (upgradedSuffix !== avatarMediaUrl) return upgradedSuffix
+
+  try {
+    const url = new URL(avatarMediaUrl)
+    const requestedSize = url.searchParams.get('name')
+    if (
+      url.hostname === 'pbs.twimg.com' &&
+      requestedSize &&
+      ['normal', 'small', 'medium', '200x200'].includes(requestedSize)
+    ) {
+      url.searchParams.set('name', '400x400')
+      return url.toString()
+    }
+  } catch {
+    // Stored avatar values can be relative URLs. Leave unknown forms intact.
+  }
+
+  return avatarMediaUrl
+}
+
 export function getLatestAvatarMediaUrl(
   profile: AvatarProfile | AvatarProfile[] | null | undefined,
 ): string | undefined {


### PR DESCRIPTION
## What changed

- add a reusable `noClamp` tweet-card option and enable it for the homepage live stream, including embedded quoted tweet text
- request Twitter's 400x400 avatar variant for the large profile-page image while leaving small avatars unchanged
- keep one fixed reply rail for nested threads so deep conversations no longer lose horizontal space at every level
- add focused coverage for all three behaviors

## Why

Homepage stream tweets were truncated by the compact card layout, profile hero images reused low-resolution thumbnail URLs, and recursive reply indentation progressively squeezed deeply nested threads.

## Validation

- `pnpm exec jest --selectProjects client --runInBand src/components/TweetCard.test.tsx src/components/portal/Portal.test.tsx src/components/ThreadView.test.tsx`
- `pnpm exec jest --selectProjects server --runInBand src/lib/avatar.test.ts`
- `pnpm type-check`
- `pnpm lint` (passes with one pre-existing `<img>` warning in `UnifiedTweetList.test.tsx`)

Closes #558
Closes #590
Closes #586
