### PR TITLE
Improve Bangers filters, loading feedback, and layout

### DIFF
--- a/src/app/bangers/page.tsx
+++ b/src/app/bangers/page.tsx
@@ -7,7 +7,6 @@ import { getInitialPortalBangersPage } from '@/lib/portal/data'
 import type {
   PortalBangersPeriod,
   PortalBangersScope,
-  PortalBangersSort,
 } from '@/lib/portal/types'
 
 export const metadata = { title: 'Bangers · Community Archive' }
@@ -25,8 +24,7 @@ export default async function BangersPage({
   searchParams: BangersSearchParams
 }) {
   if (!(await getIsMember())) redirect('/')
-  const sort: PortalBangersSort =
-    paramValue(searchParams.sort) === 'recent' ? 'recent' : 'quotes'
+  const sort = 'quotes' as const
   const scope: PortalBangersScope =
     paramValue(searchParams.scope) === 'members' ? 'members' : 'all'
   const periodValue = paramValue(searchParams.period)

--- a/src/components/portal/BangersExplorer.test.tsx
+++ b/src/components/portal/BangersExplorer.test.tsx
@@ -130,7 +130,7 @@ describe('BangersExplorer', () => {
     jest.restoreAllMocks()
   })
 
-  test('defaults to Best of all time and orders the controls by intent', () => {
+  test('defaults to Best of all time without a separate rank control', () => {
     renderExplorer()
 
     const orderedMasonryItems = Array.from(
@@ -150,18 +150,14 @@ describe('BangersExplorer', () => {
         (item) => within(item).getByTestId('tweet-row').dataset.rank,
       ),
     ).toEqual(['1', '2', '3'])
-    expect(screen.getByRole('link', { name: 'Best' })).toHaveAttribute(
-      'aria-current',
-      'page',
-    )
-    expect(screen.getByRole('link', { name: 'Best' })).toHaveAttribute(
-      'href',
-      '/bangers?period=all',
-    )
-    expect(screen.getByRole('link', { name: 'Recent' })).toHaveAttribute(
-      'href',
-      '/bangers?sort=recent&period=all',
-    )
+    expect(
+      screen.getByRole('heading', { name: 'Best of all time' }),
+    ).toBeVisible()
+    expect(screen.queryByText('Rank')).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Best' })).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: 'Recent' }),
+    ).not.toBeInTheDocument()
     expect(
       screen.getByRole('link', { name: 'Archive members' }),
     ).toHaveAttribute('href', '/bangers?scope=members&period=all')
@@ -169,50 +165,43 @@ describe('BangersExplorer', () => {
       screen.getByRole('combobox', { name: 'Filter by time' }),
     ).toHaveTextContent('All time')
     const when = screen.getByText('When')
-    const rank = screen.getByText('Rank')
     const tweetsBy = screen.getByText('Tweets by')
     expect(
-      when.compareDocumentPosition(rank) & Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy()
-    expect(
-      rank.compareDocumentPosition(tweetsBy) & Node.DOCUMENT_POSITION_FOLLOWING,
+      when.compareDocumentPosition(tweetsBy) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy()
     expect(screen.queryByText('Likes')).not.toBeInTheDocument()
     expect(screen.queryByText('Reposts')).not.toBeInTheDocument()
     expect(screen.getByTestId('bangers-masonry')).toHaveClass(
-      'flex',
-      'lg:grid',
-      'lg:grid-cols-2',
+      'columns-1',
+      'lg:columns-2',
+      'xl:columns-3',
     )
     expect(
-      within(screen.getByTestId('bangers-masonry-column-0'))
-        .getAllByTestId('tweet-row')
-        .map((row) => row.dataset.rank),
-    ).toEqual(['1', '3'])
-    expect(
-      within(screen.getByTestId('bangers-masonry-column-1'))
-        .getAllByTestId('tweet-row')
-        .map((row) => row.dataset.rank),
-    ).toEqual(['2'])
+      screen.getAllByTestId('tweet-row').map((row) => row.dataset.rank),
+    ).toEqual(['1', '2', '3'])
     expect(
       orderedMasonryItems.map((item) => item.dataset.masonryOrder),
     ).toEqual(['1', '2', '3'])
   })
 
-  test('keeps today selected across ranking and author links', () => {
+  test('keeps today selected across author links', () => {
     renderExplorer(page(), 'today')
 
     expect(
       screen.getByRole('combobox', { name: 'Filter by time' }),
     ).toHaveTextContent('Today')
-    expect(screen.getByRole('link', { name: 'Recent' })).toHaveAttribute(
-      'href',
-      '/bangers?sort=recent&period=today',
-    )
     expect(
       screen.getByRole('link', { name: 'Archive members' }),
     ).toHaveAttribute('href', '/bangers?scope=members&period=today')
     expect(screen.getByText(/from the last 24 hours/)).toBeVisible()
+  })
+
+  test('makes the active seven-day window unmistakable', () => {
+    renderExplorer(page(), 'week')
+
+    expect(
+      screen.getByRole('heading', { name: 'Best of the last 7 days' }),
+    ).toBeVisible()
   })
 
   test('orders all time above today and offers the last three months', async () => {
@@ -230,20 +219,51 @@ describe('BangersExplorer', () => {
     ])
   })
 
-  test('explains the Best ranking on hover and keyboard focus', async () => {
+  test('shows a pending state while navigating to another time range', async () => {
     const user = userEvent.setup()
     renderExplorer()
 
-    const best = screen.getByRole('link', { name: 'Best' })
-    await user.hover(best)
+    const timeFilter = screen.getByRole('combobox', {
+      name: 'Filter by time',
+    })
+    await user.click(timeFilter)
+    await user.click(screen.getByRole('option', { name: 'Last 7 days' }))
 
-    expect(await screen.findByRole('tooltip')).toHaveTextContent(
-      /Best means most quoted by distinct archive uploaders/i,
+    expect(push).toHaveBeenCalledWith('/bangers?period=week')
+    expect(screen.getByText('Loading bangers…')).toBeVisible()
+    expect(timeFilter).toBeDisabled()
+  })
+
+  test('preserves modified-click behavior on author scope links', () => {
+    renderExplorer()
+
+    let defaultPreventedBeforeTestCleanup: boolean | undefined
+    document.addEventListener(
+      'click',
+      (event) => {
+        defaultPreventedBeforeTestCleanup = event.defaultPrevented
+        event.preventDefault()
+      },
+      { once: true },
     )
+    fireEvent.click(screen.getByRole('link', { name: 'Archive members' }), {
+      metaKey: true,
+    })
 
-    await user.unhover(best)
-    best.focus()
-    expect(await screen.findByRole('tooltip')).toBeVisible()
+    expect(defaultPreventedBeforeTestCleanup).toBe(false)
+    expect(screen.queryByText('Loading bangers…')).not.toBeInTheDocument()
+    expect(push).not.toHaveBeenCalled()
+  })
+
+  test('shows a pending state for ordinary author scope navigation', () => {
+    renderExplorer()
+
+    document.addEventListener('click', (event) => event.preventDefault(), {
+      once: true,
+    })
+    fireEvent.click(screen.getByRole('link', { name: 'Archive members' }))
+
+    expect(screen.getByText('Loading bangers…')).toBeVisible()
   })
 
   test('searches names and text and can clear the result', () => {
@@ -291,7 +311,7 @@ describe('BangersExplorer', () => {
     expect(screen.getByText('All 4 matching bangers loaded.')).toBeVisible()
   })
 
-  test('loads more when either masonry column reaches its end', async () => {
+  test('loads more when the masonry approaches its end', async () => {
     const nextTweet = tweet('4', 'Loaded from the short column', 2026, 2, 8)
     jest.spyOn(global, 'fetch').mockResolvedValue({
       ok: true,
@@ -300,13 +320,13 @@ describe('BangersExplorer', () => {
     renderExplorer(page(tweets, 3, 4))
 
     const observer = IntersectionObserverMock.instances.at(-1)
-    const shortColumnSentinel = screen.getByTestId('bangers-column-sentinel-1')
-    expect(observer?.observed).toContain(shortColumnSentinel)
+    const masonrySentinel = screen.getByTestId('bangers-load-more-sentinel')
+    expect(observer?.observed).toContain(masonrySentinel)
     act(() => {
       observer?.callback(
         [
           {
-            target: shortColumnSentinel,
+            target: masonrySentinel,
             isIntersecting: true,
           } as unknown as IntersectionObserverEntry,
         ],

--- a/src/components/portal/BangersExplorer.tsx
+++ b/src/components/portal/BangersExplorer.tsx
@@ -12,12 +12,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
 import type {
   PortalBangersPage,
   PortalBangersPeriod,
@@ -55,6 +49,20 @@ function matchesQuery(tweet: PortalTweet, query: string): boolean {
 
 function dedupeTweets(tweets: PortalTweet[]): PortalTweet[] {
   return Array.from(new Map(tweets.map((tweet) => [tweet.id, tweet])).values())
+}
+
+function bangersHeading({
+  year,
+  period,
+}: {
+  year?: number
+  period?: PortalBangersPeriod
+}): string {
+  if (period === 'today') return 'Best of the last 24 hours'
+  if (period === 'week') return 'Best of the last 7 days'
+  if (period === 'three-months') return 'Best of the last 3 months'
+  if (year !== undefined) return `Best of ${year}`
+  return 'Best of all time'
 }
 
 function bangersHref({
@@ -126,12 +134,12 @@ export function BangersExplorer({
   const [loadedQuery, setLoadedQuery] = useState(initialQuery.trim())
   const [page, setPage] = useState(initialPage)
   const [isLoading, setIsLoading] = useState(false)
+  const [isNavigating, setIsNavigating] = useState(false)
   const [loadError, setLoadError] = useState<string | null>(null)
   const loadingRef = useRef(false)
   const requestVersionRef = useRef(0)
   const requestControllerRef = useRef<AbortController | null>(null)
   const loadMoreRef = useRef<HTMLDivElement | null>(null)
-  const columnLoadMoreRefs = useRef<Array<HTMLDivElement | null>>([])
   const isAllTime = allTime || (period === undefined && year === undefined)
 
   const availableYears = useMemo(() => {
@@ -151,22 +159,6 @@ export function BangersExplorer({
   const visibleTweets = useMemo(
     () => page.tweets.filter((tweet) => matchesQuery(tweet, query)),
     [page.tweets, query],
-  )
-  const masonryColumns = useMemo(
-    () =>
-      visibleTweets.reduce<
-        [
-          Array<{ tweet: PortalTweet; order: number }>,
-          Array<{ tweet: PortalTweet; order: number }>,
-        ]
-      >(
-        (columns, tweet, order) => {
-          columns[order % 2].push({ tweet, order })
-          return columns
-        },
-        [[], []],
-      ),
-    [visibleTweets],
   )
   const tweetRanks = useMemo(
     () =>
@@ -263,17 +255,15 @@ export function BangersExplorer({
   }, [loadedQuery, query, requestPage])
 
   useEffect(() => {
-    const targets = [loadMoreRef.current, ...columnLoadMoreRefs.current].filter(
-      (target): target is HTMLDivElement => Boolean(target),
-    )
-    if (targets.length === 0 || page.pagination.nextOffset === null) return
+    const target = loadMoreRef.current
+    if (!target || page.pagination.nextOffset === null) return
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries.some((entry) => entry.isIntersecting)) loadMore()
       },
       { rootMargin: '700px 0px' },
     )
-    targets.forEach((target) => observer.observe(target))
+    observer.observe(target)
     return () => observer.disconnect()
   }, [loadMore, page.pagination.nextOffset])
 
@@ -283,6 +273,10 @@ export function BangersExplorer({
     },
     [],
   )
+
+  useEffect(() => {
+    setIsNavigating(false)
+  }, [allTime, period, scope, sort, year])
 
   useEffect(() => {
     const nextUrl = bangersHref({
@@ -302,6 +296,7 @@ export function BangersExplorer({
   const clearFilters = () => {
     setQuery('')
     if (year !== undefined || period !== undefined) {
+      setIsNavigating(true)
       router.push(bangersHref({ query: '', scope, sort, allTime: true }))
     }
   }
@@ -316,7 +311,6 @@ export function BangersExplorer({
     period,
     allTime: isAllTime,
   })
-
   return (
     <section aria-label="Browse bangers">
       <div className={`${CARD} mb-6 p-4 shadow-sm sm:p-5`}>
@@ -370,6 +364,7 @@ export function BangersExplorer({
                 const nextYear = value.startsWith('year-')
                   ? Number(value.slice(5))
                   : undefined
+                setIsNavigating(true)
                 router.push(
                   bangersHref({
                     query,
@@ -384,9 +379,17 @@ export function BangersExplorer({
             >
               <SelectTrigger
                 aria-label="Filter by time"
-                className="h-9 w-[132px] rounded-[3px] border-zinc-300 bg-transparent px-3 text-[12px] font-semibold shadow-none focus:ring-brand/30 focus:ring-offset-0 dark:border-[#3a3a40]"
+                aria-busy={isNavigating}
+                disabled={isNavigating}
+                className="h-9 w-[148px] rounded-[3px] border-zinc-300 bg-transparent px-3 text-[12px] font-semibold shadow-none focus:ring-brand/30 focus:ring-offset-0 dark:border-[#3a3a40]"
               >
                 <SelectValue />
+                {isNavigating ? (
+                  <Loader2
+                    aria-label="Loading bangers"
+                    className="ml-auto h-3.5 w-3.5 animate-spin"
+                  />
+                ) : null}
               </SelectTrigger>
               <SelectContent className="rounded-[3px]">
                 <SelectItem value="all">All time</SelectItem>
@@ -410,63 +413,6 @@ export function BangersExplorer({
               <span
                 className={`mb-1.5 block text-[11px] font-bold uppercase tracking-[0.08em] ${MUTED}`}
               >
-                Rank
-              </span>
-              <div className="flex">
-                <TooltipProvider delayDuration={150}>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Link
-                        href={bangersHref({
-                          query,
-                          scope,
-                          sort: 'quotes',
-                          year,
-                          period,
-                          allTime: isAllTime,
-                        })}
-                        aria-current={sort === 'quotes' ? 'page' : undefined}
-                        className={`${segmentClassName} rounded-l-[3px] ${
-                          sort === 'quotes'
-                            ? activeSegmentClassName
-                            : idleSegmentClassName
-                        }`}
-                      >
-                        Best
-                      </Link>
-                    </TooltipTrigger>
-                    <TooltipContent side="top" className="max-w-xs text-xs">
-                      Best means most quoted by distinct archive uploaders and
-                      opted-in members. Quotes by the original author do not
-                      count.
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-                <Link
-                  href={bangersHref({
-                    query,
-                    scope,
-                    sort: 'recent',
-                    year,
-                    period,
-                    allTime: isAllTime,
-                  })}
-                  aria-current={sort === 'recent' ? 'page' : undefined}
-                  className={`${segmentClassName} -ml-px rounded-r-[3px] ${
-                    sort === 'recent'
-                      ? activeSegmentClassName
-                      : idleSegmentClassName
-                  }`}
-                >
-                  Recent
-                </Link>
-              </div>
-            </div>
-
-            <div>
-              <span
-                className={`mb-1.5 block text-[11px] font-bold uppercase tracking-[0.08em] ${MUTED}`}
-              >
                 Tweets by
               </span>
               <div className="flex">
@@ -479,6 +425,19 @@ export function BangersExplorer({
                     period,
                     allTime: isAllTime,
                   })}
+                  onClick={(event) => {
+                    const href = event.currentTarget.getAttribute('href')
+                    if (
+                      event.button === 0 &&
+                      !event.metaKey &&
+                      !event.ctrlKey &&
+                      !event.shiftKey &&
+                      !event.altKey &&
+                      href !== currentReturnTo
+                    ) {
+                      setIsNavigating(true)
+                    }
+                  }}
                   aria-current={scope === 'all' ? 'page' : undefined}
                   className={`${segmentClassName} rounded-l-[3px] ${
                     scope === 'all'
@@ -497,6 +456,19 @@ export function BangersExplorer({
                     period,
                     allTime: isAllTime,
                   })}
+                  onClick={(event) => {
+                    const href = event.currentTarget.getAttribute('href')
+                    if (
+                      event.button === 0 &&
+                      !event.metaKey &&
+                      !event.ctrlKey &&
+                      !event.shiftKey &&
+                      !event.altKey &&
+                      href !== currentReturnTo
+                    ) {
+                      setIsNavigating(true)
+                    }
+                  }}
                   aria-current={scope === 'members' ? 'page' : undefined}
                   className={`${segmentClassName} -ml-px rounded-r-[3px] ${
                     scope === 'members'
@@ -512,22 +484,50 @@ export function BangersExplorer({
         </div>
       </div>
 
-      <div className="min-h-7 mb-4 flex flex-wrap items-center justify-between gap-2 px-0.5">
-        <p aria-live="polite" className={`text-[12.5px] tabular-nums ${MUTED}`}>
-          {isSearching
-            ? 'Searching ranked bangers…'
-            : `Showing ${loadedCount.toLocaleString()} of ${totalCount.toLocaleString()} ranked ${totalCount === 1 ? 'tweet' : 'tweets'}`}
-          {!isSearching && period === 'today' ? ' from the last 24 hours' : ''}
-          {!isSearching && period === 'week' ? ' from the last 7 days' : ''}
-          {!isSearching && period === 'three-months'
-            ? ' from the last 3 months'
-            : ''}
-          {!isSearching && !period && year !== undefined ? ` from ${year}` : ''}
-          {!isSearching && loadedQuery ? ` matching “${loadedQuery}”` : ''}
-          {!isSearching && page.pagination.candidateRankingTruncated
-            ? ` · top ${page.pagination.snapshotSize.toLocaleString()} candidate snapshot`
-            : ''}
-        </p>
+      <div className="min-h-12 mb-4 flex flex-wrap items-end justify-between gap-2 px-0.5">
+        <div>
+          <h2 className="text-[19px] font-bold uppercase tracking-[0.035em]">
+            {bangersHeading({ year, period })}
+          </h2>
+          <p
+            aria-live="polite"
+            className={`mt-0.5 inline-flex items-center gap-1.5 text-[12.5px] tabular-nums ${MUTED}`}
+          >
+            {isNavigating ? (
+              <>
+                <Loader2
+                  aria-hidden="true"
+                  className="h-3.5 w-3.5 animate-spin"
+                />
+                Loading bangers…
+              </>
+            ) : isSearching ? (
+              'Searching ranked bangers…'
+            ) : (
+              `Showing ${loadedCount.toLocaleString()} of ${totalCount.toLocaleString()} ranked ${totalCount === 1 ? 'tweet' : 'tweets'}`
+            )}
+            {!isNavigating && !isSearching && period === 'today'
+              ? ' from the last 24 hours'
+              : ''}
+            {!isNavigating && !isSearching && period === 'week'
+              ? ' from the last 7 days'
+              : ''}
+            {!isNavigating && !isSearching && period === 'three-months'
+              ? ' from the last 3 months'
+              : ''}
+            {!isNavigating && !isSearching && !period && year !== undefined
+              ? ` from ${year}`
+              : ''}
+            {!isNavigating && !isSearching && loadedQuery
+              ? ` matching “${loadedQuery}”`
+              : ''}
+            {!isNavigating &&
+            !isSearching &&
+            page.pagination.candidateRankingTruncated
+              ? ` · top ${page.pagination.snapshotSize.toLocaleString()} candidate snapshot`
+              : ''}
+          </p>
+        </div>
         {hasFilters ? (
           <button
             type="button"
@@ -558,38 +558,21 @@ export function BangersExplorer({
       ) : (
         <div
           data-testid="bangers-masonry"
-          className="flex flex-col lg:grid lg:grid-cols-2 lg:items-start lg:gap-5"
+          className="columns-1 gap-5 lg:columns-2 xl:columns-3"
         >
-          {masonryColumns.map((column, columnIndex) => (
+          {visibleTweets.map((tweet, order) => (
             <div
-              key={columnIndex}
-              data-testid={`bangers-masonry-column-${columnIndex}`}
-              className="contents lg:block lg:space-y-6"
+              key={tweet.id}
+              data-masonry-order={order + 1}
+              className="mb-6 break-inside-avoid"
             >
-              {column.map(({ tweet, order }) => (
-                <div
-                  key={tweet.id}
-                  data-masonry-order={order + 1}
-                  className="mb-6 lg:mb-0"
-                  style={{ order }}
-                >
-                  <TweetCard
-                    tweet={tweet}
-                    featuredRank={tweetRanks.get(tweet.id)}
-                    showDate
-                    collapsible
-                    origin="bangers"
-                    returnTo={currentReturnTo}
-                  />
-                </div>
-              ))}
-              <div
-                ref={(element) => {
-                  columnLoadMoreRefs.current[columnIndex] = element
-                }}
-                data-testid={`bangers-column-sentinel-${columnIndex}`}
-                aria-hidden="true"
-                className="hidden h-px lg:block"
+              <TweetCard
+                tweet={tweet}
+                featuredRank={tweetRanks.get(tweet.id)}
+                showDate
+                collapsible
+                origin="bangers"
+                returnTo={currentReturnTo}
               />
             </div>
           ))}
@@ -614,6 +597,7 @@ export function BangersExplorer({
       {page.pagination.nextOffset !== null ? (
         <div
           ref={loadMoreRef}
+          data-testid="bangers-load-more-sentinel"
           className="min-h-20 flex items-center justify-center py-5"
         >
           <button


### PR DESCRIPTION
## Summary

- make Bangers always use the quote-based **Best** ranking, with recency controlled only by the **When** filter
- add a prominent heading such as **Best of the last 7 days**
- show immediate spinner/status feedback while time-range or author-scope navigation is pending
- use responsive masonry columns: one by default, two on desktop, and three on extra-wide screens
- preserve ranked DOM/focus order and standard modified-click behavior on links

## Why

The rank chooser duplicated the purpose of the time filter, slow route changes looked unresponsive, the active seven-day dataset was easy to miss, and wide screens had unused room.

## Verification

- focused BangersExplorer client suite: 11 tests passed
- TypeScript type check
- focused Next.js lint
- Prettier check
- independent code review

Closes #580
Closes #583
Addresses #588 (the duplicate loading report)
Closes #584
Closes #559