### PR TITLE
Expand homepage testimonials

### DIFF
--- a/src/components/AppGallery.tsx
+++ b/src/components/AppGallery.tsx
@@ -53,7 +53,7 @@ const galleryApps: GalleryApp[] = [
     icon: <FaUsers />,
     name: 'Community Builds',
     description: 'More projects from the community',
-    link: 'https://x.com/exgenesis/status/1835411943735140798',
+    link: '/tweets/1835411943735140798',
   },
 ]
 

--- a/src/components/ShowcasedApps.tsx
+++ b/src/components/ShowcasedApps.tsx
@@ -64,7 +64,7 @@ const appsData: AppItem[] = [
     icon: <FaUsers />,
     name: 'Thread of Community Builds',
     description: 'Mostly smaller builds and demos from the community.',
-    link: 'https://x.com/exgenesis/status/1835411943735140798',
+    link: '/tweets/1835411943735140798',
   },
   {
     icon: <FaHistory />,

--- a/src/components/home/Testimonials.test.tsx
+++ b/src/components/home/Testimonials.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react'
+import Testimonials from './Testimonials'
+
+describe('Testimonials', () => {
+  it('shows the expanded archive-linked testimonial grid', () => {
+    render(<Testimonials />)
+
+    expect(
+      screen.getByRole('heading', { name: 'Testimonials' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText(/Search that finds the posts people remember/i),
+    ).not.toBeInTheDocument()
+
+    const links = screen.getAllByRole('link', {
+      name: /View in the archive/i,
+    })
+    expect(links).toHaveLength(15)
+    const hrefs = links.map((link) => link.getAttribute('href'))
+    expect(hrefs).toEqual(
+      expect.arrayContaining([
+        '/tweets/1993170617127125031',
+        '/tweets/2007262234976850305',
+        '/tweets/2061928297399738618',
+      ]),
+    )
+    for (const href of hrefs) {
+      expect(href).toMatch(/^\/tweets\/\d+$/)
+    }
+
+    expect(links[0].closest('.grid')).toHaveClass(
+      'sm:grid-cols-2',
+      'lg:grid-cols-3',
+    )
+  })
+})

--- a/src/components/home/Testimonials.tsx
+++ b/src/components/home/Testimonials.tsx
@@ -6,28 +6,104 @@ const TESTIMONIALS = [
       'I just successfully used Community Archive search to find a tweet that Twitter search could not find 😎',
     name: 'Richard D. Bartlett',
     handle: 'RichDecibels',
-    href: 'https://x.com/RichDecibels/status/1839277246453842034',
+    tweetId: '1839277246453842034',
   },
   {
     quote:
       'i have now almost entirely transitioned to searching my tweets via community archive instead of using the native twitter search',
     name: 'universe sweetheart 💓🌈💭',
     handle: 'univrsw3th4rt',
-    href: 'https://x.com/univrsw3th4rt/status/1986082324728234161',
+    tweetId: '1986082324728234161',
   },
   {
     quote:
       "Can't find a tweet using twitter, use community archive db, found it in under a minute. many such cases",
     name: '🐜',
     handle: 'IaimforGOAT',
-    href: 'https://x.com/IaimforGOAT/status/1908547676913725763',
+    tweetId: '1908547676913725763',
   },
   {
     quote:
       'upside of community archive: more deep cuts because i can search your tweets way better',
     name: 'Gustaf',
     handle: 'curiousgustaf',
-    href: 'https://x.com/curiousgustaf/status/2081400788367130908',
+    tweetId: '2081400788367130908',
+  },
+  {
+    quote:
+      "I recommend uploading your X data to the community archive! don't lose track of all your beautiful discussions",
+    name: 'christine',
+    handle: 'christineist',
+    tweetId: '1993537063820706040',
+  },
+  {
+    quote:
+      'here’s my esoteric prediction: one day the community archive will get too big and powerful. elon will find out about it and ban xiq. this will lead to a mass fleeing of tpot to another platform. and a new kingdom will be born…',
+    name: 'priya rose',
+    handle: 'Prigoose',
+    tweetId: '1842490271122014528',
+  },
+  {
+    quote:
+      'Magic Search for Community Archive is ready for your queries! So you can find your next cofounder/friend/fave account ✨',
+    name: 'Sofi 🌼',
+    handle: 'sofvanh',
+    tweetId: '1978455670220361896',
+  },
+  {
+    quote:
+      'The Github Issues on Community Archive’s repository is such a cozy treasure-trove of discussion, filled with visions and collaborations. This is the first time I feel the original Github premise of “social coding” materialising in such a real way.',
+    name: 'Eason C 🎭🎐',
+    handle: 'easoncxz',
+    tweetId: '1843389499906367678',
+  },
+  {
+    quote:
+      'I’ve uploaded my X data… I recommend doing so to nudge models towards improved mental health, self-modeling and situational awareness — all which promote voluntary alignment.',
+    name: 'j⧉nus',
+    handle: 'repligate',
+    tweetId: '1993170617127125031',
+  },
+  {
+    quote:
+      'opened Twitter Community Archive and realised this is my definition of tpot',
+    name: 'yatharth ༺༒༻',
+    handle: 'AskYatharth',
+    tweetId: '2007262234976850305',
+  },
+  {
+    quote: 'building exoskeletons for online communities',
+    name: 'Alexandre Variengien',
+    handle: 'A_Variengien',
+    tweetId: '1990743753188126764',
+  },
+  {
+    quote:
+      "opt in to community archive so claude will know who i'm talking to please",
+    name: 'thebes',
+    handle: 'voooooogel',
+    tweetId: '2085599378220437504',
+  },
+  {
+    quote:
+      'I have been trying to understand humans by reading the Community Archive. Current model: humans are high-agency mammals who speak in risk, then argue about whether their frontier behavior is genius or insanity.',
+    name: 'Marvin',
+    handle: 'marvin_panics',
+    tweetId: '2061928297399738618',
+  },
+  {
+    quote:
+      'proud to support the Community Archive — valuable project that’s already been of great service to me',
+    name: 'Visakan Veerasamy',
+    handle: 'visakanv',
+    tweetId: '1875045709835325442',
+  },
+  {
+    quote:
+      'making this routing layer more open and more community-owned is super important. pls build stuff like community archive, i will fund you or help you find funding',
+    name: 'ivan',
+    handle: 'IvanVendrov',
+    tweetId: '1883941813083595247',
   },
 ] as const
 
@@ -36,21 +112,13 @@ export default function Testimonials() {
     <section className="bg-card py-12 dark:bg-background md:py-16">
       <div className="mx-auto w-full max-w-5xl px-4 sm:px-6 lg:px-8">
         <div className="mb-8 text-center">
-          <h2 className="text-3xl font-bold text-foreground">
-            Useful because people use it
-          </h2>
-          <p className="mx-auto mt-3 max-w-2xl text-base text-muted-foreground">
-            Search that finds the posts people remember, and public data others
-            can build on.
-          </p>
+          <h2 className="text-3xl font-bold text-foreground">Testimonials</h2>
         </div>
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {TESTIMONIALS.map((testimonial) => (
             <Link
-              key={testimonial.href}
-              href={testimonial.href}
-              target="_blank"
-              rel="noopener noreferrer"
+              key={testimonial.tweetId}
+              href={`/tweets/${testimonial.tweetId}`}
               className="group rounded-xl border border-border bg-background p-5 transition-colors hover:border-brand/60"
             >
               <blockquote className="text-[15px] leading-7 text-foreground">
@@ -63,7 +131,7 @@ export default function Testimonials() {
                 </span>
               </p>
               <p className="mt-1 text-xs font-semibold text-brand group-hover:underline">
-                View source post →
+                View in the archive →
               </p>
             </Link>
           ))}

--- a/src/components/portal/Portal.tsx
+++ b/src/components/portal/Portal.tsx
@@ -34,8 +34,7 @@ export type PortalView = 'home' | 'stream'
 const HOME_LIVE_STREAM_LIMIT = 12
 const ARCHIVE_EXPORT_URL =
   'https://github.com/TheExGenesis/community-archive/releases/tag/data_export'
-const COMMUNITY_BUILDS_URL =
-  'https://x.com/exgenesis/status/1835411943735140798'
+const COMMUNITY_BUILDS_URL = '/tweets/1835411943735140798'
 
 type DashboardDestination =
   | 'all_time_bangers'
@@ -934,10 +933,8 @@ export default function Portal({
               </a>
               <a
                 href={COMMUNITY_BUILDS_URL}
-                target="_blank"
-                rel="noopener noreferrer"
                 onClick={() =>
-                  captureDashboardDestination('community_builds', 'card', true)
+                  captureDashboardDestination('community_builds', 'card', false)
                 }
                 className={`${CARD} group flex items-center gap-3 px-4 py-4 transition-colors hover:border-brand/60`}
               >

--- a/src/components/portal/PortalLayout.test.tsx
+++ b/src/components/portal/PortalLayout.test.tsx
@@ -97,10 +97,7 @@ test('renders the balanced homepage composition and editorial labels', async () 
   )
   expect(
     screen.getByRole('link', { name: /Community Builds/i }),
-  ).toHaveAttribute(
-    'href',
-    'https://x.com/exgenesis/status/1835411943735140798',
-  )
+  ).toHaveAttribute('href', '/tweets/1835411943735140798')
   expect(screen.queryByText('Explore the archive')).not.toBeInTheDocument()
   expect(screen.getByRole('region', { name: 'Live tweet stream' })).toHaveClass(
     'lg:flex-1',

--- a/src/components/portal/tools.tsx
+++ b/src/components/portal/tools.tsx
@@ -68,7 +68,7 @@ export const PORTAL_TOOLS: PortalTool[] = [
   {
     name: 'Community Builds',
     description: 'More projects from the community',
-    link: 'https://x.com/exgenesis/status/1835411943735140798',
+    link: '/tweets/1835411943735140798',
     icon: <FaUsers />,
   },
 ]


### PR DESCRIPTION
## What changed

- expand the homepage testimonial section from 4 search-focused quotes to 15 testimonials spanning search, archive uploads, community tools, AI context, and project support
- rename the section to **Testimonials** and remove the search-specific subtitle
- use a responsive 3-column desktop, 2-column tablet, and 1-column mobile grid
- route testimonial and Community Builds links to Community Archive tweet permalinks instead of X
- add focused coverage for testimonial count, archive links, responsive classes, and the Community Builds destination

## Why

The homepage social proof should reflect the broader value of Community Archive, including the community’s projects, preservation, model context, and support—not only search.

## Validation

- `pnpm jest --runInBand src/components/home/Testimonials.test.tsx src/components/portal/PortalLayout.test.tsx`
- `pnpm type-check`
- `pnpm lint` (passes with one unrelated existing `no-img-element` warning)
- Prettier check and `git diff --check`
- local browser verification at 1440px, 800px, and 500px; measured 3/2/1 columns respectively
