### PR TITLE
Refresh the homepage tweet count from ClickHouse

### DIFF
--- a/memos/20260813-1140-homepage-clickhouse-count.md
+++ b/memos/20260813-1140-homepage-clickhouse-count.md
@@ -1,0 +1,49 @@
+# Homepage ClickHouse tweet count
+
+Date: 2026-08-13 11:40 PDT
+
+Issue: [#621](https://github.com/TheExGenesis/community-archive/issues/621)
+
+## Outcome
+
+The public homepage now requests a dedicated ClickHouse corpus-count endpoint
+and revalidates the result every five minutes. If the gateway or projection is
+unavailable, the page falls back to the existing Supabase
+`global_activity_summary` snapshot rather than dropping the statistic.
+
+The control-plane change must be deployed before the website change. The new
+gateway endpoint scans `tweet_content_versions` for exact unique tweet IDs,
+caches the result for five minutes, and serves the last successful value for up
+to one hour while refreshing in the background. This avoids rerunning the
+heavier daily summary and ranking computation on homepage cadence.
+
+## Why ClickHouse is safe again
+
+The homepage was intentionally returned to Supabase in #607 because ClickHouse
+did not yet receive archive-upload tweets. That blocker has since been removed
+by the independent ten-minute archive reconciler.
+
+Read-only production checks immediately before this change found:
+
+- completed archive upload watermark `692` in both PostgreSQL and ClickHouse;
+- exact archive-derived tweet parity of `7,112,809 / 7,112,809`;
+- an active ten-minute archive-sync timer with a successful run less than one
+  minute old;
+- `15,324,337` exact unique tweets in ClickHouse at 18:37 UTC, computed in
+  about 2.5 seconds under the production resource limits.
+
+## Failure and rollout behavior
+
+- The website keeps the Supabase daily summary as its last-known-good fallback.
+- The existing server-only bearer token remains the only way to reach the
+  predefined ClickHouse route; no ClickHouse credentials enter the browser.
+- Deploy the query-gateway change first and verify `/analytics/corpus-count`,
+  then deploy the website. Either side can be rolled back independently.
+
+## Validation
+
+- Query gateway: 62 tests, TypeScript, and Bun production bundle passed.
+- Website: 73 suites and 317 tests passed, along with TypeScript, lint, focused
+  formatting, and the production build. The build retained only the existing
+  dynamic-route diagnostics, missing local environment warnings, and image
+  lint warning.

--- a/src/lib/clickhouseGateway.ts
+++ b/src/lib/clickhouseGateway.ts
@@ -1,4 +1,5 @@
 const ALLOWED_ENDPOINTS: Record<string, ReadonlySet<string>> = {
+  'corpus-count': new Set(),
   summary: new Set(),
   search: new Set([
     'q',

--- a/src/lib/clickhouseLab.test.ts
+++ b/src/lib/clickhouseLab.test.ts
@@ -41,6 +41,17 @@ describe('ClickHouse staging lab guard', () => {
     ).toThrow('Unsupported ClickHouse analytics endpoint')
   })
 
+  test('allows the parameterless corpus-count endpoint', () => {
+    const target = analyticsGatewayRequestUrl(
+      ['corpus-count'],
+      new URLSearchParams('raw_sql=DROP'),
+      'https://stream.example/analytics',
+    )
+    expect(target.toString()).toBe(
+      'https://stream.example/analytics/corpus-count',
+    )
+  })
+
   test('allows only bounded tweet-search parameters', () => {
     const target = analyticsGatewayRequestUrl(
       ['search'],

--- a/src/lib/portal/data.test.ts
+++ b/src/lib/portal/data.test.ts
@@ -172,6 +172,20 @@ describe('portal page resilience', () => {
 
     jest.spyOn(global, 'fetch').mockImplementation(async (input, init) => {
       const url = new URL(String(input))
+      if (url.pathname.endsWith('/corpus-count')) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              totalTweets: '15334092',
+              sourceUpdatedAt: '2026-08-13 18:34:09.903',
+              collectedAt: '2026-08-13 18:34:20.907',
+              source: 'clickhouse.tweet_content_versions',
+              countMode: 'unique_tweets_observed',
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        )
+      }
       if (url.pathname.endsWith('/portal-stream')) {
         return new Response('gateway unavailable', { status: 503 })
       }
@@ -247,7 +261,7 @@ describe('portal page resilience', () => {
 
     await expect(getPortalData()).resolves.toMatchObject({
       stats: {
-        totalTweets: 15_100_732,
+        totalTweets: 15_334_092,
         accountCount: 42,
         firstYear: 2007,
         currentYear: 2026,
@@ -269,7 +283,7 @@ describe('portal page resilience', () => {
 
     await expect(getPortalData()).resolves.toMatchObject({
       stats: {
-        totalTweets: 15_100_732,
+        totalTweets: 15_334_092,
         accountCount: 42,
         firstYear: 2007,
         currentYear: 2026,
@@ -298,24 +312,61 @@ describe('portal reads', () => {
     process.env.CLICKHOUSE_ANALYTICS_API_TOKEN = 'test-token'
   })
 
-  test('reads the homepage corpus total from the Supabase summary', async () => {
+  test('reads the homepage corpus total from ClickHouse', async () => {
     const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValueOnce(
       new Response(
-        JSON.stringify([
-          {
-            total_tweets: 15_100_732,
-            last_updated: '2026-08-12T05:15:00.098756+00:00',
+        JSON.stringify({
+          data: {
+            totalTweets: '15334092',
+            sourceUpdatedAt: '2026-08-13 18:34:09.903',
+            collectedAt: '2026-08-13 18:34:20.907',
+            source: 'clickhouse.tweet_content_versions',
+            countMode: 'unique_tweets_observed',
           },
-        ]),
+        }),
         { status: 200, headers: { 'content-type': 'application/json' } },
       ),
     )
 
     await expect(fetchPortalCorpusStats()).resolves.toEqual({
+      totalTweets: 15_334_092,
+      generatedAt: '2026-08-13T18:34:20.907Z',
+    })
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL('https://analytics.community-archive.org/analytics/corpus-count'),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-token',
+        }),
+      }),
+    )
+  })
+
+  test('falls back to the Supabase summary when ClickHouse fails', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation()
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce(
+        new Response('gateway unavailable', { status: 503 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              total_tweets: 15_100_732,
+              last_updated: '2026-08-12T05:15:00.098756+00:00',
+            },
+          ]),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      )
+
+    await expect(fetchPortalCorpusStats()).resolves.toEqual({
       totalTweets: 15_100_732,
       generatedAt: '2026-08-12T05:15:00.098Z',
     })
-    expect(fetchMock).toHaveBeenCalledWith(
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
       'https://prod-project.supabase.co/rest/v1/global_activity_summary?select=total_tweets%2Clast_updated',
       expect.objectContaining({
         headers: expect.objectContaining({
@@ -323,6 +374,10 @@ describe('portal reads', () => {
           'Accept-Profile': 'public',
         }),
       }),
+    )
+    expect(consoleError).toHaveBeenCalledWith(
+      'Portal ClickHouse corpus count failed; falling back to Supabase:',
+      expect.any(Error),
     )
   })
 

--- a/src/lib/portal/data.ts
+++ b/src/lib/portal/data.ts
@@ -52,6 +52,16 @@ interface PortalCorpusStats {
   generatedAt: string
 }
 
+interface ClickHouseCorpusCountResponse {
+  data: {
+    totalTweets: unknown
+    sourceUpdatedAt: unknown
+    collectedAt: unknown
+    source: 'clickhouse.tweet_content_versions'
+    countMode: 'unique_tweets_observed'
+  }
+}
+
 const PORTAL_READ_TIMEOUT_MS = 10_000
 export const PORTAL_BANGERS_PAGE_SIZE = 30
 const PORTAL_BANGERS_PERIOD_SCAN_PAGE_SIZE = 100
@@ -220,8 +230,24 @@ function portalSnapshotTimestamp(value: string, label: string): string {
   return timestamp.toISOString()
 }
 
-/** Supabase is authoritative for archive uploads until that path reaches ClickHouse. */
-export async function fetchPortalCorpusStats(): Promise<PortalCorpusStats> {
+function portalClickHouseTimestamp(value: string, label: string): string {
+  const normalized = /[zZ]$|[+-]\d\d:\d\d$/.test(value)
+    ? value
+    : `${value.replace(' ', 'T')}Z`
+  return portalSnapshotTimestamp(normalized, label)
+}
+
+function portalClickHouseCount(value: unknown, label: string): number {
+  if (
+    (typeof value !== 'string' && typeof value !== 'number') ||
+    (typeof value === 'string' && !/^\d+$/.test(value))
+  ) {
+    throw new Error(`Portal ${label} returned an invalid response`)
+  }
+  return portalSnapshotCount(Number(value), label)
+}
+
+async function fetchSupabasePortalCorpusStats(): Promise<PortalCorpusStats> {
   const rows = await portalRestRows<{
     total_tweets: number | null
     last_updated: string
@@ -241,6 +267,37 @@ export async function fetchPortalCorpusStats(): Promise<PortalCorpusStats> {
       rows[0].last_updated,
       'corpus summary timestamp',
     ),
+  }
+}
+
+/**
+ * ClickHouse owns the live analytical corpus count. Supabase's daily summary
+ * remains a last-known-good fallback during gateway or projection failures.
+ */
+export async function fetchPortalCorpusStats(): Promise<PortalCorpusStats> {
+  try {
+    const response =
+      await fetchAnalyticsGatewayJson<ClickHouseCorpusCountResponse>(
+        ['corpus-count'],
+        new URLSearchParams(),
+        { timeoutMs: PORTAL_READ_TIMEOUT_MS },
+      )
+    return {
+      totalTweets: portalClickHouseCount(
+        response.data.totalTweets,
+        'ClickHouse corpus tweet count',
+      ),
+      generatedAt: portalClickHouseTimestamp(
+        String(response.data.collectedAt),
+        'ClickHouse corpus count timestamp',
+      ),
+    }
+  } catch (error) {
+    console.error(
+      'Portal ClickHouse corpus count failed; falling back to Supabase:',
+      error,
+    )
+    return fetchSupabasePortalCorpusStats()
   }
 }
 


### PR DESCRIPTION
## Summary

- load the public homepage corpus total from the new authenticated ClickHouse `/analytics/corpus-count` route
- retain the existing daily Supabase summary as a last-known-good fallback
- allowlist only the parameterless count route through the server-only gateway client
- cover the ClickHouse success path, Supabase fallback, and endpoint allowlist

## Root cause

The homepage currently reads Supabase's daily `global_activity_summary`, while the continuously updated analytical corpus is in ClickHouse. The earlier ClickHouse cutover was reverted because archive uploads were missing there; the independent archive reconciler has since closed that gap and is parity-verified.

## Impact

The displayed count now revalidates every five minutes from ClickHouse and remains available if the gateway has a transient failure. No ClickHouse credentials or bearer tokens are exposed to the browser.

The required backend dependency is already deployed and verified from control-panel PR #55.

## Validation

- 73 Jest suites / 317 tests passed
- TypeScript passed
- Next lint passed with one unrelated existing `<img>` warning
- production build passed with existing dynamic-route and missing-local-environment diagnostics
- focused Prettier checks passed
- live gateway: 401 without auth, 200 with auth, 15,324,363 unique tweets, service active with zero restarts
- archive reconciliation: upload watermark 692/692 and exact archive-derived parity 7,112,809/7,112,809

Fixes #621
