### PR TITLE
Document protected preview verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,10 @@ Staging synchronization is automatic; production synchronization is not:
 Use Node 20 from `.nvmrc` and pnpm. Prefer the narrowest relevant check, then
 expand verification in proportion to risk.
 
+For non-interactive smoke checks against SSO-protected Vercel previews, follow
+`docs/staging.md`. Do not disable deployment protection to make a preview
+machine-readable.
+
 ```bash
 pnpm dev                 # Next.js with local Supabase
 pnpm dev-remote-db       # Next.js with configured remote development DB

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -165,6 +165,37 @@ For PR-created Vercel Preview deployments, add the values from `.env.staging.gen
 
 After updating Preview env vars, redeploy the PR preview so the new values are picked up.
 
+### Programmatic smoke checks for protected previews
+
+The project's Vercel Preview deployments require SSO. For a non-interactive
+smoke check, run `vercel curl` from a checkout linked to the project through
+`.vercel/project.json`; it supplies deployment-protection access without
+disabling the protection setting.
+
+Community Archive's request middleware blocks the default curl user agent and
+JavaScript-challenges ordinary first-time page requests. Use one of the
+middleware's intentional social-preview user agents when checking rendered
+HTML or archive permalinks:
+
+```bash
+PREVIEW_URL=https://example-preview.vercel.app
+
+npx --yes vercel@latest curl / \
+  --deployment "$PREVIEW_URL" \
+  -- --silent --show-error --user-agent Twitterbot/1.0 \
+  --write-out '\nHTTP_STATUS:%{http_code}\n'
+
+npx --yes vercel@latest curl /tweets/<tweet-id> \
+  --deployment "$PREVIEW_URL" \
+  -- --silent --show-error --user-agent Twitterbot/1.0 \
+  --write-out '\nHTTP_STATUS:%{http_code}\n'
+```
+
+This verifies deployed server-rendered HTML and route availability. It does not
+replace a visual browser check; use an authenticated Vercel browser session for
+interactive preview QA, or perform the responsive visual pass locally before
+the remote smoke check.
+
 ## Keeping Staging Schema Current
 
 The `Sync staging database` GitHub Action soft-resets staging from the repo schema and mock seed data:


### PR DESCRIPTION
## What changed

- document how to use authenticated `vercel curl` for SSO-protected preview deployments without disabling deployment protection
- record the Community Archive middleware user-agent requirement for non-interactive HTML and permalink smoke checks
- distinguish deployed route/HTML checks from responsive visual browser QA
- point agents from the repository guide to the canonical staging runbook

## Why

The protected preview and the application's own request middleware form two separate access gates. Without this procedure, a successful preview can look unavailable first through the Vercel login page and then through an application-level 403 from the default curl user agent.

## Impact

Documentation only. No runtime behavior, protection setting, or production state changes.

## Validation

- verified the documented `vercel curl` flow against PR #606's protected preview
- confirmed the preview homepage and representative testimonial and Community Builds permalinks returned HTTP 200
- Prettier Markdown check with repository-independent configuration
- `git diff --check`
