### PR TITLE
Render portal counts at request time

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,9 @@ import { getPortalData } from '@/lib/portal/data'
 
 // The first request after a daily analytics-cache rollover builds the bounded
 // ClickHouse snapshot; subsequent homepage requests reuse the shared Data Cache.
+// Force request-time rendering so the portal's component fallbacks do not catch
+// Next's static-render probe and freeze build-time fallback data into this route.
+export const dynamic = 'force-dynamic'
 export const maxDuration = 60
 
 // Guests and members share one homepage/dashboard composition. Authentication

--- a/src/app/stream/page.tsx
+++ b/src/app/stream/page.tsx
@@ -2,6 +2,9 @@ import Portal from '@/components/portal/Portal'
 import { getPortalData } from '@/lib/portal/data'
 
 export const metadata = { title: 'Stream · Community Archive' }
+// Keep the stream and homepage on the same request-time analytics snapshots;
+// portal fallbacks must not turn a static-render probe into cached route data.
+export const dynamic = 'force-dynamic'
 export const maxDuration = 60
 
 export default async function StreamPage() {

--- a/src/lib/homepageRoute.test.tsx
+++ b/src/lib/homepageRoute.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
-import Homepage from '@/app/page'
+import Homepage, { dynamic as homepageRenderingMode } from '@/app/page'
 import { getIsMember } from '@/lib/portal/auth'
 import { getPortalData } from '@/lib/portal/data'
 
@@ -28,6 +28,10 @@ describe('Homepage OAuth actions', () => {
     getPortalDataMock.mockResolvedValue(
       {} as Awaited<ReturnType<typeof getPortalData>>,
     )
+  })
+
+  it('renders at request time so portal fallback data is not frozen at build time', () => {
+    expect(homepageRenderingMode).toBe('force-dynamic')
   })
 
   it('keeps an authenticated OAuth return on the opt-in completion surface', async () => {

--- a/src/lib/portalStreamPage.test.tsx
+++ b/src/lib/portalStreamPage.test.tsx
@@ -1,4 +1,4 @@
-import StreamPage from '@/app/stream/page'
+import StreamPage, { dynamic as streamRenderingMode } from '@/app/stream/page'
 import { getPortalData } from '@/lib/portal/data'
 import type { PortalData } from '@/lib/portal/types'
 
@@ -14,6 +14,10 @@ jest.mock('@/components/portal/Portal', () => ({
 const getPortalDataMock = getPortalData as jest.MockedFunction<
   typeof getPortalData
 >
+
+test('renders at request time so portal fallback data is not frozen at build time', () => {
+  expect(streamRenderingMode).toBe('force-dynamic')
+})
 
 test('renders the public stream without a membership check', async () => {
   const data = {} as PortalData


### PR DESCRIPTION
## Summary
- force the homepage and live-stream routes to render at request time
- prevent Next.js static-render probes from being caught as portal fallback data and frozen into separate route builds
- preserve the existing shared analytics Data Cache for both pages
- add regression assertions for each route rendering mode

PR #656 removed the client-side projection, but protected-preview verification exposed a second source of divergence: the two routes could capture different build-time fallback snapshots.

## Validation
- 80 Jest suites, 348 tests passed
- TypeScript passed
- ESLint passed (one pre-existing img warning)
- Prettier passed
- production build passed and reports both / and /stream as dynamic server-rendered routes

Closes #653