### PR TITLE
Fix contributor details and profile badges

### DIFF
--- a/src/app/about/page.test.tsx
+++ b/src/app/about/page.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, within } from '@testing-library/react'
+import AboutPage from './page'
+
+describe('AboutPage contributors', () => {
+  it('shows the current and past contributors with their X accounts', () => {
+    render(<AboutPage />)
+
+    const currentHeading = screen.getByRole('heading', {
+      name: 'Current Contributors',
+    })
+    const currentSection = currentHeading.closest('section')
+    expect(currentSection).not.toBeNull()
+
+    const xiqLink = within(currentSection!).getByRole('link', {
+      name: 'Francisco Carvalho, or Xiq',
+    })
+    expect(xiqLink).toHaveAttribute('href', 'https://x.com/exgenesis')
+    expect(
+      within(currentSection!).getByRole('link', { name: 'Christine' }),
+    ).toHaveAttribute('href', 'https://x.com/christineist')
+
+    const xiqCard = xiqLink.closest('.rounded-lg')
+    expect(xiqCard?.querySelector('svg')).toBeNull()
+
+    const pastHeading = screen.getByRole('heading', {
+      name: 'Past Contributors',
+    })
+    const pastSection = pastHeading.closest('section')
+    expect(pastSection).not.toBeNull()
+    expect(
+      within(pastSection!).getByRole('link', { name: 'Defender' }),
+    ).toHaveAttribute('href', 'https://x.com/DefenderOfBasic')
+    expect(
+      within(pastSection!).getByRole('link', {
+        name: 'Alexandre Variengien',
+      }),
+    ).toHaveAttribute('href', 'https://x.com/A_Variengien')
+    expect(
+      within(pastSection!).queryByText('Christine'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('removes the retired mission copy and hall-of-fame heading', () => {
+    render(<AboutPage />)
+
+    expect(
+      screen.queryByText(/Twitter conversations represent a unique record/),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('heading', { name: 'Contributor Hall of Fame' }),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,13 +1,10 @@
 import React from 'react'
 import Link from 'next/link'
-import { FaTwitter, FaGithub, FaDiscord } from 'react-icons/fa'
-
-const pastContributors: Array<{ name: string; href?: string }> = [
-  { name: '@IaimforGOAT', href: 'https://x.com/IaimforGOAT' },
-  { name: 'Defender' },
-  { name: 'Alexandre Variengien' },
-  { name: 'Christine' },
-]
+import { FaGithub, FaDiscord } from 'react-icons/fa'
+import {
+  currentProjectContributors,
+  pastProjectContributors,
+} from '@/lib/projectContributors'
 
 export default function AboutPage() {
   return (
@@ -25,71 +22,58 @@ export default function AboutPage() {
           <strong>collect, host, and serve</strong> this data, empowering
           communities to use it for any purpose they choose.
         </p>
-        <p className="text-muted-foreground">
-          Twitter conversations represent a unique record of how ideas spread,
-          communities form, and culture evolves. By preserving this data openly,
-          we enable researchers, developers, and communities to learn from and
-          build upon this shared history.
-        </p>
       </section>
 
       <section className="mb-12">
-        <h2 className="mb-4 mt-8 text-2xl font-semibold">Current Team</h2>
+        <h2 className="mb-4 mt-8 text-2xl font-semibold">
+          Current Contributors
+        </h2>
 
         <div className="space-y-6">
-          <div className="flex items-start gap-4 rounded-lg bg-muted p-4 dark:bg-card">
-            <div className="flex-1">
+          {currentProjectContributors.map((contributor) => (
+            <div
+              key={contributor.username}
+              className="rounded-lg bg-muted p-4 dark:bg-card"
+            >
               <h3 className="mb-1 text-xl font-semibold">
                 <a
-                  href="https://x.com/exgenesis"
+                  href={`https://x.com/${contributor.username}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="transition-colors hover:text-brand"
                 >
-                  Xis
+                  {contributor.name}
                 </a>
               </h3>
-              <p className="text-muted-foreground">Creator & Lead</p>
+              {contributor.role && (
+                <p className="text-muted-foreground">{contributor.role}</p>
+              )}
             </div>
-            <a
-              href="https://x.com/exgenesis"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-2xl text-muted-foreground transition-colors hover:text-brand"
-            >
-              <FaTwitter />
-            </a>
-          </div>
+          ))}
         </div>
       </section>
 
       <section className="mb-12">
-        <h2 className="mb-2 mt-8 text-2xl font-semibold">
-          Contributor Hall of Fame
-        </h2>
+        <h2 className="mb-2 mt-8 text-2xl font-semibold">Past Contributors</h2>
         <p className="mb-4 text-muted-foreground">
           Past contributors whose work helped build Community Archive.
         </p>
 
         <div className="grid gap-4 sm:grid-cols-2">
-          {pastContributors.map((contributor) => (
+          {pastProjectContributors.map((contributor) => (
             <div
-              key={contributor.name}
+              key={contributor.username}
               className="rounded-lg bg-muted p-4 dark:bg-card"
             >
               <h3 className="text-lg font-semibold">
-                {contributor.href ? (
-                  <a
-                    href={contributor.href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="transition-colors hover:text-brand"
-                  >
-                    {contributor.name}
-                  </a>
-                ) : (
-                  contributor.name
-                )}
+                <a
+                  href={`https://x.com/${contributor.username}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="transition-colors hover:text-brand"
+                >
+                  {contributor.name}
+                </a>
               </h3>
             </div>
           ))}

--- a/src/app/user/[account_id]/page.tsx
+++ b/src/app/user/[account_id]/page.tsx
@@ -20,6 +20,7 @@ import { FilterCriteria } from '@/lib/queries/tweetQueries'
 import { Archive, Radio } from 'lucide-react'
 import { getHighResolutionAvatarUrl } from '@/lib/avatar'
 import { getClickHouseUserProfile } from '@/lib/clickhouseUserProfile'
+import { ProjectContributorBadge } from '@/components/ProjectContributorBadge'
 
 // Style constants (glows removed)
 const unifiedDeepBlueBase = 'bg-card dark:bg-background'
@@ -51,6 +52,7 @@ const UserProfile = ({ userData }: { userData: FormattedUser }) => {
           </h1>
           <p className="text-lg text-muted-foreground">@{account.username}</p>
           <div className="mt-3 flex flex-wrap justify-center gap-2 sm:justify-start">
+            <ProjectContributorBadge username={account.username} />
             {account.has_archive && (
               <Badge variant="outline" className="gap-1.5">
                 <Archive aria-hidden="true" className="h-3.5 w-3.5" />

--- a/src/components/ProjectContributorBadge.test.tsx
+++ b/src/components/ProjectContributorBadge.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react'
+import { ProjectContributorBadge } from './ProjectContributorBadge'
+
+describe('ProjectContributorBadge', () => {
+  it.each([
+    'exgenesis',
+    'christineist',
+    'DefenderOfBasic',
+    'A_Variengien',
+    'IaimforGOAT',
+  ])('identifies %s as a project contributor', (username) => {
+    render(<ProjectContributorBadge username={username} />)
+
+    expect(screen.getByText('Project contributor')).toBeInTheDocument()
+  })
+
+  it('matches contributor usernames case-insensitively', () => {
+    render(<ProjectContributorBadge username="@CHRISTINEIST" />)
+
+    expect(screen.getByText('Project contributor')).toBeInTheDocument()
+  })
+
+  it('does not badge other archive members', () => {
+    render(<ProjectContributorBadge username="archive_member" />)
+
+    expect(screen.queryByText('Project contributor')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/ProjectContributorBadge.tsx
+++ b/src/components/ProjectContributorBadge.tsx
@@ -1,0 +1,17 @@
+import { Award } from 'lucide-react'
+import { isProjectContributor } from '@/lib/projectContributors'
+import { Badge } from '@/components/ui/badge'
+
+export function ProjectContributorBadge({ username }: { username: string }) {
+  if (!isProjectContributor(username)) return null
+
+  return (
+    <Badge
+      variant="outline"
+      className="gap-1.5 border-brand/40 bg-brand/10 text-brand"
+    >
+      <Award aria-hidden="true" className="h-3.5 w-3.5" />
+      Project contributor
+    </Badge>
+  )
+}

--- a/src/lib/projectContributors.ts
+++ b/src/lib/projectContributors.ts
@@ -1,0 +1,36 @@
+export type ProjectContributor = {
+  name: string
+  username: string
+  role?: string
+}
+
+export const currentProjectContributors: ProjectContributor[] = [
+  {
+    name: 'Francisco Carvalho, or Xiq',
+    username: 'exgenesis',
+    role: 'Creator & Lead',
+  },
+  {
+    name: 'Christine',
+    username: 'christineist',
+    role: 'Contributor',
+  },
+]
+
+export const pastProjectContributors: ProjectContributor[] = [
+  { name: '@IaimforGOAT', username: 'IaimforGOAT' },
+  { name: 'Defender', username: 'DefenderOfBasic' },
+  { name: 'Alexandre Variengien', username: 'A_Variengien' },
+]
+
+const projectContributorUsernames = new Set(
+  [...currentProjectContributors, ...pastProjectContributors].map(
+    ({ username }) => username.toLowerCase(),
+  ),
+)
+
+export function isProjectContributor(username: string) {
+  return projectContributorUsernames.has(
+    username.replace(/^@/, '').toLowerCase(),
+  )
+}


### PR DESCRIPTION
## Summary

- correct the About page author name, current/past contributor grouping, and X account links
- remove the retired mission paragraph, hall-of-fame wording, and Xiq Twitter icon
- add a distinct project-contributor badge to the named contributors' public profiles
- keep About-page display data and badge eligibility in one shared contributor registry

## Root cause

The About page stored incomplete contributor details directly in the component, while public profiles only distinguished archive uploaders and opt-in members. There was no shared project-contributor identity for the About page and profile UI to use.

## Validation

- `pnpm exec jest --selectProjects client --runInBand src/app/about/page.test.tsx src/components/ProjectContributorBadge.test.tsx` (9 tests passed)
- `pnpm type-check`
- focused `next lint` on all changed TypeScript/TSX files

Fixes #612
