### PR TITLE
Route Trends evidence through exact server search cache

### DIFF
--- a/src/lib/clickhouseGateway.ts
+++ b/src/lib/clickhouseGateway.ts
@@ -12,6 +12,7 @@ const ALLOWED_ENDPOINTS: Record<string, ReadonlySet<string>> = {
     'limit',
     'offset',
   ]),
+  'trend-evidence': new Set(['q', 'mode', 'since', 'until', 'limit']),
   'word-trend': new Set(['q', 'bucket', 'match', 'from', 'to']),
   'stream-stats': new Set(['start', 'end', 'granularity', 'scope']),
   'recent-bangers': new Set(['limit', 'hours']),

--- a/src/lib/clickhouseLab.test.ts
+++ b/src/lib/clickhouseLab.test.ts
@@ -65,6 +65,19 @@ describe('ClickHouse staging lab guard', () => {
     )
   })
 
+  test('allows only bounded trend-evidence parameters', () => {
+    const target = analyticsGatewayRequestUrl(
+      ['trend-evidence'],
+      new URLSearchParams(
+        'q=tpot&mode=all&since=2024-01-01&until=2026-01-01&limit=50&offset=40',
+      ),
+      'https://analytics.example',
+    )
+    expect(target.toString()).toBe(
+      'https://analytics.example/trend-evidence?q=tpot&mode=all&since=2024-01-01&until=2026-01-01&limit=50',
+    )
+  })
+
   test('routes public search to its dedicated ClickHouse gateway', () => {
     expect(
       clickHouseSearchGatewayBaseUrl(

--- a/src/lib/portal/analytics.test.ts
+++ b/src/lib/portal/analytics.test.ts
@@ -268,6 +268,7 @@ describe('ClickHouse-backed portal analytics', () => {
     )
 
     expect(fetcher).toHaveBeenCalledTimes(2)
+    expect(fetcherMock.mock.calls[0]?.[0]).toEqual(['trend-evidence'])
     expect(result.map(({ id }) => id)).toEqual(['102', '101', '100'])
     expect(fetcherMock.mock.calls[0]?.[1]?.toString()).toContain(
       'since=2024-01-01&until=2026-01-01',

--- a/src/lib/portal/analytics.ts
+++ b/src/lib/portal/analytics.ts
@@ -345,8 +345,8 @@ export async function fetchPortalTrendEvidence(
           { timeoutMs: 30_000 },
         ),
     ),
-    // The gateway composes cached calendar shards but still serializes a cold
-    // ClickHouse search. Keep multi-term evidence requests ordered.
+    // The gateway caches exact term/range searches and serializes cold
+    // ClickHouse work. Keep multi-term evidence requests ordered.
     1,
   )
 

--- a/src/lib/portal/analytics.ts
+++ b/src/lib/portal/analytics.ts
@@ -331,13 +331,12 @@ export async function fetchPortalTrendEvidence(
     includeTerms.map(
       (term) => () =>
         fetcher<ClickHouseSearchResponse>(
-          ['search'],
+          ['trend-evidence'],
           (() => {
             const params = new URLSearchParams({
               q: term,
               mode: 'all',
               limit: String(candidateLimit),
-              offset: '0',
             })
             if (since) params.set('since', since)
             if (until) params.set('until', until)
@@ -346,8 +345,8 @@ export async function fetchPortalTrendEvidence(
           { timeoutMs: 30_000 },
         ),
     ),
-    // The current query gateway intentionally serializes corpus searches.
-    // Keep evidence requests ordered while trend aggregation stays concurrent.
+    // The gateway composes cached calendar shards but still serializes a cold
+    // ClickHouse search. Keep multi-term evidence requests ordered.
     1,
   )
 


### PR DESCRIPTION
Closes #629

## Summary

- allowlist the authenticated trend-evidence gateway endpoint
- route each included Trends term through one ordinary newest-first full-text search with optional exact since/until dates
- reuse the dedicated server-side exact-result cache on repeated term/range requests
- keep the existing browser cache, immediate local filtering, per-term reuse, request coalescing, and 1.2-second range debounce unchanged
- preserve multi-term de-duplication and newest-first output

## Backend dependency

- control-plane PR: TheExGenesis/community-archive-control-panel#58
- production gateway functional build: 463f9c7ef7dd
- default warm: 19/19 aggregates and 7/7 exact evidence searches
- cold custom all-time request: 2.26s; repeat hit: 9.6ms
- cold filtered request: 623ms; repeat hit: 6.6ms
- Grafana dashboard version 24 published

## Verification

- 30 focused product server tests pass
- TypeScript check passes
- pull-request workflow and Vercel preview pass
- signed-in preview loaded two custom terms and a cold 2025 range without UI or console errors

## Rollback

Reverting this endpoint selection sends Trends evidence back to /analytics/search; the deployed gateway cache is additive and can roll back independently.