### PR TITLE
Unify the public and member homepage access model

### DIFF
--- a/src/app/api/portal/bangers/route.ts
+++ b/src/app/api/portal/bangers/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getIsMember } from '@/lib/portal/auth'
 import {
   getPortalBangersPage,
   PORTAL_BANGERS_PAGE_SIZE,
@@ -13,10 +12,15 @@ import type {
 export const dynamic = 'force-dynamic'
 export const maxDuration = 60
 
-function privateJson(body: unknown, status = 200) {
+function publicJson(body: unknown, status = 200) {
   return NextResponse.json(body, {
     status,
-    headers: { 'Cache-Control': 'private, no-store' },
+    headers: {
+      'Cache-Control':
+        status === 200
+          ? 'public, s-maxage=60, stale-while-revalidate=300'
+          : 'private, no-store',
+    },
   })
 }
 
@@ -36,10 +40,6 @@ function boundedInteger(
 }
 
 export async function GET(request: NextRequest) {
-  if (!(await getIsMember())) {
-    return privateJson({ error: 'Sign in to browse bangers' }, 401)
-  }
-
   try {
     const params = new URL(request.url).searchParams
     const offset = boundedInteger(params.get('offset'), 0, 0, 1_000_000)
@@ -75,7 +75,7 @@ export async function GET(request: NextRequest) {
     const query = (params.get('q') || '').trim()
     if (query.length > 120) throw new Error('Banger search is too long')
 
-    return privateJson(
+    return publicJson(
       await getPortalBangersPage({
         limit: PORTAL_BANGERS_PAGE_SIZE,
         offset,
@@ -91,7 +91,7 @@ export async function GET(request: NextRequest) {
     const isInputError =
       message.startsWith('Invalid') || message === 'Banger search is too long'
     if (!isInputError) console.error('Portal bangers request failed:', error)
-    return privateJson(
+    return publicJson(
       {
         error: isInputError
           ? message

--- a/src/app/bangers/page.tsx
+++ b/src/app/bangers/page.tsx
@@ -1,8 +1,6 @@
 import Link from 'next/link'
-import { redirect } from 'next/navigation'
 import { BangersExplorer } from '@/components/portal/BangersExplorer'
 import { MUTED, SERIF } from '@/components/portal/styles'
-import { getIsMember } from '@/lib/portal/auth'
 import { getInitialPortalBangersPage } from '@/lib/portal/data'
 import type {
   PortalBangersPeriod,
@@ -23,7 +21,6 @@ export default async function BangersPage({
 }: {
   searchParams: BangersSearchParams
 }) {
-  if (!(await getIsMember())) redirect('/')
   const sort = 'quotes' as const
   const scope: PortalBangersScope =
     paramValue(searchParams.scope) === 'members' ? 'members' : 'all'

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,4 @@
 import ClassicHomepage from '@/components/home/ClassicHomepage'
-import Portal from '@/components/portal/Portal'
 import { hasPendingOptInAction } from '@/lib/homepageAccess'
 import { getIsMember } from '@/lib/portal/auth'
 import { getPortalData } from '@/lib/portal/data'
@@ -19,18 +18,12 @@ interface HomepageProps {
 }
 
 export default async function Homepage({ searchParams }: HomepageProps = {}) {
-  // OAuth returns to /?action=optin. Even though the new session makes this
-  // user eligible for the signed-in portal, keep this request on the classic
-  // homepage so HeroCTAButtons can consume and persist the pending consent
-  // action before the portal branch takes over.
-  if (hasPendingOptInAction(searchParams?.action)) {
-    return <ClassicHomepage />
-  }
-
-  if (!(await getIsMember())) {
-    return <ClassicHomepage />
-  }
-
-  const data = await getPortalData()
-  return <Portal data={data} view="home" />
+  const [isMember, data] = await Promise.all([getIsMember(), getPortalData()])
+  return (
+    <ClassicHomepage
+      data={data}
+      isMember={isMember}
+      showCta={!isMember || hasPendingOptInAction(searchParams?.action)}
+    />
+  )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,13 +4,12 @@ import { getIsMember } from '@/lib/portal/auth'
 import { getPortalData } from '@/lib/portal/data'
 
 // The first request after a daily analytics-cache rollover builds the bounded
-// ClickHouse snapshot; subsequent member requests reuse the shared Data Cache.
+// ClickHouse snapshot; subsequent homepage requests reuse the shared Data Cache.
 export const maxDuration = 60
 
-// Signed-in members get the live archive portal; everyone else sees the
-// classic marketing homepage. Auth comes from cookies, so this page renders
-// dynamically — the portal's data layer does its own caching (24h for heavy
-// aggregates, minutes for stats and the initial stream).
+// Guests and members share one homepage/dashboard composition. Authentication
+// only selects the hero action and access links; the portal data layer handles
+// its own caching (24h for heavy aggregates, minutes for stats and the stream).
 interface HomepageProps {
   searchParams?: {
     action?: string | string[]

--- a/src/app/stream/page.tsx
+++ b/src/app/stream/page.tsx
@@ -1,13 +1,10 @@
-import { redirect } from 'next/navigation'
 import Portal from '@/components/portal/Portal'
-import { getIsMember } from '@/lib/portal/auth'
 import { getPortalData } from '@/lib/portal/data'
 
 export const metadata = { title: 'Stream · Community Archive' }
 export const maxDuration = 60
 
 export default async function StreamPage() {
-  if (!(await getIsMember())) redirect('/')
   const data = await getPortalData('stream')
   return <Portal data={data} view="stream" />
 }

--- a/src/app/supporters/page.tsx
+++ b/src/app/supporters/page.tsx
@@ -1,0 +1,93 @@
+import Link from 'next/link'
+import { FaHeart } from 'react-icons/fa'
+import TieredSupportersDisplay from '@/components/TieredSupportersDisplay'
+import { getOpenCollectiveContributors } from '@/lib/supporters'
+
+export const metadata = { title: 'Supporters · Community Archive' }
+
+export default async function SupportersPage() {
+  const contributors = await getOpenCollectiveContributors()
+  const contributorsWithImages = contributors.filter(
+    (contributor) => contributor.image,
+  )
+  const topTenNames = contributors.slice(0, 10).map(({ name }) => name)
+
+  return (
+    <main className="bg-muted py-12 dark:bg-card md:py-16 lg:py-20">
+      <div className="mx-auto w-full max-w-5xl space-y-8 px-4 sm:px-6 lg:px-8">
+        <div className="text-center">
+          <h1 className="text-4xl font-bold text-foreground">Our Supporters</h1>
+          <p className="mt-3 text-base text-muted-foreground">
+            Thanks to everyone who makes the public archive possible.
+          </p>
+        </div>
+
+        <div className="mx-auto max-w-4xl rounded-2xl border border-border bg-card p-6 md:p-8">
+          <div className="mb-6 text-center">
+            <p className="mb-4 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+              Major Backers
+            </p>
+            <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-3">
+              <Link
+                href="https://survivalandflourishing.fund/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium text-muted-foreground transition-colors hover:text-brand"
+              >
+                Survival and Flourishing Fund
+              </Link>
+              <span className="text-muted-foreground">•</span>
+              <Link
+                href="https://x.com/VitalikButerin"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium text-muted-foreground transition-colors hover:text-brand"
+              >
+                Vitalik Buterin via Kanro
+              </Link>
+              <span className="text-muted-foreground">•</span>
+              <Link
+                href="https://x.com/pwang"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium text-muted-foreground transition-colors hover:text-brand"
+              >
+                Peter Wang
+              </Link>
+            </div>
+          </div>
+
+          <div className="my-6 border-t border-border" />
+          <p className="mb-4 text-center text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+            Community Backers
+          </p>
+          <TieredSupportersDisplay
+            highestDonorWithImage={contributorsWithImages[0] ?? null}
+            otherDonorsForStack={contributorsWithImages.slice(1, 10)}
+            topTenNames={topTenNames}
+            additionalSupportersCount={Math.max(
+              0,
+              contributors.length - topTenNames.length,
+            )}
+            totalAmountRaised={contributors.reduce(
+              (sum, contributor) => sum + contributor.totalAmountDonated,
+              0,
+            )}
+            totalSupportersCount={contributors.length}
+          />
+        </div>
+
+        <div className="text-center">
+          <Link
+            href="https://opencollective.com/community-archive/donate"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center justify-center rounded-xl bg-green-600 px-6 py-3 font-medium text-white transition-colors hover:bg-green-700 dark:bg-green-400 dark:text-green-950 dark:hover:bg-green-300"
+          >
+            <FaHeart className="mr-2" /> Support the Project
+          </Link>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/app/trends/page.tsx
+++ b/src/app/trends/page.tsx
@@ -12,7 +12,7 @@ export const metadata = { title: 'Trends · Community Archive' }
 export const maxDuration = 60
 
 export default async function TrendsPage() {
-  if (!(await getIsMember())) redirect('/')
+  if (!(await getIsMember())) redirect('/login?redirect=/trends')
   const initial = await loadPortalComponentData(
     'trends-explorer',
     getPortalTrendSnapshot,

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -15,6 +15,10 @@ const Footer = () => {
         Data Policy
       </Link>
       <span className="mx-2">•</span>
+      <Link href="/supporters" className="hover:underline">
+        Supporters
+      </Link>
+      <span className="mx-2">•</span>
       <Link href="/stream-monitor" className="hover:underline">
         Stream Monitor
       </Link>

--- a/src/components/home/ClassicHomepage.test.tsx
+++ b/src/components/home/ClassicHomepage.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import ClassicHomepage from './ClassicHomepage'
+import type { PortalData } from '@/lib/portal/types'
+import { getTopFollowedAccounts } from '@/lib/clickhouseAnalytics'
+import { createServerClient } from '@/utils/supabase'
+
+jest.mock('next/headers', () => ({ cookies: jest.fn(() => ({})) }))
+jest.mock('next/dynamic', () => {
+  const mockReact = jest.requireActual<typeof import('react')>('react')
+  let dynamicIndex = 0
+  return {
+    __esModule: true,
+    default: () => {
+      const testId = dynamicIndex++ === 0 ? 'hero-cta' : 'archive-upload'
+      return function DynamicStub() {
+        return mockReact.createElement('div', { 'data-testid': testId })
+      }
+    },
+  }
+})
+jest.mock('@/components/HomepageSearch', () => ({
+  __esModule: true,
+  default: () => <div data-testid="homepage-search" />,
+}))
+jest.mock('@/components/AvatarList', () => ({
+  __esModule: true,
+  default: () => <div data-testid="social-proof" />,
+}))
+jest.mock('@/components/home/Testimonials', () => ({
+  __esModule: true,
+  default: () => <div data-testid="testimonials" />,
+}))
+jest.mock('@/components/portal/Portal', () => ({
+  __esModule: true,
+  default: () => <div data-testid="shared-dashboard" />,
+}))
+jest.mock('@/lib/clickhouseAnalytics', () => ({
+  getTopFollowedAccounts: jest.fn(),
+}))
+jest.mock('@/utils/supabase', () => ({ createServerClient: jest.fn() }))
+
+const data = {
+  stats: {
+    totalTweets: 14_000_000,
+    accountCount: 700,
+    streamedLast24Hours: 0,
+    joinedThisWeek: 0,
+    firstYear: 2006,
+    currentYear: 2026,
+    generatedAt: '2026-08-12T00:00:00.000Z',
+  },
+  trends: { years: [], series: [], weekly: [], computedAt: '' },
+  initialStream: [],
+  research: [],
+  recentBangers: [],
+  historicalBangers: [],
+  failures: {
+    liveAnalytics: false,
+    memberCount: false,
+    joinedThisWeek: false,
+    corpusRange: false,
+    trends: false,
+    initialStream: false,
+    research: false,
+    recentBangers: false,
+    historicalBangers: false,
+  },
+} satisfies PortalData
+
+describe('ClassicHomepage audience actions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(getTopFollowedAccounts as jest.Mock).mockResolvedValue([])
+    ;(createServerClient as jest.Mock).mockReturnValue({})
+  })
+
+  it('keeps search above the shared dashboard for signed-in members', async () => {
+    render(await ClassicHomepage({ data, isMember: true, showCta: false }))
+
+    expect(screen.getByTestId('homepage-search')).toBeInTheDocument()
+    expect(screen.queryByTestId('hero-cta')).not.toBeInTheDocument()
+    expect(screen.getByTestId('shared-dashboard')).toBeInTheDocument()
+  })
+
+  it('keeps the CTA above the same dashboard for guests', async () => {
+    render(await ClassicHomepage({ data, isMember: false, showCta: true }))
+
+    expect(screen.getByTestId('hero-cta')).toBeInTheDocument()
+    expect(screen.queryByTestId('homepage-search')).not.toBeInTheDocument()
+    expect(screen.getByTestId('shared-dashboard')).toBeInTheDocument()
+  })
+})

--- a/src/components/home/ClassicHomepage.tsx
+++ b/src/components/home/ClassicHomepage.tsx
@@ -1,28 +1,15 @@
-import { createServerClient } from '@/utils/supabase'
-import { cookies } from 'next/headers'
-import AvatarList from '@/components/AvatarList'
-import { SupabaseClient } from '@supabase/supabase-js'
-import {
-  FaGithub,
-  FaDiscord,
-  FaBook,
-  FaHeart,
-  FaDatabase,
-} from 'react-icons/fa'
-import Link from 'next/link'
-import { getStats } from '@/lib/stats'
-import TieredSupportersDisplay, {
-  Contributor,
-} from '@/components/TieredSupportersDisplay'
 import dynamic from 'next/dynamic'
-import FeaturedAppsSection from '@/components/FeaturedAppsSection'
-import AppGallery from '@/components/AppGallery'
-import HomepageSearch from '@/components/HomepageSearch'
-import { canShowHomepageSearch } from '@/lib/homepageAccess'
+import Link from 'next/link'
+import { cookies } from 'next/headers'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import AvatarList from '@/components/AvatarList'
+import Portal from '@/components/portal/Portal'
+import Testimonials from '@/components/home/Testimonials'
 import { formatNumber } from '@/lib/formatNumber'
 import { getTopFollowedAccounts } from '@/lib/clickhouseAnalytics'
+import type { PortalData } from '@/lib/portal/types'
+import { createServerClient } from '@/utils/supabase'
 
-// Dynamically import client components with ssr disabled
 const DynamicHeroCTAButtons = dynamic(
   () => import('@/components/HeroCTAButtons'),
   {
@@ -48,7 +35,7 @@ const DynamicUploadArchiveSection = dynamic(
 )
 
 const getLegacyMostFollowedAccounts = async (supabase: SupabaseClient) => {
-  let { data, error } = await supabase
+  const { data, error } = await supabase
     .from('global_activity_summary')
     .select('top_accounts_with_followers')
     .single()
@@ -62,7 +49,7 @@ const getLegacyMostFollowedAccounts = async (supabase: SupabaseClient) => {
 
 const getMostFollowedAccounts = async (supabase: SupabaseClient) => {
   try {
-    return await getTopFollowedAccounts(7)
+    return await getTopFollowedAccounts(8)
   } catch (error) {
     console.error(
       'Failed to fetch top accounts from ClickHouse; using the legacy summary:',
@@ -72,191 +59,71 @@ const getMostFollowedAccounts = async (supabase: SupabaseClient) => {
   }
 }
 
-async function getOpenCollectiveContributors(): Promise<Contributor[]> {
-  try {
-    const res = await fetch(
-      'https://opencollective.com/community-archive/members/all.json',
-      { next: { revalidate: 3600 } },
-    )
-    if (!res.ok) {
-      console.error(`Failed to fetch Open Collective data: ${res.status}`)
-      return []
-    }
-    const members: any[] = await res.json()
-
-    members.sort((a, b) => {
-      const amountA =
-        typeof a.totalAmountDonated === 'number' ? a.totalAmountDonated : 0
-      const amountB =
-        typeof b.totalAmountDonated === 'number' ? b.totalAmountDonated : 0
-      if (amountB !== amountA) {
-        return amountB - amountA
-      }
-      return a.name.localeCompare(b.name)
-    })
-
-    return members
-      .filter(
-        (m) =>
-          m.isActive &&
-          m.role !== 'ADMIN' &&
-          (m.role === 'BACKER' ||
-            (m.role === 'MEMBER' &&
-              typeof m.totalAmountDonated === 'number' &&
-              m.totalAmountDonated > 0)),
-      )
-      .map((m) => ({
-        name: m.name,
-        role: m.role,
-        type: m.type,
-        isActive: m.isActive,
-        profile: m.profile,
-        image: m.image || null,
-        slug: m.slug,
-        totalAmountDonated:
-          typeof m.totalAmountDonated === 'number' ? m.totalAmountDonated : 0,
-      }))
-  } catch (error) {
-    console.error('Error fetching Open Collective contributors:', error)
-    return []
-  }
+interface ClassicHomepageProps {
+  data: PortalData
+  isMember: boolean
+  showCta: boolean
 }
 
-interface InfoPanelProps {
-  icon: React.ReactElement
-  title: string
-  description: string
-  href: string
-}
-
-const InfoPanel: React.FC<InfoPanelProps> = ({
-  icon,
-  title,
-  description,
-  href,
-}) => {
-  const isExternal = href.startsWith('http')
-
-  return (
-    <Link
-      href={href}
-      target={isExternal ? '_blank' : undefined}
-      rel={isExternal ? 'noopener noreferrer' : undefined}
-      className="group flex items-center gap-4 rounded-xl border border-border bg-card p-4 transition-colors hover:bg-accent"
-    >
-      <div className="flex-shrink-0 text-2xl text-brand">{icon}</div>
-      <div className="min-w-0 flex-1">
-        <h3 className="font-semibold text-foreground">{title}</h3>
-        <p className="text-sm text-muted-foreground">{description}</p>
-      </div>
-    </Link>
-  )
-}
-
-export default async function ClassicHomepage() {
-  const cookieStore = await cookies()
+export default async function ClassicHomepage({
+  data,
+  isMember,
+  showCta,
+}: ClassicHomepageProps) {
+  const cookieStore = cookies()
   const supabase = createServerClient(cookieStore)
-  const [
-    {
+  const mostFollowed = (await getMostFollowedAccounts(supabase)).slice(0, 8)
+
+  let isOptedIn = false
+  if (showCta && isMember) {
+    const {
       data: { user },
-    },
-    mostFollowedAccounts,
-    financialContributors,
-    stats,
-  ] = await Promise.all([
-    supabase.auth.getUser(),
-    getMostFollowedAccounts(supabase),
-    getOpenCollectiveContributors(),
-    getStats(supabase).catch((error) => {
-      console.error('Failed to fetch stats for homepage:', error)
-      return {
-        userCount: null,
-        tweetCount: null,
-        userMentionsCount: null,
-      }
-    }),
-  ])
-
-  let optedInStatus: boolean | null = null
-  if (user) {
-    const { data: optInData, error: optInError } = await supabase
-      .from('optin')
-      .select('opted_in')
-      .eq('user_id', user.id)
-      .maybeSingle()
-
-    if (optInError) {
-      console.error('Failed to fetch homepage opt-in status:', optInError)
+    } = await supabase.auth.getUser()
+    if (user) {
+      const { data: optInData, error } = await supabase
+        .from('optin')
+        .select('opted_in')
+        .eq('user_id', user.id)
+        .maybeSingle()
+      if (error) console.error('Failed to fetch homepage opt-in status:', error)
+      isOptedIn = optInData?.opted_in ?? false
     }
-
-    optedInStatus = optInData?.opted_in ?? false
   }
 
-  const isOptedIn = canShowHomepageSearch(user?.id, optedInStatus)
-  const mostFollowed = mostFollowedAccounts.slice(0, 8)
-
-  const totalAmountRaised = financialContributors.reduce(
-    (sum, contributor) => sum + contributor.totalAmountDonated,
-    0,
-  )
-  const totalSupportersCount = financialContributors.length
-
-  const contributorsWithImages = financialContributors.filter((c) => c.image)
-  const highestDonorWithImage =
-    contributorsWithImages.length > 0 ? contributorsWithImages[0] : null
-  const otherDonorsForStack = contributorsWithImages.slice(1, 10)
-
-  const topTenFinancialContributors = financialContributors.slice(0, 10)
-  const topTenNames = topTenFinancialContributors.map((c) => c.name)
-  const additionalSupportersCount = Math.max(
-    0,
-    financialContributors.length - topTenNames.length,
-  )
-
-  const sectionPaddingClasses = 'py-12 md:py-16 lg:py-20'
-  const contentWrapperClasses =
-    'w-full max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10'
-
-  const socialProof = (
-    <div className="mx-auto w-full max-w-3xl">
-      {mostFollowed.length > 0 ? (
-        <AvatarList initialAvatars={mostFollowed} compact />
-      ) : (
-        <p className="text-center text-sm text-muted-foreground">
-          Featured archives are currently unavailable.
-        </p>
-      )}
-    </div>
-  )
+  // Guests only need the weekly preview on the homepage. Keep the historical
+  // series out of their RSC payload; the full explorer remains login-only.
+  const homepageData: PortalData = isMember
+    ? data
+    : {
+        ...data,
+        trends: { ...data.trends, years: [], series: [] },
+      }
 
   return (
     <main>
-      {/* Section 1: Audience-specific hero */}
-      <section className="overflow-hidden bg-card pb-12 pt-14 dark:bg-background md:flex md:min-h-[66vh] md:pb-16 md:pt-20">
-        <div
-          className={`${contentWrapperClasses} space-y-11 text-center md:flex md:flex-1 md:flex-col md:justify-evenly md:space-y-0`}
-        >
+      <section className="overflow-hidden bg-card pb-12 pt-14 dark:bg-background md:pb-16 md:pt-20">
+        <div className="relative z-10 mx-auto w-full max-w-5xl space-y-9 px-4 text-center sm:px-6 lg:px-8">
           <div className="space-y-3">
             <h1 className="text-5xl font-bold tracking-tight text-foreground md:text-6xl">
               Community Archive
             </h1>
             <p className="text-xl leading-8 text-muted-foreground">
-              {stats.tweetCount !== null && stats.userCount !== null ? (
+              {data.failures.liveAnalytics || data.failures.memberCount ? (
                 <>
-                  We preserve{' '}
-                  <strong className="font-semibold text-foreground">
-                    {formatNumber(stats.tweetCount)} public tweets
-                  </strong>{' '}
-                  from{' '}
-                  <strong className="font-semibold text-foreground">
-                    {formatNumber(stats.userCount)} community members
-                  </strong>
-                  .
+                  We preserve public conversations as open source
+                  infrastructure.
                 </>
               ) : (
                 <>
-                  We preserve public conversations as open source public
-                  infrastructure.
+                  We preserve{' '}
+                  <strong className="font-semibold text-foreground">
+                    {formatNumber(data.stats.totalTweets)} public tweets
+                  </strong>{' '}
+                  from{' '}
+                  <strong className="font-semibold text-foreground">
+                    {formatNumber(data.stats.accountCount)} community members
+                  </strong>
+                  .
                 </>
               )}
             </p>
@@ -266,7 +133,7 @@ export default async function ClassicHomepage() {
                 href="https://survivalandflourishing.fund/"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="font-medium text-muted-foreground transition-colors hover:text-brand hover:underline"
+                className="font-medium transition-colors hover:text-brand hover:underline"
               >
                 Survival and Flourishing Fund
               </Link>{' '}
@@ -275,204 +142,48 @@ export default async function ClassicHomepage() {
                 href="https://x.com/VitalikButerin"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="font-medium text-muted-foreground transition-colors hover:text-brand hover:underline"
+                className="font-medium transition-colors hover:text-brand hover:underline"
               >
                 Vitalik Buterin
               </Link>
             </p>
           </div>
 
-          {isOptedIn ? (
-            <HomepageSearch />
-          ) : (
-            <>
-              <DynamicHeroCTAButtons initialIsOptedIn={false} />
-              <div className="pt-8 md:pt-0">
-                <p className="mb-5 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground/80">
-                  With archives from
-                </p>
-                {socialProof}
-              </div>
-            </>
-          )}
-        </div>
-      </section>
+          {showCta ? (
+            <DynamicHeroCTAButtons initialIsOptedIn={isOptedIn} />
+          ) : null}
 
-      {/* Section 2: Explore the archive - Featured Apps */}
-      <section
-        id="products"
-        className={`bg-muted dark:bg-card ${sectionPaddingClasses} scroll-mt-16 overflow-hidden`}
-      >
-        <div className={contentWrapperClasses}>
-          <FeaturedAppsSection />
-          <AppGallery />
-        </div>
-      </section>
-
-      {isOptedIn ? (
-        <section className="overflow-hidden bg-card py-12 dark:bg-background md:py-16">
-          <div className={`${contentWrapperClasses} text-center`}>
-            <h2 className="text-3xl font-bold text-foreground md:text-4xl">
-              Fill the gaps in the public record
-            </h2>
-            <p className="mx-auto mb-8 mt-4 max-w-2xl text-base leading-7 text-muted-foreground">
-              We update the public archive every night with recent tweets.
-              Upload your X archive to backfill older posts, then use the
-              extension to contribute new tweets in real time while you browse.
+          <div className="pt-2">
+            <p className="mb-5 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground/80">
+              With archives from
             </p>
-            <DynamicHeroCTAButtons initialIsOptedIn />
-            <div className="mt-10 md:mt-12">{socialProof}</div>
+            <div className="mx-auto w-full max-w-3xl">
+              {mostFollowed.length > 0 ? (
+                <AvatarList initialAvatars={mostFollowed} compact />
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  Featured archives are currently unavailable.
+                </p>
+              )}
+            </div>
           </div>
-        </section>
-      ) : null}
+        </div>
+      </section>
 
-      {/* Section 3: Upload Your Archive */}
+      <section className="bg-zinc-100/80 py-4 dark:bg-transparent sm:py-7">
+        <Portal data={homepageData} view="home" isMember={isMember} embedded />
+      </section>
+
       <section
         id="upload-archive"
-        className={`bg-muted dark:bg-card ${sectionPaddingClasses} scroll-mt-16 overflow-hidden`}
+        className="scroll-mt-16 overflow-hidden bg-muted py-12 dark:bg-card md:py-16 lg:py-20"
       >
-        <div className={contentWrapperClasses}>
+        <div className="relative z-10 mx-auto w-full max-w-5xl px-4 sm:px-6 lg:px-8">
           <DynamicUploadArchiveSection />
         </div>
       </section>
 
-      {/* Section 4: Data & Source Code */}
-      <section
-        className={`bg-card dark:bg-background ${sectionPaddingClasses} overflow-hidden`}
-      >
-        <div className={`${contentWrapperClasses} space-y-8`}>
-          <div className="text-center">
-            <h2 className="text-3xl font-bold text-foreground">
-              Data & Source Code
-            </h2>
-            <p className="mx-auto mt-3 max-w-xl px-4 text-base text-muted-foreground md:px-0">
-              Access the data, explore the code, and see how everything works.
-            </p>
-          </div>
-          <div className="mx-auto grid max-w-4xl grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            <InfoPanel
-              icon={<FaGithub />}
-              title="GitHub"
-              description="Source code and contributions"
-              href="https://github.com/TheExGenesis/community-archive"
-            />
-            <InfoPanel
-              icon={<FaDiscord />}
-              title="Discord"
-              description="Join the community"
-              href="https://discord.gg/RArTGrUawX"
-            />
-            <InfoPanel
-              icon={<FaBook />}
-              title="Documentation"
-              description="API docs and examples"
-              href="/docs"
-            />
-            <InfoPanel
-              icon={<FaDatabase />}
-              title="Data Dump"
-              description="Download the full dataset"
-              href="https://github.com/TheExGenesis/community-archive/releases/tag/data_export"
-            />
-          </div>
-        </div>
-      </section>
-
-      {/* Section 5: Our Supporters */}
-      <section
-        className={`bg-muted dark:bg-card ${sectionPaddingClasses} overflow-hidden`}
-      >
-        <div className={`${contentWrapperClasses} space-y-8`}>
-          <div className="text-center">
-            <h2 className="text-3xl font-bold text-foreground">
-              Our Supporters
-            </h2>
-            <p className="mt-3 text-base text-muted-foreground">
-              Thanks to everyone who makes this possible
-            </p>
-          </div>
-
-          {/* Main supporters card */}
-          <div className="mx-auto max-w-4xl rounded-2xl border border-border bg-card p-6 md:p-8">
-            {/* Major Backers */}
-            <div className="mb-6 text-center">
-              <p className="mb-4 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-                Major Backers
-              </p>
-              <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-3">
-                <Link
-                  href="https://survivalandflourishing.fund/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-base font-medium text-muted-foreground transition-colors hover:text-brand"
-                >
-                  Survival and Flourishing Fund
-                </Link>
-                <span className="text-muted-foreground">•</span>
-                <span className="text-base font-medium text-muted-foreground">
-                  <Link
-                    href="https://x.com/VitalikButerin"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="transition-colors hover:text-brand"
-                  >
-                    Vitalik Buterin
-                  </Link>{' '}
-                  via{' '}
-                  <Link
-                    href="https://kanro.fi/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="transition-colors hover:text-brand"
-                  >
-                    Kanro
-                  </Link>
-                </span>
-                <span className="text-muted-foreground">•</span>
-                <Link
-                  href="https://x.com/pwang"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-base font-medium text-muted-foreground transition-colors hover:text-brand"
-                >
-                  Peter Wang
-                </Link>
-              </div>
-            </div>
-
-            {/* Divider */}
-            <div className="my-6 border-t border-border"></div>
-
-            {/* Community Supporters */}
-            <div className="mb-4 text-center">
-              <p className="mb-4 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-                Community Backers
-              </p>
-            </div>
-            <TieredSupportersDisplay
-              highestDonorWithImage={highestDonorWithImage}
-              otherDonorsForStack={otherDonorsForStack}
-              topTenNames={topTenNames}
-              additionalSupportersCount={additionalSupportersCount}
-              totalAmountRaised={totalAmountRaised}
-              totalSupportersCount={totalSupportersCount}
-            />
-          </div>
-
-          {/* Donate button */}
-          <div className="text-center">
-            <Link
-              href="https://opencollective.com/community-archive/donate"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <button className="inline-flex items-center justify-center rounded-xl bg-green-600 px-6 py-3 text-base font-medium text-white transition-colors hover:bg-green-700 dark:bg-green-400 dark:text-green-950 dark:hover:bg-green-300">
-                <FaHeart className="mr-2" /> Support the Project
-              </button>
-            </Link>
-          </div>
-        </div>
-      </section>
+      <Testimonials />
     </main>
   )
 }

--- a/src/components/home/ClassicHomepage.tsx
+++ b/src/components/home/ClassicHomepage.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { cookies } from 'next/headers'
 import type { SupabaseClient } from '@supabase/supabase-js'
 import AvatarList from '@/components/AvatarList'
+import HomepageSearch from '@/components/HomepageSearch'
 import Portal from '@/components/portal/Portal'
 import Testimonials from '@/components/home/Testimonials'
 import { formatNumber } from '@/lib/formatNumber'
@@ -151,6 +152,8 @@ export default async function ClassicHomepage({
 
           {showCta ? (
             <DynamicHeroCTAButtons initialIsOptedIn={isOptedIn} />
+          ) : isMember ? (
+            <HomepageSearch />
           ) : null}
 
           <div className="pt-2">

--- a/src/components/home/Testimonials.tsx
+++ b/src/components/home/Testimonials.tsx
@@ -1,0 +1,74 @@
+import Link from 'next/link'
+
+const TESTIMONIALS = [
+  {
+    quote:
+      'I just successfully used Community Archive search to find a tweet that Twitter search could not find 😎',
+    name: 'Richard D. Bartlett',
+    handle: 'RichDecibels',
+    href: 'https://x.com/RichDecibels/status/1839277246453842034',
+  },
+  {
+    quote:
+      'i have now almost entirely transitioned to searching my tweets via community archive instead of using the native twitter search',
+    name: 'universe sweetheart 💓🌈💭',
+    handle: 'univrsw3th4rt',
+    href: 'https://x.com/univrsw3th4rt/status/1986082324728234161',
+  },
+  {
+    quote:
+      "Can't find a tweet using twitter, use community archive db, found it in under a minute. many such cases",
+    name: '🐜',
+    handle: 'IaimforGOAT',
+    href: 'https://x.com/IaimforGOAT/status/1908547676913725763',
+  },
+  {
+    quote:
+      'upside of community archive: more deep cuts because i can search your tweets way better',
+    name: 'Gustaf',
+    handle: 'curiousgustaf',
+    href: 'https://x.com/curiousgustaf/status/2081400788367130908',
+  },
+] as const
+
+export default function Testimonials() {
+  return (
+    <section className="bg-card py-12 dark:bg-background md:py-16">
+      <div className="mx-auto w-full max-w-5xl px-4 sm:px-6 lg:px-8">
+        <div className="mb-8 text-center">
+          <h2 className="text-3xl font-bold text-foreground">
+            Useful because people use it
+          </h2>
+          <p className="mx-auto mt-3 max-w-2xl text-base text-muted-foreground">
+            Search that finds the posts people remember, and public data others
+            can build on.
+          </p>
+        </div>
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          {TESTIMONIALS.map((testimonial) => (
+            <Link
+              key={testimonial.href}
+              href={testimonial.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group rounded-xl border border-border bg-background p-5 transition-colors hover:border-brand/60"
+            >
+              <blockquote className="text-[15px] leading-7 text-foreground">
+                “{testimonial.quote}”
+              </blockquote>
+              <p className="mt-4 text-sm font-semibold text-foreground">
+                {testimonial.name}{' '}
+                <span className="font-normal text-muted-foreground">
+                  @{testimonial.handle}
+                </span>
+              </p>
+              <p className="mt-1 text-xs font-semibold text-brand group-hover:underline">
+                View source post →
+              </p>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/portal/Portal.test.tsx
+++ b/src/components/portal/Portal.test.tsx
@@ -2,11 +2,6 @@ import { act, render, screen } from '@testing-library/react'
 import Portal, { type PortalView } from './Portal'
 import type { PortalData, PortalTweet } from '@/lib/portal/types'
 
-jest.mock('@/components/HomepageSearch', () => ({
-  __esModule: true,
-  default: () => null,
-}))
-
 jest.mock('./TweetRow', () => ({
   TweetRow: ({ tweet, noClamp }: { tweet: PortalTweet; noClamp?: boolean }) => (
     <div data-no-clamp={String(Boolean(noClamp))}>{tweet.text}</div>
@@ -241,11 +236,6 @@ describe('portal component failures', () => {
     })
 
     expect(
-      screen.getByText(
-        'We preserve public conversations as open source infrastructure.',
-      ),
-    ).toBeInTheDocument()
-    expect(
       screen.getByText('Tweet totals are temporarily unavailable.'),
     ).toBeInTheDocument()
     expect(
@@ -269,6 +259,7 @@ describe('portal component failures', () => {
     expect(
       screen.getByText('Historical bangers are temporarily unavailable.'),
     ).toBeInTheDocument()
-    expect(screen.getByText('Explore the archive')).toBeInTheDocument()
+    expect(screen.getByText('Community Builds')).toBeInTheDocument()
+    expect(screen.queryByText('Explore the archive')).not.toBeInTheDocument()
   })
 })

--- a/src/components/portal/Portal.tsx
+++ b/src/components/portal/Portal.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Link from 'next/link'
-import { FaDatabase, FaExternalLinkAlt } from 'react-icons/fa'
+import { FaDatabase, FaExternalLinkAlt, FaUsers } from 'react-icons/fa'
 import {
   PortalData,
   PortalTweet,
@@ -10,7 +10,6 @@ import {
   RESEARCH_SOURCE,
 } from '@/lib/portal/types'
 import { PORTAL_ARTICLES } from './articles'
-import { PORTAL_TOOLS } from './tools'
 import { CARD, MUTED, FAINT, BODY, SERIF } from './styles'
 import TweetCard from '@/components/TweetCard'
 import {
@@ -23,7 +22,6 @@ import {
   liveCounterRefreshInterval,
   PORTAL_STREAM_POLL_INTERVAL_MS,
 } from './live'
-import HomepageSearch from '@/components/HomepageSearch'
 import {
   comparePortalTweetChronology,
   selectHomepageStream,
@@ -36,17 +34,17 @@ export type PortalView = 'home' | 'stream'
 const HOME_LIVE_STREAM_LIMIT = 12
 const ARCHIVE_EXPORT_URL =
   'https://github.com/TheExGenesis/community-archive/releases/tag/data_export'
+const COMMUNITY_BUILDS_URL =
+  'https://x.com/exgenesis/status/1835411943735140798'
 
 type DashboardDestination =
   | 'all_time_bangers'
-  | 'best_strands'
+  | 'community_builds'
   | 'data_export'
   | 'live_stream'
   | 'recent_bangers'
   | 'research'
   | 'research_article'
-  | 'tool'
-  | 'tools'
   | 'trends'
 
 function captureDashboardDestination(
@@ -66,6 +64,9 @@ const compact = (n: number) =>
     notation: 'compact',
     maximumFractionDigits: 1,
   }).format(n)
+
+const signInHref = (returnTo: string) =>
+  `/login?redirect=${encodeURIComponent(returnTo)}`
 
 const fmtDelta = (term: TermWeek) => {
   if (term.status === 'new') return 'new'
@@ -431,9 +432,13 @@ function LiveStreamHeading({
 export default function Portal({
   data,
   view,
+  isMember = true,
+  embedded = false,
 }: {
   data: PortalData
   view: PortalView
+  isMember?: boolean
+  embedded?: boolean
 }) {
   const { stats, trends } = data
 
@@ -614,7 +619,6 @@ export default function Portal({
     [withDelta],
   )
 
-  const bestStrands = PORTAL_TOOLS.find((t) => t.name === 'Best Strands')
   const recentBanger = data.recentBangers[0] ?? null
   const historicalBanger = data.historicalBangers[0] ?? null
 
@@ -631,65 +635,13 @@ export default function Portal({
     ).padStart(2, '0')} UTC`
   }, [stats.generatedAt])
 
+  const Root = embedded ? 'div' : 'main'
+
   return (
-    <main className="min-h-screen bg-zinc-100/80 dark:bg-transparent">
+    <Root className="min-h-screen bg-zinc-100/80 dark:bg-transparent">
       {/* ------------------------------------------------ Home ---------- */}
       {view === 'home' && (
         <div className="mx-auto max-w-[1320px] px-4 py-6 sm:px-6">
-          {/* Hero: same gist as the logged-out homepage */}
-          <div className="mx-auto mb-40 mt-36 w-full max-w-[48rem] space-y-3 text-center">
-            <h1
-              className="text-6xl font-bold tracking-tight text-foreground"
-              style={SERIF}
-            >
-              Community Archive
-            </h1>
-            <p className="text-xl leading-8 text-zinc-500 dark:text-[#a7a7b4]">
-              {data.failures.liveAnalytics || data.failures.memberCount ? (
-                <>
-                  We preserve public conversations as open source
-                  infrastructure.
-                </>
-              ) : (
-                <>
-                  We preserve{' '}
-                  <strong className="font-semibold text-foreground">
-                    {compact(stats.totalTweets)} public tweets
-                  </strong>{' '}
-                  from{' '}
-                  <strong className="font-semibold text-foreground">
-                    {stats.accountCount.toLocaleString('en-US')} community
-                    members
-                  </strong>
-                  .
-                </>
-              )}
-            </p>
-            <p className={`text-xs ${FAINT}`}>
-              Backed by{' '}
-              <a
-                href="https://survivalandflourishing.fund/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className={`font-medium ${MUTED} transition-colors hover:text-brand hover:underline`}
-              >
-                Survival and Flourishing Fund
-              </a>{' '}
-              and{' '}
-              <a
-                href="https://x.com/VitalikButerin"
-                target="_blank"
-                rel="noopener noreferrer"
-                className={`font-medium ${MUTED} transition-colors hover:text-brand hover:underline`}
-              >
-                Vitalik Buterin
-              </a>
-            </p>
-            <div className="pt-4">
-              <HomepageSearch />
-            </div>
-          </div>
-
           <ArchiveOverview
             stats={stats}
             generatedDate={generatedDate}
@@ -745,8 +697,8 @@ export default function Portal({
                 <PanelHeader
                   title="Trending terms · 7 days"
                   action={{
-                    label: 'Trends explorer',
-                    href: '/trends',
+                    label: isMember ? 'Trends explorer' : 'Sign in for Trends',
+                    href: isMember ? '/trends' : signInHref('/trends'),
                     analyticsDestination: 'trends',
                   }}
                 />
@@ -954,41 +906,6 @@ export default function Portal({
                   )}
                 </div>
               </div>
-              {bestStrands && (
-                <a
-                  href={bestStrands.link}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onClick={() =>
-                    captureDashboardDestination('best_strands', 'card', true)
-                  }
-                  className={`${CARD} group overflow-hidden transition-colors hover:border-brand/60`}
-                >
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
-                    src={bestStrands.image}
-                    alt={`${bestStrands.name} preview`}
-                    loading="lazy"
-                    className="aspect-[2/1] w-full border-b border-zinc-200 object-cover dark:border-[#26262a]"
-                  />
-                  <div className="flex items-start gap-2.5 px-4 py-3">
-                    <span className="mt-0.5 flex-shrink-0 text-[15px] text-brand">
-                      {bestStrands.icon}
-                    </span>
-                    <span className="min-w-0">
-                      <span className="flex items-center gap-1.5 text-[13.5px] font-bold">
-                        {bestStrands.name}
-                        <FaExternalLinkAlt className="h-2.5 w-2.5 flex-shrink-0 text-zinc-900 opacity-0 transition-opacity group-hover:opacity-70 dark:text-white" />
-                      </span>
-                      <span
-                        className={`mt-0.5 block text-[12px] leading-snug ${MUTED}`}
-                      >
-                        {bestStrands.description}
-                      </span>
-                    </span>
-                  </div>
-                </a>
-              )}
               <a
                 href={ARCHIVE_EXPORT_URL}
                 target="_blank"
@@ -1015,54 +932,32 @@ export default function Portal({
                   Download →
                 </span>
               </a>
-            </div>
-          </div>
-
-          {/* Tools */}
-          <div id="products" className={`${CARD} mt-4 scroll-mt-32`}>
-            <PanelHeader
-              title="Explore the archive"
-              action={{
-                label: 'All tools',
-                href: '/tools',
-                analyticsDestination: 'tools',
-              }}
-              divider={false}
-            />
-            <div className="grid grid-cols-1 gap-2.5 p-4 sm:grid-cols-2 lg:grid-cols-4">
-              {PORTAL_TOOLS.filter(
-                (t) =>
-                  !t.image &&
-                  !['Banger Bot', 'Highlights Bot'].includes(t.name),
-              ).map((tool) => (
-                <a
-                  key={tool.name}
-                  href={tool.link}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onClick={() =>
-                    captureDashboardDestination('tool', 'card', true)
-                  }
-                  className="group rounded-[4px] border border-zinc-200 bg-zinc-50 px-3 py-2.5 transition-colors hover:border-brand/60 dark:border-[#26262a] dark:bg-[#121214] dark:hover:border-brand/60"
-                >
-                  <div className="flex items-start gap-2.5">
-                    <span className="mt-0.5 flex-shrink-0 text-[15px] text-brand">
-                      {tool.icon}
-                    </span>
-                    <span className="min-w-0">
-                      <span className="flex items-center gap-1.5 text-[13px] font-bold">
-                        {tool.name}
-                        <FaExternalLinkAlt className="h-2.5 w-2.5 flex-shrink-0 text-zinc-900 opacity-0 transition-opacity group-hover:opacity-70 dark:text-white" />
-                      </span>
-                      <span
-                        className={`mt-0.5 block text-[12px] leading-snug ${MUTED}`}
-                      >
-                        {tool.description}
-                      </span>
-                    </span>
-                  </div>
-                </a>
-              ))}
+              <a
+                href={COMMUNITY_BUILDS_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() =>
+                  captureDashboardDestination('community_builds', 'card', true)
+                }
+                className={`${CARD} group flex items-center gap-3 px-4 py-4 transition-colors hover:border-brand/60`}
+              >
+                <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-[4px] border border-zinc-200 bg-zinc-50 text-brand dark:border-[#2a2a2e] dark:bg-[#121214]">
+                  <FaUsers className="h-4 w-4" />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block text-[13.5px] font-bold">
+                    Community Builds
+                  </span>
+                  <span
+                    className={`mt-0.5 block text-[12px] leading-snug ${MUTED}`}
+                  >
+                    Projects made with Community Archive data
+                  </span>
+                </span>
+                <span className="flex-shrink-0 text-[12px] font-semibold text-brand">
+                  Explore →
+                </span>
+              </a>
             </div>
           </div>
         </div>
@@ -1138,7 +1033,7 @@ export default function Portal({
           </div>
         </div>
       )}
-    </main>
+    </Root>
   )
 }
 

--- a/src/components/portal/PortalLayout.test.tsx
+++ b/src/components/portal/PortalLayout.test.tsx
@@ -2,11 +2,6 @@ import { act, render, screen } from '@testing-library/react'
 import Portal from './Portal'
 import type { PortalData, PortalTweet, ResearchPost } from '@/lib/portal/types'
 
-jest.mock('@/components/HomepageSearch', () => ({
-  __esModule: true,
-  default: () => null,
-}))
-
 jest.mock('./TweetRow', () => ({
   TweetRow: ({ tweet }: { tweet: PortalTweet }) => <div>{tweet.text}</div>,
 }))
@@ -100,6 +95,13 @@ test('renders the balanced homepage composition and editorial labels', async () 
     'href',
     'https://github.com/TheExGenesis/community-archive/releases/tag/data_export',
   )
+  expect(
+    screen.getByRole('link', { name: /Community Builds/i }),
+  ).toHaveAttribute(
+    'href',
+    'https://x.com/exgenesis/status/1835411943735140798',
+  )
+  expect(screen.queryByText('Explore the archive')).not.toBeInTheDocument()
   expect(screen.getByRole('region', { name: 'Live tweet stream' })).toHaveClass(
     'lg:flex-1',
     'lg:max-h-none',
@@ -108,6 +110,39 @@ test('renders the balanced homepage composition and editorial labels', async () 
   expect(
     screen.getByRole('region', { name: 'Live tweet stream' }).parentElement,
   ).toHaveClass('lg:h-[420px]', 'lg:min-h-[420px]')
+
+  unmount()
+  jest.clearAllTimers()
+  jest.useRealTimers()
+  jest.restoreAllMocks()
+})
+
+test('keeps the public dashboard useful while routing protected tools through sign-in', async () => {
+  jest.useFakeTimers()
+  jest.setSystemTime(Date.parse('2026-08-07T13:00:00.000Z'))
+  jest.spyOn(global, 'fetch').mockResolvedValue({
+    ok: true,
+    json: async () => ({ tweets: [], updateCursor: null }),
+  } as Response)
+
+  const { unmount } = render(
+    <Portal data={data} view="home" isMember={false} embedded />,
+  )
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+
+  expect(screen.getByRole('link', { name: /Recent bangers/i })).toHaveAttribute(
+    'href',
+    '/bangers?period=week',
+  )
+  expect(
+    screen.getByRole('link', { name: /Sign in for Trends/i }),
+  ).toHaveAttribute('href', '/login?redirect=%2Ftrends')
+  expect(
+    screen.getByRole('link', { name: /Sign in for firehose/i }),
+  ).toHaveAttribute('href', '/login?redirect=%2Fstream')
 
   unmount()
   jest.clearAllTimers()

--- a/src/components/portal/PortalLayout.test.tsx
+++ b/src/components/portal/PortalLayout.test.tsx
@@ -117,7 +117,7 @@ test('renders the balanced homepage composition and editorial labels', async () 
   jest.restoreAllMocks()
 })
 
-test('keeps the public dashboard useful while routing protected tools through sign-in', async () => {
+test('keeps the public dashboard useful while routing Trends through sign-in', async () => {
   jest.useFakeTimers()
   jest.setSystemTime(Date.parse('2026-08-07T13:00:00.000Z'))
   jest.spyOn(global, 'fetch').mockResolvedValue({
@@ -140,9 +140,10 @@ test('keeps the public dashboard useful while routing protected tools through si
   expect(
     screen.getByRole('link', { name: /Sign in for Trends/i }),
   ).toHaveAttribute('href', '/login?redirect=%2Ftrends')
-  expect(
-    screen.getByRole('link', { name: /Sign in for firehose/i }),
-  ).toHaveAttribute('href', '/login?redirect=%2Fstream')
+  expect(screen.getByRole('link', { name: /Open firehose/i })).toHaveAttribute(
+    'href',
+    '/stream',
+  )
 
   unmount()
   jest.clearAllTimers()

--- a/src/lib/homepageRoute.test.tsx
+++ b/src/lib/homepageRoute.test.tsx
@@ -7,11 +7,11 @@ import { getPortalData } from '@/lib/portal/data'
 jest.mock('server-only', () => ({}), { virtual: true })
 jest.mock('@/components/home/ClassicHomepage', () => ({
   __esModule: true,
-  default: () => <div>classic homepage</div>,
-}))
-jest.mock('@/components/portal/Portal', () => ({
-  __esModule: true,
-  default: () => <div>member portal</div>,
+  default: ({ isMember, showCta }: { isMember: boolean; showCta: boolean }) => (
+    <div>
+      shared homepage · member {String(isMember)} · CTA {String(showCta)}
+    </div>
+  ),
 }))
 jest.mock('@/lib/portal/auth', () => ({ getIsMember: jest.fn() }))
 jest.mock('@/lib/portal/data', () => ({ getPortalData: jest.fn() }))
@@ -33,16 +33,29 @@ describe('Homepage OAuth actions', () => {
   it('keeps an authenticated OAuth return on the opt-in completion surface', async () => {
     const page = await Homepage({ searchParams: { action: 'optin' } })
 
-    expect(renderToStaticMarkup(page)).toContain('classic homepage')
-    expect(getIsMemberMock).not.toHaveBeenCalled()
-    expect(getPortalDataMock).not.toHaveBeenCalled()
-  })
-
-  it('renders the portal normally after the pending action is cleared', async () => {
-    const page = await Homepage({ searchParams: {} })
-
-    expect(renderToStaticMarkup(page)).toContain('member portal')
+    expect(renderToStaticMarkup(page)).toContain(
+      'shared homepage · member true · CTA true',
+    )
     expect(getIsMemberMock).toHaveBeenCalledTimes(1)
     expect(getPortalDataMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the same dashboard without the CTA for signed-in visitors', async () => {
+    const page = await Homepage({ searchParams: {} })
+
+    expect(renderToStaticMarkup(page)).toContain(
+      'shared homepage · member true · CTA false',
+    )
+    expect(getIsMemberMock).toHaveBeenCalledTimes(1)
+    expect(getPortalDataMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the shared dashboard with the CTA for logged-out visitors', async () => {
+    getIsMemberMock.mockResolvedValue(false)
+    const page = await Homepage({ searchParams: {} })
+
+    expect(renderToStaticMarkup(page)).toContain(
+      'shared homepage · member false · CTA true',
+    )
   })
 })

--- a/src/lib/navigation.test.ts
+++ b/src/lib/navigation.test.ts
@@ -32,6 +32,21 @@ describe('member navigation', () => {
     expect(isNavItemActive('/stream', '/stream')).toBe(true)
     expect(isNavItemActive('/search', '/bangers?period=all')).toBe(false)
   })
+
+  it('keeps Bangers public while reserving Trends for signed-in members', () => {
+    expect(getPrimaryNav(false)).toContainEqual({
+      href: '/bangers?period=all',
+      label: 'Bangers',
+    })
+    expect(getPrimaryNav(false)).not.toContainEqual({
+      href: '/trends',
+      label: 'Trends',
+    })
+    expect(getPrimaryNav(true)).toContainEqual({
+      href: '/trends',
+      label: 'Trends',
+    })
+  })
 })
 
 describe('tweet detail navigation', () => {

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -111,10 +111,9 @@ export const getPrimaryNav = (isMember: boolean): NavItem[] =>
         { href: BANGERS_ALL_TIME_HREF, label: 'Bangers' },
         { href: '/trends', label: 'Trends' },
         { href: '/research', label: 'Research' },
-        { href: '/tools', label: 'Tools' },
       ]
     : [
-        { href: '/#products', label: 'Tools' },
+        { href: BANGERS_ALL_TIME_HREF, label: 'Bangers' },
         { href: '/user-dir', label: 'Library' },
         { href: '/docs', label: 'Docs' },
         { href: '/#upload-archive', label: 'Upload archive' },

--- a/src/lib/portalBangersRoute.test.ts
+++ b/src/lib/portalBangersRoute.test.ts
@@ -1,24 +1,19 @@
 import { NextRequest } from 'next/server'
 import { GET } from '@/app/api/portal/bangers/route'
-import { getIsMember } from '@/lib/portal/auth'
 import { getPortalBangersPage } from '@/lib/portal/data'
 
-jest.mock('@/lib/portal/auth', () => ({ getIsMember: jest.fn() }))
 jest.mock('@/lib/portal/data', () => ({
   getPortalBangersPage: jest.fn(),
   PORTAL_BANGERS_PAGE_SIZE: 30,
 }))
 
-const getIsMemberMock = getIsMember as jest.MockedFunction<typeof getIsMember>
 const getPortalBangersPageMock = getPortalBangersPage as jest.MockedFunction<
   typeof getPortalBangersPage
 >
 
 describe('portal bangers route', () => {
   beforeEach(() => {
-    getIsMemberMock.mockReset()
     getPortalBangersPageMock.mockReset()
-    getIsMemberMock.mockResolvedValue(true)
     getPortalBangersPageMock.mockResolvedValue({
       tweets: [],
       pagination: {
@@ -33,15 +28,14 @@ describe('portal bangers route', () => {
     })
   })
 
-  test('requires a signed-in member', async () => {
-    getIsMemberMock.mockResolvedValue(false)
-
+  test('serves public bangers with shared-cache headers', async () => {
     const response = await GET(
       new NextRequest('https://community-archive.org/api/portal/bangers'),
     )
 
-    expect(response.status).toBe(401)
-    expect(getPortalBangersPageMock).not.toHaveBeenCalled()
+    expect(response.status).toBe(200)
+    expect(response.headers.get('cache-control')).toContain('public')
+    expect(getPortalBangersPageMock).toHaveBeenCalled()
   })
 
   test('forwards bounded paging, ranking, scope, year, and search', async () => {

--- a/src/lib/portalStreamPage.test.tsx
+++ b/src/lib/portalStreamPage.test.tsx
@@ -1,0 +1,26 @@
+import StreamPage from '@/app/stream/page'
+import { getPortalData } from '@/lib/portal/data'
+import type { PortalData } from '@/lib/portal/types'
+
+jest.mock('@/lib/portal/data', () => ({
+  getPortalData: jest.fn(),
+}))
+
+jest.mock('@/components/portal/Portal', () => ({
+  __esModule: true,
+  default: ({ view }: { view: string }) => <div>Portal view: {view}</div>,
+}))
+
+const getPortalDataMock = getPortalData as jest.MockedFunction<
+  typeof getPortalData
+>
+
+test('renders the public stream without a membership check', async () => {
+  const data = {} as PortalData
+  getPortalDataMock.mockResolvedValue(data)
+
+  const page = await StreamPage()
+
+  expect(getPortalDataMock).toHaveBeenCalledWith('stream')
+  expect(page.props).toMatchObject({ data, view: 'stream' })
+})

--- a/src/lib/supporters.ts
+++ b/src/lib/supporters.ts
@@ -1,0 +1,72 @@
+import 'server-only'
+import type { Contributor } from '@/components/TieredSupportersDisplay'
+
+interface OpenCollectiveMember {
+  name?: unknown
+  role?: unknown
+  type?: unknown
+  isActive?: unknown
+  profile?: unknown
+  image?: unknown
+  slug?: unknown
+  totalAmountDonated?: unknown
+}
+
+export async function getOpenCollectiveContributors(): Promise<Contributor[]> {
+  try {
+    const response = await fetch(
+      'https://opencollective.com/community-archive/members/all.json',
+      { next: { revalidate: 3600 } },
+    )
+    if (!response.ok) {
+      console.error(`Failed to fetch Open Collective data: ${response.status}`)
+      return []
+    }
+
+    const payload: unknown = await response.json()
+    if (!Array.isArray(payload)) return []
+
+    return payload
+      .flatMap((value): Contributor[] => {
+        const member = value as OpenCollectiveMember
+        const amount =
+          typeof member.totalAmountDonated === 'number'
+            ? member.totalAmountDonated
+            : 0
+        const eligibleRole =
+          member.role === 'BACKER' || (member.role === 'MEMBER' && amount > 0)
+        if (
+          member.isActive !== true ||
+          !eligibleRole ||
+          typeof member.name !== 'string' ||
+          typeof member.role !== 'string' ||
+          typeof member.type !== 'string' ||
+          typeof member.profile !== 'string'
+        ) {
+          return []
+        }
+
+        return [
+          {
+            name: member.name,
+            role: member.role,
+            type: member.type,
+            isActive: true,
+            profile: member.profile,
+            image: typeof member.image === 'string' ? member.image : null,
+            slug:
+              typeof member.slug === 'string' ? member.slug : member.profile,
+            totalAmountDonated: amount,
+          },
+        ]
+      })
+      .sort(
+        (left, right) =>
+          right.totalAmountDonated - left.totalAmountDonated ||
+          left.name.localeCompare(right.name),
+      )
+  } catch (error) {
+    console.error('Error fetching Open Collective contributors:', error)
+    return []
+  }
+}


### PR DESCRIPTION
## Summary

- renders one shared homepage dashboard for guests and signed-in members
- keeps the guest CTA for logged-out visitors and restores homepage search for signed-in members
- retains compact archive social proof for both audiences
- makes Bangers public at both the page and API layers
- keeps Trends login-only, with return-path-aware sign-in links
- removes the old Explore and Data & Source Code homepage sections
- leaves Community Builds as the only build collection linked from the homepage, directly below the archive export card
- moves supporters to `/supporters` and links the page from the footer
- adds a compact testimonial section using canonical source-post links recovered from the issue screenshot
- makes the homepage headline use the same portal analytics snapshot for guests and members

Closes #501
Closes #565
Closes #527
Closes #452
Closes #536
Closes #564
Closes #585

Related to #498. This PR implements the agreed Trends/Bangers access boundary; it intentionally does not close the broader raw archive-download access work.

## Access and data choices

Guest and member homepages share the same portal component and server-side data load. Authentication changes only the hero action (guest CTA versus member search) and access-controlled links. Guests receive the weekly Trends preview shown on the dashboard, but the full historical Trends series is removed from their RSC payload. The Trends explorer page and API remain authenticated. Bangers reads only the archive's public serving data, so its page and paginated API are public and cacheable.

## Verification

- `pnpm type-check`
- focused server/client Jest suite: 6 suites, 22 tests
- focused audience tests prove member search remains, the guest CTA remains, and both audiences render the shared dashboard
- `pnpm lint` (passes; one pre-existing `no-img-element` warning in `UnifiedTweetList.test.tsx`)
- local browser pass for guest CTA → dashboard → upload → testimonials
- verified guest Trends redirect to `/login?redirect=/trends`
- verified public Bangers navigation does not auth-redirect
- verified `/supporters` renders live Open Collective totals

The local checkout did not include the production ClickHouse gateway URL, so the browser pass exercised the dashboard's graceful unavailable-panel state. The draft should receive a remote preview check with the real gateway before merge.
