### PR TITLE
Scope avatar resolution by display context

### DIFF
--- a/src/app/clickhouse/user/[identifier]/ClickHouseUserClient.tsx
+++ b/src/app/clickhouse/user/[identifier]/ClickHouseUserClient.tsx
@@ -223,6 +223,7 @@ export default function ClickHouseUserClient({
                 <AvatarImage
                   src={account.avatarUrl || undefined}
                   alt={`@${account.username}`}
+                  avatarSize="high"
                 />
                 <AvatarFallback className="text-3xl">
                   {(account.displayName || account.username || '?')

--- a/src/app/missing-accounts/page.tsx
+++ b/src/app/missing-accounts/page.tsx
@@ -9,6 +9,7 @@ import {
   Radio,
 } from 'lucide-react'
 
+import { getSmallAvatarUrl } from '@/lib/avatar'
 import type { MissingAccount } from '@/lib/missingAccounts'
 import { getMissingAccounts } from '@/lib/missingAccounts'
 
@@ -49,7 +50,7 @@ function accountUrl(account: MissingAccount): string {
 }
 
 function AccountIdentity({ account }: { account: MissingAccount }) {
-  const avatarUrl = supportedAvatarUrl(account.avatarUrl)
+  const avatarUrl = getSmallAvatarUrl(supportedAvatarUrl(account.avatarUrl))
   const displayName =
     account.displayName || account.username || 'Unknown account'
   const fallback = (account.username || account.displayName || '?')

--- a/src/app/user-dir/page.tsx
+++ b/src/app/user-dir/page.tsx
@@ -287,7 +287,7 @@ export default function UserDirectoryPage() {
                     <div className="flex min-w-0 items-center gap-3">
                       <Avatar className="h-11 w-11 border border-border">
                         <AvatarImage
-                          src={user.avatar_media_url || '/placeholder.jpg'}
+                          src={user.avatar_media_url || undefined}
                           alt={`${user.account_display_name}'s avatar`}
                         />
                         <AvatarFallback>

--- a/src/components/metaTwitter/ProfileHeader.test.tsx
+++ b/src/components/metaTwitter/ProfileHeader.test.tsx
@@ -1,0 +1,48 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { ProfileHeader } from './ProfileHeader'
+import type { ProfileHeaderData } from '@/lib/metaTwitter/types'
+
+type MockImageProps = React.ComponentProps<'img'> & {
+  fill?: boolean
+  priority?: boolean
+}
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: ({
+    fill,
+    priority,
+    alt = '',
+    ...props
+  }: MockImageProps) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={alt} {...props} />
+  ),
+}))
+
+const profile: ProfileHeaderData = {
+  account_id: '42',
+  username: 'alice',
+  account_display_name: 'Alice',
+  created_at: '2010-01-01T00:00:00.000Z',
+  bio: null,
+  website: null,
+  location: null,
+  avatar_media_url: 'https://pbs.twimg.com/profile_images/42/avatar_normal.jpg',
+  header_media_url: null,
+  num_tweets: 100,
+  num_followers: 200,
+  num_following: 50,
+  num_likes: 300,
+  has_archive: false,
+}
+
+test('requests a high-resolution avatar for the profile header', () => {
+  render(<ProfileHeader profile={profile} archivedAt={null} />)
+
+  expect(screen.getByAltText("Alice's avatar")).toHaveAttribute(
+    'src',
+    'https://pbs.twimg.com/profile_images/42/avatar_400x400.jpg',
+  )
+})

--- a/src/components/metaTwitter/ProfileHeader.tsx
+++ b/src/components/metaTwitter/ProfileHeader.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image'
+import { getHighResolutionAvatarUrl } from '@/lib/avatar'
 import { formatNumber } from '@/lib/formatNumber'
 import type { ProfileHeaderData } from '@/lib/metaTwitter/types'
 
@@ -32,6 +33,7 @@ export function ProfileHeader({
   const headerUrl = profile.header_media_url
     ? `${profile.header_media_url.replace(/\/$/, '')}/1500x500`
     : null
+  const avatarUrl = getHighResolutionAvatarUrl(profile.avatar_media_url)
 
   return (
     <header>
@@ -49,12 +51,13 @@ export function ProfileHeader({
       </div>
       <div className="px-4 pb-4 sm:px-6">
         <div className="flex items-start justify-between gap-3">
-          {profile.avatar_media_url ? (
+          {avatarUrl ? (
             <Image
-              src={profile.avatar_media_url}
+              src={avatarUrl}
               alt={`${profile.account_display_name}'s avatar`}
               width={132}
               height={132}
+              sizes="132px"
               priority
               className="relative z-10 -mt-[66px] h-[132px] w-[132px] rounded-full border-4 border-card bg-muted object-cover"
             />

--- a/src/components/metaTwitter/Workspace.tsx
+++ b/src/components/metaTwitter/Workspace.tsx
@@ -4,6 +4,7 @@ import type { RefObject } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import TweetCard from '@/components/TweetCard'
+import { getSmallAvatarUrl } from '@/lib/avatar'
 import { formatNumber } from '@/lib/formatNumber'
 import { bangerPortalTweet } from '@/lib/metaTwitter/bangerPortalTweet'
 import { tweetPermalinkHref } from '@/lib/navigation'
@@ -245,14 +246,16 @@ export function Workspace({
                 </div>
               )}
               {people.map((person) => {
+                const avatarUrl = getSmallAvatarUrl(person.avatar_media_url)
                 const content = (
                   <div className="flex items-center gap-2.5">
-                    {person.avatar_media_url ? (
+                    {avatarUrl ? (
                       <Image
-                        src={person.avatar_media_url}
+                        src={avatarUrl}
                         alt=""
                         width={36}
                         height={36}
+                        sizes="36px"
                         className="h-9 w-9 flex-none rounded-full object-cover"
                       />
                     ) : (

--- a/src/components/ui/avatar.test.tsx
+++ b/src/components/ui/avatar.test.tsx
@@ -1,0 +1,58 @@
+import '@testing-library/jest-dom'
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { Avatar, AvatarImage } from './avatar'
+
+jest.mock('@radix-ui/react-avatar', () => ({
+  Root: React.forwardRef<HTMLElement, React.ComponentProps<'span'>>(
+    function MockAvatarRoot(props, ref) {
+      return <span ref={ref} {...props} />
+    },
+  ),
+  Image: React.forwardRef<HTMLImageElement, React.ComponentProps<'img'>>(
+    function MockAvatarImage({ alt = '', ...props }, ref) {
+      // eslint-disable-next-line @next/next/no-img-element
+      return <img ref={ref} alt={alt} {...props} />
+    },
+  ),
+  Fallback: React.forwardRef<HTMLElement, React.ComponentProps<'span'>>(
+    function MockAvatarFallback(props, ref) {
+      return <span ref={ref} {...props} />
+    },
+  ),
+}))
+
+describe('AvatarImage', () => {
+  it('requests the small variant by default', () => {
+    render(
+      <Avatar>
+        <AvatarImage
+          src="https://pbs.twimg.com/profile_images/42/avatar_400x400.jpg"
+          alt="Compact avatar"
+        />
+      </Avatar>,
+    )
+
+    expect(screen.getByAltText('Compact avatar')).toHaveAttribute(
+      'src',
+      'https://pbs.twimg.com/profile_images/42/avatar_normal.jpg',
+    )
+  })
+
+  it('allows profile headers to opt into the high-resolution variant', () => {
+    render(
+      <Avatar>
+        <AvatarImage
+          avatarSize="high"
+          src="https://pbs.twimg.com/profile_images/42/avatar_normal.jpg"
+          alt="Profile avatar"
+        />
+      </Avatar>,
+    )
+
+    expect(screen.getByAltText('Profile avatar')).toHaveAttribute(
+      'src',
+      'https://pbs.twimg.com/profile_images/42/avatar_400x400.jpg',
+    )
+  })
+})

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react'
 import * as AvatarPrimitive from '@radix-ui/react-avatar'
 
+import { getAvatarUrl, type AvatarSize } from '@/lib/avatar'
 import { cn } from '@/utils/tailwind'
 
 const Avatar = React.forwardRef<
@@ -22,10 +23,13 @@ Avatar.displayName = AvatarPrimitive.Root.displayName
 
 const AvatarImage = React.forwardRef<
   React.ElementRef<typeof AvatarPrimitive.Image>,
-  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
->(({ className, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image> & {
+    avatarSize?: AvatarSize
+  }
+>(({ avatarSize = 'small', className, src, ...props }, ref) => (
   <AvatarPrimitive.Image
     ref={ref}
+    src={getAvatarUrl(src, avatarSize)}
     className={cn('aspect-square h-full w-full', className)}
     {...props}
   />

--- a/src/lib/avatar.test.ts
+++ b/src/lib/avatar.test.ts
@@ -1,4 +1,8 @@
-import { getHighResolutionAvatarUrl, getLatestAvatarMediaUrl } from './avatar'
+import {
+  getHighResolutionAvatarUrl,
+  getLatestAvatarMediaUrl,
+  getSmallAvatarUrl,
+} from './avatar'
 
 describe('getHighResolutionAvatarUrl', () => {
   it('upgrades stored Twitter thumbnail suffixes', () => {
@@ -27,6 +31,38 @@ describe('getHighResolutionAvatarUrl', () => {
       'https://example.com/avatar.jpg',
     )
     expect(getHighResolutionAvatarUrl(null)).toBeUndefined()
+  })
+})
+
+describe('getSmallAvatarUrl', () => {
+  it('normalizes larger Twitter suffixes for compact avatars', () => {
+    expect(
+      getSmallAvatarUrl(
+        'https://pbs.twimg.com/profile_images/123/avatar_400x400.jpg',
+      ),
+    ).toBe('https://pbs.twimg.com/profile_images/123/avatar_normal.jpg')
+    expect(
+      getSmallAvatarUrl(
+        'https://pbs.twimg.com/profile_images/123/avatar_bigger.png',
+      ),
+    ).toBe('https://pbs.twimg.com/profile_images/123/avatar_normal.png')
+  })
+
+  it('normalizes a pbs.twimg.com query-size request', () => {
+    expect(
+      getSmallAvatarUrl(
+        'https://pbs.twimg.com/profile_images/123/avatar.jpg?format=jpg&name=400x400',
+      ),
+    ).toBe(
+      'https://pbs.twimg.com/profile_images/123/avatar.jpg?format=jpg&name=normal',
+    )
+  })
+
+  it('leaves unknown URLs unchanged', () => {
+    expect(getSmallAvatarUrl('https://example.com/avatar.jpg')).toBe(
+      'https://example.com/avatar.jpg',
+    )
+    expect(getSmallAvatarUrl(null)).toBeUndefined()
   })
 })
 

--- a/src/lib/avatar.ts
+++ b/src/lib/avatar.ts
@@ -3,8 +3,56 @@ export type AvatarProfile = {
   archive_upload_id?: number | null
 }
 
+export type AvatarSize = 'small' | 'high'
+
 const TWITTER_AVATAR_SIZE_SUFFIX =
-  /_(?:normal|bigger|mini|200x200)(?=\.[a-z0-9]+(?:[?#]|$))/i
+  /_(?:normal|bigger|mini|200x200|400x400)(?=\.[a-z0-9]+(?:[?#]|$))/i
+const TWITTER_AVATAR_QUERY_SIZES = new Set([
+  'mini',
+  'normal',
+  'bigger',
+  'small',
+  'medium',
+  'large',
+  '200x200',
+  '400x400',
+])
+
+/**
+ * Selects a Twitter/X avatar variant for the display context. Unknown and
+ * non-Twitter URLs are left intact so stored relative or proxied URLs keep
+ * working.
+ */
+export function getAvatarUrl(
+  avatarMediaUrl: string | null | undefined,
+  size: AvatarSize,
+): string | undefined {
+  if (!avatarMediaUrl) return undefined
+
+  const sizeName = size === 'high' ? '400x400' : 'normal'
+  const resizedSuffix = avatarMediaUrl.replace(
+    TWITTER_AVATAR_SIZE_SUFFIX,
+    `_${sizeName}`,
+  )
+  if (resizedSuffix !== avatarMediaUrl) return resizedSuffix
+
+  try {
+    const url = new URL(avatarMediaUrl)
+    const requestedSize = url.searchParams.get('name')
+    if (
+      url.hostname === 'pbs.twimg.com' &&
+      requestedSize &&
+      TWITTER_AVATAR_QUERY_SIZES.has(requestedSize.toLowerCase())
+    ) {
+      url.searchParams.set('name', sizeName)
+      return url.toString()
+    }
+  } catch {
+    // Stored avatar values can be relative URLs. Leave unknown forms intact.
+  }
+
+  return avatarMediaUrl
+}
 
 /**
  * Requests Twitter's larger profile image variant when the stored URL points
@@ -14,30 +62,13 @@ const TWITTER_AVATAR_SIZE_SUFFIX =
 export function getHighResolutionAvatarUrl(
   avatarMediaUrl: string | null | undefined,
 ): string | undefined {
-  if (!avatarMediaUrl) return undefined
+  return getAvatarUrl(avatarMediaUrl, 'high')
+}
 
-  const upgradedSuffix = avatarMediaUrl.replace(
-    TWITTER_AVATAR_SIZE_SUFFIX,
-    '_400x400',
-  )
-  if (upgradedSuffix !== avatarMediaUrl) return upgradedSuffix
-
-  try {
-    const url = new URL(avatarMediaUrl)
-    const requestedSize = url.searchParams.get('name')
-    if (
-      url.hostname === 'pbs.twimg.com' &&
-      requestedSize &&
-      ['normal', 'small', 'medium', '200x200'].includes(requestedSize)
-    ) {
-      url.searchParams.set('name', '400x400')
-      return url.toString()
-    }
-  } catch {
-    // Stored avatar values can be relative URLs. Leave unknown forms intact.
-  }
-
-  return avatarMediaUrl
+export function getSmallAvatarUrl(
+  avatarMediaUrl: string | null | undefined,
+): string | undefined {
+  return getAvatarUrl(avatarMediaUrl, 'small')
 }
 
 export function getLatestAvatarMediaUrl(

--- a/src/lib/clickhouseUserProfile.test.ts
+++ b/src/lib/clickhouseUserProfile.test.ts
@@ -43,7 +43,7 @@ test('maps a corpus account into the public profile contract', async () => {
         username: 'alice',
         account_display_name: 'Alice',
         avatar_media_url:
-          'https://pbs.twimg.com/profile_images/42/avatar_400x400.jpg',
+          'https://pbs.twimg.com/profile_images/42/avatar_normal.jpg',
         num_followers: 12,
         num_tweets: 45,
         has_archive: false,

--- a/src/lib/clickhouseUserProfile.ts
+++ b/src/lib/clickhouseUserProfile.ts
@@ -1,6 +1,5 @@
 import 'server-only'
 import { fetchAnalyticsGatewayJson } from '@/lib/clickhouseGateway'
-import { getHighResolutionAvatarUrl } from '@/lib/avatar'
 import type { FormattedUser } from '@/lib/types'
 
 interface ClickHouseUserResponse {
@@ -103,8 +102,7 @@ export async function getClickHouseUserProfile(
         bio: optionalText(account?.bio),
         website: null,
         location: null,
-        avatar_media_url:
-          getHighResolutionAvatarUrl(optionalText(account?.avatarUrl)) ?? null,
+        avatar_media_url: optionalText(account?.avatarUrl),
         header_media_url: optionalText(account?.headerUrl),
         archive_at: null,
         num_tweets: optionalCount(account?.statusCount),

--- a/src/lib/metaTwitter/bangers.test.ts
+++ b/src/lib/metaTwitter/bangers.test.ts
@@ -97,7 +97,7 @@ test('loads every scoped page of profile bangers above the quote threshold', asy
         tweet_id: '100',
         quote_count: 8,
         avatar_media_url:
-          'https://pbs.twimg.com/profile_images/42/avatar_400x400.jpg',
+          'https://pbs.twimg.com/profile_images/42/avatar_normal.jpg',
         media: [
           {
             media_url: 'https://pbs.twimg.com/media/100.jpg',
@@ -112,7 +112,7 @@ test('loads every scoped page of profile bangers above the quote threshold', asy
           account_id: '77',
           username: 'quoted_member',
           avatar_media_url:
-            'https://pbs.twimg.com/profile_images/77/quoted_400x400.jpg',
+            'https://pbs.twimg.com/profile_images/77/quoted_normal.jpg',
           full_text: 'The quoted source',
           media: [
             {

--- a/src/lib/metaTwitter/bangers.ts
+++ b/src/lib/metaTwitter/bangers.ts
@@ -6,7 +6,6 @@ import {
   type AnalyticsGatewayFetcher,
 } from '@/lib/clickhouseGateway'
 import { devLog } from '@/lib/devLog'
-import { getHighResolutionAvatarUrl } from '@/lib/avatar'
 import type { BangerTweet } from './types'
 import {
   PROFILE_BANGERS_INITIAL_LIMIT,
@@ -180,11 +179,9 @@ const mapQuotedTweet = (
         ? row.accountDisplayName
         : row.username,
     avatar_media_url:
-      getHighResolutionAvatarUrl(
-        typeof row.avatarMediaUrl === 'string' && row.avatarMediaUrl
-          ? row.avatarMediaUrl
-          : null,
-      ) ?? null,
+      typeof row.avatarMediaUrl === 'string' && row.avatarMediaUrl.trim()
+        ? row.avatarMediaUrl
+        : null,
     media: Array.isArray(row.media) ? row.media.map(mapMedia) : [],
   }
 }
@@ -243,11 +240,9 @@ const mapBanger = (value: unknown, accountId: string): BangerTweet => {
         ? row.displayName
         : row.username,
     avatar_media_url:
-      getHighResolutionAvatarUrl(
-        typeof row.avatarMediaUrl === 'string' && row.avatarMediaUrl
-          ? row.avatarMediaUrl
-          : null,
-      ) ?? null,
+      typeof row.avatarMediaUrl === 'string' && row.avatarMediaUrl.trim()
+        ? row.avatarMediaUrl
+        : null,
     media: Array.isArray(row.media) ? row.media.map(mapMedia) : [],
     quote_count: quoteCount,
     quoting_accounts: safeCount(

--- a/src/lib/metaTwitter/clickhouseSidebar.test.ts
+++ b/src/lib/metaTwitter/clickhouseSidebar.test.ts
@@ -65,7 +65,7 @@ test('maps year-scoped ClickHouse media and interactions for the sidebar', async
         name: 'Bob',
         interactions: 9,
         avatar_media_url:
-          'https://pbs.twimg.com/profile_images/7/avatar_400x400.jpg',
+          'https://pbs.twimg.com/profile_images/7/avatar_normal.jpg',
         in_archive: true,
       },
     ],

--- a/src/lib/metaTwitter/clickhouseSidebar.ts
+++ b/src/lib/metaTwitter/clickhouseSidebar.ts
@@ -5,7 +5,6 @@ import {
   fetchAnalyticsGatewayJson,
   type AnalyticsGatewayFetcher,
 } from '@/lib/clickhouseGateway'
-import { getHighResolutionAvatarUrl } from '@/lib/avatar'
 import { devLog } from '@/lib/devLog'
 import type { ArchiveMediaItem, ArchivePerson } from './types'
 
@@ -121,9 +120,9 @@ const personItem = (value: unknown): ArchivePerson | null => {
         : null,
     interactions,
     avatar_media_url:
-      getHighResolutionAvatarUrl(
-        typeof row.avatarUrl === 'string' ? row.avatarUrl : null,
-      ) ?? null,
+      typeof row.avatarUrl === 'string' && row.avatarUrl.trim()
+        ? row.avatarUrl
+        : null,
     in_archive: true,
   }
 }

--- a/src/lib/metaTwitter/data.ts
+++ b/src/lib/metaTwitter/data.ts
@@ -4,7 +4,6 @@ import { createClient, SupabaseClient } from '@supabase/supabase-js'
 import { unstable_cache } from 'next/cache'
 import { Database } from '@/database-types'
 import { devLog } from '@/lib/devLog'
-import { getHighResolutionAvatarUrl } from '@/lib/avatar'
 import type {
   ArchiveMediaItem,
   ArchivePerson,
@@ -58,8 +57,7 @@ async function fetchProfileHeader(
     bio: profile?.bio ?? null,
     website: profile?.website ?? null,
     location: profile?.location ?? null,
-    avatar_media_url:
-      getHighResolutionAvatarUrl(profile?.avatar_media_url) ?? null,
+    avatar_media_url: profile?.avatar_media_url ?? null,
     header_media_url: profile?.header_media_url ?? null,
     has_archive: true,
   }


### PR DESCRIPTION
## Summary

- keep stored and gateway avatar URLs size-neutral
- default shared and direct compact avatar renderers to Twitter/X's small `_normal` variant
- explicitly opt only profile headers into the `400x400` variant
- send null Library avatars directly to initials instead of requesting a placeholder first
- add focused tests for small and high-resolution rendering contexts

## Root cause

The profile refresh introduced high-resolution conversion in data mappers used by compact tweet, quote, and sidebar avatars. Avatar size belongs to the rendering context, not the data layer.

A read-only production check also showed that the initial placeholders in the reported Library screenshot have `null` `avatar_media_url` values. Adjacent stored avatar URLs and both of their size variants are healthy, so resizing cannot recover those null rows. Missing-data recovery remains tracked by #649.

## User impact

Profile headers retain crisp high-resolution avatars. Directory rows, tweet cards, quoted tweets, search/navigation avatars, and compact sidebars consistently request small images. Members with no stored avatar avoid a failed placeholder request and render initials directly.

## Validation

- `pnpm type-check`
- focused Next.js lint: no warnings or errors
- client Jest: 3 suites, 4 assertions
- server Jest: 4 suites, 20 assertions
- local Playwright against remote read-only directory data: 50 members rendered, no overlay or console errors, sampled avatars all loaded from `_normal` URLs, and no compact Twitter avatar requested a larger variant

Closes #654
