### PR TITLE
Fix homepage tweet count source

### DIFF
--- a/memos/20260812-1413-homepage-tweet-count-source.md
+++ b/memos/20260812-1413-homepage-tweet-count-source.md
@@ -1,0 +1,52 @@
+# Homepage tweet-count source diagnosis
+
+Date: 2026-08-12 14:13 PDT
+
+Issue: [#604](https://github.com/TheExGenesis/community-archive/issues/604)
+
+## Outcome
+
+The homepage corpus total was reading ClickHouse's `canonical_corpus` summary,
+but that projection does not yet receive tweets inserted by the archive-upload
+processor. The homepage now reads the existing Supabase
+`global_activity_summary` for the corpus total and snapshot timestamp. It still
+uses ClickHouse `stream-stats` for the rolling browser-firehose rate.
+
+No schema or production-data mutation was required.
+
+## Production evidence
+
+Read-only checks on 2026-08-12 found:
+
+| Source                                   |                   Tweets | Archive coverage                                                      |
+| ---------------------------------------- | -----------------------: | --------------------------------------------------------------------- |
+| Supabase exact `public.tweets` count     |               15,131,587 | 7,055,522 archived tweets; latest archive upload ID 691               |
+| Supabase daily `global_activity_summary` |               15,100,732 | Refreshed at 05:15 UTC                                                |
+| ClickHouse current projection            | approximately 14,850,618 | approximately 6,719,954 archived tweets; latest archive upload ID 651 |
+| ClickHouse homepage gateway snapshot     |               14,833,838 | Collected at 04:31 UTC                                                |
+
+The current projection trailed the exact Supabase corpus by approximately
+280,969 tweets. Its archive provenance also stopped 40 upload IDs behind
+Supabase. This matches the documented topology: archive uploads write to
+PostgreSQL today, while the browser extension and autorefresh write directly to
+both stores.
+
+## Code routing
+
+- `fetchPortalCorpusStats()` reads `total_tweets,last_updated` from Supabase and
+  caches the result for five minutes.
+- `fetchPortalLiveAnalytics()` no longer requests the ClickHouse global
+  summary; it requests only the rolling `stream-stats` data it owns.
+- The combined portal failure state still degrades the tweet metric safely if
+  either the corpus snapshot or live-rate request fails.
+
+Do not move the homepage total back to ClickHouse until archive-upload replay,
+ongoing emission, source-count parity, and freshness have all been verified.
+
+## Validation
+
+- `pnpm test:ci`: 68 suites, 296 tests passed.
+- `pnpm type-check`: passed.
+- `pnpm lint`: passed with one pre-existing `<img>` warning in
+  `UnifiedTweetList.test.tsx`.
+- Focused portal tests and Prettier checks passed.

--- a/src/lib/portal/analytics.test.ts
+++ b/src/lib/portal/analytics.test.ts
@@ -12,17 +12,8 @@ import { fetchAnalyticsGatewayJson } from '@/lib/clickhouseGateway'
 type AnalyticsFetcher = typeof fetchAnalyticsGatewayJson
 
 describe('ClickHouse-backed portal analytics', () => {
-  test('maps the canonical summary and rolling 24-hour stream stats', async () => {
-    const fetcher = jest.fn(async (path: string[]) => {
-      if (path[0] === 'summary') {
-        return {
-          data: {
-            totalTweets: '14800000',
-            sourceUpdatedAt: '2026-08-07 11:55:00.000',
-            collectedAt: '2026-08-07 12:00:00.000',
-          },
-        }
-      }
+  test('maps the rolling 24-hour stream stats', async () => {
+    const fetcher = jest.fn(async () => {
       return {
         summary: {
           totalTweets: '1234',
@@ -36,16 +27,12 @@ describe('ClickHouse-backed portal analytics', () => {
     await expect(
       fetchPortalLiveAnalytics(new Date('2026-08-07T12:00:00.000Z'), fetcher),
     ).resolves.toEqual({
-      totalTweets: 14_800_000,
       streamedLast24Hours: 1234,
-      generatedAt: '2026-08-07T12:00:00.000Z',
       latestObservedAt: '2026-08-07T11:59:00.000Z',
     })
 
-    expect(fetcher).toHaveBeenCalledTimes(2)
-    const streamCall = (fetcher as jest.Mock).mock.calls.find(
-      ([path]) => path[0] === 'stream-stats',
-    )
+    expect(fetcher).toHaveBeenCalledTimes(1)
+    const streamCall = (fetcher as jest.Mock).mock.calls[0]
     expect(streamCall?.[1].toString()).toBe(
       'start=2026-08-06T12%3A00%3A00.000Z&end=2026-08-07T12%3A00%3A00.000Z&granularity=hour&scope=firehose',
     )
@@ -293,29 +280,19 @@ describe('ClickHouse-backed portal analytics', () => {
     })
   })
 
-  test('rejects invalid ClickHouse counts instead of rendering false zeros', async () => {
-    const fetcher = jest.fn(async (path: string[]) =>
-      path[0] === 'summary'
-        ? {
-            data: {
-              totalTweets: 'not-a-count',
-              sourceUpdatedAt: '2026-08-07T12:00:00.000Z',
-              collectedAt: '2026-08-07T12:00:00.000Z',
-            },
-          }
-        : {
-            summary: {
-              totalTweets: '1',
-              latestObservedAt: null,
-              scope: 'firehose',
-              countMode: 'unique_tweets_observed',
-            },
-          },
-    ) as unknown as AnalyticsFetcher
+  test('rejects invalid ClickHouse stream counts instead of rendering false zeros', async () => {
+    const fetcher = jest.fn(async () => ({
+      summary: {
+        totalTweets: 'not-a-count',
+        latestObservedAt: null,
+        scope: 'firehose',
+        countMode: 'unique_tweets_observed',
+      },
+    })) as unknown as AnalyticsFetcher
 
     await expect(
       fetchPortalLiveAnalytics(new Date('2026-08-07T12:00:00.000Z'), fetcher),
-    ).rejects.toThrow('invalid tweet count')
+    ).rejects.toThrow('invalid last-24-hours streamed count')
   })
 
   test('maps recent member bangers and requests the 30-minute cache window', async () => {

--- a/src/lib/portal/analytics.ts
+++ b/src/lib/portal/analytics.ts
@@ -32,14 +32,6 @@ type AnalyticsFetcher = typeof fetchAnalyticsGatewayJson
 // Keep corpus-scan fan-out aligned with the two-query production capacity.
 const DEFAULT_ANALYTICS_CONCURRENCY = 2
 
-interface ClickHouseSummaryResponse {
-  data: {
-    totalTweets: string | number
-    sourceUpdatedAt: string
-    collectedAt: string
-  }
-}
-
 interface ClickHouseStreamStatsResponse {
   summary: {
     totalTweets: string | number
@@ -124,9 +116,7 @@ interface ClickHouseTopQuotesResponse {
 }
 
 export interface PortalLiveAnalytics {
-  totalTweets: number
   streamedLast24Hours: number
-  generatedAt: string
   latestObservedAt: string | null
 }
 
@@ -412,14 +402,11 @@ export async function fetchPortalLiveAnalytics(
     scope: 'firehose',
   })
 
-  const [summary, stream] = await Promise.all([
-    fetcher<ClickHouseSummaryResponse>(['summary'], new URLSearchParams(), {
-      timeoutMs: 25_000,
-    }),
-    fetcher<ClickHouseStreamStatsResponse>(['stream-stats'], streamParams, {
-      timeoutMs: 25_000,
-    }),
-  ])
+  const stream = await fetcher<ClickHouseStreamStatsResponse>(
+    ['stream-stats'],
+    streamParams,
+    { timeoutMs: 25_000 },
+  )
 
   if (
     stream.summary?.scope !== 'firehose' ||
@@ -429,12 +416,10 @@ export async function fetchPortalLiveAnalytics(
   }
 
   return {
-    totalTweets: safeCount(summary.data.totalTweets, 'tweet count'),
     streamedLast24Hours: safeCount(
       stream.summary.totalTweets,
       'last-24-hours streamed count',
     ),
-    generatedAt: safeTimestamp(summary.data.collectedAt, 'snapshot timestamp'),
     latestObservedAt: stream.summary.latestObservedAt
       ? safeTimestamp(stream.summary.latestObservedAt, 'observation timestamp')
       : null,

--- a/src/lib/portal/data.test.ts
+++ b/src/lib/portal/data.test.ts
@@ -15,6 +15,7 @@ jest.mock('./research', () => ({
 }))
 
 import {
+  fetchPortalCorpusStats,
   fetchPortalMemberCount,
   getInitialPortalBangersPage,
   getPortalBangersPage,
@@ -162,9 +163,7 @@ describe('portal page resilience', () => {
       computedAt: '2026-08-07T20:00:00.000Z',
     })
     fetchPortalLiveAnalyticsMock.mockResolvedValue({
-      totalTweets: 1_000,
       streamedLast24Hours: 25,
-      generatedAt: '2026-08-07T20:00:00.000Z',
       latestObservedAt: '2026-08-07T20:00:00.000Z',
     })
     fetchPortalRecentBangersMock.mockResolvedValue([])
@@ -181,6 +180,20 @@ describe('portal page resilience', () => {
           status: 200,
           headers: { 'content-range': '0-0/42' },
         })
+      }
+      if (url.pathname.endsWith('/global_activity_summary')) {
+        return new Response(
+          JSON.stringify([
+            {
+              total_tweets: 15_100_732,
+              last_updated: '2026-08-07T20:00:00.000Z',
+            },
+          ]),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          },
+        )
       }
       if (url.pathname.endsWith('/tweets')) {
         const createdAt = url.searchParams.get('order')?.endsWith('.asc')
@@ -234,7 +247,7 @@ describe('portal page resilience', () => {
 
     await expect(getPortalData()).resolves.toMatchObject({
       stats: {
-        totalTweets: 1_000,
+        totalTweets: 15_100_732,
         accountCount: 42,
         firstYear: 2007,
         currentYear: 2026,
@@ -249,14 +262,14 @@ describe('portal page resilience', () => {
     })
   })
 
-  test('preserves member and corpus metrics when live analytics fails', async () => {
+  test('preserves the Supabase corpus total when live analytics fails', async () => {
     fetchPortalLiveAnalyticsMock.mockRejectedValueOnce(
       new Error('live analytics unavailable'),
     )
 
     await expect(getPortalData()).resolves.toMatchObject({
       stats: {
-        totalTweets: 0,
+        totalTweets: 15_100_732,
         accountCount: 42,
         firstYear: 2007,
         currentYear: 2026,
@@ -283,6 +296,34 @@ describe('portal reads', () => {
     process.env.CLICKHOUSE_ANALYTICS_API_URL =
       'https://analytics.community-archive.org/analytics'
     process.env.CLICKHOUSE_ANALYTICS_API_TOKEN = 'test-token'
+  })
+
+  test('reads the homepage corpus total from the Supabase summary', async () => {
+    const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify([
+          {
+            total_tweets: 15_100_732,
+            last_updated: '2026-08-12T05:15:00.098756+00:00',
+          },
+        ]),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    )
+
+    await expect(fetchPortalCorpusStats()).resolves.toEqual({
+      totalTweets: 15_100_732,
+      generatedAt: '2026-08-12T05:15:00.098Z',
+    })
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://prod-project.supabase.co/rest/v1/global_activity_summary?select=total_tweets%2Clast_updated',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          apikey: 'prod-public-anon',
+          'Accept-Profile': 'public',
+        }),
+      }),
+    )
   })
 
   afterEach(() => {

--- a/src/lib/portal/data.ts
+++ b/src/lib/portal/data.ts
@@ -47,6 +47,11 @@ interface PortalCorpusRange {
   currentYear: number
 }
 
+interface PortalCorpusStats {
+  totalTweets: number
+  generatedAt: string
+}
+
 const PORTAL_READ_TIMEOUT_MS = 10_000
 export const PORTAL_BANGERS_PAGE_SIZE = 30
 const PORTAL_BANGERS_PERIOD_SCAN_PAGE_SIZE = 100
@@ -198,6 +203,45 @@ function exactCount(response: Response, label: string): number {
     throw new Error(`Portal ${label} count returned an invalid response`)
   }
   return count
+}
+
+function portalSnapshotCount(value: number | null, label: string): number {
+  if (value === null || !Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`Portal ${label} returned an invalid response`)
+  }
+  return value
+}
+
+function portalSnapshotTimestamp(value: string, label: string): string {
+  const timestamp = new Date(value)
+  if (Number.isNaN(timestamp.getTime())) {
+    throw new Error(`Portal ${label} returned an invalid response`)
+  }
+  return timestamp.toISOString()
+}
+
+/** Supabase is authoritative for archive uploads until that path reaches ClickHouse. */
+export async function fetchPortalCorpusStats(): Promise<PortalCorpusStats> {
+  const rows = await portalRestRows<{
+    total_tweets: number | null
+    last_updated: string
+  }>(
+    'global_activity_summary',
+    new URLSearchParams({ select: 'total_tweets,last_updated' }),
+  )
+  if (rows.length !== 1) {
+    throw new Error('Portal corpus summary returned an invalid response')
+  }
+  return {
+    totalTweets: portalSnapshotCount(
+      rows[0].total_tweets,
+      'corpus tweet count',
+    ),
+    generatedAt: portalSnapshotTimestamp(
+      rows[0].last_updated,
+      'corpus summary timestamp',
+    ),
+  }
 }
 
 /** Archive uploaders plus opted-in members, deduplicated by production. */
@@ -634,6 +678,11 @@ const getCachedCorpusRange = unstable_cache(
   ['portal-corpus-range-v1'],
   { revalidate: 86_400 },
 )
+const getCachedCorpusStats = unstable_cache(
+  async (_sourceKey: string) => fetchPortalCorpusStats(),
+  ['portal-corpus-stats-v1'],
+  { revalidate: 300 },
+)
 const getCachedLiveAnalytics = unstable_cache(
   async (_sourceKey: string) => fetchPortalLiveAnalytics(),
   ['portal-live-analytics-v1'],
@@ -936,6 +985,7 @@ export async function getPortalData(
   const [
     trends,
     corpusRange,
+    corpusStats,
     liveAnalytics,
     memberCount,
     joinedThisWeek,
@@ -955,12 +1005,15 @@ export async function getPortalData(
       { firstYear: 0, currentYear: 0 },
     ),
     loadPortalComponentData(
+      'corpus-stats',
+      () => getCachedCorpusStats(sourceKey),
+      { totalTweets: 0, generatedAt: new Date().toISOString() },
+    ),
+    loadPortalComponentData(
       'live-analytics',
       () => getCachedLiveAnalytics(sourceKey),
       {
-        totalTweets: 0,
         streamedLast24Hours: 0,
-        generatedAt: new Date().toISOString(),
         latestObservedAt: null,
       },
     ),
@@ -1005,20 +1058,20 @@ export async function getPortalData(
       : Promise.resolve({ data: [], failed: false }),
   ])
   const stats: PortalStats = {
-    totalTweets: liveAnalytics.data.totalTweets,
+    totalTweets: corpusStats.data.totalTweets,
     accountCount: memberCount.data,
     streamedLast24Hours: liveAnalytics.data.streamedLast24Hours,
     joinedThisWeek: joinedThisWeek.data,
     firstYear: corpusRange.data.firstYear,
     currentYear: corpusRange.data.currentYear,
-    generatedAt: liveAnalytics.data.generatedAt,
+    generatedAt: corpusStats.data.generatedAt,
   }
   const selectedStream =
     view === 'home'
       ? selectHomepageStream(
           [...initialStream.data, ...recentBangers.data],
           30,
-          new Date(liveAnalytics.data.generatedAt),
+          new Date(corpusStats.data.generatedAt),
         )
       : initialStream.data
   return {
@@ -1029,7 +1082,7 @@ export async function getPortalData(
     recentBangers: recentBangers.data,
     historicalBangers: historicalBangers.data,
     failures: {
-      liveAnalytics: liveAnalytics.failed,
+      liveAnalytics: corpusStats.failed || liveAnalytics.failed,
       memberCount: memberCount.failed,
       joinedThisWeek: joinedThisWeek.failed,
       corpusRange: corpusRange.failed,


### PR DESCRIPTION
## What changed

- Read the homepage corpus total and snapshot timestamp from Supabase `global_activity_summary`.
- Keep ClickHouse responsible for the rolling 24-hour browser-firehose rate only.
- Cache the Supabase summary for five minutes and preserve the existing partial-failure behavior.
- Add regression coverage and a production-evidence memo.

## Why

The homepage was displaying ClickHouse's `canonical_corpus` summary, but the archive-upload processor currently writes only to Supabase. Read-only production checks found 15,131,587 exact Supabase tweets versus approximately 14,850,618 in the current ClickHouse projection. ClickHouse archive provenance stopped at upload ID 651 while Supabase had reached 691, explaining the roughly 281K-tweet gap.

This routes the public corpus total to the source that currently contains every ingestion path while retaining ClickHouse for live analytical data.

Closes #604

## Validation

- `pnpm test:ci` — 68 suites / 296 tests passed
- `pnpm type-check` — passed
- `pnpm lint` — passed with one pre-existing `<img>` warning in `UnifiedTweetList.test.tsx`
- Focused portal tests and Prettier checks passed
