### PR TITLE
Require login for raw archive downloads

### DIFF
--- a/src/app/user/[account_id]/DownloadArchiveButton.test.tsx
+++ b/src/app/user/[account_id]/DownloadArchiveButton.test.tsx
@@ -1,0 +1,48 @@
+/** @jest-environment jsdom */
+
+import React from 'react'
+import '@testing-library/jest-dom'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { DownloadArchiveButton } from './DownloadArchiveButton'
+;(globalThis as typeof globalThis & { React: typeof React }).React = React
+
+const download = jest.fn()
+const from = jest.fn(() => ({ download }))
+
+jest.mock('@/utils/supabase', () => ({
+  createBrowserClient: () => ({ storage: { from } }),
+}))
+
+describe('DownloadArchiveButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    download.mockResolvedValue({
+      data: new Blob(['archive']),
+      error: null,
+    })
+    window.URL.createObjectURL = jest.fn(() => 'blob:archive')
+    window.URL.revokeObjectURL = jest.fn()
+    jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('downloads through authenticated Supabase storage', async () => {
+    const user = userEvent.setup()
+    render(<DownloadArchiveButton username="ArchiveMember" />)
+
+    await user.click(
+      screen.getByRole('button', { name: /download raw archive/i }),
+    )
+
+    await waitFor(() => {
+      expect(from).toHaveBeenCalledWith('archives')
+      expect(download).toHaveBeenCalledWith('archivemember/archive.json')
+    })
+    expect(window.URL.createObjectURL).toHaveBeenCalled()
+    expect(window.URL.revokeObjectURL).toHaveBeenCalledWith('blob:archive')
+  })
+})

--- a/src/app/user/[account_id]/DownloadArchiveButton.tsx
+++ b/src/app/user/[account_id]/DownloadArchiveButton.tsx
@@ -2,15 +2,17 @@
 
 import { Button } from '@/components/ui/button'
 import { FileDown } from 'lucide-react'
+import { createBrowserClient } from '@/utils/supabase'
 
 export function DownloadArchiveButton({ username }: { username: string }) {
-  const archiveUrl = `https://fabxmporizzqflnftavs.supabase.co/storage/v1/object/public/archives/${username.toLowerCase()}/archive.json`
-
   const handleDownload = async () => {
     try {
-      // Fetch the file
-      const response = await fetch(archiveUrl)
-      const blob = await response.blob()
+      const supabase = createBrowserClient()
+      const { data: blob, error } = await supabase.storage
+        .from('archives')
+        .download(`${username.toLowerCase()}/archive.json`)
+
+      if (error) throw error
 
       // Create a temporary link element
       const downloadUrl = window.URL.createObjectURL(blob)
@@ -41,7 +43,8 @@ export function DownloadArchiveButton({ username }: { username: string }) {
         Download Raw Archive
       </Button>
       <p className="mt-1 text-xs text-muted-foreground">
-        Downloads the complete Twitter archive in JSON format
+        Downloads the complete Twitter archive in JSON format. Sign-in is
+        required.
       </p>
     </div>
   )

--- a/src/app/user/[account_id]/page.tsx
+++ b/src/app/user/[account_id]/page.tsx
@@ -17,6 +17,8 @@ import TweetList from '@/components/TweetList'
 import { FilterCriteria } from '@/lib/queries/tweetQueries'
 import { Archive, Radio } from 'lucide-react'
 import { getHighResolutionAvatarUrl } from '@/lib/avatar'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
 
 // Style constants (glows removed)
 const unifiedDeepBlueBase = 'bg-card dark:bg-background'
@@ -24,7 +26,15 @@ const sectionPaddingClasses = 'py-12 md:py-16 lg:py-20'
 const contentWrapperClasses =
   'w-full max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10'
 
-const UserProfile = ({ userData }: { userData: FormattedUser }) => {
+const UserProfile = ({
+  userData,
+  isAuthenticated,
+  returnPath,
+}: {
+  userData: FormattedUser
+  isAuthenticated: boolean
+  returnPath: string
+}) => {
   const account = userData
   return (
     // Profile info card - Removed shadow
@@ -116,7 +126,22 @@ const UserProfile = ({ userData }: { userData: FormattedUser }) => {
       </div>
       {account.has_archive && (
         <div className="mt-6 text-center sm:text-left">
-          <DownloadArchiveButton username={account.username} />
+          {isAuthenticated ? (
+            <DownloadArchiveButton username={account.username} />
+          ) : (
+            <div className="mt-4">
+              <Button asChild variant="outline">
+                <Link
+                  href={`/login?redirect=${encodeURIComponent(returnPath)}`}
+                >
+                  Sign in to download raw archive
+                </Link>
+              </Button>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Raw archive downloads require an account.
+              </p>
+            </div>
+          )}
         </div>
       )}
     </div>
@@ -132,7 +157,10 @@ export default async function User({
   const cookieStore = cookies()
   const supabase = createServerClient(cookieStore)
 
-  const userData = await getUserData(supabase, account_id)
+  const [userData, authResult] = await Promise.all([
+    getUserData(supabase, account_id),
+    supabase.auth.getUser(),
+  ])
 
   if (!userData) {
     // Styled error message for consistency - Removed glow and shadow
@@ -193,7 +221,11 @@ export default async function User({
             <Skeleton className="h-60 w-full rounded-lg bg-muted p-8 dark:bg-card" />
           }
         >
-          <UserProfile userData={userData} />
+          <UserProfile
+            userData={userData}
+            isAuthenticated={Boolean(authResult.data.user)}
+            returnPath={`/user/${account_id}`}
+          />
         </Suspense>
 
         {showingSummaryData && (

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -39,7 +39,7 @@ pop3_port = 54326
 file_size_limit = "5000MiB"
 
 [storage.buckets.archives]
-public = true
+public = false
 file_size_limit = "5000MiB"
 # objects_path = "../data/local_seed/archives"
 

--- a/supabase/migrations/20260812104500_require_login_for_archive_downloads.sql
+++ b/supabase/migrations/20260812104500_require_login_for_archive_downloads.sql
@@ -1,0 +1,20 @@
+-- Raw user archives contain the complete uploaded JSON and must not be
+-- downloadable anonymously. Upload/update/delete policies remain scoped to
+-- the archive owner; this policy permits downloads only with a valid session.
+
+BEGIN;
+
+UPDATE storage.buckets
+SET public = false
+WHERE id = 'archives';
+
+DROP POLICY IF EXISTS "Archives are publicly readable" ON storage.objects;
+DROP POLICY IF EXISTS "Authenticated users can read archives" ON storage.objects;
+
+CREATE POLICY "Authenticated users can read archives"
+ON storage.objects
+FOR SELECT
+TO authenticated
+USING (bucket_id = 'archives');
+
+COMMIT;

--- a/supabase/schemas/060_policies.sql
+++ b/supabase/schemas/060_policies.sql
@@ -1,10 +1,11 @@
 -- Row Level Security policies and enablement
 
--- Storage policies for the public archives bucket. Writes are restricted to
+-- Storage policies for the private archives bucket. Any signed-in Community
+-- Archive user may download raw archives, while writes remain restricted to
 -- the folder named by trusted, server-controlled app_metadata; the upload
 -- client derives the same name from its verified Twitter identity (#372).
-CREATE POLICY "Archives are publicly readable" ON "storage"."objects"
-  FOR SELECT TO public
+CREATE POLICY "Authenticated users can read archives" ON "storage"."objects"
+  FOR SELECT TO "authenticated"
   USING (("bucket_id" = 'archives'::"text"));
 
 CREATE POLICY "Users can upload their own archive" ON "storage"."objects"


### PR DESCRIPTION
## What changed

- makes the `archives` storage bucket private in the migration and local Supabase config
- replaces anonymous public URLs with authenticated Supabase Storage downloads
- shows logged-out profile visitors a sign-in CTA with a return path
- updates the declarative storage policy to match the migration
- preserves the existing owner-scoped upload, update, and delete policies

## Why

Raw user archives contain the complete uploaded JSON. The UI previously fetched a public bucket URL, so hiding the button alone would not enforce the login requirement. This changes the actual storage boundary. The intended product rule allows any signed-in Community Archive user to download an archive; write access remains owner-scoped.

## Rollout

The automatic PR workflow replayed the migration successfully against staging. Apply `20260812104500_require_login_for_archive_downloads.sql` to production before deploying the frontend. Verify an anonymous public object URL fails, an authenticated download succeeds, and an authenticated owner can still upload, update, and delete their archive. This agent did not apply the production migration, merge, or deploy.

## Validation

- focused client test passes: 1 test
- TypeScript passes
- lint passes with one pre-existing unrelated test-image warning
- focused TypeScript formatting passes
- declarative policy and local bucket config match the migration
- migration safely replaces either the legacy public policy or an already-loaded declarative authenticated policy during clean staging replay
- `git diff --check` passes
- GitHub Pull Request Workflow passes
- staging database sync passes
- Supabase Preview passes
- Vercel passes

Initial CI note: the first GitHub Actions failure was an external Supabase CLI postinstall download failure after GitHub returned HTTP 503. A subsequent staging replay exposed the duplicate-policy ordering case, which this revision fixes idempotently.

Not run locally: production policy smoke queries and `pnpm migrations:check` require unavailable production database credentials. Production remains unchanged.

Progress on #498. Related to #589.