### PR TITLE
Document archive storage policy rollout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,12 @@ Staging synchronization is automatic; production synchronization is not:
   branches. Fork PRs are skipped because they cannot access staging secrets.
 - Editing only `supabase/schemas/` is insufficient. Generate and commit the
   migration that the workflow can apply.
+- A Storage access change must keep three sources aligned: the bucket
+  declaration in `supabase/config.toml`, the desired RLS policy in
+  `supabase/schemas/060_policies.sql`, and a replay-safe migration in
+  `supabase/migrations/`. Verify the bucket's public flag and anonymous versus
+  authenticated object access on staging; a green staging sync does not change
+  production.
 - Before merging a PR with migrations, run the read-only
   `pnpm migrations:check`. If production is behind, report the pending
   migration in the PR or handoff.


### PR DESCRIPTION
## Summary
- register the three-source contract for Supabase Storage access changes
- require staging checks for the bucket flag plus anonymous and authenticated object access
- preserve the staging-versus-production authorization boundary

## Audit basis
This guidance was validated while preparing authenticated raw-archive downloads in PR #595. It records only the reusable operational procedure, not feature behavior.

## Validation
- compared against the canonical declarative schema and staging migration guidance
- staged only AGENTS.md
- git diff --check

No migration, deployment, or production change is included.