### PR TITLE
Prefer username profile URLs

### DIFF
--- a/src/app/user/[account_id]/page.tsx
+++ b/src/app/user/[account_id]/page.tsx
@@ -21,6 +21,8 @@ import { Archive, Radio } from 'lucide-react'
 import { getHighResolutionAvatarUrl } from '@/lib/avatar'
 import { getClickHouseUserProfile } from '@/lib/clickhouseUserProfile'
 import { ProjectContributorBadge } from '@/components/ProjectContributorBadge'
+import { userProfileHref } from '@/lib/navigation'
+import { redirect } from 'next/navigation'
 
 // Style constants (glows removed)
 const unifiedDeepBlueBase = 'bg-card dark:bg-background'
@@ -163,6 +165,15 @@ export default async function User({
         </div>
       </section>
     )
+  }
+
+  const requestedProfileHref = `/user/${encodeURIComponent(account_id)}`
+  const canonicalProfileHref = userProfileHref(
+    userData.username,
+    userData.account_id,
+  )
+  if (canonicalProfileHref !== requestedProfileHref) {
+    redirect(canonicalProfileHref)
   }
 
   const { data: summaryData, error: summaryError } = directoryUser

--- a/src/components/AvatarList.tsx
+++ b/src/components/AvatarList.tsx
@@ -4,6 +4,8 @@ import { useState, useEffect } from 'react'
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
 import { AvatarType } from '@/lib/types'
 import { formatNumber } from '@/lib/formatNumber'
+import Link from 'next/link'
+import { userProfileHref } from '@/lib/navigation'
 
 type AvatarListProps = {
   initialAvatars: AvatarType[]
@@ -33,9 +35,9 @@ const AvatarList = ({
           }`}
         >
           {avatars.map((avatar) => (
-            <a
+            <Link
               key={avatar.username}
-              href={`/user/${avatar.account_id}`}
+              href={userProfileHref(avatar.username, avatar.account_id)}
               className={`flex flex-col items-center text-center ${
                 compact ? 'w-16' : 'w-20'
               }`}
@@ -64,7 +66,7 @@ const AvatarList = ({
                 {avatar.num_followers &&
                   `${formatNumber(avatar.num_followers)} followers`}
               </span>
-            </a>
+            </Link>
           ))}
         </div>
       </div>

--- a/src/components/TopMentionedMissingUsers.tsx
+++ b/src/components/TopMentionedMissingUsers.tsx
@@ -18,6 +18,7 @@ import { devLog } from '@/lib/devLog'
 import { Label } from '@/components/ui/label'
 import { formatNumber } from '@/lib/formatNumber'
 import { getLatestAvatarMediaUrl } from '@/lib/avatar'
+import { userProfileHref } from '@/lib/navigation'
 
 export type MentionedUser = {
   mentioned_user_id: string
@@ -81,8 +82,7 @@ export default function TopMentionedUsers({
         const media_url = getLatestAvatarMediaUrl(accountData.profile)
         return {
           ...user,
-          mentioned_user_id:
-            accountData.account_id || user.mentioned_user_id,
+          mentioned_user_id: accountData.account_id || user.mentioned_user_id,
           account_display_name: accountData.account_display_name!,
           avatar_media_url: media_url,
           uploaded: true,
@@ -102,7 +102,7 @@ export default function TopMentionedUsers({
 
   const getUserLink = (user: MentionedUser) => {
     return user.uploaded
-      ? `/user/${user.mentioned_user_id}`
+      ? userProfileHref(user.screen_name, user.mentioned_user_id)
       : `https://twitter.com/${user.screen_name}`
   }
 

--- a/src/components/UnifiedTweetList.test.tsx
+++ b/src/components/UnifiedTweetList.test.tsx
@@ -67,14 +67,14 @@ describe('UnifiedTweetList compact view', () => {
       screen.getAllByRole('link', {
         name: "View @archive_user's profile",
       })[0],
-    ).toHaveAttribute('href', '/user/123?username=archive_user')
+    ).toHaveAttribute('href', '/user/archive_user')
     expect(screen.getByAltText('Tweet image 1')).toBeInTheDocument()
     expect(screen.getByText('Quoted User')).toBeInTheDocument()
     expect(
       screen.getAllByRole('link', {
         name: "View @quoted_user's profile",
       })[0],
-    ).toHaveAttribute('href', '/user/456?username=quoted_user')
+    ).toHaveAttribute('href', '/user/quoted_user')
     expect(
       screen.getByText(
         'The quoted tweet is visible in compact search results.',

--- a/src/lib/navigation.test.ts
+++ b/src/lib/navigation.test.ts
@@ -9,14 +9,14 @@ import {
 
 describe('user profile navigation', () => {
   it('prefers readable usernames while retaining account-ID compatibility', () => {
-    expect(userProfileHref('@archive_user', '123')).toBe(
-      '/user/123?username=archive_user',
-    )
+    expect(userProfileHref('exgenesis', '322603863')).toBe('/user/exgenesis')
+    expect(userProfileHref('@archive_user', '123')).toBe('/user/archive_user')
+    expect(userProfileHref('archive_user')).toBe('/user/archive_user')
     expect(userProfileHref(undefined, '123')).toBe('/user/123')
     expect(userProfileHref('not valid', '123')).toBe('/user/123')
     expect(userProfileHref('123', '456')).toBe('/user/456')
     expect(userProfileHref('a'.repeat(15), '456')).toBe(
-      `/user/456?username=${'a'.repeat(15)}`,
+      `/user/${'a'.repeat(15)}`,
     )
     expect(userProfileHref('a'.repeat(16), '456')).toBe('/user/456')
   })

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -19,15 +19,8 @@ export function userProfileHref(
     !/^\d+$/.test(cleanUsername)
       ? cleanUsername
       : null
-  if (accountId) {
-    const pathname = `/user/${encodeURIComponent(accountId)}`
-    return validUsername
-      ? `${pathname}?username=${encodeURIComponent(validUsername)}`
-      : pathname
-  }
-  return validUsername
-    ? `/user/${encodeURIComponent(`@${validUsername}`)}`
-    : '/user-dir'
+  if (validUsername) return `/user/${encodeURIComponent(validUsername)}`
+  return accountId ? `/user/${encodeURIComponent(accountId)}` : '/user-dir'
 }
 
 export interface TweetBackLink {

--- a/src/lib/queries/fetchUsers.test.ts
+++ b/src/lib/queries/fetchUsers.test.ts
@@ -43,7 +43,7 @@ describe('getDirectoryProfileHref', () => {
           account_id: '123456789',
         }),
       ),
-    ).toBe('/user/123456789?username=archive_member')
+    ).toBe('/user/archive_member')
   })
 
   it('uses the username for opt-in-only members too', () => {
@@ -51,7 +51,7 @@ describe('getDirectoryProfileHref', () => {
       getDirectoryProfileHref(
         directoryUser({ directory_id: 'optin:42', account_id: null }),
       ),
-    ).toBe('/user/optin%3A42?username=archive_member')
+    ).toBe('/user/archive_member')
   })
 })
 


### PR DESCRIPTION
## What changed

- Generate profile links as `/user/{username}` whenever a valid username is available.
- Redirect legacy account-ID profile requests to the readable username URL after resolving the profile.
- Keep account-ID URLs as a fallback for missing, invalid, or numeric-only usernames.
- Route homepage avatar and mentioned-user links through the shared profile URL helper.

## Why

Profile links currently expose an account ID plus a redundant `username` query parameter. Username-first URLs are shorter, more readable, and easier to share.

## User impact

Profiles such as `exgenesis` now use `/user/exgenesis` instead of `/user/322603863?username=exgenesis`. Existing account-ID links continue to resolve and are redirected to the username form when possible.

## Validation

- `pnpm exec jest --runInBand src/lib/navigation.test.ts src/lib/queries/fetchUsers.test.ts src/components/UnifiedTweetList.test.tsx`
- `pnpm type-check`
- Prettier checks for all changed files
- `git diff --check`