### PR TITLE
Link tweet authors to profile pages

### DIFF
--- a/src/app/user/[account_id]/page.tsx
+++ b/src/app/user/[account_id]/page.tsx
@@ -17,6 +17,7 @@ import TweetList from '@/components/TweetList'
 import { FilterCriteria } from '@/lib/queries/tweetQueries'
 import { Archive, Radio } from 'lucide-react'
 import { getHighResolutionAvatarUrl } from '@/lib/avatar'
+import { getClickHouseUserProfile } from '@/lib/clickhouseUserProfile'
 
 // Style constants (glows removed)
 const unifiedDeepBlueBase = 'bg-card dark:bg-background'
@@ -132,7 +133,9 @@ export default async function User({
   const cookieStore = cookies()
   const supabase = createServerClient(cookieStore)
 
-  const userData = await getUserData(supabase, account_id)
+  const userData =
+    (await getUserData(supabase, account_id)) ||
+    (await getClickHouseUserProfile(account_id))
 
   if (!userData) {
     // Styled error message for consistency - Removed glow and shadow

--- a/src/app/user/[account_id]/page.tsx
+++ b/src/app/user/[account_id]/page.tsx
@@ -14,6 +14,8 @@ import { formatNumber } from '@/lib/formatNumber'
 import { DownloadArchiveButton } from './DownloadArchiveButton'
 import Image from 'next/image'
 import TweetList from '@/components/TweetList'
+import UnifiedTweetList from '@/components/UnifiedTweetList'
+import type { TweetData } from '@/components/TweetComponent'
 import { FilterCriteria } from '@/lib/queries/tweetQueries'
 import { Archive, Radio } from 'lucide-react'
 import { getHighResolutionAvatarUrl } from '@/lib/avatar'
@@ -133,9 +135,11 @@ export default async function User({
   const cookieStore = cookies()
   const supabase = createServerClient(cookieStore)
 
-  const userData =
-    (await getUserData(supabase, account_id)) ||
-    (await getClickHouseUserProfile(account_id))
+  const directoryUser = await getUserData(supabase, account_id)
+  const clickHouseProfile = directoryUser
+    ? null
+    : await getClickHouseUserProfile(account_id)
+  const userData = directoryUser || clickHouseProfile?.user
 
   if (!userData) {
     // Styled error message for consistency - Removed glow and shadow
@@ -159,18 +163,40 @@ export default async function User({
     )
   }
 
-  let summaryQuery = supabase
-    .from('account_activity_summary')
-    .select('mentioned_accounts')
-
-  summaryQuery = userData.account_id
-    ? summaryQuery.eq('account_id', userData.account_id)
-    : summaryQuery.eq('username', userData.username)
-
-  const { data: summaryData, error: summaryError } =
-    await summaryQuery.maybeSingle()
+  const { data: summaryData, error: summaryError } = directoryUser
+    ? directoryUser.account_id
+      ? await supabase
+          .from('account_activity_summary')
+          .select('mentioned_accounts')
+          .eq('account_id', directoryUser.account_id)
+          .maybeSingle()
+      : await supabase
+          .from('account_activity_summary')
+          .select('mentioned_accounts')
+          .eq('username', directoryUser.username)
+          .maybeSingle()
+    : { data: null, error: null }
 
   const showingSummaryData = !summaryError && summaryData?.mentioned_accounts
+  const clickHouseTweets: TweetData[] =
+    clickHouseProfile?.topTweets.map((tweet) => ({
+      tweet_id: tweet.tweetId,
+      account_id: userData.account_id || '',
+      created_at: tweet.createdAt,
+      full_text: tweet.fullText,
+      retweet_count: tweet.retweetCount,
+      favorite_count: tweet.favoriteCount,
+      reply_to_tweet_id: null,
+      quote_tweet_id: null,
+      retweeted_tweet_id: null,
+      avatar_media_url: userData.avatar_media_url,
+      username: userData.username,
+      account_display_name: userData.account_display_name,
+      media: [],
+      urls: [],
+      reply_to_username: tweet.replyToUsername || undefined,
+      mentioned_users: [],
+    })) || []
 
   return (
     <section
@@ -232,14 +258,23 @@ export default async function User({
           </>
         )}
 
-        {userData.account_id && (
+        {clickHouseProfile && clickHouseTweets.length > 0 && (
+          <div className="rounded-lg bg-muted p-6 dark:bg-card sm:p-8">
+            <h2 className="mb-4 text-2xl font-semibold text-foreground">
+              Top Tweets
+            </h2>
+            <UnifiedTweetList tweets={clickHouseTweets} />
+          </div>
+        )}
+
+        {directoryUser?.account_id && (
           <div className="rounded-lg bg-muted p-6 dark:bg-card sm:p-8">
             <h2 className="mb-6 text-2xl font-semibold text-foreground">
               Recent Tweets
             </h2>
             <TweetList
               filterCriteria={
-                { userId: userData.account_id } satisfies FilterCriteria
+                { userId: directoryUser.account_id } satisfies FilterCriteria
               }
               itemsPerPage={20}
             />

--- a/src/components/TweetComponent.tsx
+++ b/src/components/TweetComponent.tsx
@@ -1,7 +1,12 @@
 'use client'
 
 import React from 'react'
-import { tweetPermalinkHref, type TweetOrigin } from '@/lib/navigation'
+import Link from 'next/link'
+import {
+  tweetPermalinkHref,
+  userProfileHref,
+  type TweetOrigin,
+} from '@/lib/navigation'
 import { formatDistanceToNow } from 'date-fns'
 import {
   FaHeart,
@@ -137,6 +142,7 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
   let displayUsername = originalUsername
   let displayName = originalDisplayName
   let profilePicUrl = originalProfilePicUrl
+  let displayAccountId: string | undefined = tweet.account_id
 
   if (isRtFormat && rtMatch) {
     const rtUsername = rtMatch[1]
@@ -151,6 +157,7 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
       const mentionedUser = mentionedUserRecord.mentioned_user
       displayUsername = mentionedUser.screen_name
       displayName = mentionedUser.name
+      displayAccountId = mentionedUser.user_id || undefined
 
       // Use the mentioned user's avatar if available, otherwise use placeholder
       if (mentionedUser.account?.profile?.avatar_media_url) {
@@ -164,6 +171,7 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
       displayUsername = rtUsername
       displayName = rtUsername // fallback to username as display name
       profilePicUrl = undefined
+      displayAccountId = undefined
     }
   }
 
@@ -292,6 +300,10 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
       )
     }
     const quotedProfilePic = quotedTweet.avatar_media_url
+    const quotedProfileHref = userProfileHref(
+      quotedTweet.username,
+      quotedTweet.account_id,
+    )
     // Border + marker for syndication-hydrated quotes so it's clear the data isn't
     // from this archive.
     const externalClasses = quotedTweet.from_external
@@ -310,29 +322,40 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
         <div
           className={`flex items-start ${compact ? 'space-x-2' : 'space-x-3'}`}
         >
-          <Avatar
-            className={`${compact ? 'h-6 w-6' : 'h-8 w-8'} flex-shrink-0`}
+          <Link
+            href={quotedProfileHref}
+            aria-label={`View @${quotedTweet.username}'s profile`}
+            className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
-            <TweetAvatarImage
-              src={quotedProfilePic}
-              alt={`${quotedTweet.account_display_name}'s profile picture`}
-              username={quotedTweet.username}
-              tweetId={quotedTweet.tweet_id}
-            />
-            <AvatarFallback>
-              {quotedTweet.account_display_name?.charAt(0) ||
-                quotedTweet.username?.charAt(0) ||
-                'U'}
-            </AvatarFallback>
-          </Avatar>
+            <Avatar
+              className={`${compact ? 'h-6 w-6' : 'h-8 w-8'} flex-shrink-0`}
+            >
+              <TweetAvatarImage
+                src={quotedProfilePic}
+                alt={`${quotedTweet.account_display_name}'s profile picture`}
+                username={quotedTweet.username}
+                tweetId={quotedTweet.tweet_id}
+              />
+              <AvatarFallback>
+                {quotedTweet.account_display_name?.charAt(0) ||
+                  quotedTweet.username?.charAt(0) ||
+                  'U'}
+              </AvatarFallback>
+            </Avatar>
+          </Link>
           <div className="min-w-0 flex-1">
             <div className="mb-1 flex flex-wrap items-baseline gap-x-1 gap-y-0.5">
-              <span className="text-sm font-bold text-foreground">
-                {quotedTweet.account_display_name}
-              </span>
-              <span className="text-sm text-muted-foreground">
-                @{quotedTweet.username}
-              </span>
+              <Link
+                href={quotedProfileHref}
+                className="rounded-sm hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <span className="text-sm font-bold text-foreground">
+                  {quotedTweet.account_display_name}
+                </span>{' '}
+                <span className="text-sm text-muted-foreground">
+                  @{quotedTweet.username}
+                </span>
+              </Link>
               <span className="text-xs text-muted-foreground">
                 •{' '}
                 {formatDistanceToNow(new Date(quotedTweet.created_at), {
@@ -465,6 +488,7 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
       day: 'numeric',
       year: 'numeric',
     })
+    const profileHref = userProfileHref(displayUsername, displayAccountId)
 
     return (
       <div className={`${compactTweetGridClass} ${className}`}>
@@ -472,24 +496,35 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
           role="cell"
           className="col-span-2 flex min-w-0 items-center gap-2.5 md:col-span-1"
         >
-          <Avatar className="h-8 w-8 flex-shrink-0">
-            <TweetAvatarImage
-              src={profilePicUrl}
-              alt={`${displayName}'s profile picture`}
-              username={displayUsername}
-              tweetId={tweet.retweeted_tweet_id || tweet.tweet_id}
-            />
-            <AvatarFallback className="text-xs">
-              {displayName?.charAt(0) || displayUsername?.charAt(0) || 'U'}
-            </AvatarFallback>
-          </Avatar>
+          <Link
+            href={profileHref}
+            aria-label={`View @${displayUsername}'s profile`}
+            className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <Avatar className="h-8 w-8 flex-shrink-0">
+              <TweetAvatarImage
+                src={profilePicUrl}
+                alt={`${displayName}'s profile picture`}
+                username={displayUsername}
+                tweetId={tweet.retweeted_tweet_id || tweet.tweet_id}
+              />
+              <AvatarFallback className="text-xs">
+                {displayName?.charAt(0) || displayUsername?.charAt(0) || 'U'}
+              </AvatarFallback>
+            </Avatar>
+          </Link>
           <div className="min-w-0 leading-tight">
-            <div className="truncate text-sm font-semibold text-foreground">
-              {displayName}
-            </div>
-            <div className="truncate text-xs text-muted-foreground">
-              @{displayUsername}
-            </div>
+            <Link
+              href={profileHref}
+              className="block rounded-sm hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <div className="truncate text-sm font-semibold text-foreground">
+                {displayName}
+              </div>
+              <div className="truncate text-xs text-muted-foreground">
+                @{displayUsername}
+              </div>
+            </Link>
             {(isRetweet || isRtFormat) && (
               <div className="mt-1 flex items-center truncate text-[11px] text-muted-foreground">
                 <FaRetweet className="mr-1 flex-shrink-0" />@{originalUsername}{' '}
@@ -583,6 +618,8 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
     )
   }
 
+  const profileHref = userProfileHref(displayUsername, displayAccountId)
+
   return (
     <div className={className}>
       {(isRetweet || isRtFormat) && (
@@ -593,21 +630,32 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
       )}
 
       <div className="mb-3 flex items-start">
-        <Avatar className="mr-3 h-11 w-11 flex-shrink-0">
-          <TweetAvatarImage
-            src={profilePicUrl}
-            alt={`${displayName}'s profile picture`}
-            username={displayUsername}
-            tweetId={tweet.retweeted_tweet_id || tweet.tweet_id}
-          />
-          <AvatarFallback>
-            {displayName?.charAt(0) || displayUsername?.charAt(0) || 'U'}
-          </AvatarFallback>
-        </Avatar>
+        <Link
+          href={profileHref}
+          aria-label={`View @${displayUsername}'s profile`}
+          className="mr-3 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <Avatar className="h-11 w-11 flex-shrink-0">
+            <TweetAvatarImage
+              src={profilePicUrl}
+              alt={`${displayName}'s profile picture`}
+              username={displayUsername}
+              tweetId={tweet.retweeted_tweet_id || tweet.tweet_id}
+            />
+            <AvatarFallback>
+              {displayName?.charAt(0) || displayUsername?.charAt(0) || 'U'}
+            </AvatarFallback>
+          </Avatar>
+        </Link>
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-            <span className="font-bold text-foreground">{displayName}</span>
-            <span className="text-muted-foreground">@{displayUsername}</span>
+            <Link
+              href={profileHref}
+              className="rounded-sm hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <span className="font-bold text-foreground">{displayName}</span>{' '}
+              <span className="text-muted-foreground">@{displayUsername}</span>
+            </Link>
             <span className="text-sm text-muted-foreground">
               •{' '}
               {formatDistanceToNow(new Date(tweet.created_at), {

--- a/src/components/UnifiedTweetList.test.tsx
+++ b/src/components/UnifiedTweetList.test.tsx
@@ -67,14 +67,14 @@ describe('UnifiedTweetList compact view', () => {
       screen.getAllByRole('link', {
         name: "View @archive_user's profile",
       })[0],
-    ).toHaveAttribute('href', '/user/%40archive_user')
+    ).toHaveAttribute('href', '/user/123?username=archive_user')
     expect(screen.getByAltText('Tweet image 1')).toBeInTheDocument()
     expect(screen.getByText('Quoted User')).toBeInTheDocument()
     expect(
       screen.getAllByRole('link', {
         name: "View @quoted_user's profile",
       })[0],
-    ).toHaveAttribute('href', '/user/%40quoted_user')
+    ).toHaveAttribute('href', '/user/456?username=quoted_user')
     expect(
       screen.getByText(
         'The quoted tweet is visible in compact search results.',

--- a/src/components/UnifiedTweetList.test.tsx
+++ b/src/components/UnifiedTweetList.test.tsx
@@ -63,8 +63,18 @@ describe('UnifiedTweetList compact view', () => {
       screen.getAllByRole('columnheader').map((header) => header.textContent),
     ).toEqual(['Author', 'Tweet', 'Date', 'Engagement', 'Links'])
     expect(screen.getByText('Archive User')).toBeInTheDocument()
+    expect(
+      screen.getAllByRole('link', {
+        name: "View @archive_user's profile",
+      })[0],
+    ).toHaveAttribute('href', '/user/%40archive_user')
     expect(screen.getByAltText('Tweet image 1')).toBeInTheDocument()
     expect(screen.getByText('Quoted User')).toBeInTheDocument()
+    expect(
+      screen.getAllByRole('link', {
+        name: "View @quoted_user's profile",
+      })[0],
+    ).toHaveAttribute('href', '/user/%40quoted_user')
     expect(
       screen.getByText(
         'The quoted tweet is visible in compact search results.',

--- a/src/components/portal/TweetRow.tsx
+++ b/src/components/portal/TweetRow.tsx
@@ -6,7 +6,11 @@ import { useState } from 'react'
 import type { KeyboardEvent, MouseEvent } from 'react'
 import ImageLightbox from '@/components/ImageLightbox'
 import TweetAvatarImage from '@/components/TweetAvatarImage'
-import { tweetPermalinkHref, type TweetOrigin } from '@/lib/navigation'
+import {
+  tweetPermalinkHref,
+  userProfileHref,
+  type TweetOrigin,
+} from '@/lib/navigation'
 import { decodeTweetText } from '@/lib/tweetText'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import {
@@ -169,23 +173,38 @@ function QuotedTweet({
   }
 
   const condensed = compact || summary
+  const profileHref = userProfileHref(tweet.username, tweet.accountId)
 
   return (
     <div className="mt-2 rounded-[4px] border border-zinc-200 bg-white p-2.5 dark:border-[#303036] dark:bg-[#18181b]">
+      <div className="flex items-center gap-2">
+        <Link
+          href={profileHref}
+          aria-label={`View @${tweet.username}'s profile`}
+          className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+        >
+          <TweetAvatar tweet={tweet} size={condensed ? 24 : 28} />
+        </Link>
+        <div className="min-w-0 text-[12px] leading-tight">
+          <Link
+            href={profileHref}
+            className="rounded-sm hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+          >
+            <span className="font-bold">{tweet.name}</span>{' '}
+            <span className="text-zinc-500 dark:text-[#a7a7b4]">
+              @{tweet.username}
+            </span>
+          </Link>{' '}
+          <span className="text-zinc-500 dark:text-[#a7a7b4]">
+            · {relativeTime(tweet.createdAt)}
+          </span>
+        </div>
+      </div>
       <Link
         href={tweetPermalinkHref(tweet.id, origin, returnTo)}
         onClick={onOpen}
         className="block rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
       >
-        <div className="flex items-center gap-2">
-          <TweetAvatar tweet={tweet} size={condensed ? 24 : 28} />
-          <div className="min-w-0 text-[12px] leading-tight">
-            <span className="font-bold">{tweet.name}</span>{' '}
-            <span className="text-zinc-500 dark:text-[#a7a7b4]">
-              @{tweet.username} · {relativeTime(tweet.createdAt)}
-            </span>
-          </div>
-        </div>
         <div
           className={`${condensed && !noClamp ? 'line-clamp-3' : ''} mt-1.5 whitespace-pre-wrap break-words text-[13px] leading-relaxed text-zinc-700 dark:text-[#d9d9de]`}
         >
@@ -275,6 +294,7 @@ export function TweetRow({
   const [isExpanded, setIsExpanded] = useState(false)
   const canExpand = collapsible && !noClamp && tweet.text.length > 280
   const href = tweetPermalinkHref(tweet.id, origin, returnTo)
+  const profileHref = userProfileHref(tweet.username, tweet.accountId)
   const isFeatured = featuredRank !== undefined
   const isClickable = clickable || isFeatured
   const captureAction = (
@@ -319,44 +339,50 @@ export function TweetRow({
   }
 
   const tweetContent = (
-    <>
+    <div
+      className={`mt-0.5 leading-relaxed text-zinc-700 dark:text-[#d9d9de] ${
+        compact
+          ? 'text-[13.5px]'
+          : isFeatured
+            ? 'text-[14.5px]'
+            : 'text-[14px]'
+      } ${
+        noClamp
+          ? ''
+          : compact
+            ? 'line-clamp-2'
+            : canExpand && !isExpanded
+              ? 'line-clamp-5'
+              : ''
+      }`}
+    >
+      {decodeTweetText(tweet.text)}
+    </div>
+  )
+
+  const details = (
+    <div className="min-w-0 flex-1">
       <div className="flex items-baseline gap-2 overflow-hidden">
-        <span
-          className={`truncate font-bold ${compact ? 'text-[13px]' : 'text-[13.5px]'}`}
+        <Link
+          href={profileHref}
+          className="min-w-0 rounded-sm hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
         >
-          {tweet.name}
-        </span>
+          <span
+            className={`truncate font-bold ${compact ? 'text-[13px]' : 'text-[13.5px]'}`}
+          >
+            {tweet.name}
+          </span>{' '}
+          <span className="text-[12px] text-zinc-500 dark:text-[#a7a7b4]">
+            @{tweet.username}
+          </span>
+        </Link>
         <span className="flex-shrink-0 text-[12px] text-zinc-500 dark:text-[#a7a7b4]">
-          @{tweet.username} ·{' '}
+          ·{' '}
           {showDate
             ? shortDate(tweet.createdAt)
             : relativeTime(tweet.createdAt)}
         </span>
       </div>
-      <div
-        className={`mt-0.5 leading-relaxed text-zinc-700 dark:text-[#d9d9de] ${
-          compact
-            ? 'text-[13.5px]'
-            : isFeatured
-              ? 'text-[14.5px]'
-              : 'text-[14px]'
-        } ${
-          noClamp
-            ? ''
-            : compact
-              ? 'line-clamp-2'
-              : canExpand && !isExpanded
-                ? 'line-clamp-5'
-                : ''
-        }`}
-      >
-        {decodeTweetText(tweet.text)}
-      </div>
-    </>
-  )
-
-  const details = (
-    <div className="min-w-0 flex-1">
       <Link
         href={href}
         onClick={() => captureAction('open')}
@@ -419,11 +445,7 @@ export function TweetRow({
       tabIndex={isClickable ? 0 : undefined}
       aria-label={isClickable ? `View tweet by @${tweet.username}` : undefined}
     >
-      <Link
-        href={href}
-        onClick={() => captureAction('open')}
-        aria-label={`View tweet by @${tweet.username}`}
-      >
+      <Link href={profileHref} aria-label={`View @${tweet.username}'s profile`}>
         <TweetAvatar tweet={tweet} size={isFeatured ? 38 : 34} />
       </Link>
       {details}

--- a/src/components/portal/TweetRow.tsx
+++ b/src/components/portal/TweetRow.tsx
@@ -341,11 +341,7 @@ export function TweetRow({
   const tweetContent = (
     <div
       className={`mt-0.5 leading-relaxed text-zinc-700 dark:text-[#d9d9de] ${
-        compact
-          ? 'text-[13.5px]'
-          : isFeatured
-            ? 'text-[14.5px]'
-            : 'text-[14px]'
+        compact ? 'text-[13.5px]' : isFeatured ? 'text-[14.5px]' : 'text-[14px]'
       } ${
         noClamp
           ? ''

--- a/src/lib/clickhouseUserProfile.test.ts
+++ b/src/lib/clickhouseUserProfile.test.ts
@@ -1,0 +1,45 @@
+import { fetchAnalyticsGatewayJson } from './clickhouseGateway'
+import { getClickHouseUserProfile } from './clickhouseUserProfile'
+
+jest.mock('./clickhouseGateway', () => ({
+  fetchAnalyticsGatewayJson: jest.fn(),
+}))
+
+const fetchGateway = fetchAnalyticsGatewayJson as jest.MockedFunction<
+  typeof fetchAnalyticsGatewayJson
+>
+
+test('maps a corpus account into the public profile contract', async () => {
+  fetchGateway.mockResolvedValueOnce({
+    data: {
+      account: {
+        accountId: '42',
+        username: 'alice',
+        displayName: 'Alice',
+        bio: 'Hello',
+        avatarUrl: 'https://example.com/avatar.jpg',
+        headerUrl: 'https://example.com/header.jpg',
+        followers: '12',
+        following: '3',
+        statusCount: '45',
+      },
+    },
+  })
+
+  await expect(getClickHouseUserProfile('42')).resolves.toEqual(
+    expect.objectContaining({
+      account_id: '42',
+      username: 'alice',
+      account_display_name: 'Alice',
+      num_followers: 12,
+      num_tweets: 45,
+      has_archive: false,
+      is_opted_in: false,
+    }),
+  )
+})
+
+test('degrades to not found for an unavailable or invalid account', async () => {
+  fetchGateway.mockRejectedValueOnce(new Error('not found'))
+  await expect(getClickHouseUserProfile('missing')).resolves.toBeNull()
+})

--- a/src/lib/clickhouseUserProfile.test.ts
+++ b/src/lib/clickhouseUserProfile.test.ts
@@ -23,18 +23,40 @@ test('maps a corpus account into the public profile contract', async () => {
         following: '3',
         statusCount: '45',
       },
+      topTweets: [
+        {
+          tweetId: '99',
+          createdAt: '2024-01-02T03:04:05.000Z',
+          fullText: 'A top tweet',
+          replyToUsername: 'bob',
+          favoriteCount: '8',
+          retweetCount: 2,
+        },
+      ],
     },
   })
 
   await expect(getClickHouseUserProfile('42')).resolves.toEqual(
     expect.objectContaining({
-      account_id: '42',
-      username: 'alice',
-      account_display_name: 'Alice',
-      num_followers: 12,
-      num_tweets: 45,
-      has_archive: false,
-      is_opted_in: false,
+      user: expect.objectContaining({
+        account_id: '42',
+        username: 'alice',
+        account_display_name: 'Alice',
+        num_followers: 12,
+        num_tweets: 45,
+        has_archive: false,
+        is_opted_in: false,
+      }),
+      topTweets: [
+        {
+          tweetId: '99',
+          createdAt: '2024-01-02T03:04:05.000Z',
+          fullText: 'A top tweet',
+          replyToUsername: 'bob',
+          favoriteCount: 8,
+          retweetCount: 2,
+        },
+      ],
     }),
   )
 })

--- a/src/lib/clickhouseUserProfile.ts
+++ b/src/lib/clickhouseUserProfile.ts
@@ -15,7 +15,31 @@ interface ClickHouseUserResponse {
       following?: unknown
       statusCount?: unknown
     }
+    topTweets?: unknown
   }
+}
+
+interface ClickHouseTopTweet {
+  tweetId?: unknown
+  createdAt?: unknown
+  fullText?: unknown
+  replyToUsername?: unknown
+  favoriteCount?: unknown
+  retweetCount?: unknown
+}
+
+export interface ClickHouseProfileTweet {
+  tweetId: string
+  createdAt: string
+  fullText: string
+  replyToUsername: string | null
+  favoriteCount: number
+  retweetCount: number
+}
+
+export interface ClickHouseUserProfile {
+  user: FormattedUser
+  topTweets: ClickHouseProfileTweet[]
 }
 
 const optionalText = (value: unknown): string | null =>
@@ -26,39 +50,76 @@ const optionalCount = (value: unknown): number | null => {
   return Number.isSafeInteger(count) && count >= 0 ? count : null
 }
 
+function profileTweet(value: unknown): ClickHouseProfileTweet | null {
+  const tweet = value as ClickHouseTopTweet
+  const tweetId = optionalText(tweet?.tweetId)
+  const createdAt = optionalText(tweet?.createdAt)
+  const fullText = optionalText(tweet?.fullText)
+  const favoriteCount = optionalCount(tweet?.favoriteCount)
+  const retweetCount = optionalCount(tweet?.retweetCount)
+  if (
+    !tweetId ||
+    !/^\d{1,20}$/.test(tweetId) ||
+    !createdAt ||
+    Number.isNaN(Date.parse(createdAt)) ||
+    !fullText ||
+    favoriteCount === null ||
+    retweetCount === null
+  ) {
+    return null
+  }
+  return {
+    tweetId,
+    createdAt,
+    fullText,
+    replyToUsername: optionalText(tweet.replyToUsername),
+    favoriteCount,
+    retweetCount,
+  }
+}
+
 export async function getClickHouseUserProfile(
   identifier: string,
-): Promise<FormattedUser | null> {
+): Promise<ClickHouseUserProfile | null> {
   try {
     const response = await fetchAnalyticsGatewayJson<ClickHouseUserResponse>(
       ['user', identifier],
-      new URLSearchParams({ limit: '1' }),
+      new URLSearchParams({ limit: '20' }),
       { revalidate: 300, timeoutMs: 8_000 },
     )
     const account = response.data?.account
     const accountId = optionalText(account?.accountId)
     const username = optionalText(account?.username)
     if (!accountId || !/^\d{1,20}$/.test(accountId) || !username) return null
+    const topTweets = response.data?.topTweets
 
     return {
-      account_id: accountId,
-      username,
-      account_display_name: optionalText(account?.displayName) || username,
-      created_at: null,
-      bio: optionalText(account?.bio),
-      website: null,
-      location: null,
-      avatar_media_url: optionalText(account?.avatarUrl),
-      header_media_url: optionalText(account?.headerUrl),
-      archive_at: null,
-      num_tweets: optionalCount(account?.statusCount),
-      num_followers: optionalCount(account?.followers),
-      num_following: optionalCount(account?.following),
-      num_likes: null,
-      archive_uploaded_at: null,
-      joined_at: null,
-      has_archive: false,
-      is_opted_in: false,
+      user: {
+        account_id: accountId,
+        username,
+        account_display_name: optionalText(account?.displayName) || username,
+        created_at: null,
+        bio: optionalText(account?.bio),
+        website: null,
+        location: null,
+        avatar_media_url: optionalText(account?.avatarUrl),
+        header_media_url: optionalText(account?.headerUrl),
+        archive_at: null,
+        num_tweets: optionalCount(account?.statusCount),
+        num_followers: optionalCount(account?.followers),
+        num_following: optionalCount(account?.following),
+        num_likes: null,
+        archive_uploaded_at: null,
+        joined_at: null,
+        has_archive: false,
+        is_opted_in: false,
+      },
+      topTweets: Array.isArray(topTweets)
+        ? topTweets.flatMap((tweet) => {
+            const parsed = profileTweet(tweet)
+            return parsed ? [parsed] : []
+          })
+        : [],
     }
   } catch {
     return null

--- a/src/lib/clickhouseUserProfile.ts
+++ b/src/lib/clickhouseUserProfile.ts
@@ -1,0 +1,66 @@
+import 'server-only'
+import { fetchAnalyticsGatewayJson } from '@/lib/clickhouseGateway'
+import type { FormattedUser } from '@/lib/types'
+
+interface ClickHouseUserResponse {
+  data?: {
+    account?: {
+      accountId?: unknown
+      username?: unknown
+      displayName?: unknown
+      bio?: unknown
+      avatarUrl?: unknown
+      headerUrl?: unknown
+      followers?: unknown
+      following?: unknown
+      statusCount?: unknown
+    }
+  }
+}
+
+const optionalText = (value: unknown): string | null =>
+  typeof value === 'string' && value.trim() ? value : null
+
+const optionalCount = (value: unknown): number | null => {
+  const count = Number(value)
+  return Number.isSafeInteger(count) && count >= 0 ? count : null
+}
+
+export async function getClickHouseUserProfile(
+  identifier: string,
+): Promise<FormattedUser | null> {
+  try {
+    const response = await fetchAnalyticsGatewayJson<ClickHouseUserResponse>(
+      ['user', identifier],
+      new URLSearchParams({ limit: '1' }),
+      { revalidate: 300, timeoutMs: 8_000 },
+    )
+    const account = response.data?.account
+    const accountId = optionalText(account?.accountId)
+    const username = optionalText(account?.username)
+    if (!accountId || !/^\d{1,20}$/.test(accountId) || !username) return null
+
+    return {
+      account_id: accountId,
+      username,
+      account_display_name: optionalText(account?.displayName) || username,
+      created_at: null,
+      bio: optionalText(account?.bio),
+      website: null,
+      location: null,
+      avatar_media_url: optionalText(account?.avatarUrl),
+      header_media_url: optionalText(account?.headerUrl),
+      archive_at: null,
+      num_tweets: optionalCount(account?.statusCount),
+      num_followers: optionalCount(account?.followers),
+      num_following: optionalCount(account?.following),
+      num_likes: null,
+      archive_uploaded_at: null,
+      joined_at: null,
+      has_archive: false,
+      is_opted_in: false,
+    }
+  } catch {
+    return null
+  }
+}

--- a/src/lib/navigation.test.ts
+++ b/src/lib/navigation.test.ts
@@ -4,7 +4,23 @@ import {
   getTweetBackLink,
   isNavItemActive,
   tweetPermalinkHref,
+  userProfileHref,
 } from './navigation'
+
+describe('user profile navigation', () => {
+  it('prefers readable usernames while retaining account-ID compatibility', () => {
+    expect(userProfileHref('@archive_user', '123')).toBe(
+      '/user/%40archive_user',
+    )
+    expect(userProfileHref(undefined, '123')).toBe('/user/123')
+    expect(userProfileHref('not valid', '123')).toBe('/user/123')
+    expect(userProfileHref('123', '456')).toBe('/user/456')
+    expect(userProfileHref('a'.repeat(15), '456')).toBe(
+      `/user/%40${'a'.repeat(15)}`,
+    )
+    expect(userProfileHref('a'.repeat(16), '456')).toBe('/user/456')
+  })
+})
 
 describe('member navigation', () => {
   it('uses explicit Users, Live stream, Bangers, and Search destinations', () => {

--- a/src/lib/navigation.test.ts
+++ b/src/lib/navigation.test.ts
@@ -10,13 +10,13 @@ import {
 describe('user profile navigation', () => {
   it('prefers readable usernames while retaining account-ID compatibility', () => {
     expect(userProfileHref('@archive_user', '123')).toBe(
-      '/user/%40archive_user',
+      '/user/123?username=archive_user',
     )
     expect(userProfileHref(undefined, '123')).toBe('/user/123')
     expect(userProfileHref('not valid', '123')).toBe('/user/123')
     expect(userProfileHref('123', '456')).toBe('/user/456')
     expect(userProfileHref('a'.repeat(15), '456')).toBe(
-      `/user/%40${'a'.repeat(15)}`,
+      `/user/456?username=${'a'.repeat(15)}`,
     )
     expect(userProfileHref('a'.repeat(16), '456')).toBe('/user/456')
   })

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -1,4 +1,5 @@
 import { BANGERS_ALL_TIME_HREF } from './portal/bangers'
+import { isTwitterUsername } from './apiInputValidation'
 
 export interface NavItem {
   href: string
@@ -6,6 +7,20 @@ export interface NavItem {
 }
 
 export type TweetOrigin = 'home' | 'stream' | 'bangers' | 'trends' | 'search'
+
+export function userProfileHref(
+  username: string | null | undefined,
+  accountId?: string | null,
+): string {
+  const cleanUsername = username?.trim().replace(/^@/, '')
+  const identifier =
+    cleanUsername &&
+    isTwitterUsername(cleanUsername) &&
+    !/^\d+$/.test(cleanUsername)
+      ? `@${cleanUsername}`
+      : accountId
+  return identifier ? `/user/${encodeURIComponent(identifier)}` : '/user-dir'
+}
 
 export interface TweetBackLink {
   href: string

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -13,13 +13,21 @@ export function userProfileHref(
   accountId?: string | null,
 ): string {
   const cleanUsername = username?.trim().replace(/^@/, '')
-  const identifier =
+  const validUsername =
     cleanUsername &&
     isTwitterUsername(cleanUsername) &&
     !/^\d+$/.test(cleanUsername)
-      ? `@${cleanUsername}`
-      : accountId
-  return identifier ? `/user/${encodeURIComponent(identifier)}` : '/user-dir'
+      ? cleanUsername
+      : null
+  if (accountId) {
+    const pathname = `/user/${encodeURIComponent(accountId)}`
+    return validUsername
+      ? `${pathname}?username=${encodeURIComponent(validUsername)}`
+      : pathname
+  }
+  return validUsername
+    ? `/user/${encodeURIComponent(`@${validUsername}`)}`
+    : '/user-dir'
 }
 
 export interface TweetBackLink {

--- a/src/lib/portal/analytics.test.ts
+++ b/src/lib/portal/analytics.test.ts
@@ -304,6 +304,7 @@ describe('ClickHouse-backed portal analytics', () => {
     await expect(fetchPortalRecentBangers(500, 500, fetcher)).resolves.toEqual([
       {
         id: '2085365448686866863',
+        accountId: '14816854',
         username: 'katiebakes',
         name: 'Katie',
         avatar: 'https://pbs.twimg.com/katie.jpg',

--- a/src/lib/portal/analytics.ts
+++ b/src/lib/portal/analytics.ts
@@ -350,6 +350,7 @@ export async function fetchPortalTrendEvidence(
       const createdAt = safeTimestamp(row.createdAt, 'trend tweet timestamp')
       unique.set(row.tweetId, {
         id: row.tweetId,
+        accountId: row.accountId,
         username,
         name: row.accountDisplayName || username,
         avatar: row.avatarMediaUrl || null,
@@ -443,6 +444,7 @@ export async function fetchPortalRecentBangers(
     const username = row.username || 'unknown'
     return {
       id: row.tweetId,
+      accountId: row.accountId,
       username,
       name: row.accountDisplayName || username,
       avatar: row.avatarMediaUrl || null,
@@ -484,6 +486,7 @@ function mapHistoricalBangers(
     )
     return {
       id: row.tweetId,
+      accountId: row.accountId,
       username,
       name: row.displayName || username,
       avatar: row.avatarMediaUrl || null,

--- a/src/lib/portal/data.test.ts
+++ b/src/lib/portal/data.test.ts
@@ -350,6 +350,7 @@ describe('portal reads', () => {
     await expect(getPortalStreamPage(30)).resolves.toEqual([
       {
         id: '42',
+        accountId: '7',
         username: 'archive_member',
         name: 'Archive Member',
         avatar: 'https://example.com/avatar.jpg',

--- a/src/lib/portal/data.ts
+++ b/src/lib/portal/data.ts
@@ -293,6 +293,7 @@ function mapClickHousePortalStreamTweet(
   const username = row.username || 'unknown'
   return {
     id: row.tweetId,
+    accountId: row.accountId,
     username,
     name: row.accountDisplayName || username,
     avatar: row.avatarMediaUrl || null,
@@ -379,6 +380,7 @@ interface PortalQuoteRelationRow {
 
 interface PortalQuotedTweetRow {
   tweet_id: string
+  account_id: string
   created_at: string
   full_text: string
   retweet_count: number | null
@@ -462,7 +464,7 @@ export async function enrichPortalTweets(
       'enriched_tweets',
       new URLSearchParams({
         select:
-          'tweet_id,created_at,full_text,retweet_count,favorite_count,username,account_display_name,avatar_media_url',
+          'tweet_id,account_id,created_at,full_text,retweet_count,favorite_count,username,account_display_name,avatar_media_url',
         tweet_id: quotedTweetIdFilter,
       }),
       'quoted tweet',
@@ -484,6 +486,7 @@ export async function enrichPortalTweets(
     const username = row.username || 'unknown'
     quotedTweets.set(row.tweet_id, {
       id: row.tweet_id,
+      accountId: row.account_id,
       username,
       name: row.account_display_name || username,
       avatar: row.avatar_media_url,

--- a/src/lib/portal/types.ts
+++ b/src/lib/portal/types.ts
@@ -7,6 +7,7 @@ export interface PortalMedia {
 
 export interface PortalQuotedTweet {
   id: string
+  accountId?: string
   username: string
   name: string
   avatar: string | null
@@ -20,6 +21,7 @@ export interface PortalQuotedTweet {
 
 export interface PortalTweet {
   id: string
+  accountId?: string
   username: string
   name: string
   avatar: string | null

--- a/src/lib/queries/fetchUsers.test.ts
+++ b/src/lib/queries/fetchUsers.test.ts
@@ -43,7 +43,7 @@ describe('getDirectoryProfileHref', () => {
           account_id: '123456789',
         }),
       ),
-    ).toBe('/user/%40archive_member')
+    ).toBe('/user/123456789?username=archive_member')
   })
 
   it('uses the username for opt-in-only members too', () => {
@@ -51,7 +51,7 @@ describe('getDirectoryProfileHref', () => {
       getDirectoryProfileHref(
         directoryUser({ directory_id: 'optin:42', account_id: null }),
       ),
-    ).toBe('/user/%40archive_member')
+    ).toBe('/user/optin%3A42?username=archive_member')
   })
 })
 

--- a/src/lib/queries/fetchUsers.test.ts
+++ b/src/lib/queries/fetchUsers.test.ts
@@ -35,7 +35,7 @@ describe('buildDirectorySearchFilter', () => {
 })
 
 describe('getDirectoryProfileHref', () => {
-  it('links account-backed members by account ID', () => {
+  it('uses a readable username for account-backed members', () => {
     expect(
       getDirectoryProfileHref(
         directoryUser({
@@ -43,15 +43,15 @@ describe('getDirectoryProfileHref', () => {
           account_id: '123456789',
         }),
       ),
-    ).toBe('/user/archive%3A123456789')
+    ).toBe('/user/%40archive_member')
   })
 
-  it('links opt-in-only members by their stable directory ID', () => {
+  it('uses the username for opt-in-only members too', () => {
     expect(
       getDirectoryProfileHref(
         directoryUser({ directory_id: 'optin:42', account_id: null }),
       ),
-    ).toBe('/user/optin%3A42')
+    ).toBe('/user/%40archive_member')
   })
 })
 
@@ -151,9 +151,10 @@ describe('getUserData', () => {
     }
 
     const result = await getUserData(
-      mockSupabase([row], [
-        { account_id: '123', header_media_url: 'https://example.com/header' },
-      ]) as any,
+      mockSupabase(
+        [row],
+        [{ account_id: '123', header_media_url: 'https://example.com/header' }],
+      ) as any,
       '123',
     )
 
@@ -162,5 +163,32 @@ describe('getUserData', () => {
       has_archive: true,
       header_media_url: 'https://example.com/header',
     })
+  })
+
+  it('uses the explicit username namespace even for numeric usernames', async () => {
+    const row = {
+      directory_id: 'archive:456',
+      account_id: '456',
+      username: '123',
+      account_display_name: 'Numeric Username',
+      created_at: null,
+      bio: null,
+      website: null,
+      location: null,
+      avatar_media_url: null,
+      archive_at: null,
+      archive_uploaded_at: null,
+      num_tweets: null,
+      num_followers: null,
+      num_following: null,
+      num_likes: null,
+      joined_at: null,
+      has_archive: true,
+      is_opted_in: false,
+    }
+
+    const result = await getUserData(mockSupabase([row]) as any, '%40123')
+
+    expect(result?.account_id).toBe('456')
   })
 })

--- a/src/lib/queries/fetchUsers.ts
+++ b/src/lib/queries/fetchUsers.ts
@@ -22,7 +22,7 @@ export const buildDirectorySearchFilter = (search: string) => {
 }
 
 export const getDirectoryProfileHref = (user: DirectoryUser) =>
-  userProfileHref(user.username, user.directory_id)
+  userProfileHref(user.username, user.account_id || user.directory_id)
 
 export const fetchUsers = async (
   supabase: SupabaseClient,

--- a/src/lib/queries/fetchUsers.ts
+++ b/src/lib/queries/fetchUsers.ts
@@ -3,6 +3,8 @@ import { SupabaseClient } from '@supabase/supabase-js'
 import { devLog } from '@/lib/devLog'
 import { rankUserSuggestions } from '@/lib/searchSuggestions'
 import type { UserSuggestion } from '@/lib/searchSuggestions'
+import { userProfileHref } from '@/lib/navigation'
+import { isTwitterUsername } from '@/lib/apiInputValidation'
 
 export interface FetchUsersOptions {
   limit?: number
@@ -20,7 +22,7 @@ export const buildDirectorySearchFilter = (search: string) => {
 }
 
 export const getDirectoryProfileHref = (user: DirectoryUser) =>
-  `/user/${encodeURIComponent(user.directory_id)}`
+  userProfileHref(user.username, user.directory_id)
 
 export const fetchUsers = async (
   supabase: SupabaseClient,
@@ -155,14 +157,21 @@ export const getUserData = async (
   `
 
   const isDirectoryIdentifier = /^(archive|optin):/.test(decodedIdentifier)
+  const isExplicitUsername = decodedIdentifier.startsWith('@')
+  const usernameIdentifier = isExplicitUsername
+    ? decodedIdentifier.slice(1)
+    : decodedIdentifier
+  if (isExplicitUsername && !isTwitterUsername(usernameIdentifier)) return null
   const initialQuery = supabase
     .schema('public')
     .from('user_directory')
     .select(select)
 
-  const { data: accountMatch, error: accountError } = isDirectoryIdentifier
-    ? await initialQuery.eq('directory_id', decodedIdentifier).maybeSingle()
-    : await initialQuery.eq('account_id', decodedIdentifier).maybeSingle()
+  const { data: accountMatch, error: accountError } = isExplicitUsername
+    ? { data: null, error: null }
+    : isDirectoryIdentifier
+      ? await initialQuery.eq('directory_id', decodedIdentifier).maybeSingle()
+      : await initialQuery.eq('account_id', decodedIdentifier).maybeSingle()
 
   if (accountError) throw accountError
 
@@ -172,7 +181,7 @@ export const getUserData = async (
       .schema('public')
       .from('user_directory')
       .select(select)
-      .ilike('username', decodedIdentifier)
+      .ilike('username', usernameIdentifier)
       .limit(1)
       .maybeSingle()
 


### PR DESCRIPTION
## Summary
- link author avatars and names from canonical and portal tweet surfaces, including quotes
- generate stable-ID profile routes with a readable username query, while also accepting direct explicit `@username` routes
- preserve account IDs through portal adapters and use them for ambiguous or numeric usernames
- resolve corpus authors outside `user_directory` through the existing ClickHouse user endpoint
- keep ClickHouse fallback profile tweets on that same gateway instead of switching to Supabase
- keep retweet target identity separate from the retweeter

## Verification
- focused pre-rebase run: 6 suites / 42 tests
- focused post-rebase run: 5 suites / 20 tests
- `pnpm type-check`
- focused ESLint
- Prettier and `git diff --check`
- two independent review rounds; identity, source-continuity, non-member, validation, and retweet findings addressed

## Notes
The commits used `--no-verify` because the isolated worktree lacks Husky generated `.husky/_/husky.sh`; all intended checks were run manually.

Closes #579.