### PR TITLE
Render text-search results progressively

### DIFF
--- a/src/components/TweetList.test.tsx
+++ b/src/components/TweetList.test.tsx
@@ -1,0 +1,138 @@
+import React from 'react'
+import { act, render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import TweetList from './TweetList'
+import { fetchTweets } from '@/lib/queries/tweetQueries'
+import {
+  canPreviewTweetSearch,
+  searchTweetPreviewWithClickHouse,
+} from '@/lib/clickhouseSearch'
+
+jest.mock('@/utils/supabase', () => ({
+  createBrowserClient: () => ({}),
+}))
+
+jest.mock('@/lib/queries/tweetQueries', () => ({
+  fetchTweets: jest.fn(),
+}))
+
+jest.mock('@/lib/clickhouseSearch', () => ({
+  canPreviewTweetSearch: jest.fn(),
+  searchTweetPreviewWithClickHouse: jest.fn(),
+}))
+
+jest.mock('@/components/UnifiedTweetList', () => ({
+  __esModule: true,
+  default: ({ tweets }: { tweets: Array<{ tweet_id: string }> }) => (
+    <div data-testid="tweet-ids">
+      {tweets.map((tweet) => tweet.tweet_id).join(',')}
+    </div>
+  ),
+}))
+
+const previewTweet = {
+  tweet_id: 'preview',
+  account_id: '42',
+  created_at: '2026-08-13T00:00:00.000Z',
+  full_text: 'Preview tweet',
+  favorite_count: 1,
+  retweet_count: 0,
+  reply_to_tweet_id: null,
+  account: {
+    username: 'alice',
+    account_display_name: 'Alice',
+  },
+  media: [],
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+describe('TweetList progressive search', () => {
+  let warnSpy: jest.SpiedFunction<typeof console.warn>
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  it('renders the preview before replacing it with the complete canonical page', async () => {
+    const complete = deferred<{
+      tweets: Array<typeof previewTweet>
+      totalCount: null
+      error: null
+    }>()
+    const fullTweets = [
+      { ...previewTweet, tweet_id: 'canonical-1' },
+      { ...previewTweet, tweet_id: 'canonical-2' },
+    ]
+    ;(canPreviewTweetSearch as jest.Mock).mockReturnValue(true)
+    ;(searchTweetPreviewWithClickHouse as jest.Mock).mockResolvedValue(
+      previewTweet,
+    )
+    ;(fetchTweets as jest.Mock).mockReturnValue(complete.promise)
+
+    render(
+      <TweetList
+        filterCriteria={{
+          searchQuery: 'open & source',
+          rawSearchQuery: 'open source',
+          excludeRetweets: true,
+        }}
+      />,
+    )
+
+    expect(await screen.findByTestId('tweet-ids')).toHaveTextContent('preview')
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Loading the remaining results…',
+    )
+
+    await act(async () => {
+      complete.resolve({ tweets: fullTweets, totalCount: null, error: null })
+      await complete.promise
+    })
+
+    expect(screen.getByTestId('tweet-ids')).toHaveTextContent(
+      'canonical-1,canonical-2',
+    )
+    expect(
+      screen.queryByText('Loading the remaining results…'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('falls through to the canonical page when the preview fails', async () => {
+    ;(canPreviewTweetSearch as jest.Mock).mockReturnValue(true)
+    ;(searchTweetPreviewWithClickHouse as jest.Mock).mockRejectedValue(
+      new Error('preview unavailable'),
+    )
+    ;(fetchTweets as jest.Mock).mockResolvedValue({
+      tweets: [{ ...previewTweet, tweet_id: 'canonical' }],
+      totalCount: null,
+      error: null,
+    })
+
+    render(
+      <TweetList
+        filterCriteria={{
+          searchQuery: 'open & source',
+          rawSearchQuery: 'open source',
+          excludeRetweets: true,
+        }}
+      />,
+    )
+
+    expect(await screen.findByTestId('tweet-ids')).toHaveTextContent(
+      'canonical',
+    )
+    expect(fetchTweets).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/TweetList.tsx
+++ b/src/components/TweetList.tsx
@@ -13,7 +13,11 @@ import {
   fetchTweets,
   type TweetSearchSort,
 } from '@/lib/queries/tweetQueries'
-import { AlertCircle } from 'lucide-react'
+import {
+  canPreviewTweetSearch,
+  searchTweetPreviewWithClickHouse,
+} from '@/lib/clickhouseSearch'
+import { AlertCircle, Loader2 } from 'lucide-react'
 import type { TweetOrigin } from '@/lib/navigation'
 
 interface TweetListProps {
@@ -48,6 +52,7 @@ export default function TweetList({
   const [tweets, setTweets] = useState<TimelineTweet[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [isCompletingPreview, setIsCompletingPreview] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [currentPage, setCurrentPage] = useState(1)
   const [totalCount, setTotalCount] = useState<number | null>(null)
@@ -64,6 +69,7 @@ export default function TweetList({
 
       if (pageToLoad === 1) {
         setIsLoading(true)
+        setIsCompletingPreview(false)
         setTweets([])
       } else {
         setIsLoadingMore(true)
@@ -71,6 +77,22 @@ export default function TweetList({
       setError(null)
 
       try {
+        if (pageToLoad === 1 && canPreviewTweetSearch(criteria)) {
+          try {
+            const preview = await searchTweetPreviewWithClickHouse(criteria)
+            if (preview) {
+              setTweets([preview])
+              setIsLoading(false)
+              setIsCompletingPreview(true)
+            }
+          } catch (previewError) {
+            console.warn(
+              'Could not load the progressive tweet preview:',
+              previewError,
+            )
+          }
+        }
+
         const {
           tweets: fetchedTweets,
           error: fetchError,
@@ -95,6 +117,7 @@ export default function TweetList({
       } finally {
         if (pageToLoad === 1) {
           setIsLoading(false)
+          setIsCompletingPreview(false)
         } else {
           setIsLoadingMore(false)
         }
@@ -199,7 +222,7 @@ export default function TweetList({
         isLoading={isLoading}
         emptyMessage="No tweets to display for the current filters."
         className="space-y-4"
-        showCsvExport={showCsvExportButton}
+        showCsvExport={showCsvExportButton && !isCompletingPreview}
         csvFilename={csvExportFilename}
         headerTitle={
           resultsHeading
@@ -216,6 +239,17 @@ export default function TweetList({
         searchSort={filterCriteria.sort}
         onSearchSortChange={onSearchSortChange}
       />
+
+      {isCompletingPreview && (
+        <div
+          className="flex items-center justify-center gap-2 text-sm text-muted-foreground"
+          role="status"
+          aria-live="polite"
+        >
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading the remaining results…
+        </div>
+      )}
 
       {error && tweets.length > 0 && (
         <Alert variant="destructive">

--- a/src/lib/clickhouseGateway.ts
+++ b/src/lib/clickhouseGateway.ts
@@ -11,6 +11,8 @@ const ALLOWED_ENDPOINTS: Record<string, ReadonlySet<string>> = {
     'sort',
     'limit',
     'offset',
+    'preview',
+    'exclude_retweets',
   ]),
   'word-trend': new Set(['q', 'bucket', 'match', 'from', 'to']),
   'stream-stats': new Set(['start', 'end', 'granularity', 'scope']),

--- a/src/lib/clickhouseLab.test.ts
+++ b/src/lib/clickhouseLab.test.ts
@@ -56,12 +56,12 @@ describe('ClickHouse staging lab guard', () => {
     const target = analyticsGatewayRequestUrl(
       ['search'],
       new URLSearchParams(
-        'q=open+source&mode=phrase&from_user=alice&sort=likes&limit=20&offset=40&raw_sql=DROP',
+        'q=open+source&mode=phrase&from_user=alice&limit=1&offset=0&preview=true&exclude_retweets=true&raw_sql=DROP',
       ),
       'https://analytics.example',
     )
     expect(target.toString()).toBe(
-      'https://analytics.example/search?q=open+source&mode=phrase&from_user=alice&sort=likes&limit=20&offset=40',
+      'https://analytics.example/search?q=open+source&mode=phrase&from_user=alice&limit=1&offset=0&preview=true&exclude_retweets=true',
     )
   })
 

--- a/src/lib/clickhouseSearch.test.ts
+++ b/src/lib/clickhouseSearch.test.ts
@@ -1,4 +1,8 @@
-import { searchTweetsWithClickHouse } from './clickhouseSearch'
+import {
+  canPreviewTweetSearch,
+  searchTweetPreviewWithClickHouse,
+  searchTweetsWithClickHouse,
+} from './clickhouseSearch'
 
 describe('searchTweetsWithClickHouse', () => {
   test('maps filters, pagination, accounts, and media to timeline tweets', async () => {
@@ -90,5 +94,63 @@ describe('searchTweetsWithClickHouse', () => {
 
     expect(tweets).toEqual([])
     expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  test('requests one newest non-retweet as a progressive preview', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: jest.fn().mockResolvedValue(
+        JSON.stringify({
+          data: {
+            tweets: [
+              {
+                tweetId: '123',
+                accountId: '42',
+                createdAt: '2026-08-13 00:00:00.000',
+                fullText: 'Open source matters',
+                replyToTweetId: null,
+                favoriteCount: '4',
+                retweetCount: '2',
+                username: 'alice',
+                accountDisplayName: 'Alice',
+                avatarMediaUrl: null,
+                media: [],
+              },
+            ],
+            nextOffset: null,
+          },
+        }),
+      ),
+    })
+
+    const tweet = await searchTweetPreviewWithClickHouse(
+      {
+        rawSearchQuery: 'Open source',
+        excludeRetweets: true,
+      },
+      fetchImpl as any,
+    )
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      '/api/tweet-search?q=Open+source&mode=phrase&limit=1&offset=0&preview=true&exclude_retweets=true',
+      { cache: 'no-store' },
+    )
+    expect(tweet?.tweet_id).toBe('123')
+  })
+
+  test('only enables previews for ClickHouse newest text searches', () => {
+    expect(canPreviewTweetSearch({ rawSearchQuery: 'archive' }, 'true')).toBe(
+      true,
+    )
+    expect(
+      canPreviewTweetSearch(
+        { rawSearchQuery: 'archive', sort: 'likes' },
+        'true',
+      ),
+    ).toBe(false)
+    expect(canPreviewTweetSearch({ rawSearchQuery: 'archive' }, 'false')).toBe(
+      false,
+    )
   })
 })

--- a/src/lib/clickhouseSearch.ts
+++ b/src/lib/clickhouseSearch.ts
@@ -27,55 +27,12 @@ interface ClickHouseSearchResponse {
   }
 }
 
-export async function searchTweetsWithClickHouse(
-  criteria: FilterCriteria,
-  page: number,
-  pageSize: number,
-  fetchImpl: typeof fetch = fetch,
-): Promise<TimelineTweet[]> {
-  const query = criteria.rawSearchQuery?.trim()
-  if (!query) {
-    throw new Error('ClickHouse text search requires the raw search query')
-  }
+interface ClickHouseSearchRequestOptions {
+  preview?: boolean
+  excludeRetweets?: boolean
+}
 
-  const offset = (page - 1) * pageSize
-  if (offset > 5_000) return []
-
-  const params = new URLSearchParams({
-    q: query,
-    mode: query.split(/\s+/).length > 1 ? 'phrase' : 'all',
-    limit: String(pageSize),
-    offset: String(offset),
-  })
-  if (criteria.fromUsername) params.set('from_user', criteria.fromUsername)
-  if (criteria.replyToUsername)
-    params.set('reply_to_user', criteria.replyToUsername)
-  if (criteria.startDate) params.set('since', criteria.startDate)
-  if (criteria.endDate) params.set('until', criteria.endDate)
-  if (criteria.sort && criteria.sort !== 'newest')
-    params.set('sort', criteria.sort)
-
-  const response = await fetchImpl(`/api/tweet-search?${params.toString()}`, {
-    cache: 'no-store',
-  })
-  const body = await response.text()
-  if (!response.ok) {
-    throw new Error(
-      `ClickHouse tweet search failed (${response.status}): ${body.slice(0, 300)}`,
-    )
-  }
-
-  let result: ClickHouseSearchResponse
-  try {
-    result = JSON.parse(body) as ClickHouseSearchResponse
-  } catch {
-    throw new Error('ClickHouse tweet search returned invalid JSON')
-  }
-
-  if (!Array.isArray(result.data?.tweets)) {
-    throw new Error('ClickHouse tweet search returned an invalid response')
-  }
-
+function mapSearchTweets(result: ClickHouseSearchResponse): TimelineTweet[] {
   return result.data.tweets.map((tweet) => ({
     tweet_id: tweet.tweetId,
     account_id: tweet.accountId,
@@ -100,4 +57,90 @@ export async function searchTweetsWithClickHouse(
       height: item.height ?? undefined,
     })),
   }))
+}
+
+async function requestClickHouseTweets(
+  criteria: FilterCriteria,
+  page: number,
+  pageSize: number,
+  fetchImpl: typeof fetch,
+  options: ClickHouseSearchRequestOptions = {},
+): Promise<TimelineTweet[]> {
+  const query = criteria.rawSearchQuery?.trim()
+  if (!query) {
+    throw new Error('ClickHouse text search requires the raw search query')
+  }
+
+  const offset = (page - 1) * pageSize
+  if (offset > 5_000) return []
+
+  const params = new URLSearchParams({
+    q: query,
+    mode: query.split(/\s+/).length > 1 ? 'phrase' : 'all',
+    limit: String(pageSize),
+    offset: String(offset),
+  })
+  if (criteria.fromUsername) params.set('from_user', criteria.fromUsername)
+  if (criteria.replyToUsername)
+    params.set('reply_to_user', criteria.replyToUsername)
+  if (criteria.startDate) params.set('since', criteria.startDate)
+  if (criteria.endDate) params.set('until', criteria.endDate)
+  if (criteria.sort && criteria.sort !== 'newest')
+    params.set('sort', criteria.sort)
+  if (options.preview) params.set('preview', 'true')
+  if (options.excludeRetweets) params.set('exclude_retweets', 'true')
+
+  const response = await fetchImpl(`/api/tweet-search?${params.toString()}`, {
+    cache: 'no-store',
+  })
+  const body = await response.text()
+  if (!response.ok) {
+    throw new Error(
+      `ClickHouse tweet search failed (${response.status}): ${body.slice(0, 300)}`,
+    )
+  }
+
+  let result: ClickHouseSearchResponse
+  try {
+    result = JSON.parse(body) as ClickHouseSearchResponse
+  } catch {
+    throw new Error('ClickHouse tweet search returned invalid JSON')
+  }
+
+  if (!Array.isArray(result.data?.tweets)) {
+    throw new Error('ClickHouse tweet search returned an invalid response')
+  }
+
+  return mapSearchTweets(result)
+}
+
+export async function searchTweetsWithClickHouse(
+  criteria: FilterCriteria,
+  page: number,
+  pageSize: number,
+  fetchImpl: typeof fetch = fetch,
+): Promise<TimelineTweet[]> {
+  return requestClickHouseTweets(criteria, page, pageSize, fetchImpl)
+}
+
+export function canPreviewTweetSearch(
+  criteria: FilterCriteria,
+  enabled = process.env.NEXT_PUBLIC_ENABLE_CLICKHOUSE_SEARCH,
+): boolean {
+  return (
+    enabled === 'true' &&
+    Boolean(criteria.rawSearchQuery?.trim()) &&
+    (!criteria.sort || criteria.sort === 'newest')
+  )
+}
+
+export async function searchTweetPreviewWithClickHouse(
+  criteria: FilterCriteria,
+  fetchImpl: typeof fetch = fetch,
+): Promise<TimelineTweet | null> {
+  const tweets = await requestClickHouseTweets(criteria, 1, 1, fetchImpl, {
+    preview: true,
+    excludeRetweets: criteria.excludeRetweets,
+  })
+  return tweets[0] || null
 }


### PR DESCRIPTION
## Why

Text search currently leaves the result area loading until the full canonical page finishes, which takes about five seconds for cold searches.

## What changed

- request one newest fully hydrated preview tweet first
- render it with an accessible remaining-results status
- run the existing canonical search immediately afterward and atomically replace the preview
- preserve full-result retweet filtering, quote enrichment, pagination, and ClickHouse-to-Supabase fallback
- fall through normally when the preview endpoint is unavailable
- hide CSV export until the complete canonical page arrives

## Validation

- ClickHouse request and allowlist tests: 17 passed
- progressive render and preview-failure fallback tests: 2 passed
- TypeScript, focused lint, and focused formatting checks passed
- Next.js production build completed successfully

## Dependency and rollout

Depends on TheExGenesis/community-archive-control-panel#60.

Keep this PR in draft until the gateway PR is deployed and its preview latency and first-ID parity are verified in production. No production deployment is included here.