### PR TITLE
Order Bangers masonry left to right

### DIFF
--- a/src/components/portal/BangersExplorer.test.tsx
+++ b/src/components/portal/BangersExplorer.test.tsx
@@ -37,6 +37,26 @@ jest.mock('@/components/TweetCard', () => ({
   ),
 }))
 
+function mockViewportWidth(width: number) {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: jest.fn((query: string) => {
+      const minWidth = Number(query.match(/min-width: (\d+)px/)?.[1] ?? 0)
+      return {
+        matches: width >= minWidth,
+        media: query,
+        onchange: null,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      }
+    }),
+  })
+}
+
 class IntersectionObserverMock {
   static instances: IntersectionObserverMock[] = []
   readonly observed: Element[] = []
@@ -78,6 +98,12 @@ const tweets = [
   tweet('2', 'Older favorite', 2025, 9, 100),
   tweet('1', 'Newest thought', 2026, 3, 10),
 ]
+const masonryTweets = [
+  ...tweets,
+  tweet('4', 'Fourth thought', 2026, 2, 8),
+  tweet('5', 'Fifth thought', 2026, 1, 7),
+  tweet('6', 'Sixth thought', 2026, 1, 6),
+]
 
 function page(
   pageTweets = tweets,
@@ -116,6 +142,7 @@ function renderExplorer(initialPage = page(), period?: PortalBangersPeriod) {
 describe('BangersExplorer', () => {
   beforeEach(() => {
     window.history.replaceState({}, '', '/bangers')
+    mockViewportWidth(1440)
     push.mockReset()
     mockCapturePostHogEvent.mockReset()
     IntersectionObserverMock.instances = []
@@ -178,16 +205,70 @@ describe('BangersExplorer', () => {
     expect(screen.queryByText('Likes')).not.toBeInTheDocument()
     expect(screen.queryByText('Reposts')).not.toBeInTheDocument()
     expect(screen.getByTestId('bangers-masonry')).toHaveClass(
-      'columns-1',
-      'lg:columns-2',
-      'xl:columns-3',
+      'grid',
+      'items-start',
+      'gap-5',
     )
+    expect(screen.getByTestId('bangers-masonry')).toHaveStyle({
+      gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+    })
     expect(
-      screen.getAllByTestId('tweet-row').map((row) => row.dataset.rank),
-    ).toEqual(['1', '2', '3'])
+      within(screen.getByTestId('bangers-masonry-column-0'))
+        .getAllByTestId('tweet-row')
+        .map((row) => row.dataset.rank),
+    ).toEqual(['1'])
+    expect(
+      within(screen.getByTestId('bangers-masonry-column-1'))
+        .getAllByTestId('tweet-row')
+        .map((row) => row.dataset.rank),
+    ).toEqual(['2'])
+    expect(
+      within(screen.getByTestId('bangers-masonry-column-2'))
+        .getAllByTestId('tweet-row')
+        .map((row) => row.dataset.rank),
+    ).toEqual(['3'])
     expect(
       orderedMasonryItems.map((item) => item.dataset.masonryOrder),
     ).toEqual(['1', '2', '3'])
+  })
+
+  test('distributes ranked bangers left to right in the two-column layout', () => {
+    mockViewportWidth(1100)
+    renderExplorer(page(masonryTweets))
+
+    expect(screen.getByTestId('bangers-masonry')).toHaveStyle({
+      gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+    })
+    expect(
+      within(screen.getByTestId('bangers-masonry-column-0'))
+        .getAllByTestId('tweet-row')
+        .map((row) => row.dataset.rank),
+    ).toEqual(['1', '3', '5'])
+    expect(
+      within(screen.getByTestId('bangers-masonry-column-1'))
+        .getAllByTestId('tweet-row')
+        .map((row) => row.dataset.rank),
+    ).toEqual(['2', '4', '6'])
+  })
+
+  test('distributes ranked bangers left to right in the three-column layout', () => {
+    renderExplorer(page(masonryTweets))
+
+    expect(
+      within(screen.getByTestId('bangers-masonry-column-0'))
+        .getAllByTestId('tweet-row')
+        .map((row) => row.dataset.rank),
+    ).toEqual(['1', '4'])
+    expect(
+      within(screen.getByTestId('bangers-masonry-column-1'))
+        .getAllByTestId('tweet-row')
+        .map((row) => row.dataset.rank),
+    ).toEqual(['2', '5'])
+    expect(
+      within(screen.getByTestId('bangers-masonry-column-2'))
+        .getAllByTestId('tweet-row')
+        .map((row) => row.dataset.rank),
+    ).toEqual(['3', '6'])
   })
 
   test('keeps today selected across author links', () => {

--- a/src/components/portal/BangersExplorer.tsx
+++ b/src/components/portal/BangersExplorer.tsx
@@ -39,6 +39,10 @@ const activeSegmentClassName =
   'border-zinc-800 bg-zinc-900 text-white dark:border-zinc-100 dark:bg-zinc-100 dark:text-zinc-950'
 const idleSegmentClassName =
   'border-zinc-300 bg-transparent text-zinc-600 hover:border-zinc-500 hover:text-zinc-950 dark:border-[#3a3a40] dark:text-[#a7a7b4] dark:hover:border-zinc-500 dark:hover:text-white'
+const masonryBreakpoints = [
+  { query: '(min-width: 1280px)', columns: 3 },
+  { query: '(min-width: 1024px)', columns: 2 },
+] as const
 
 type BangersAction =
   | 'filters_cleared'
@@ -88,6 +92,33 @@ function matchesQuery(tweet: PortalTweet, query: string): boolean {
 
 function dedupeTweets(tweets: PortalTweet[]): PortalTweet[] {
   return Array.from(new Map(tweets.map((tweet) => [tweet.id, tweet])).values())
+}
+
+function useMasonryColumnCount(): number {
+  const [columnCount, setColumnCount] = useState(1)
+
+  useEffect(() => {
+    const mediaQueries = masonryBreakpoints.map(({ query, columns }) => ({
+      media: window.matchMedia(query),
+      columns,
+    }))
+    const updateColumnCount = () => {
+      setColumnCount(
+        mediaQueries.find(({ media }) => media.matches)?.columns ?? 1,
+      )
+    }
+
+    updateColumnCount()
+    mediaQueries.forEach(({ media }) =>
+      media.addEventListener('change', updateColumnCount),
+    )
+    return () =>
+      mediaQueries.forEach(({ media }) =>
+        media.removeEventListener('change', updateColumnCount),
+      )
+  }, [])
+
+  return columnCount
 }
 
 function bangersHeading({
@@ -180,6 +211,7 @@ export function BangersExplorer({
   const requestControllerRef = useRef<AbortController | null>(null)
   const loadMoreRef = useRef<HTMLDivElement | null>(null)
   const isAllTime = allTime || (period === undefined && year === undefined)
+  const masonryColumnCount = useMasonryColumnCount()
 
   const availableYears = useMemo(() => {
     const years = page.pagination.yearCounts.map(({ year }) => year)
@@ -198,6 +230,17 @@ export function BangersExplorer({
   const visibleTweets = useMemo(
     () => page.tweets.filter((tweet) => matchesQuery(tweet, query)),
     [page.tweets, query],
+  )
+  const masonryColumns = useMemo(
+    () =>
+      visibleTweets.reduce<Array<Array<{ tweet: PortalTweet; order: number }>>>(
+        (columns, tweet, order) => {
+          columns[order % masonryColumnCount].push({ tweet, order })
+          return columns
+        },
+        Array.from({ length: masonryColumnCount }, () => []),
+      ),
+    [masonryColumnCount, visibleTweets],
   )
   const tweetRanks = useMemo(
     () =>
@@ -648,22 +691,34 @@ export function BangersExplorer({
       ) : (
         <div
           data-testid="bangers-masonry"
-          className="columns-1 gap-5 lg:columns-2 xl:columns-3"
+          className="grid items-start gap-5"
+          style={{
+            gridTemplateColumns: `repeat(${masonryColumnCount}, minmax(0, 1fr))`,
+          }}
         >
-          {visibleTweets.map((tweet, order) => (
+          {masonryColumns.map((column, columnIndex) => (
             <div
-              key={tweet.id}
-              data-masonry-order={order + 1}
-              className="mb-6 break-inside-avoid"
+              key={columnIndex}
+              data-testid={`bangers-masonry-column-${columnIndex}`}
+              className="contents lg:block lg:space-y-6"
             >
-              <TweetCard
-                tweet={tweet}
-                featuredRank={tweetRanks.get(tweet.id)}
-                showDate
-                collapsible
-                origin="bangers"
-                returnTo={currentReturnTo}
-              />
+              {column.map(({ tweet, order }) => (
+                <div
+                  key={tweet.id}
+                  data-masonry-order={order + 1}
+                  className="mb-6 lg:mb-0"
+                  style={{ order }}
+                >
+                  <TweetCard
+                    tweet={tweet}
+                    featuredRank={tweetRanks.get(tweet.id)}
+                    showDate
+                    collapsible
+                    origin="bangers"
+                    returnTo={currentReturnTo}
+                  />
+                </div>
+              ))}
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary

- Distribute Bangers cards round-robin across the active responsive columns.
- Preserve the existing one-, two-, and three-column masonry breakpoints.
- Add regression coverage for left-to-right ordering in both desktop layouts.

## Root cause

CSS multi-column layout fills cards top-to-bottom by column, so ranked results did not read left-to-right across the masonry. The component now chooses the responsive column count and assigns ranked cards to columns in row order.

## Validation

- Focused BangersExplorer client suite: 13 tests passed.
- TypeScript type-check passed.
- Focused ESLint passed.
- Focused Prettier check passed.
- Repository pre-commit generation completed; unrelated live database type drift was intentionally excluded.

Fixes #611
