### PR TITLE
Meta Twitter: user profile as a curated archive of chapters and topics

### DIFF
--- a/src/app/user/[account_id]/page.tsx
+++ b/src/app/user/[account_id]/page.tsx
@@ -110,7 +110,6 @@ export default async function UserPage({ params, searchParams }: PageProps) {
     return {
       year: y.year,
       count: y.count,
-      phrase: chapter?.phrase,
       topics: (chapter?.topics ?? []).map((t) => ({
         label: t.label,
         slug: t.slug,

--- a/src/app/user/[account_id]/page.tsx
+++ b/src/app/user/[account_id]/page.tsx
@@ -1,288 +1,164 @@
-import { Suspense } from 'react'
-import { Skeleton } from '@/components/ui/skeleton'
-import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
-import { Badge } from '@/components/ui/badge'
-import TopMentionedUsers, {
-  MentionedUser,
-} from '@/components/TopMentionedMissingUsers'
-import AccountTopTweets from './AccountTopTweets'
-import { createServerClient } from '@/utils/supabase'
-import { FormattedUser } from '@/lib/types'
-import { cookies } from 'next/headers'
-import { getUserData } from '@/lib/queries/fetchUsers'
-import { formatNumber } from '@/lib/formatNumber'
-import { DownloadArchiveButton } from './DownloadArchiveButton'
-import Image from 'next/image'
-import TweetList from '@/components/TweetList'
-import UnifiedTweetList from '@/components/UnifiedTweetList'
-import type { TweetData } from '@/components/TweetComponent'
-import { FilterCriteria } from '@/lib/queries/tweetQueries'
-import { Archive, Radio } from 'lucide-react'
-import { getHighResolutionAvatarUrl } from '@/lib/avatar'
-import { getClickHouseUserProfile } from '@/lib/clickhouseUserProfile'
-import { ProjectContributorBadge } from '@/components/ProjectContributorBadge'
+import { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import { ProfileHeader } from '@/components/metaTwitter/ProfileHeader'
+import { ArchiveNav, NavChapter } from '@/components/metaTwitter/ArchiveNav'
+import {
+  Workspace,
+  WorkspacePill,
+} from '@/components/metaTwitter/Workspace'
+import {
+  getCachedActiveYears,
+  getCachedArchivedAt,
+  getCachedChapterData,
+  getCachedProfileHeader,
+  getCachedTweetsByIds,
+  resolveAccountId,
+  type ArchiveTweet,
+} from '@/lib/metaTwitter/data'
+import { getMetaTwitterConfig, type TopicConfig } from '@/lib/metaTwitter/config'
 
-// Style constants (glows removed)
-const unifiedDeepBlueBase = 'bg-card dark:bg-background'
-const sectionPaddingClasses = 'py-12 md:py-16 lg:py-20'
-const contentWrapperClasses =
-  'w-full max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10'
-
-const UserProfile = ({ userData }: { userData: FormattedUser }) => {
-  const account = userData
-  return (
-    // Profile info card - Removed shadow
-    <div className="mb-8 rounded-lg bg-muted p-6 dark:bg-card sm:p-8">
-      <div className="flex flex-col items-center space-y-4 sm:flex-row sm:items-start sm:space-x-6 sm:space-y-0">
-        <Avatar className="h-24 w-24 ring-2 ring-brand ring-offset-2 dark:ring-offset-background sm:h-28 sm:w-28">
-          <AvatarImage
-            src={
-              getHighResolutionAvatarUrl(account.avatar_media_url) ||
-              '/placeholder.jpg'
-            }
-            alt={`${account.account_display_name}'s avatar`}
-          />
-          <AvatarFallback className="text-3xl">
-            {account.account_display_name.charAt(0).toUpperCase()}
-          </AvatarFallback>
-        </Avatar>
-        <div className="flex-grow text-center sm:text-left">
-          <h1 className="text-3xl font-bold text-foreground sm:text-4xl">
-            {account.account_display_name}
-          </h1>
-          <p className="text-lg text-muted-foreground">@{account.username}</p>
-          <div className="mt-3 flex flex-wrap justify-center gap-2 sm:justify-start">
-            <ProjectContributorBadge username={account.username} />
-            {account.has_archive && (
-              <Badge variant="outline" className="gap-1.5">
-                <Archive aria-hidden="true" className="h-3.5 w-3.5" />
-                Archive contributor
-              </Badge>
-            )}
-            {account.is_opted_in && (
-              <Badge variant="outline" className="gap-1.5">
-                <Radio aria-hidden="true" className="h-3.5 w-3.5" />
-                Opted in
-              </Badge>
-            )}
-          </div>
-          {account.bio && (
-            <p className="mt-3 text-sm text-muted-foreground sm:text-base">
-              {account.bio}
-            </p>
-          )}
-          <div className="mt-3 space-y-1 text-sm text-muted-foreground">
-            {account.location && <p>📍 {account.location}</p>}
-            {account.created_at && (
-              <p>
-                📅 Joined Twitter:{' '}
-                {new Date(account.created_at).toLocaleDateString()}
-              </p>
-            )}
-            {account.joined_at && (
-              <p>
-                🤝 Community member since:{' '}
-                {new Date(account.joined_at).toLocaleDateString()}
-              </p>
-            )}
-            {account.archive_at && (
-              <p>
-                🗄️ Archived: {new Date(account.archive_at).toLocaleDateString()}
-              </p>
-            )}
-          </div>
-        </div>
-      </div>
-      <div className="mt-6 flex flex-wrap justify-center gap-x-6 gap-y-3 border-t border-border pt-6 text-sm text-muted-foreground dark:border-border dark:text-muted-foreground sm:justify-start">
-        <p>
-          <strong className="font-semibold text-foreground">
-            {formatNumber(account.num_tweets)}
-          </strong>{' '}
-          Tweets
-        </p>
-        <p>
-          <strong className="font-semibold text-foreground">
-            {formatNumber(account.num_followers)}
-          </strong>{' '}
-          Followers
-        </p>
-        <p>
-          <strong className="font-semibold text-foreground">
-            {formatNumber(account.num_following)}
-          </strong>{' '}
-          Following
-        </p>
-        <p>
-          <strong className="font-semibold text-foreground">
-            {formatNumber(account.num_likes)}
-          </strong>{' '}
-          Likes
-        </p>
-      </div>
-      {account.has_archive && (
-        <div className="mt-6 text-center sm:text-left">
-          <DownloadArchiveButton username={account.username} />
-        </div>
-      )}
-    </div>
-  )
+interface PageProps {
+  params: { account_id: string }
+  searchParams: { chapter?: string; topic?: string }
 }
 
-export default async function User({
+export async function generateMetadata({
   params,
-}: {
-  params: { account_id: string }
-}) {
-  const { account_id } = params
-  const cookieStore = cookies()
-  const supabase = createServerClient(cookieStore)
-
-  const directoryUser = await getUserData(supabase, account_id)
-  const clickHouseProfile = directoryUser
-    ? null
-    : await getClickHouseUserProfile(account_id)
-  const userData = directoryUser || clickHouseProfile?.user
-
-  if (!userData) {
-    // Styled error message for consistency - Removed glow and shadow
-    return (
-      <section
-        className={`${unifiedDeepBlueBase} ${sectionPaddingClasses} flex flex-grow items-center justify-center overflow-hidden`}
-      >
-        <div className={`${contentWrapperClasses} text-center`}>
-          {/* Error card - Removed shadow */}
-          <div className="rounded-lg bg-muted p-8 dark:bg-card">
-            <h1 className="text-2xl font-bold text-red-600 dark:text-red-400">
-              Error Fetching User Data
-            </h1>
-            <p className="mt-2 text-muted-foreground">
-              Could not retrieve information for this user. Please try again
-              later.
-            </p>
-          </div>
-        </div>
-      </section>
-    )
+}: PageProps): Promise<Metadata> {
+  const accountId = await resolveAccountId(params.account_id)
+  if (!accountId) return { title: 'User not found' }
+  const profile = await getCachedProfileHeader(accountId)
+  if (!profile) return { title: 'User not found' }
+  return {
+    title: `${profile.account_display_name} (@${profile.username}) — Community Archive`,
+    description: profile.bio ?? undefined,
   }
+}
 
-  const { data: summaryData, error: summaryError } = directoryUser
-    ? directoryUser.account_id
-      ? await supabase
-          .from('account_activity_summary')
-          .select('mentioned_accounts')
-          .eq('account_id', directoryUser.account_id)
-          .maybeSingle()
-      : await supabase
-          .from('account_activity_summary')
-          .select('mentioned_accounts')
-          .eq('username', directoryUser.username)
-          .maybeSingle()
-    : { data: null, error: null }
+export default async function UserPage({ params, searchParams }: PageProps) {
+  const accountId = await resolveAccountId(params.account_id)
+  if (!accountId) notFound()
 
-  const showingSummaryData = !summaryError && summaryData?.mentioned_accounts
-  const clickHouseTweets: TweetData[] =
-    clickHouseProfile?.topTweets.map((tweet) => ({
-      tweet_id: tweet.tweetId,
-      account_id: userData.account_id || '',
-      created_at: tweet.createdAt,
-      full_text: tweet.fullText,
-      retweet_count: tweet.retweetCount,
-      favorite_count: tweet.favoriteCount,
-      reply_to_tweet_id: null,
-      quote_tweet_id: null,
-      retweeted_tweet_id: null,
-      avatar_media_url: userData.avatar_media_url,
-      username: userData.username,
-      account_display_name: userData.account_display_name,
-      media: [],
-      urls: [],
-      reply_to_username: tweet.replyToUsername || undefined,
-      mentioned_users: [],
-    })) || []
+  const [profile, archivedAt, activeYears] = await Promise.all([
+    getCachedProfileHeader(accountId),
+    getCachedArchivedAt(accountId),
+    getCachedActiveYears(accountId),
+  ])
+  if (!profile) notFound()
+
+  const config = getMetaTwitterConfig(accountId)
+  const basePath = `/user/${encodeURIComponent(params.account_id)}`
+
+  // --- Resolve the selected chapter/topic from the URL ---
+  const requestedYear = searchParams.chapter
+    ? parseInt(searchParams.chapter, 10)
+    : null
+  const year =
+    requestedYear && activeYears.some((y) => y.year === requestedYear)
+      ? requestedYear
+      : null
+  const isOverall = year === null
+
+  const chapterConfig = year
+    ? (config?.chapters.find((c) => c.year === year) ?? null)
+    : null
+  const availableTopics: TopicConfig[] = isOverall
+    ? (config?.overallTopics ?? [])
+    : (chapterConfig?.topics ?? [])
+  const topic =
+    (searchParams.topic &&
+      availableTopics.find((t) => t.slug === searchParams.topic)) ||
+    null
+
+  // --- Fetch workspace data for the selected scope ---
+  const chapterData = await getCachedChapterData(
+    accountId,
+    year ?? undefined,
+    topic?.terms,
+  )
+  const hofIds = config?.hallOfFamePinned ?? []
+  const pinnedTweets: ArchiveTweet[] =
+    isOverall && !topic && hofIds.length > 0
+      ? await getCachedTweetsByIds(accountId, hofIds)
+      : []
+
+  const seen = new Set<string>()
+  const tweets = [
+    ...pinnedTweets,
+    ...chapterData.topTweets,
+    ...chapterData.newestTweets,
+  ].filter((t) => {
+    if (seen.has(t.tweet_id)) return false
+    seen.add(t.tweet_id)
+    return true
+  })
+
+  // --- Presentation strings ---
+  const contextTitle = isOverall
+    ? topic
+      ? `Overall → ${topic.label}`
+      : 'Hall of Fame'
+    : topic
+      ? `${year} → ${topic.label}`
+      : String(year)
+  const contextDesc = topic
+    ? (topic.description ?? null)
+    : isOverall
+      ? (config?.overallDescription ??
+        `The best of @${profile.username}'s archive.`)
+      : (chapterConfig?.description ?? null)
+
+  const pills: WorkspacePill[] = availableTopics.map((t) => {
+    const active = topic?.slug === t.slug
+    const chapterParam = year ? `chapter=${year}&` : ''
+    return {
+      label: t.label,
+      slug: t.slug,
+      active,
+      // Clicking the active pill deselects it (back to the bare chapter).
+      href: active
+        ? `${basePath}${year ? `?chapter=${year}` : ''}`
+        : `${basePath}?${chapterParam}topic=${t.slug}`,
+    }
+  })
+
+  const navChapters: NavChapter[] = activeYears.map((y) => ({
+    year: y.year,
+    count: y.count,
+    topics: (config?.chapters.find((c) => c.year === y.year)?.topics ?? []).map(
+      (t) => ({ label: t.label, slug: t.slug }),
+    ),
+  }))
 
   return (
-    <section
-      className={`${unifiedDeepBlueBase} ${sectionPaddingClasses} flex-grow overflow-hidden`}
-    >
-      <div className={`${contentWrapperClasses} space-y-8`}>
-        {/* Banner Image - Removed shadow */}
-        {userData?.header_media_url && (
-          <div className="relative mb-8 h-48 w-full overflow-hidden rounded-xl md:h-64">
-            <Image
-              src={userData.header_media_url}
-              alt={`${userData.account_display_name}'s cover photo`}
-              layout="fill"
-              objectFit="cover"
-              priority
-            />
-          </div>
-        )}
-
-        {/* UserProfile Suspense - Removed shadow from Skeleton */}
-        <Suspense
-          fallback={
-            <Skeleton className="h-60 w-full rounded-lg bg-muted p-8 dark:bg-card" />
-          }
-        >
-          <UserProfile userData={userData} />
-        </Suspense>
-
-        {showingSummaryData && (
-          <>
-            {/* Most Mentioned Accounts card - Removed shadow */}
-            <div className="rounded-lg bg-muted p-6 dark:bg-card sm:p-8">
-              <h2 className="mb-4 text-2xl font-semibold text-foreground">
-                Most Mentioned Accounts
-              </h2>
-              <Suspense
-                fallback={
-                  <Skeleton className="h-[20vh] w-full rounded bg-muted" />
-                }
-              >
-                <TopMentionedUsers
-                  users={summaryData.mentioned_accounts as MentionedUser[]}
-                  height="h-[20vh]"
-                />
-              </Suspense>
-            </div>
-
-            {/* Top Tweets card - Removed shadow */}
-            <div className="rounded-lg bg-muted p-6 dark:bg-card sm:p-8">
-              <h2 className="mb-4 text-2xl font-semibold text-foreground">
-                Top Tweets
-              </h2>
-              <Suspense
-                fallback={<Skeleton className="h-96 w-full rounded bg-muted" />}
-              >
-                <AccountTopTweets userData={userData} />
-              </Suspense>
-            </div>
-          </>
-        )}
-
-        {clickHouseProfile && clickHouseTweets.length > 0 && (
-          <div className="rounded-lg bg-muted p-6 dark:bg-card sm:p-8">
-            <h2 className="mb-4 text-2xl font-semibold text-foreground">
-              Top Tweets
-            </h2>
-            <UnifiedTweetList tweets={clickHouseTweets} />
-          </div>
-        )}
-
-        {directoryUser?.account_id && (
-          <div className="rounded-lg bg-muted p-6 dark:bg-card sm:p-8">
-            <h2 className="mb-6 text-2xl font-semibold text-foreground">
-              Recent Tweets
-            </h2>
-            <TweetList
-              filterCriteria={
-                { userId: directoryUser.account_id } satisfies FilterCriteria
-              }
-              itemsPerPage={20}
-            />
-          </div>
-        )}
+    <div className="flex justify-center px-4 py-8 sm:px-6">
+      <div className="h-fit w-full max-w-[1220px] overflow-hidden rounded-2xl border border-border bg-card shadow-[0_2px_16px_rgba(0,0,0,0.06)]">
+        <ProfileHeader profile={profile} archivedAt={archivedAt} />
+        <div className="grid grid-cols-1 items-start border-t border-border lg:grid-cols-[250px_1fr]">
+          <ArchiveNav
+            basePath={basePath}
+            chapters={navChapters}
+            activeYear={year}
+            activeTopicSlug={topic?.slug ?? null}
+          />
+          <Workspace
+            accountId={accountId}
+            username={profile.username}
+            displayName={profile.account_display_name}
+            avatarUrl={profile.avatar_media_url}
+            isOverall={isOverall}
+            contextTitle={contextTitle}
+            contextDesc={contextDesc}
+            pills={pills}
+            tweets={tweets}
+            hofIds={hofIds}
+            media={chapterData.media}
+            mediaCount={chapterData.mediaCount}
+            people={chapterData.people}
+            peopleTitle={isOverall ? 'Top mutuals' : 'People in this chapter'}
+          />
+        </div>
       </div>
-    </section>
+    </div>
   )
 }

--- a/src/app/user/[account_id]/page.tsx
+++ b/src/app/user/[account_id]/page.tsx
@@ -2,10 +2,7 @@ import { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { ProfileHeader } from '@/components/metaTwitter/ProfileHeader'
 import { ArchiveNav, NavChapter } from '@/components/metaTwitter/ArchiveNav'
-import {
-  Workspace,
-  WorkspacePill,
-} from '@/components/metaTwitter/Workspace'
+import { Workspace } from '@/components/metaTwitter/Workspace'
 import {
   getCachedActiveYears,
   getCachedArchivedAt,
@@ -108,27 +105,18 @@ export default async function UserPage({ params, searchParams }: PageProps) {
         `The best of @${profile.username}'s archive.`)
       : (chapterConfig?.description ?? null)
 
-  const pills: WorkspacePill[] = availableTopics.map((t) => {
-    const active = topic?.slug === t.slug
-    const chapterParam = year ? `chapter=${year}&` : ''
+  const navChapters: NavChapter[] = activeYears.map((y) => {
+    const chapter = config?.chapters.find((c) => c.year === y.year)
     return {
-      label: t.label,
-      slug: t.slug,
-      active,
-      // Clicking the active pill deselects it (back to the bare chapter).
-      href: active
-        ? `${basePath}${year ? `?chapter=${year}` : ''}`
-        : `${basePath}?${chapterParam}topic=${t.slug}`,
+      year: y.year,
+      count: y.count,
+      phrase: chapter?.phrase,
+      topics: (chapter?.topics ?? []).map((t) => ({
+        label: t.label,
+        slug: t.slug,
+      })),
     }
   })
-
-  const navChapters: NavChapter[] = activeYears.map((y) => ({
-    year: y.year,
-    count: y.count,
-    topics: (config?.chapters.find((c) => c.year === y.year)?.topics ?? []).map(
-      (t) => ({ label: t.label, slug: t.slug }),
-    ),
-  }))
 
   return (
     <div className="flex justify-center px-4 py-8 sm:px-6">
@@ -149,7 +137,6 @@ export default async function UserPage({ params, searchParams }: PageProps) {
             isOverall={isOverall}
             contextTitle={contextTitle}
             contextDesc={contextDesc}
-            pills={pills}
             tweets={tweets}
             hofIds={hofIds}
             media={chapterData.media}

--- a/src/components/metaTwitter/ArchiveNav.tsx
+++ b/src/components/metaTwitter/ArchiveNav.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 export interface NavChapter {
   year: number
   count: number
+  phrase?: string
   topics: { label: string; slug: string }[]
 }
 
@@ -43,13 +44,25 @@ export function ArchiveNav({
           <div key={chapter.year} className="contents lg:block">
             <Link
               href={`${basePath}?chapter=${chapter.year}`}
-              className={`block whitespace-nowrap px-3 pb-1 pt-3 text-sm font-extrabold lg:pt-3 ${
+              className={`block whitespace-nowrap px-3 pb-1 pt-3 text-sm lg:whitespace-normal ${
                 yearActive && !activeTopicSlug
-                  ? 'text-foreground underline decoration-2 underline-offset-4'
+                  ? 'text-foreground'
                   : 'text-foreground/80 hover:text-foreground'
               }`}
             >
-              {chapter.year}
+              <span
+                className={`font-extrabold ${yearActive && !activeTopicSlug ? 'underline decoration-2 underline-offset-4' : ''}`}
+              >
+                {chapter.year}
+              </span>
+              {chapter.phrase && (
+                <span
+                  className="hidden text-[13px] italic leading-snug text-muted-foreground lg:block"
+                  style={{ fontFamily: 'var(--font-petrona), Georgia, serif' }}
+                >
+                  {chapter.phrase}
+                </span>
+              )}
             </Link>
             {chapter.topics.map((topic) => {
               const topicActive = yearActive && activeTopicSlug === topic.slug

--- a/src/components/metaTwitter/ArchiveNav.tsx
+++ b/src/components/metaTwitter/ArchiveNav.tsx
@@ -1,0 +1,75 @@
+import Link from 'next/link'
+
+export interface NavChapter {
+  year: number
+  count: number
+  topics: { label: string; slug: string }[]
+}
+
+/**
+ * Left archive navigation: Overall, then years (newest first) with their
+ * topics. Selection state comes from the URL (chapter/topic search params).
+ */
+export function ArchiveNav({
+  basePath,
+  chapters,
+  activeYear,
+  activeTopicSlug,
+}: {
+  basePath: string
+  chapters: NavChapter[]
+  activeYear: number | null
+  activeTopicSlug: string | null
+}) {
+  const isOverall = activeYear === null
+  return (
+    <nav className="flex shrink-0 flex-row items-center gap-0.5 overflow-x-auto border-b border-border p-3 lg:sticky lg:top-0 lg:flex-col lg:items-stretch lg:overflow-visible lg:border-b-0 lg:border-r lg:px-3 lg:py-5">
+      <div className="hidden px-3 pb-2 text-[11px] font-bold uppercase tracking-[0.08em] text-muted-foreground lg:block">
+        Chapters
+      </div>
+      <Link
+        href={basePath}
+        className={`whitespace-nowrap rounded-full px-3.5 py-2 text-sm font-bold ${
+          isOverall
+            ? 'bg-foreground text-background'
+            : 'text-foreground hover:bg-muted'
+        }`}
+      >
+        Overall — Bangers
+      </Link>
+      {chapters.map((chapter) => {
+        const yearActive = activeYear === chapter.year
+        return (
+          <div key={chapter.year} className="contents lg:block">
+            <Link
+              href={`${basePath}?chapter=${chapter.year}`}
+              className={`block whitespace-nowrap px-3 pb-1 pt-3 text-sm font-extrabold lg:pt-3 ${
+                yearActive && !activeTopicSlug
+                  ? 'text-foreground underline decoration-2 underline-offset-4'
+                  : 'text-foreground/80 hover:text-foreground'
+              }`}
+            >
+              {chapter.year}
+            </Link>
+            {chapter.topics.map((topic) => {
+              const topicActive = yearActive && activeTopicSlug === topic.slug
+              return (
+                <Link
+                  key={topic.slug}
+                  href={`${basePath}?chapter=${chapter.year}&topic=${topic.slug}`}
+                  className={`whitespace-nowrap rounded-lg py-[5px] pl-3 pr-3 text-sm lg:block lg:pl-6 ${
+                    topicActive
+                      ? 'bg-accent font-bold text-accent-foreground'
+                      : 'font-normal text-muted-foreground hover:bg-muted'
+                  }`}
+                >
+                  {topic.label}
+                </Link>
+              )
+            })}
+          </div>
+        )
+      })}
+    </nav>
+  )
+}

--- a/src/components/metaTwitter/ArchiveNav.tsx
+++ b/src/components/metaTwitter/ArchiveNav.tsx
@@ -3,7 +3,6 @@ import Link from 'next/link'
 export interface NavChapter {
   year: number
   count: number
-  phrase?: string
   topics: { label: string; slug: string }[]
 }
 
@@ -44,25 +43,13 @@ export function ArchiveNav({
           <div key={chapter.year} className="contents lg:block">
             <Link
               href={`${basePath}?chapter=${chapter.year}`}
-              className={`block whitespace-nowrap px-3 pb-1 pt-3 text-sm lg:whitespace-normal ${
+              className={`block whitespace-nowrap px-3 pb-1 pt-3 text-sm font-extrabold ${
                 yearActive && !activeTopicSlug
-                  ? 'text-foreground'
+                  ? 'text-foreground underline decoration-2 underline-offset-4'
                   : 'text-foreground/80 hover:text-foreground'
               }`}
             >
-              <span
-                className={`font-extrabold ${yearActive && !activeTopicSlug ? 'underline decoration-2 underline-offset-4' : ''}`}
-              >
-                {chapter.year}
-              </span>
-              {chapter.phrase && (
-                <span
-                  className="hidden text-[13px] italic leading-snug text-muted-foreground lg:block"
-                  style={{ fontFamily: 'var(--font-petrona), Georgia, serif' }}
-                >
-                  {chapter.phrase}
-                </span>
-              )}
+              {chapter.year}
             </Link>
             {chapter.topics.map((topic) => {
               const topicActive = yearActive && activeTopicSlug === topic.slug
@@ -70,7 +57,7 @@ export function ArchiveNav({
                 <Link
                   key={topic.slug}
                   href={`${basePath}?chapter=${chapter.year}&topic=${topic.slug}`}
-                  className={`whitespace-nowrap rounded-lg py-[5px] pl-3 pr-3 text-sm lg:block lg:pl-6 ${
+                  className={`whitespace-nowrap rounded-lg py-[5px] pl-3 pr-3 text-sm leading-snug lg:block lg:whitespace-normal lg:pl-6 ${
                     topicActive
                       ? 'bg-accent font-bold text-accent-foreground'
                       : 'font-normal text-muted-foreground hover:bg-muted'

--- a/src/components/metaTwitter/ProfileHeader.tsx
+++ b/src/components/metaTwitter/ProfileHeader.tsx
@@ -47,7 +47,7 @@ export function ProfileHeader({
           <img
             src={profile.avatar_media_url ?? ''}
             alt={profile.account_display_name}
-            className="-mt-[66px] h-[132px] w-[132px] rounded-full border-4 border-card bg-[#ddd] object-cover"
+            className="relative z-10 -mt-[66px] h-[132px] w-[132px] rounded-full border-4 border-card bg-[#ddd] object-cover"
           />
           <div className="flex gap-2 pt-3.5">
             <a

--- a/src/components/metaTwitter/ProfileHeader.tsx
+++ b/src/components/metaTwitter/ProfileHeader.tsx
@@ -1,0 +1,108 @@
+import Image from 'next/image'
+import { formatNumber } from '@/lib/formatNumber'
+import type { ProfileHeaderData } from '@/lib/metaTwitter/types'
+
+const monthYear = (iso: string) =>
+  new Date(iso).toLocaleDateString('en-US', {
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  })
+
+const Stat = ({ value, label }: { value: number; label: string }) => (
+  <span>
+    <b>{formatNumber(value)}</b>{' '}
+    <span className="text-muted-foreground">{label}</span>
+  </span>
+)
+
+/** Twitter-style profile header: cover, overlapping avatar, identity, stats. */
+export function ProfileHeader({
+  profile,
+  archivedAt,
+}: {
+  profile: ProfileHeaderData
+  archivedAt: string | null
+}) {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const archiveUrl = `${supabaseUrl}/storage/v1/object/public/archives/${profile.username.toLowerCase()}/archive.json`
+
+  return (
+    <div>
+      <div className="relative h-[210px] w-full bg-muted">
+        {profile.header_media_url && (
+          <Image
+            src={`${profile.header_media_url}/1500x500`}
+            alt=""
+            fill
+            priority
+            className="object-cover"
+            sizes="(max-width: 1220px) 100vw, 1220px"
+          />
+        )}
+      </div>
+      <div className="px-6 pb-4">
+        <div className="flex items-start justify-between">
+          {/* Avatar overlaps the cover by exactly half its height */}
+          <img
+            src={profile.avatar_media_url ?? ''}
+            alt={profile.account_display_name}
+            className="-mt-[66px] h-[132px] w-[132px] rounded-full border-4 border-card bg-[#ddd] object-cover"
+          />
+          <div className="flex gap-2 pt-3.5">
+            <a
+              href={archiveUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-full border border-border bg-transparent px-4 py-[7px] text-sm font-semibold text-foreground hover:bg-muted"
+            >
+              Download archive
+            </a>
+            <a
+              href={`https://x.com/${profile.username}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-full bg-foreground px-4 py-[7px] text-sm font-semibold text-background hover:opacity-90"
+            >
+              Follow on X
+            </a>
+          </div>
+        </div>
+
+        <div className="mt-2.5 flex items-center gap-1.5">
+          <span className="text-xl font-extrabold">
+            {profile.account_display_name}
+          </span>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="#1d9bf0">
+            <path d="M22.25 12c0-1.43-.88-2.67-2.19-3.34.46-1.39.2-2.9-.81-3.91s-2.52-1.27-3.91-.81c-.66-1.31-1.91-2.19-3.34-2.19s-2.67.88-3.33 2.19c-1.4-.46-2.91-.2-3.92.81s-1.26 2.52-.8 3.91c-1.31.67-2.2 1.91-2.2 3.34s.89 2.67 2.2 3.34c-.46 1.39-.21 2.9.8 3.91s2.52 1.26 3.91.81c.67 1.31 1.91 2.19 3.34 2.19s2.68-.88 3.34-2.19c1.39.45 2.9.2 3.91-.81s1.27-2.52.81-3.91c1.31-.67 2.19-1.91 2.19-3.34zm-11.71 4.2L6.8 12.46l1.41-1.42 2.26 2.26 4.8-5.23 1.47 1.36-6.2 6.77z" />
+          </svg>
+          <span className="ml-1 rounded-full bg-muted px-2 py-0.5 text-[11px] font-semibold text-muted-foreground">
+            Archive contributor
+          </span>
+        </div>
+        <div className="text-[15px] text-muted-foreground">
+          @{profile.username}
+        </div>
+
+        {profile.bio && (
+          <div className="mt-2.5 whitespace-pre-line text-[15px] leading-[1.45]">
+            {profile.bio}
+          </div>
+        )}
+
+        <div className="mt-2.5 flex flex-wrap gap-4 text-sm text-muted-foreground">
+          {profile.location && <span>📍 {profile.location}</span>}
+          <span>📅 Joined {monthYear(profile.created_at)}</span>
+          {archivedAt && <span>🗄️ Archived {monthYear(archivedAt)}</span>}
+        </div>
+
+        <div className="mt-2.5 flex flex-wrap gap-[18px] text-sm">
+          <Stat value={profile.num_tweets} label="Posts" />
+          <Stat value={profile.num_followers} label="Followers" />
+          <Stat value={profile.num_following} label="Following" />
+          <Stat value={profile.num_likes} label="Likes" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/metaTwitter/TweetText.tsx
+++ b/src/components/metaTwitter/TweetText.tsx
@@ -1,0 +1,62 @@
+import { Fragment } from 'react'
+
+const decodeEntities = (text: string) =>
+  text
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+
+const TOKEN_RE = /(https?:\/\/\S+|@\w{1,15})/g
+
+/**
+ * Tweet body: decodes HTML entities, links URLs and @mentions, and drops the
+ * trailing t.co permalink when the tweet's media is rendered separately.
+ */
+export function TweetText({
+  text,
+  hasMedia,
+}: {
+  text: string
+  hasMedia: boolean
+}) {
+  let decoded = decodeEntities(text)
+  if (hasMedia) {
+    decoded = decoded.replace(/(?:\s*https:\/\/t\.co\/\w+)+\s*$/, '')
+  }
+  const parts = decoded.split(TOKEN_RE)
+  return (
+    <div className="mt-0.5 whitespace-pre-line text-[15px] leading-[1.45]">
+      {parts.map((part, i) => {
+        if (/^https?:\/\//.test(part)) {
+          return (
+            <a
+              key={i}
+              href={part}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-[hsl(var(--brand))] hover:underline"
+            >
+              {part.replace(/^https?:\/\//, '')}
+            </a>
+          )
+        }
+        if (/^@\w+$/.test(part)) {
+          return (
+            <a
+              key={i}
+              href={`https://x.com/${part.slice(1)}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-[hsl(var(--brand))] hover:underline"
+            >
+              {part}
+            </a>
+          )
+        }
+        return <Fragment key={i}>{part}</Fragment>
+      })}
+    </div>
+  )
+}

--- a/src/components/metaTwitter/Workspace.tsx
+++ b/src/components/metaTwitter/Workspace.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
 import { useAuthAndArchive } from '@/hooks/useAuthAndArchive'
 import { TweetText } from './TweetText'
+import { createBrowserClient } from '@/utils/supabase'
 import { formatNumber } from '@/lib/formatNumber'
 import type {
   ArchiveTweet,
@@ -11,16 +12,20 @@ import type {
   ArchivePerson,
 } from '@/lib/metaTwitter/types'
 
-export interface WorkspacePill {
-  label: string
-  slug: string
-  href: string
-  active: boolean
-}
-
 interface CurationState {
   pinned: Record<string, boolean>
   hidden: Record<string, boolean>
+  /** Tweet ids manually added to the Hall of Fame via link */
+  added: string[]
+  /** Explicit ordering for the Curated sort (tweet ids, first = top) */
+  order: string[]
+}
+
+const EMPTY_CURATION: CurationState = {
+  pinned: {},
+  hidden: {},
+  added: [],
+  order: [],
 }
 
 type SortMode = 'curated' | 'likes' | 'newest'
@@ -41,6 +46,16 @@ const personHue = (handle: string) => {
   return h
 }
 
+/** Accepts x.com/twitter.com status URLs or a raw numeric id. */
+const parseTweetId = (input: string): string | null => {
+  const trimmed = input.trim()
+  if (/^\d{5,25}$/.test(trimmed)) return trimmed
+  const match = trimmed.match(
+    /(?:twitter\.com|x\.com)\/[^/]+\/status(?:es)?\/(\d+)/i,
+  )
+  return match ? match[1] : null
+}
+
 export function Workspace({
   accountId,
   username,
@@ -49,7 +64,6 @@ export function Workspace({
   isOverall,
   contextTitle,
   contextDesc,
-  pills,
   tweets,
   hofIds,
   media,
@@ -64,7 +78,6 @@ export function Workspace({
   isOverall: boolean
   contextTitle: string
   contextDesc: string | null
-  pills: WorkspacePill[]
   tweets: ArchiveTweet[]
   hofIds: string[]
   media: ArchiveMediaItem[]
@@ -79,16 +92,17 @@ export function Workspace({
 
   const [sort, setSort] = useState<SortMode>('curated')
   const [edit, setEdit] = useState(false)
-  const [curation, setCuration] = useState<CurationState>({
-    pinned: {},
-    hidden: {},
-  })
+  const [curation, setCuration] = useState<CurationState>(EMPTY_CURATION)
+  const [addedTweets, setAddedTweets] = useState<ArchiveTweet[]>([])
+  const [addInput, setAddInput] = useState('')
+  const [addError, setAddError] = useState<string | null>(null)
+  const [adding, setAdding] = useState(false)
   const storageKey = `meta-twitter-curation:${accountId}`
 
   useEffect(() => {
     try {
       const raw = window.localStorage.getItem(storageKey)
-      if (raw) setCuration(JSON.parse(raw))
+      if (raw) setCuration({ ...EMPTY_CURATION, ...JSON.parse(raw) })
     } catch {
       /* corrupted state — start fresh */
     }
@@ -103,26 +117,88 @@ export function Workspace({
     }
   }
 
+  /** Fetch a tweet from this account's archive, shaped like the server data. */
+  const fetchArchiveTweet = async (
+    tweetId: string,
+  ): Promise<ArchiveTweet | null> => {
+    const supabase = createBrowserClient()
+    const { data } = await supabase
+      .from('tweets')
+      .select(
+        'tweet_id, account_id, created_at, full_text, favorite_count, retweet_count, reply_to_username, media:tweet_media ( media_url, media_type, width, height )',
+      )
+      .eq('tweet_id', tweetId)
+      .eq('account_id', accountId)
+      .maybeSingle()
+    if (!data) return null
+    return {
+      ...data,
+      retweet_count: data.retweet_count ?? 0,
+      reply_to_username: data.reply_to_username ?? null,
+      username,
+      account_display_name: displayName,
+      avatar_media_url: avatarUrl,
+      media: (data.media ?? []) as ArchiveTweet['media'],
+    }
+  }
+
+  // Restore manually-added tweets that aren't in the server-provided list.
+  useEffect(() => {
+    const serverIds = new Set(tweets.map((t) => t.tweet_id))
+    const missing = curation.added.filter((id) => !serverIds.has(id))
+    if (missing.length === 0) return
+    let cancelled = false
+    Promise.all(missing.map(fetchArchiveTweet)).then((results) => {
+      if (cancelled) return
+      setAddedTweets((prev) => {
+        const have = new Set(prev.map((t) => t.tweet_id))
+        const fresh = results.filter(
+          (t): t is ArchiveTweet => !!t && !have.has(t.tweet_id),
+        )
+        return fresh.length > 0 ? [...prev, ...fresh] : prev
+      })
+    })
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [curation.added, tweets])
+
+  const allTweets = useMemo(() => {
+    const seen = new Set<string>()
+    return [...tweets, ...addedTweets].filter((t) => {
+      if (seen.has(t.tweet_id)) return false
+      seen.add(t.tweet_id)
+      return true
+    })
+  }, [tweets, addedTweets])
+
   // A tweet is in the Hall of Fame if the owner pinned it, or it's a curated
   // default that hasn't been explicitly un-pinned.
-  const isPinned = (id: string) => curation.pinned[id] ?? hofIds.includes(id)
+  const isPinned = (id: string) =>
+    curation.pinned[id] ?? (hofIds.includes(id) || curation.added.includes(id))
 
   const visibleTweets = useMemo(() => {
-    let list = tweets.filter((t) => !curation.hidden[t.tweet_id])
+    let list = allTweets.filter((t) => !curation.hidden[t.tweet_id])
     if (sort === 'likes') {
       list = [...list].sort((a, b) => b.favorite_count - a.favorite_count)
     } else if (sort === 'newest') {
       list = [...list].sort((a, b) => b.created_at.localeCompare(a.created_at))
     } else {
+      const orderIndex = (id: string) => {
+        const i = curation.order.indexOf(id)
+        return i === -1 ? Number.MAX_SAFE_INTEGER : i
+      }
       list = [...list].sort(
         (a, b) =>
+          orderIndex(a.tweet_id) - orderIndex(b.tweet_id) ||
           Number(isPinned(b.tweet_id)) - Number(isPinned(a.tweet_id)) ||
           b.favorite_count - a.favorite_count,
       )
     }
     return list.slice(0, MAX_TWEETS)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tweets, curation, sort, hofIds])
+  }, [allTweets, curation, sort, hofIds])
 
   const hiddenCount = Object.values(curation.hidden).filter(Boolean).length
 
@@ -138,14 +214,56 @@ export function Workspace({
     })
   const restoreAll = () => saveCuration({ ...curation, hidden: {} })
 
+  /** Swap a tweet with its neighbor in the current curated view. */
+  const moveTweet = (id: string, direction: -1 | 1) => {
+    const ids = visibleTweets.map((t) => t.tweet_id)
+    const from = ids.indexOf(id)
+    const to = from + direction
+    if (from === -1 || to < 0 || to >= ids.length) return
+    ;[ids[from], ids[to]] = [ids[to], ids[from]]
+    saveCuration({ ...curation, order: ids })
+  }
+
+  const addTweetByLink = async () => {
+    setAddError(null)
+    const tweetId = parseTweetId(addInput)
+    if (!tweetId) {
+      setAddError('Paste an x.com or twitter.com tweet link.')
+      return
+    }
+    if (curation.added.includes(tweetId) || hofIds.includes(tweetId)) {
+      setAddError('That tweet is already in the Hall of Fame.')
+      return
+    }
+    setAdding(true)
+    try {
+      const tweet = await fetchArchiveTweet(tweetId)
+      if (!tweet) {
+        setAddError(`Couldn't find that tweet in @${username}'s archive.`)
+        return
+      }
+      setAddedTweets((prev) => [...prev, tweet])
+      saveCuration({
+        ...curation,
+        added: [...curation.added, tweetId],
+        pinned: { ...curation.pinned, [tweetId]: true },
+        hidden: { ...curation.hidden, [tweetId]: false },
+      })
+      setAddInput('')
+    } finally {
+      setAdding(false)
+    }
+  }
+
   const mediaTiles = media.slice(0, 6)
   const mediaOverflow = Math.max(mediaCount - 5, 0)
+  const canReorder = edit && sort === 'curated'
 
   return (
     <main className="flex min-w-0 flex-col gap-[18px] px-6 py-5">
-      {/* Context header */}
-      <div className="flex items-start justify-between gap-3">
-        <div>
+      {/* Context header with sort + edit controls */}
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
           <div className="text-xl font-extrabold">{contextTitle}</div>
           {contextDesc && (
             <div className="mt-0.5 text-[13px] text-muted-foreground">
@@ -153,45 +271,60 @@ export function Workspace({
             </div>
           )}
         </div>
-        {isOwner && (
-          <button
-            onClick={() => setEdit(!edit)}
-            className={`shrink-0 rounded-full border border-border px-3.5 py-1.5 text-[13px] font-semibold ${
-              edit
-                ? 'bg-foreground text-background'
-                : 'bg-card text-foreground hover:bg-muted'
-            }`}
+        <div className="flex shrink-0 items-center gap-2">
+          <select
+            value={sort}
+            onChange={(e) => setSort(e.target.value as SortMode)}
+            className="rounded-lg border border-border bg-card px-2.5 py-1.5 text-[13px] text-muted-foreground"
           >
-            {edit ? 'Done editing' : '✎ Edit archive'}
-          </button>
-        )}
+            <option value="curated">Sort: Curated</option>
+            <option value="likes">Sort: Most liked</option>
+            <option value="newest">Sort: Newest</option>
+          </select>
+          {isOwner && (
+            <button
+              onClick={() => setEdit(!edit)}
+              className={`rounded-full border border-border px-3.5 py-1.5 text-[13px] font-semibold ${
+                edit
+                  ? 'bg-foreground text-background'
+                  : 'bg-card text-foreground hover:bg-muted'
+              }`}
+            >
+              {edit ? 'Done editing' : '✎ Edit archive'}
+            </button>
+          )}
+        </div>
       </div>
 
-      {/* Pills + sort */}
-      <div className="flex flex-wrap items-center gap-2">
-        {pills.map((pill) => (
-          <Link
-            key={pill.slug}
-            href={pill.href}
-            className={`rounded-full border px-3.5 py-1.5 text-[13px] font-semibold ${
-              pill.active
-                ? 'border-foreground bg-foreground text-background'
-                : 'border-border bg-transparent text-muted-foreground hover:bg-muted'
-            }`}
-          >
-            {pill.label}
-          </Link>
-        ))}
-        <select
-          value={sort}
-          onChange={(e) => setSort(e.target.value as SortMode)}
-          className="ml-auto rounded-lg border border-border bg-card px-2.5 py-1.5 text-[13px] text-muted-foreground"
-        >
-          <option value="curated">Sort: Curated</option>
-          <option value="likes">Sort: Most liked</option>
-          <option value="newest">Sort: Newest</option>
-        </select>
-      </div>
+      {/* Add-to-Hall-of-Fame by tweet link (owner, Overall view) */}
+      {edit && isOverall && (
+        <div className="rounded-[10px] border border-dashed border-border px-3.5 py-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <input
+              value={addInput}
+              onChange={(e) => {
+                setAddInput(e.target.value)
+                setAddError(null)
+              }}
+              onKeyDown={(e) => e.key === 'Enter' && addTweetByLink()}
+              placeholder="Paste a tweet link to add it to the Hall of Fame — e.g. https://x.com/christineist/status/…"
+              className="min-w-0 flex-1 rounded-lg border border-border bg-card px-3 py-1.5 text-[13px] placeholder:text-muted-foreground/70"
+            />
+            <button
+              onClick={addTweetByLink}
+              disabled={adding || addInput.trim() === ''}
+              className="rounded-full bg-foreground px-4 py-1.5 text-[13px] font-semibold text-background disabled:opacity-50"
+            >
+              {adding ? 'Adding…' : '⭐ Add'}
+            </button>
+          </div>
+          {addError && (
+            <div className="mt-1.5 text-[13px] text-[hsl(var(--destructive))]">
+              {addError}
+            </div>
+          )}
+        </div>
+      )}
 
       {/* Hidden banner */}
       {edit && hiddenCount > 0 && (
@@ -216,12 +349,32 @@ export function Workspace({
               filtered out.
             </div>
           )}
-          {visibleTweets.map((tweet) => (
+          {visibleTweets.map((tweet, index) => (
             <div
               key={tweet.tweet_id}
               className="rounded-xl border border-border px-4 py-3.5"
             >
               <div className="flex gap-2.5">
+                {canReorder && (
+                  <div className="flex flex-col justify-center gap-1">
+                    <button
+                      title="Move up"
+                      onClick={() => moveTweet(tweet.tweet_id, -1)}
+                      disabled={index === 0}
+                      className="rounded-md border border-border bg-card px-1.5 py-0.5 text-[11px] text-muted-foreground hover:bg-muted disabled:opacity-30"
+                    >
+                      ↑
+                    </button>
+                    <button
+                      title="Move down"
+                      onClick={() => moveTweet(tweet.tweet_id, 1)}
+                      disabled={index === visibleTweets.length - 1}
+                      className="rounded-md border border-border bg-card px-1.5 py-0.5 text-[11px] text-muted-foreground hover:bg-muted disabled:opacity-30"
+                    >
+                      ↓
+                    </button>
+                  </div>
+                )}
                 {avatarUrl ? (
                   <img
                     src={avatarUrl}

--- a/src/components/metaTwitter/Workspace.tsx
+++ b/src/components/metaTwitter/Workspace.tsx
@@ -1,0 +1,407 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import { useAuthAndArchive } from '@/hooks/useAuthAndArchive'
+import { TweetText } from './TweetText'
+import { formatNumber } from '@/lib/formatNumber'
+import type {
+  ArchiveTweet,
+  ArchiveMediaItem,
+  ArchivePerson,
+} from '@/lib/metaTwitter/types'
+
+export interface WorkspacePill {
+  label: string
+  slug: string
+  href: string
+  active: boolean
+}
+
+interface CurationState {
+  pinned: Record<string, boolean>
+  hidden: Record<string, boolean>
+}
+
+type SortMode = 'curated' | 'likes' | 'newest'
+
+const MAX_TWEETS = 24
+
+const tweetDate = (iso: string) =>
+  new Date(iso).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  })
+
+const personHue = (handle: string) => {
+  let h = 0
+  for (let i = 0; i < handle.length; i++) h = (h * 31 + handle.charCodeAt(i)) % 360
+  return h
+}
+
+export function Workspace({
+  accountId,
+  username,
+  displayName,
+  avatarUrl,
+  isOverall,
+  contextTitle,
+  contextDesc,
+  pills,
+  tweets,
+  hofIds,
+  media,
+  mediaCount,
+  people,
+  peopleTitle,
+}: {
+  accountId: string
+  username: string
+  displayName: string
+  avatarUrl: string | null
+  isOverall: boolean
+  contextTitle: string
+  contextDesc: string | null
+  pills: WorkspacePill[]
+  tweets: ArchiveTweet[]
+  hofIds: string[]
+  media: ArchiveMediaItem[]
+  mediaCount: number
+  people: ArchivePerson[]
+  peopleTitle: string
+}) {
+  const { userMetadata } = useAuthAndArchive()
+  const isOwner =
+    userMetadata?.provider_id === accountId ||
+    process.env.NODE_ENV === 'development'
+
+  const [sort, setSort] = useState<SortMode>('curated')
+  const [edit, setEdit] = useState(false)
+  const [curation, setCuration] = useState<CurationState>({
+    pinned: {},
+    hidden: {},
+  })
+  const storageKey = `meta-twitter-curation:${accountId}`
+
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(storageKey)
+      if (raw) setCuration(JSON.parse(raw))
+    } catch {
+      /* corrupted state — start fresh */
+    }
+  }, [storageKey])
+
+  const saveCuration = (next: CurationState) => {
+    setCuration(next)
+    try {
+      window.localStorage.setItem(storageKey, JSON.stringify(next))
+    } catch {
+      /* storage unavailable */
+    }
+  }
+
+  // A tweet is in the Hall of Fame if the owner pinned it, or it's a curated
+  // default that hasn't been explicitly un-pinned.
+  const isPinned = (id: string) => curation.pinned[id] ?? hofIds.includes(id)
+
+  const visibleTweets = useMemo(() => {
+    let list = tweets.filter((t) => !curation.hidden[t.tweet_id])
+    if (sort === 'likes') {
+      list = [...list].sort((a, b) => b.favorite_count - a.favorite_count)
+    } else if (sort === 'newest') {
+      list = [...list].sort((a, b) => b.created_at.localeCompare(a.created_at))
+    } else {
+      list = [...list].sort(
+        (a, b) =>
+          Number(isPinned(b.tweet_id)) - Number(isPinned(a.tweet_id)) ||
+          b.favorite_count - a.favorite_count,
+      )
+    }
+    return list.slice(0, MAX_TWEETS)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tweets, curation, sort, hofIds])
+
+  const hiddenCount = Object.values(curation.hidden).filter(Boolean).length
+
+  const togglePin = (id: string) =>
+    saveCuration({
+      ...curation,
+      pinned: { ...curation.pinned, [id]: !isPinned(id) },
+    })
+  const hideTweet = (id: string) =>
+    saveCuration({
+      ...curation,
+      hidden: { ...curation.hidden, [id]: true },
+    })
+  const restoreAll = () => saveCuration({ ...curation, hidden: {} })
+
+  const mediaTiles = media.slice(0, 6)
+  const mediaOverflow = Math.max(mediaCount - 5, 0)
+
+  return (
+    <main className="flex min-w-0 flex-col gap-[18px] px-6 py-5">
+      {/* Context header */}
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="text-xl font-extrabold">{contextTitle}</div>
+          {contextDesc && (
+            <div className="mt-0.5 text-[13px] text-muted-foreground">
+              {contextDesc}
+            </div>
+          )}
+        </div>
+        {isOwner && (
+          <button
+            onClick={() => setEdit(!edit)}
+            className={`shrink-0 rounded-full border border-border px-3.5 py-1.5 text-[13px] font-semibold ${
+              edit
+                ? 'bg-foreground text-background'
+                : 'bg-card text-foreground hover:bg-muted'
+            }`}
+          >
+            {edit ? 'Done editing' : '✎ Edit archive'}
+          </button>
+        )}
+      </div>
+
+      {/* Pills + sort */}
+      <div className="flex flex-wrap items-center gap-2">
+        {pills.map((pill) => (
+          <Link
+            key={pill.slug}
+            href={pill.href}
+            className={`rounded-full border px-3.5 py-1.5 text-[13px] font-semibold ${
+              pill.active
+                ? 'border-foreground bg-foreground text-background'
+                : 'border-border bg-transparent text-muted-foreground hover:bg-muted'
+            }`}
+          >
+            {pill.label}
+          </Link>
+        ))}
+        <select
+          value={sort}
+          onChange={(e) => setSort(e.target.value as SortMode)}
+          className="ml-auto rounded-lg border border-border bg-card px-2.5 py-1.5 text-[13px] text-muted-foreground"
+        >
+          <option value="curated">Sort: Curated</option>
+          <option value="likes">Sort: Most liked</option>
+          <option value="newest">Sort: Newest</option>
+        </select>
+      </div>
+
+      {/* Hidden banner */}
+      {edit && hiddenCount > 0 && (
+        <div className="flex items-center justify-between rounded-[10px] bg-muted px-3.5 py-2.5 text-[13px] text-muted-foreground">
+          <span>
+            {hiddenCount} tweet{hiddenCount === 1 ? '' : 's'} hidden from this
+            archive
+          </span>
+          <button onClick={restoreAll} className="font-bold text-foreground">
+            Restore all
+          </button>
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 items-start gap-5 xl:grid-cols-[1fr_280px]">
+        {/* Top tweets */}
+        <div className="flex flex-col gap-3">
+          <div className="text-[15px] font-extrabold">Top tweets</div>
+          {visibleTweets.length === 0 && (
+            <div className="rounded-xl border border-dashed border-border p-7 text-center text-sm text-muted-foreground">
+              Nothing here yet — everything in this chapter was hidden or
+              filtered out.
+            </div>
+          )}
+          {visibleTweets.map((tweet) => (
+            <div
+              key={tweet.tweet_id}
+              className="rounded-xl border border-border px-4 py-3.5"
+            >
+              <div className="flex gap-2.5">
+                {avatarUrl ? (
+                  <img
+                    src={avatarUrl}
+                    alt=""
+                    className="h-10 w-10 rounded-full object-cover"
+                  />
+                ) : (
+                  <span className="grid h-10 w-10 place-items-center rounded-full bg-muted font-bold">
+                    {displayName[0]}
+                  </span>
+                )}
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-1.5 text-sm">
+                    <b>{displayName}</b>
+                    <span className="text-muted-foreground">
+                      @{username} ·{' '}
+                      <Link
+                        href={`/tweets/${tweet.tweet_id}`}
+                        className="hover:underline"
+                      >
+                        {tweetDate(tweet.created_at)}
+                      </Link>
+                    </span>
+                    {isPinned(tweet.tweet_id) && (
+                      <span className="rounded-full bg-accent px-2 py-0.5 text-[11px] font-bold text-accent-foreground">
+                        ⭐ Hall of Fame
+                      </span>
+                    )}
+                    {edit && (
+                      <span className="ml-auto inline-flex gap-1.5">
+                        <button
+                          title="Add to / remove from Hall of Fame"
+                          onClick={() => togglePin(tweet.tweet_id)}
+                          className="rounded-lg border border-border bg-card px-2 py-0.5 text-[13px]"
+                        >
+                          {isPinned(tweet.tweet_id) ? '★' : '☆'}
+                        </button>
+                        <button
+                          title="Hide from archive"
+                          onClick={() => hideTweet(tweet.tweet_id)}
+                          className="rounded-lg border border-border bg-card px-2 py-0.5 text-[13px] text-muted-foreground"
+                        >
+                          ✕
+                        </button>
+                      </span>
+                    )}
+                  </div>
+                  <TweetText
+                    text={tweet.full_text}
+                    hasMedia={tweet.media.some((m) => m.media_type === 'photo')}
+                  />
+                  {tweet.media.length > 0 && (
+                    <div
+                      className={`mt-2 grid gap-1 ${tweet.media.length > 1 ? 'grid-cols-2' : 'grid-cols-1'}`}
+                    >
+                      {tweet.media
+                        .filter((m) => m.media_type === 'photo')
+                        .slice(0, 4)
+                        .map((m) => (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img
+                            key={m.media_url}
+                            src={m.media_url}
+                            alt=""
+                            loading="lazy"
+                            className="max-h-[420px] w-full rounded-lg border border-border object-cover"
+                          />
+                        ))}
+                    </div>
+                  )}
+                  <div className="mt-2 flex gap-5 text-[13px] text-muted-foreground">
+                    <span>🔁 {formatNumber(tweet.retweet_count ?? 0)}</span>
+                    <span>♥ {formatNumber(tweet.favorite_count)}</span>
+                    <a
+                      href={`https://x.com/${username}/status/${tweet.tweet_id}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="ml-auto hover:underline"
+                    >
+                      View on X ↗
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Right rail: media + people */}
+        <div className="flex flex-col gap-5">
+          <div>
+            <div className="mb-2.5 text-[15px] font-extrabold">Media</div>
+            {mediaTiles.length === 0 ? (
+              <div className="rounded-md border border-dashed border-border p-4 text-center text-xs text-muted-foreground">
+                No media in this chapter
+              </div>
+            ) : (
+              <div className="grid grid-cols-3 gap-1">
+                {mediaTiles.map((item, i) => (
+                  <Link
+                    key={item.media_url}
+                    href={`/tweets/${item.tweet_id}`}
+                    className="relative block aspect-square overflow-hidden rounded-md bg-muted"
+                  >
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={`${item.media_url}?name=small`}
+                      alt=""
+                      loading="lazy"
+                      className="h-full w-full object-cover"
+                    />
+                    {i === 5 && mediaOverflow > 1 && (
+                      <span className="absolute inset-0 grid place-items-center bg-black/50 text-xs font-semibold text-white">
+                        +{formatNumber(mediaOverflow)}
+                      </span>
+                    )}
+                  </Link>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div>
+            <div className="mb-2.5 text-[15px] font-extrabold">
+              {peopleTitle}
+            </div>
+            <div className="flex flex-col gap-2.5">
+              {people.length === 0 && (
+                <div className="text-[13px] text-muted-foreground">
+                  No interactions found in this chapter.
+                </div>
+              )}
+              {people.map((person) => {
+                const inner = (
+                  <div className="flex items-center gap-2.5">
+                    {person.avatar_media_url ? (
+                      <img
+                        src={person.avatar_media_url}
+                        alt=""
+                        className="h-9 w-9 flex-none rounded-full object-cover"
+                      />
+                    ) : (
+                      <span
+                        className="grid h-9 w-9 flex-none place-items-center rounded-full text-sm font-bold text-black/70"
+                        style={{
+                          background: `hsl(${personHue(person.screen_name)} 45% 80%)`,
+                        }}
+                      >
+                        {person.screen_name[0].toUpperCase()}
+                      </span>
+                    )}
+                    <div className="min-w-0 text-[13px] leading-[1.3]">
+                      <b>{person.name ?? person.screen_name}</b>{' '}
+                      <span className="text-muted-foreground">
+                        @{person.screen_name}
+                      </span>
+                      <br />
+                      <span className="text-muted-foreground">
+                        {person.interactions} interaction
+                        {person.interactions === 1 ? '' : 's'}
+                      </span>
+                    </div>
+                  </div>
+                )
+                return person.in_archive ? (
+                  <Link
+                    key={person.screen_name}
+                    href={`/user/${person.user_id}`}
+                    className="rounded-lg hover:bg-muted"
+                  >
+                    {inner}
+                  </Link>
+                ) : (
+                  <div key={person.screen_name}>{inner}</div>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/lib/metaTwitter/config.ts
+++ b/src/lib/metaTwitter/config.ts
@@ -20,8 +20,6 @@ export interface TopicConfig {
 
 export interface ChapterConfig {
   year: number
-  /** Short evocative chapter title, ideally in the owner's own words */
-  phrase?: string
   /** Short generated description of the era */
   description?: string
   topics: TopicConfig[]
@@ -42,44 +40,44 @@ export interface MetaTwitterProfileConfig {
 // via FTS counts, 2026-08).
 const T = {
   cuties: {
-    label: 'Building Cuties',
+    label: 'barreled along by cuties',
     slug: 'building-cuties',
     terms: ['cuties', 'matchmaking'],
     description:
       'Building the cuties dating app — dinners, group chats, and social infrastructure as plumbing for serendipity.',
   },
   friendship: {
-    label: 'Friendship',
+    label: 'what do your friends ask you for',
     slug: 'friendship',
     terms: ['friends', 'friendship'],
     description: 'On making, keeping, and introducing friends to one another.',
   },
   dating: {
-    label: 'Dating',
+    label: 'always go on 2 dates',
     slug: 'dating',
     terms: ['dating', 'romance'],
     description: 'Dating discourse, field notes from the romantic frontier.',
   },
   community: {
-    label: 'Community',
+    label: 'oh, I have a home again',
     slug: 'community',
     terms: ['community', 'dinner party'],
     description: 'Community building — dinners as infrastructure.',
   },
   art: {
-    label: 'Art',
+    label: 'experimental art parties',
     slug: 'art',
     terms: ['art', 'painting', 'museum'],
     description: 'Art, beauty, and feeling seen by paintings.',
   },
   ai: {
-    label: 'AI & startups',
+    label: 'social ai, tools for community flourishing',
     slug: 'ai',
     terms: ['AI', 'startup'],
     description: 'AI, startups, and building in public.',
   },
   sf: {
-    label: 'SF culture',
+    label: 'go look lost at config',
     slug: 'sf',
     terms: ['sf', 'san francisco'],
     description: 'San Francisco as a group project.',
@@ -97,37 +95,57 @@ export const META_TWITTER_PROFILES: Record<string, MetaTwitterProfileConfig> = {
     chapters: [
       {
         year: 2026,
-        phrase: 'my brain opened a new brain',
         description:
           'Building in public, dinners as infrastructure, and a softer internet.',
-        topics: [T.cuties, T.community, T.ai, T.friendship],
+        topics: [
+          { ...T.cuties, label: "hey they're on cuties!" },
+          { ...T.community, label: 'like YC but for public goods' },
+          { ...T.ai, label: 'social ai, tools for community flourishing' },
+          { ...T.friendship, label: 'what do your friends ask you for' },
+        ],
       },
       {
         year: 2025,
-        phrase: 'barreled along by cuties',
         description: 'The year Cuties went from group chat to institution.',
-        topics: [T.cuties, T.friendship, T.community, T.sf],
+        topics: [
+          { ...T.cuties, label: 'barreled along by cuties' },
+          { ...T.friendship, label: 'little groups of 3-4 friends' },
+          { ...T.community, label: 'find the next N lonely' },
+          { ...T.sf, label: 'lovember is happening btw' },
+        ],
       },
       {
         year: 2024,
-        phrase: 'oh my god what a love story',
         description:
           'Cuties gets serious, the dating discourse compounds, and the bangers keep landing.',
-        topics: [T.cuties, T.dating, T.friendship, T.ai],
+        topics: [
+          { ...T.cuties, label: '3rd relationship from cuties!' },
+          { ...T.dating, label: 'always go on 2 dates' },
+          { ...T.friendship, label: 'weddings of all of my major friendships' },
+          { ...T.ai, label: 'fertility clinic or open ai?' },
+        ],
       },
       {
         year: 2023,
-        phrase: 'the darling effect',
         description:
           'Peak dating discourse, viral late-twenties wisdom, and the first cuties experiments.',
-        topics: [T.dating, T.friendship, T.community, T.art],
+        topics: [
+          { ...T.dating, label: '+5 admiration points' },
+          { ...T.friendship, label: "you can't just cut and leave" },
+          { ...T.community, label: 'doing the community a favor' },
+          { ...T.art, label: 'those who get rothko paintings' },
+        ],
       },
       {
         year: 2022,
-        phrase: 'fun, meaningful and interesting work',
         description:
           'Friendship maximalism, art feelings, and the group chat era.',
-        topics: [T.friendship, T.art, T.dating, T.ai],
+        topics: [
+          { ...T.friendship, label: 'treat everyone like friends' },
+          { ...T.art, label: 'experimental art parties' },
+          { ...T.dating, label: 'a massive singles group chat' },
+          { ...T.ai, label: 'therapy of the future' },
+        ],
       },
     ],
     hallOfFamePinned: [

--- a/src/lib/metaTwitter/config.ts
+++ b/src/lib/metaTwitter/config.ts
@@ -20,6 +20,8 @@ export interface TopicConfig {
 
 export interface ChapterConfig {
   year: number
+  /** Short evocative chapter title, ideally in the owner's own words */
+  phrase?: string
   /** Short generated description of the era */
   description?: string
   topics: TopicConfig[]
@@ -95,29 +97,34 @@ export const META_TWITTER_PROFILES: Record<string, MetaTwitterProfileConfig> = {
     chapters: [
       {
         year: 2026,
+        phrase: 'my brain opened a new brain',
         description:
           'Building in public, dinners as infrastructure, and a softer internet.',
         topics: [T.cuties, T.community, T.ai, T.friendship],
       },
       {
         year: 2025,
+        phrase: 'barreled along by cuties',
         description: 'The year Cuties went from group chat to institution.',
         topics: [T.cuties, T.friendship, T.community, T.sf],
       },
       {
         year: 2024,
+        phrase: 'oh my god what a love story',
         description:
           'Cuties gets serious, the dating discourse compounds, and the bangers keep landing.',
         topics: [T.cuties, T.dating, T.friendship, T.ai],
       },
       {
         year: 2023,
+        phrase: 'the darling effect',
         description:
           'Peak dating discourse, viral late-twenties wisdom, and the first cuties experiments.',
         topics: [T.dating, T.friendship, T.community, T.art],
       },
       {
         year: 2022,
+        phrase: 'fun, meaningful and interesting work',
         description:
           'Friendship maximalism, art feelings, and the group chat era.',
         topics: [T.friendship, T.art, T.dating, T.ai],

--- a/src/lib/metaTwitter/config.ts
+++ b/src/lib/metaTwitter/config.ts
@@ -1,0 +1,138 @@
+/**
+ * Chapter/topic configuration for the Meta Twitter profile.
+ *
+ * Topics are the human-readable "what was this person into" labels per year.
+ * Each topic carries FTS terms used to scope tweets/media to that theme.
+ * For now this is hand-curated for @christineist (the pilot profile); the
+ * long-term plan is AI-generated defaults editable by the profile owner.
+ */
+
+export interface TopicConfig {
+  /** Human-readable label, e.g. "Building Cuties" */
+  label: string
+  /** URL-safe slug, e.g. "building-cuties" */
+  slug: string
+  /** Full-text-search terms OR'd together to scope tweets to this topic */
+  terms: string[]
+  /** Optional one-line description shown in the context header */
+  description?: string
+}
+
+export interface ChapterConfig {
+  year: number
+  /** Short generated description of the era */
+  description?: string
+  topics: TopicConfig[]
+}
+
+export interface MetaTwitterProfileConfig {
+  accountId: string
+  /** Description for the Overall / Hall of Fame chapter */
+  overallDescription: string
+  /** Topic pills shown on the Overall view (recurring interests across years) */
+  overallTopics: TopicConfig[]
+  chapters: ChapterConfig[]
+  /** Tweet IDs pinned into the Hall of Fame regardless of engagement */
+  hallOfFamePinned: string[]
+}
+
+// Shared topic building blocks (term lists validated against the live archive
+// via FTS counts, 2026-08).
+const T = {
+  cuties: {
+    label: 'Building Cuties',
+    slug: 'building-cuties',
+    terms: ['cuties', 'matchmaking'],
+    description:
+      'Building the cuties dating app — dinners, group chats, and social infrastructure as plumbing for serendipity.',
+  },
+  friendship: {
+    label: 'Friendship',
+    slug: 'friendship',
+    terms: ['friends', 'friendship'],
+    description: 'On making, keeping, and introducing friends to one another.',
+  },
+  dating: {
+    label: 'Dating',
+    slug: 'dating',
+    terms: ['dating', 'romance'],
+    description: 'Dating discourse, field notes from the romantic frontier.',
+  },
+  community: {
+    label: 'Community',
+    slug: 'community',
+    terms: ['community', 'dinner party'],
+    description: 'Community building — dinners as infrastructure.',
+  },
+  art: {
+    label: 'Art',
+    slug: 'art',
+    terms: ['art', 'painting', 'museum'],
+    description: 'Art, beauty, and feeling seen by paintings.',
+  },
+  ai: {
+    label: 'AI & startups',
+    slug: 'ai',
+    terms: ['AI', 'startup'],
+    description: 'AI, startups, and building in public.',
+  },
+  sf: {
+    label: 'SF culture',
+    slug: 'sf',
+    terms: ['sf', 'san francisco'],
+    description: 'San Francisco as a group project.',
+  },
+} satisfies Record<string, TopicConfig>
+
+/** Profiles with curated Meta Twitter config, keyed by account_id. */
+export const META_TWITTER_PROFILES: Record<string, MetaTwitterProfileConfig> = {
+  // christine (@christineist) — pilot profile
+  '826134955549790208': {
+    accountId: '826134955549790208',
+    overallDescription:
+      "the five-minute version of nine years — christine's greatest hits",
+    overallTopics: [T.cuties, T.friendship, T.dating, T.community, T.art, T.ai],
+    chapters: [
+      {
+        year: 2026,
+        description:
+          'Building in public, dinners as infrastructure, and a softer internet.',
+        topics: [T.cuties, T.community, T.ai, T.friendship],
+      },
+      {
+        year: 2025,
+        description: 'The year Cuties went from group chat to institution.',
+        topics: [T.cuties, T.friendship, T.community, T.sf],
+      },
+      {
+        year: 2024,
+        description:
+          'Cuties gets serious, the dating discourse compounds, and the bangers keep landing.',
+        topics: [T.cuties, T.dating, T.friendship, T.ai],
+      },
+      {
+        year: 2023,
+        description:
+          'Peak dating discourse, viral late-twenties wisdom, and the first cuties experiments.',
+        topics: [T.dating, T.friendship, T.community, T.art],
+      },
+      {
+        year: 2022,
+        description:
+          'Friendship maximalism, art feelings, and the group chat era.',
+        topics: [T.friendship, T.art, T.dating, T.ai],
+      },
+    ],
+    hallOfFamePinned: [
+      '1683951437716549636', // late twenties decisions compound
+      '1812364916906471452', // uncanny valley parallel-track friendships
+      '1780801621011685885', // oh my god what a love story
+      '1797180600308408522', // Francine Van Hove paintings
+      '1672424637886525440', // darling effect
+    ],
+  },
+}
+
+export const getMetaTwitterConfig = (
+  accountId: string,
+): MetaTwitterProfileConfig | null => META_TWITTER_PROFILES[accountId] ?? null

--- a/src/lib/metaTwitter/data.ts
+++ b/src/lib/metaTwitter/data.ts
@@ -1,0 +1,441 @@
+import 'server-only'
+
+import { createClient, SupabaseClient } from '@supabase/supabase-js'
+import { unstable_cache } from 'next/cache'
+import { Database } from '@/database-types'
+import { devLog } from '@/lib/devLog'
+import type {
+  ArchiveTweet,
+  ArchiveMediaItem,
+  ArchivePerson,
+  ProfileHeaderData,
+} from './types'
+
+export type {
+  ArchiveTweet,
+  ArchiveMediaItem,
+  ArchivePerson,
+  ProfileHeaderData,
+}
+
+/**
+ * Data layer for the Meta Twitter profile page.
+ *
+ * Follows the portal pattern (src/lib/portal/data.ts): a cookie-free anon
+ * client so aggregates can live inside unstable_cache without opting the
+ * route into per-request work.
+ */
+
+const getMetaClient = (): SupabaseClient<Database> => {
+  const isDevelopment = process.env.NODE_ENV === 'development'
+  const useRemoteDevDb = process.env.NEXT_PUBLIC_USE_REMOTE_DEV_DB === 'true'
+  const url =
+    isDevelopment && !useRemoteDevDb
+      ? process.env.NEXT_PUBLIC_LOCAL_SUPABASE_URL!
+      : process.env.NEXT_PUBLIC_SUPABASE_URL!
+  const anonKey =
+    isDevelopment && !useRemoteDevDb
+      ? process.env.NEXT_PUBLIC_LOCAL_ANON_KEY!
+      : process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  return createClient<Database>(url, anonKey, {
+    auth: { persistSession: false },
+  })
+}
+
+const TWEET_SELECT = `
+  tweet_id, account_id, created_at, full_text, favorite_count, retweet_count,
+  reply_to_username,
+  account:all_account!inner ( username, account_display_name ),
+  media:tweet_media ( media_url, media_type, width, height )
+`
+
+interface RawTweetRow {
+  tweet_id: string
+  account_id: string
+  created_at: string
+  full_text: string
+  favorite_count: number
+  retweet_count: number | null
+  reply_to_username: string | null
+  account: { username: string; account_display_name: string | null } | null
+  media:
+    | { media_url: string; media_type: string; width: number; height: number }[]
+    | null
+}
+
+const normalizeTweet = (
+  row: RawTweetRow,
+  avatarUrl: string | null,
+): ArchiveTweet => ({
+  tweet_id: row.tweet_id,
+  account_id: row.account_id,
+  created_at: row.created_at,
+  full_text: row.full_text,
+  favorite_count: row.favorite_count,
+  retweet_count: row.retweet_count,
+  reply_to_username: row.reply_to_username,
+  username: row.account?.username ?? '',
+  account_display_name:
+    row.account?.account_display_name ?? row.account?.username ?? '',
+  avatar_media_url: avatarUrl,
+  media: row.media ?? [],
+})
+
+async function fetchProfileHeader(
+  accountId: string,
+): Promise<ProfileHeaderData | null> {
+  const supabase = getMetaClient()
+  const [{ data: account }, { data: profile }] = await Promise.all([
+    supabase
+      .from('all_account')
+      .select(
+        'account_id, username, account_display_name, created_at, num_tweets, num_followers, num_following, num_likes',
+      )
+      .eq('account_id', accountId)
+      .maybeSingle(),
+    supabase
+      .from('all_profile')
+      .select('bio, website, location, avatar_media_url, header_media_url')
+      .eq('account_id', accountId)
+      .order('archive_upload_id', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+  ])
+  if (!account) return null
+  return {
+    ...account,
+    account_display_name: account.account_display_name ?? account.username,
+    bio: profile?.bio ?? null,
+    website: profile?.website ?? null,
+    location: profile?.location ?? null,
+    avatar_media_url:
+      profile?.avatar_media_url?.replace('_normal.', '_400x400.') ?? null,
+    header_media_url: profile?.header_media_url ?? null,
+  } as ProfileHeaderData
+}
+
+/** Years (descending) in which the account actually tweeted, with counts. */
+async function fetchActiveYears(
+  accountId: string,
+): Promise<{ year: number; count: number }[]> {
+  const supabase = getMetaClient()
+  const { data: first } = await supabase
+    .from('tweets')
+    .select('created_at')
+    .eq('account_id', accountId)
+    .order('created_at', { ascending: true })
+    .limit(1)
+    .maybeSingle()
+  if (!first) return []
+  const firstYear = new Date(first.created_at).getUTCFullYear()
+  const nowYear = new Date().getUTCFullYear()
+  const years: { year: number; count: number }[] = []
+  const jobs: Promise<void>[] = []
+  for (let year = firstYear; year <= nowYear; year++) {
+    jobs.push(
+      (async () => {
+        const { count } = await supabase
+          .from('tweets')
+          .select('tweet_id', { count: 'exact', head: true })
+          .eq('account_id', accountId)
+          .gte('created_at', `${year}-01-01`)
+          .lt('created_at', `${year + 1}-01-01`)
+        if (count && count > 0) years.push({ year, count })
+      })(),
+    )
+  }
+  await Promise.all(jobs)
+  return years.sort((a, b) => b.year - a.year)
+}
+
+interface TweetQueryScope {
+  accountId: string
+  year?: number
+  /** FTS terms OR'd together (topic scope) */
+  terms?: string[]
+}
+
+const applyScope = (query: any, scope: TweetQueryScope) => {
+  let q = query.eq('account_id', scope.accountId)
+  if (scope.year) {
+    q = q
+      .gte('created_at', `${scope.year}-01-01`)
+      .lt('created_at', `${scope.year + 1}-01-01`)
+  }
+  if (scope.terms && scope.terms.length > 0) {
+    const orQuery = scope.terms
+      .map((t) => `fts.wfts.${t.replace(/[,()]/g, ' ').trim()}`)
+      .join(',')
+    q = q.or(orQuery)
+  }
+  return q
+}
+
+/**
+ * Top tweets for a scope. Originals only (no RTs, no replies) so the archive
+ * reads as the person's own voice; ranked by likes.
+ */
+async function fetchTopTweets(
+  scope: TweetQueryScope,
+  sort: 'likes' | 'newest',
+  limit: number,
+): Promise<ArchiveTweet[]> {
+  const supabase = getMetaClient()
+  let query = applyScope(
+    supabase.from('tweets').select(TWEET_SELECT),
+    scope,
+  )
+    .is('reply_to_tweet_id', null)
+    .not('full_text', 'ilike', 'RT @%')
+  query =
+    sort === 'likes'
+      ? query.order('favorite_count', { ascending: false })
+      : query.order('created_at', { ascending: false })
+  const { data, error } = await query.limit(limit)
+  if (error) {
+    devLog('metaTwitter fetchTopTweets error', { error, scope })
+    return []
+  }
+  const avatar = await getCachedProfileHeader(scope.accountId)
+  return ((data ?? []) as unknown as RawTweetRow[]).map((row) =>
+    normalizeTweet(row, avatar?.avatar_media_url ?? null),
+  )
+}
+
+/** Media gallery for a scope: photos from the account's tweets, by likes. */
+async function fetchMedia(
+  scope: TweetQueryScope,
+  limit: number,
+): Promise<ArchiveMediaItem[]> {
+  const supabase = getMetaClient()
+  const { data, error } = await applyScope(
+    supabase
+      .from('tweets')
+      .select(
+        'tweet_id, created_at, favorite_count, media:tweet_media!inner ( media_url, media_type, width, height )',
+      ),
+    scope,
+  )
+    .not('full_text', 'ilike', 'RT @%')
+    .order('favorite_count', { ascending: false })
+    .limit(limit)
+  if (error) {
+    devLog('metaTwitter fetchMedia error', { error, scope })
+    return []
+  }
+  const items: ArchiveMediaItem[] = []
+  for (const row of (data ?? []) as any[]) {
+    for (const m of row.media ?? []) {
+      if (m.media_type !== 'photo') continue
+      items.push({
+        ...m,
+        tweet_id: row.tweet_id,
+        created_at: row.created_at,
+        favorite_count: row.favorite_count,
+      })
+    }
+  }
+  return items
+}
+
+/**
+ * People the account interacted with most in a scope, approximated by who
+ * they replied to (reply_to_username on their own tweets), aggregated in JS —
+ * no group-by over PostgREST, and no per-chapter RPC exists.
+ */
+async function fetchTopPeople(
+  scope: TweetQueryScope,
+  limit: number,
+): Promise<ArchivePerson[]> {
+  const supabase = getMetaClient()
+  const { data, error } = await applyScope(
+    supabase.from('tweets').select('reply_to_username, reply_to_user_id'),
+    scope,
+  )
+    .not('reply_to_username', 'is', null)
+    .order('created_at', { ascending: false })
+    .limit(3000)
+  if (error) {
+    devLog('metaTwitter fetchTopPeople error', { error, scope })
+    return []
+  }
+  const counts = new Map<string, ArchivePerson>()
+  for (const row of data ?? []) {
+    const screenName = row.reply_to_username as string
+    if (!screenName) continue
+    // Skip self-replies (threads)
+    if (row.reply_to_user_id === scope.accountId) continue
+    const existing = counts.get(screenName.toLowerCase())
+    if (existing) {
+      existing.interactions++
+    } else {
+      counts.set(screenName.toLowerCase(), {
+        user_id: (row.reply_to_user_id as string) ?? screenName,
+        screen_name: screenName,
+        name: null,
+        interactions: 1,
+      })
+    }
+  }
+  const top = Array.from(counts.values())
+    .sort((a, b) => b.interactions - a.interactions)
+    .slice(0, limit)
+
+  // Hydrate avatars + display names for people who are in the archive.
+  const ids = top.map((p) => p.user_id).filter(Boolean)
+  if (ids.length > 0) {
+    const { data: profiles } = await supabase
+      .from('all_profile')
+      .select('account_id, avatar_media_url')
+      .in('account_id', ids)
+      .order('archive_upload_id', { ascending: false })
+    const { data: accounts } = await supabase
+      .from('all_account')
+      .select('account_id, account_display_name')
+      .in('account_id', ids)
+    const avatarByAccount = new Map<string, string>()
+    for (const p of profiles ?? []) {
+      if (p.avatar_media_url && !avatarByAccount.has(p.account_id)) {
+        avatarByAccount.set(p.account_id, p.avatar_media_url)
+      }
+    }
+    const nameByAccount = new Map<string, string>(
+      (accounts ?? []).map((a) => [a.account_id, a.account_display_name ?? '']),
+    )
+    for (const person of top) {
+      person.avatar_media_url = avatarByAccount.get(person.user_id) ?? null
+      person.in_archive = nameByAccount.has(person.user_id)
+      if (nameByAccount.get(person.user_id)) {
+        person.name = nameByAccount.get(person.user_id)!
+      }
+    }
+  }
+  return top
+}
+
+/** Per-scope media count (cheap head count for section labels). */
+async function fetchMediaCount(scope: TweetQueryScope): Promise<number> {
+  const supabase = getMetaClient()
+  const { count } = await applyScope(
+    supabase
+      .from('tweets')
+      .select('tweet_id, media:tweet_media!inner(media_id)', {
+        count: 'exact',
+        head: true,
+      }),
+    scope,
+  )
+  return count ?? 0
+}
+
+// ---------------------------------------------------------------------------
+// Cached entry points. Keys are versioned; bump the suffix to bust.
+// ---------------------------------------------------------------------------
+
+const DAY = 86400
+
+export const getCachedProfileHeader = unstable_cache(
+  fetchProfileHeader,
+  ['meta-twitter-profile-header-v1'],
+  { revalidate: 3600 },
+)
+
+/**
+ * Resolve a /user/[account_id] route param (raw account_id, username, or
+ * "archive:"/"optin:" directory id) to a plain account_id.
+ */
+export const resolveAccountId = unstable_cache(
+  async (param: string): Promise<string | null> => {
+    let decoded: string
+    try {
+      decoded = decodeURIComponent(param)
+    } catch {
+      return null
+    }
+    decoded = decoded.replace(/^(archive|optin):/, '')
+    if (/^\d+$/.test(decoded)) return decoded
+    const supabase = getMetaClient()
+    const { data } = await supabase
+      .from('all_account')
+      .select('account_id')
+      .ilike('username', decoded)
+      .limit(1)
+      .maybeSingle()
+    return data?.account_id ?? null
+  },
+  ['meta-twitter-resolve-account-v1'],
+  { revalidate: DAY },
+)
+
+/** Latest archive upload date, for the "Archived <month year>" meta chip. */
+export const getCachedArchivedAt = unstable_cache(
+  async (accountId: string): Promise<string | null> => {
+    const supabase = getMetaClient()
+    const { data } = await supabase
+      .from('archive_upload')
+      .select('archive_at')
+      .eq('account_id', accountId)
+      .order('archive_at', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+    return data?.archive_at ?? null
+  },
+  ['meta-twitter-archived-at-v1'],
+  { revalidate: DAY },
+)
+
+export const getCachedActiveYears = unstable_cache(
+  fetchActiveYears,
+  ['meta-twitter-active-years-v1'],
+  { revalidate: DAY },
+)
+
+export const getCachedChapterData = unstable_cache(
+  async (
+    accountId: string,
+    year: number | undefined,
+    terms: string[] | undefined,
+  ) => {
+    const scope: TweetQueryScope = { accountId, year, terms }
+    // People are scoped to the chapter (year), not the topic — topic-filtered
+    // reply sets are too sparse to rank meaningfully.
+    const peopleScope: TweetQueryScope = { accountId, year }
+    const [topTweets, newestTweets, media, people, mediaCount] =
+      await Promise.all([
+        fetchTopTweets(scope, 'likes', 24),
+        fetchTopTweets(scope, 'newest', 24),
+        fetchMedia(scope, 18),
+        fetchTopPeople(peopleScope, 8),
+        fetchMediaCount(scope),
+      ])
+    return { topTweets, newestTweets, media, people, mediaCount }
+  },
+  ['meta-twitter-chapter-v2'],
+  { revalidate: DAY },
+)
+
+export const getCachedTweetsByIds = unstable_cache(
+  async (accountId: string, tweetIds: string[]): Promise<ArchiveTweet[]> => {
+    if (tweetIds.length === 0) return []
+    const supabase = getMetaClient()
+    const { data, error } = await supabase
+      .from('tweets')
+      .select(TWEET_SELECT)
+      .eq('account_id', accountId)
+      .in('tweet_id', tweetIds)
+    if (error) {
+      devLog('metaTwitter getCachedTweetsByIds error', { error })
+      return []
+    }
+    const avatar = await getCachedProfileHeader(accountId)
+    const byId = new Map(
+      ((data ?? []) as unknown as RawTweetRow[]).map((row) => [
+        row.tweet_id,
+        normalizeTweet(row, avatar?.avatar_media_url ?? null),
+      ]),
+    )
+    return tweetIds.map((id) => byId.get(id)).filter(Boolean) as ArchiveTweet[]
+  },
+  ['meta-twitter-tweets-by-ids-v1'],
+  { revalidate: DAY },
+)

--- a/src/lib/metaTwitter/types.ts
+++ b/src/lib/metaTwitter/types.ts
@@ -1,0 +1,50 @@
+/** Shared Meta Twitter types, importable from both server and client code. */
+
+export interface ArchiveTweet {
+  tweet_id: string
+  account_id: string
+  created_at: string
+  full_text: string
+  favorite_count: number
+  retweet_count: number | null
+  reply_to_username: string | null
+  username: string
+  account_display_name: string
+  avatar_media_url: string | null
+  media: { media_url: string; media_type: string; width: number; height: number }[]
+}
+
+export interface ArchiveMediaItem {
+  media_url: string
+  media_type: string
+  width: number
+  height: number
+  tweet_id: string
+  created_at: string
+  favorite_count: number
+}
+
+export interface ArchivePerson {
+  user_id: string
+  screen_name: string
+  name: string | null
+  interactions: number
+  avatar_media_url?: string | null
+  in_archive?: boolean
+}
+
+export interface ProfileHeaderData {
+  account_id: string
+  username: string
+  account_display_name: string
+  created_at: string
+  num_tweets: number
+  num_followers: number
+  num_following: number
+  num_likes: number
+  bio: string | null
+  website: string | null
+  location: string | null
+  avatar_media_url: string | null
+  header_media_url: string | null
+}


### PR DESCRIPTION
## What

Rebuilds the user profile page (`/user/[account_id]`) as a **"Meta Twitter"** — a Twitter-familiar profile reorganized as a curated personal archive:

**Profile → historical chapters → topics → curated tweets/media/people**

The idea: instead of an unfiltered chronological feed, a profile opens on the person's **Hall of Fame** (their greatest hits), with a left-hand chapter navigation that tells the story of their years and eras. Piloted on @christineist's archive.

### Layout
- Twitter-style header: cover, overlapping avatar, badges, bio, location/joined/archived meta, stats, Download archive / Follow on X.
- Left chapter nav: **Overall — Bangers**, then years derived from the account's actual tweet history. Chapter topics are rendered as snippets of the owner's own tweets (e.g. 2026 → *social ai, tools for community flourishing*), each mapped to a stable slug + full-text-search terms.
- Workspace: context header (`2023 → +5 admiration points`), sort (Curated / Most liked / Newest), top tweets with inline media, media grid with +N overflow, top people for the chapter.

### Data (all live)
- New data layer `src/lib/metaTwitter/data.ts`: cookie-free anon client + `unstable_cache` (same pattern as the portal data layer), so the route stays cheap.
- Topic scoping via FTS on `tweets.fts`; media joined from `tweet_media`; top people via reply-frequency aggregation with avatar hydration from `all_profile`.
- Per-account chapter/topic config in `src/lib/metaTwitter/config.ts` (currently hand-curated for @christineist; FTS terms validated against real per-year counts). **Accounts without config still render fully** — years, top tweets, media, top people — just without named topics. The long-term intent is AI-generated topic configs that owners can edit.

### Curation (owner edit mode)
- ⭐ pin to / unpin from Hall of Fame; ✕ hide with a restore-all banner.
- Add any tweet from the archive to the Hall of Fame by pasting an x.com link.
- Manual reordering (↑/↓), applied only to the Curated sort.
- Owner = Supabase session whose Twitter `provider_id` matches the profile; controls are hidden from other viewers. State currently persists in localStorage (anon key is read-only) — a `meta_twitter_curation` table is the natural follow-up and I'm happy to add it if there's appetite.

### Routing
- `?chapter=<year>&topic=<slug>` search params, server-rendered per navigation, shareable URLs.
- The route still accepts account ids, usernames, and `archive:`/`optin:` directory ids; adds `generateMetadata` and proper `notFound()`.

## Known behavior changes for review
- This replaces the current user page for all accounts. If you'd rather roll it out gradually, an easy gate is to render the new view only for accounts with a chapter config (or a flag) and keep the old page otherwise — happy to do that in this PR.
- The recent ClickHouse fallback for streamed-only profiles (#616) is not yet wired into the new page: accounts not resolvable in Supabase currently 404. I'd like maintainers' read on the right UX here (render the new shell from ClickHouse data vs. keep the old page for those).
- The old page's components (`AccountTopTweets*`, etc.) are left in place and unused pending review.

## Verification
- Verified in-browser against the production DB: Overall/chapter/topic navigation, sorting, edit mode (pin/hide/add/reorder with reload persistence), light + dark mode, mobile (nav collapses to a horizontal chapter strip).
- `pnpm type-check` and `pnpm lint` clean (only pre-existing `<img>` warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
