### PR TITLE
Load profile enrichment without blocking first paint

### DIFF
--- a/src/app/api/profile/[account_id]/bangers/route.ts
+++ b/src/app/api/profile/[account_id]/bangers/route.ts
@@ -31,7 +31,7 @@ const publicJson = (body: unknown, status = 200) =>
     headers: {
       'Cache-Control':
         status === 200
-          ? 'public, s-maxage=300, stale-while-revalidate=3600'
+          ? 'public, s-maxage=86400, stale-while-revalidate=604800'
           : 'private, no-store',
     },
   })

--- a/src/app/api/profile/[account_id]/interactions/route.ts
+++ b/src/app/api/profile/[account_id]/interactions/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getClickHouseProfileInteractionsOrThrow } from '@/lib/metaTwitter/clickhouseSidebar'
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 60
+
+const ACCOUNT_ID_PATTERN = /^\d{1,20}$/
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { account_id: string } },
+) {
+  if (!ACCOUNT_ID_PATTERN.test(params.account_id)) {
+    return NextResponse.json(
+      { error: 'Invalid profile account' },
+      { status: 400, headers: { 'Cache-Control': 'private, no-store' } },
+    )
+  }
+  const yearValue = request.nextUrl.searchParams.get('year')
+  let year: number | undefined
+  if (yearValue !== null) {
+    year = Number(yearValue)
+    if (
+      !Number.isInteger(year) ||
+      year < 2006 ||
+      year > new Date().getUTCFullYear() + 1
+    ) {
+      return NextResponse.json(
+        { error: 'Invalid profile year' },
+        { status: 400, headers: { 'Cache-Control': 'private, no-store' } },
+      )
+    }
+  }
+
+  try {
+    return NextResponse.json(
+      await getClickHouseProfileInteractionsOrThrow(params.account_id, year),
+      {
+        headers: {
+          'Cache-Control':
+            'public, s-maxage=86400, stale-while-revalidate=604800',
+        },
+      },
+    )
+  } catch (error) {
+    console.error('Profile interactions request failed:', error)
+    return NextResponse.json(
+      { error: 'Profile interactions are temporarily unavailable' },
+      { status: 502, headers: { 'Cache-Control': 'private, no-store' } },
+    )
+  }
+}

--- a/src/app/api/profile/[account_id]/media/route.ts
+++ b/src/app/api/profile/[account_id]/media/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getClickHouseProfileMediaOrThrow } from '@/lib/metaTwitter/clickhouseSidebar'
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 60
+
+const ACCOUNT_ID_PATTERN = /^\d{1,20}$/
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { account_id: string } },
+) {
+  if (!ACCOUNT_ID_PATTERN.test(params.account_id)) {
+    return NextResponse.json(
+      { error: 'Invalid profile account' },
+      { status: 400, headers: { 'Cache-Control': 'private, no-store' } },
+    )
+  }
+  const yearValue = request.nextUrl.searchParams.get('year')
+  let year: number | undefined
+  if (yearValue !== null) {
+    year = Number(yearValue)
+    if (
+      !Number.isInteger(year) ||
+      year < 2006 ||
+      year > new Date().getUTCFullYear() + 1
+    ) {
+      return NextResponse.json(
+        { error: 'Invalid profile year' },
+        { status: 400, headers: { 'Cache-Control': 'private, no-store' } },
+      )
+    }
+  }
+
+  try {
+    return NextResponse.json(
+      await getClickHouseProfileMediaOrThrow(params.account_id, year),
+      {
+        headers: {
+          'Cache-Control':
+            'public, s-maxage=86400, stale-while-revalidate=604800',
+        },
+      },
+    )
+  } catch (error) {
+    console.error('Profile media request failed:', error)
+    return NextResponse.json(
+      { error: 'Profile media is temporarily unavailable' },
+      { status: 502, headers: { 'Cache-Control': 'private, no-store' } },
+    )
+  }
+}

--- a/src/app/user/[account_id]/page.tsx
+++ b/src/app/user/[account_id]/page.tsx
@@ -12,7 +12,6 @@ import {
   PROFILE_BANGERS_INITIAL_LIMIT,
   resolveProfileChapterYear,
 } from '@/lib/metaTwitter/profilePagination'
-import { getClickHouseProfileSidebar } from '@/lib/metaTwitter/clickhouseSidebar'
 import {
   getCachedArchivedAt,
   getCachedProfileHeader,
@@ -88,24 +87,18 @@ async function ProfileArchiveContent({
   basePath: string
   candidateYear: number | null
 }) {
-  const [candidatePage, candidateSidebar] = await Promise.all([
-    getProfileBangersPage(accountId, {
-      limit: PROFILE_BANGERS_INITIAL_LIMIT,
-      year: candidateYear ?? undefined,
-    }),
-    getClickHouseProfileSidebar(accountId, candidateYear ?? undefined),
-  ])
+  const candidatePage = await getProfileBangersPage(accountId, {
+    limit: PROFILE_BANGERS_INITIAL_LIMIT,
+    year: candidateYear ?? undefined,
+  })
 
   const year = resolveProfileChapterYear(candidateYear, candidatePage)
-  const [initialPage, sidebar] =
+  const initialPage =
     year === candidateYear
-      ? [candidatePage, candidateSidebar]
-      : await Promise.all([
-          getProfileBangersPage(accountId, {
-            limit: PROFILE_BANGERS_INITIAL_LIMIT,
-          }),
-          getClickHouseProfileSidebar(accountId, undefined),
-        ])
+      ? candidatePage
+      : await getProfileBangersPage(accountId, {
+          limit: PROFILE_BANGERS_INITIAL_LIMIT,
+        })
 
   const navChapters: NavChapter[] = initialPage.yearCounts
 
@@ -117,7 +110,6 @@ async function ProfileArchiveContent({
       chapters={navChapters}
       initialYear={year}
       initialPage={initialPage}
-      initialSidebar={sidebar}
     />
   )
 }

--- a/src/components/metaTwitter/ProfileArchive.test.tsx
+++ b/src/components/metaTwitter/ProfileArchive.test.tsx
@@ -144,10 +144,15 @@ test('switches chapters immediately while their small data requests are pending'
   await waitFor(() =>
     expect(
       fetchMock.mock.calls.some(([input]) =>
-        String(input).includes('/sidebar?year=2025'),
+        String(input).includes('/media?year=2025'),
       ),
     ).toBe(true),
   )
+  expect(
+    fetchMock.mock.calls.some(([input]) =>
+      String(input).includes('/interactions?year=2025'),
+    ),
+  ).toBe(true)
 })
 
 test('preserves modified-click behavior on chapter links', async () => {
@@ -308,8 +313,11 @@ test('stops automatic infinite-scroll retries after a failed page', async () => 
   const user = userEvent.setup()
   const fetchMock = jest.spyOn(global, 'fetch').mockImplementation((input) => {
     const url = new URL(String(input), 'https://community-archive.org')
-    if (url.pathname.endsWith('/sidebar')) {
-      return Promise.resolve(jsonResponse(initialSidebar))
+    if (url.pathname.endsWith('/media')) {
+      return Promise.resolve(jsonResponse({ media: [], mediaCount: 0 }))
+    }
+    if (url.pathname.endsWith('/interactions')) {
+      return Promise.resolve(jsonResponse({ people: [] }))
     }
     if (!url.searchParams.has('year')) {
       return Promise.reject(new Error('gateway unavailable'))
@@ -363,8 +371,11 @@ test('can retry an unavailable initial banger page from offset zero', async () =
   const user = userEvent.setup()
   const fetchMock = jest.spyOn(global, 'fetch').mockImplementation((input) => {
     const url = new URL(String(input), 'https://community-archive.org')
-    if (url.pathname.endsWith('/sidebar')) {
-      return Promise.resolve(jsonResponse(initialSidebar))
+    if (url.pathname.endsWith('/media')) {
+      return Promise.resolve(jsonResponse({ media: [], mediaCount: 0 }))
+    }
+    if (url.pathname.endsWith('/interactions')) {
+      return Promise.resolve(jsonResponse({ people: [] }))
     }
     return Promise.resolve(
       jsonResponse({
@@ -407,17 +418,20 @@ test('can retry an unavailable initial banger page from offset zero', async () =
   ).toBe(true)
 })
 
-test('does not remember a failed sidebar request as an empty result', async () => {
+test('retries failed media without blocking successful interactions', async () => {
   const user = userEvent.setup()
-  let sidebarCalls = 0
+  let mediaCalls = 0
   const fetchMock = jest.spyOn(global, 'fetch').mockImplementation((input) => {
     const url = new URL(String(input), 'https://community-archive.org')
-    if (url.pathname.endsWith('/sidebar')) {
-      sidebarCalls += 1
-      if (sidebarCalls === 1) {
+    if (url.pathname.endsWith('/media')) {
+      mediaCalls += 1
+      if (mediaCalls === 1) {
         return Promise.reject(new Error('gateway unavailable'))
       }
-      return Promise.resolve(jsonResponse(initialSidebar))
+      return Promise.resolve(jsonResponse({ media: [], mediaCount: 0 }))
+    }
+    if (url.pathname.endsWith('/interactions')) {
+      return Promise.resolve(jsonResponse({ people: [] }))
     }
     return Promise.resolve(
       jsonResponse({
@@ -448,12 +462,13 @@ test('does not remember a failed sidebar request as an empty result', async () =
     />,
   )
 
-  await user.click(
-    await screen.findByRole('button', { name: 'Retry media and people' }),
-  )
+  await user.click(await screen.findByRole('button', { name: 'Retry media' }))
 
   await screen.findByText('No media in this chapter')
-  expect(sidebarCalls).toBe(2)
+  expect(
+    screen.getByText('No interactions found in this chapter.'),
+  ).toBeVisible()
+  expect(mediaCalls).toBe(2)
   expect(fetchMock).toHaveBeenCalled()
 })
 
@@ -463,8 +478,11 @@ test('does not start a stale chapter preload over an in-flight active feed', asy
   const activeChapter = deferredResponse()
   const fetchMock = jest.spyOn(global, 'fetch').mockImplementation((input) => {
     const url = new URL(String(input), 'https://community-archive.org')
-    if (url.pathname.endsWith('/sidebar')) {
-      return Promise.resolve(jsonResponse(initialSidebar))
+    if (url.pathname.endsWith('/media')) {
+      return Promise.resolve(jsonResponse({ media: [], mediaCount: 0 }))
+    }
+    if (url.pathname.endsWith('/interactions')) {
+      return Promise.resolve(jsonResponse({ people: [] }))
     }
     const year = url.searchParams.get('year')
     const offset = Number(url.searchParams.get('offset') ?? 0)

--- a/src/components/metaTwitter/ProfileArchive.tsx
+++ b/src/components/metaTwitter/ProfileArchive.tsx
@@ -22,6 +22,15 @@ interface SidebarData {
   available?: boolean
 }
 
+interface MediaData {
+  media: ArchiveMediaItem[]
+  mediaCount: number
+}
+
+interface PeopleData {
+  people: ArchivePerson[]
+}
+
 interface FeedState {
   tweets: BangerTweet[]
   total: number
@@ -67,35 +76,53 @@ export function ProfileArchive({
   chapters: NavChapter[]
   initialYear: number | null
   initialPage: ProfileBangersPageState
-  initialSidebar: SidebarData
+  initialSidebar?: SidebarData
 }) {
   const initialFeedKey = feedKey(initialYear, 'quotes')
+  const initialScopeKey = scopeKey(initialYear)
+  const hasInitialSidebar = initialSidebar?.available !== false
   const [activeYear, setActiveYear] = useState<number | null>(initialYear)
   const [sort, setSort] = useState<ProfileBangerSort>('quotes')
   const [feeds, setFeeds] = useState<Record<string, FeedState>>({
     [initialFeedKey]: initialPage,
   })
-  const [sidebars, setSidebars] = useState<Record<string, SidebarData>>(
-    initialSidebar.available === false
-      ? {}
-      : { [scopeKey(initialYear)]: initialSidebar },
+  const [mediaByScope, setMediaByScope] = useState<Record<string, MediaData>>(
+    initialSidebar && hasInitialSidebar
+      ? {
+          [initialScopeKey]: {
+            media: initialSidebar.media,
+            mediaCount: initialSidebar.mediaCount,
+          },
+        }
+      : {},
+  )
+  const [peopleByScope, setPeopleByScope] = useState<
+    Record<string, PeopleData>
+  >(
+    initialSidebar && hasInitialSidebar
+      ? { [initialScopeKey]: { people: initialSidebar.people } }
+      : {},
   )
   const [loadingFeeds, setLoadingFeeds] = useState<Record<string, boolean>>({})
   const [failedFeeds, setFailedFeeds] = useState<Record<string, boolean>>({
     [initialFeedKey]: !initialPage.available,
   })
-  const [failedSidebars, setFailedSidebars] = useState<Record<string, boolean>>(
-    {
-      [scopeKey(initialYear)]: initialSidebar.available === false,
-    },
+  const [failedMedia, setFailedMedia] = useState<Record<string, boolean>>({
+    [initialScopeKey]: initialSidebar?.available === false,
+  })
+  const [failedPeople, setFailedPeople] = useState<Record<string, boolean>>({
+    [initialScopeKey]: initialSidebar?.available === false,
+  })
+  const [loadingMedia, setLoadingMedia] = useState<Record<string, boolean>>({})
+  const [loadingPeople, setLoadingPeople] = useState<Record<string, boolean>>(
+    {},
   )
-  const [loadingSidebars, setLoadingSidebars] = useState<
-    Record<string, boolean>
-  >({})
   const feedsRef = useRef(feeds)
-  const sidebarsRef = useRef(sidebars)
+  const mediaRef = useRef(mediaByScope)
+  const peopleRef = useRef(peopleByScope)
   const feedRequests = useRef(new Map<string, Promise<void>>())
-  const sidebarRequests = useRef(new Map<string, Promise<void>>())
+  const mediaRequests = useRef(new Map<string, Promise<void>>())
+  const peopleRequests = useRef(new Map<string, Promise<void>>())
   const automaticallyFilledFeeds = useRef(new Set<string>())
   const loadMoreRef = useRef<HTMLDivElement>(null)
 
@@ -114,15 +141,30 @@ export function ProfileArchive({
     [],
   )
 
-  const updateSidebars = useCallback(
+  const updateMedia = useCallback(
     (
       updater: (
-        current: Record<string, SidebarData>,
-      ) => Record<string, SidebarData>,
+        current: Record<string, MediaData>,
+      ) => Record<string, MediaData>,
     ) => {
-      setSidebars((current) => {
+      setMediaByScope((current) => {
         const next = updater(current)
-        sidebarsRef.current = next
+        mediaRef.current = next
+        return next
+      })
+    },
+    [],
+  )
+
+  const updatePeople = useCallback(
+    (
+      updater: (
+        current: Record<string, PeopleData>,
+      ) => Record<string, PeopleData>,
+    ) => {
+      setPeopleByScope((current) => {
+        const next = updater(current)
+        peopleRef.current = next
         return next
       })
     },
@@ -206,43 +248,81 @@ export function ProfileArchive({
     [loadFeedPage],
   )
 
-  const loadSidebar = useCallback(
+  const loadMedia = useCallback(
     (year: number | null) => {
       const key = scopeKey(year)
-      if (sidebarsRef.current[key]) return Promise.resolve()
-      const existing = sidebarRequests.current.get(key)
+      if (mediaRef.current[key]) return Promise.resolve()
+      const existing = mediaRequests.current.get(key)
       if (existing) return existing
 
       const params = new URLSearchParams()
       if (year !== null) params.set('year', String(year))
       const query = params.toString()
-      setLoadingSidebars((current) => ({ ...current, [key]: true }))
-      setFailedSidebars((current) => ({ ...current, [key]: false }))
+      setLoadingMedia((current) => ({ ...current, [key]: true }))
+      setFailedMedia((current) => ({ ...current, [key]: false }))
       const request = fetch(
-        `/api/profile/${encodeURIComponent(accountId)}/sidebar${query ? `?${query}` : ''}`,
+        `/api/profile/${encodeURIComponent(accountId)}/media${query ? `?${query}` : ''}`,
       )
         .then(async (response) => {
-          if (!response.ok) throw new Error('Profile sidebar request failed')
-          const sidebar = (await response.json()) as SidebarData
-          if (!Array.isArray(sidebar.media) || !Array.isArray(sidebar.people)) {
-            throw new Error('Profile sidebar response was invalid')
+          if (!response.ok) throw new Error('Profile media request failed')
+          const media = (await response.json()) as MediaData
+          if (!Array.isArray(media.media)) {
+            throw new Error('Profile media response was invalid')
           }
-          updateSidebars((current) => ({
+          updateMedia((current) => ({
             ...current,
-            [key]: { ...sidebar, available: true },
+            [key]: media,
           }))
         })
         .catch(() => {
-          setFailedSidebars((current) => ({ ...current, [key]: true }))
+          setFailedMedia((current) => ({ ...current, [key]: true }))
         })
         .finally(() => {
-          sidebarRequests.current.delete(key)
-          setLoadingSidebars((current) => ({ ...current, [key]: false }))
+          mediaRequests.current.delete(key)
+          setLoadingMedia((current) => ({ ...current, [key]: false }))
         })
-      sidebarRequests.current.set(key, request)
+      mediaRequests.current.set(key, request)
       return request
     },
-    [accountId, updateSidebars],
+    [accountId, updateMedia],
+  )
+
+  const loadPeople = useCallback(
+    (year: number | null) => {
+      const key = scopeKey(year)
+      if (peopleRef.current[key]) return Promise.resolve()
+      const existing = peopleRequests.current.get(key)
+      if (existing) return existing
+
+      const params = new URLSearchParams()
+      if (year !== null) params.set('year', String(year))
+      const query = params.toString()
+      setLoadingPeople((current) => ({ ...current, [key]: true }))
+      setFailedPeople((current) => ({ ...current, [key]: false }))
+      const request = fetch(
+        `/api/profile/${encodeURIComponent(accountId)}/interactions${query ? `?${query}` : ''}`,
+      )
+        .then(async (response) => {
+          if (!response.ok) {
+            throw new Error('Profile interactions request failed')
+          }
+          const people = (await response.json()) as PeopleData
+          if (!Array.isArray(people.people)) {
+            throw new Error('Profile interactions response was invalid')
+          }
+          updatePeople((current) => ({ ...current, [key]: people }))
+        })
+        .catch(() => {
+          setFailedPeople((current) => ({ ...current, [key]: true }))
+        })
+        .finally(() => {
+          peopleRequests.current.delete(key)
+          setLoadingPeople((current) => ({ ...current, [key]: false }))
+        })
+      peopleRequests.current.set(key, request)
+      return request
+    },
+    [accountId, updatePeople],
   )
 
   const activeKey = feedKey(activeYear, sort)
@@ -251,9 +331,13 @@ export function ProfileArchive({
   const activeNextOffset = activeFeed?.nextOffset
   const activeFeedLoading = Boolean(loadingFeeds[activeKey])
   const activeFeedFailed = Boolean(failedFeeds[activeKey])
-  const activeSidebar = sidebars[scopeKey(activeYear)]
-  const activeSidebarLoading = Boolean(loadingSidebars[scopeKey(activeYear)])
-  const activeSidebarFailed = Boolean(failedSidebars[scopeKey(activeYear)])
+  const activeScopeKey = scopeKey(activeYear)
+  const activeMedia = mediaByScope[activeScopeKey]
+  const activePeople = peopleByScope[activeScopeKey]
+  const activeMediaLoading = Boolean(loadingMedia[activeScopeKey])
+  const activePeopleLoading = Boolean(loadingPeople[activeScopeKey])
+  const activeMediaFailed = Boolean(failedMedia[activeScopeKey])
+  const activePeopleFailed = Boolean(failedPeople[activeScopeKey])
   const hasMore = activeFeedLoaded && activeNextOffset !== null
 
   useEffect(() => {
@@ -289,8 +373,12 @@ export function ProfileArchive({
   ])
 
   useEffect(() => {
-    void loadSidebar(activeYear)
-  }, [activeYear, loadSidebar])
+    void loadMedia(activeYear)
+  }, [activeYear, loadMedia])
+
+  useEffect(() => {
+    void loadPeople(activeYear)
+  }, [activeYear, loadPeople])
 
   useEffect(() => {
     const initialFill = loadNextPage(initialYear, 'quotes')
@@ -389,15 +477,20 @@ export function ProfileArchive({
         totalTweets={context.total}
         bangersAvailable={activeFeed?.available !== false}
         bangersLoading={activeFeedLoading || (!activeFeed && !activeFeedFailed)}
-        media={activeSidebar?.media ?? []}
-        mediaCount={activeSidebar?.mediaCount ?? 0}
-        people={activeSidebar?.people ?? []}
+        media={activeMedia?.media ?? []}
+        mediaCount={activeMedia?.mediaCount ?? 0}
+        people={activePeople?.people ?? []}
         peopleTitle={activeYear ? `People in ${activeYear}` : 'Top people'}
-        sidebarLoading={
-          activeSidebarLoading || (!activeSidebar && !activeSidebarFailed)
+        mediaLoading={
+          activeMediaLoading || (!activeMedia && !activeMediaFailed)
         }
-        sidebarFailed={activeSidebarFailed}
-        onRetrySidebar={() => void loadSidebar(activeYear)}
+        mediaFailed={activeMediaFailed}
+        onRetryMedia={() => void loadMedia(activeYear)}
+        peopleLoading={
+          activePeopleLoading || (!activePeople && !activePeopleFailed)
+        }
+        peopleFailed={activePeopleFailed}
+        onRetryPeople={() => void loadPeople(activeYear)}
         sort={sort}
         onSortChange={selectSort}
         hasMore={

--- a/src/components/metaTwitter/Workspace.test.tsx
+++ b/src/components/metaTwitter/Workspace.test.tsx
@@ -84,9 +84,12 @@ test('shows the initial canonical banger cards with media and profile return lin
       mediaCount={0}
       people={[]}
       peopleTitle="Top people"
-      sidebarLoading={false}
-      sidebarFailed={false}
-      onRetrySidebar={jest.fn()}
+      mediaLoading={false}
+      mediaFailed={false}
+      onRetryMedia={jest.fn()}
+      peopleLoading={false}
+      peopleFailed={false}
+      onRetryPeople={jest.fn()}
       sort="quotes"
       onSortChange={jest.fn()}
       hasMore

--- a/src/components/metaTwitter/Workspace.tsx
+++ b/src/components/metaTwitter/Workspace.tsx
@@ -35,9 +35,12 @@ export function Workspace({
   mediaCount,
   people,
   peopleTitle,
-  sidebarLoading,
-  sidebarFailed,
-  onRetrySidebar,
+  mediaLoading,
+  mediaFailed,
+  onRetryMedia,
+  peopleLoading,
+  peopleFailed,
+  onRetryPeople,
   sort,
   onSortChange,
   hasMore,
@@ -57,9 +60,12 @@ export function Workspace({
   mediaCount: number
   people: ArchivePerson[]
   peopleTitle: string
-  sidebarLoading: boolean
-  sidebarFailed: boolean
-  onRetrySidebar: () => void
+  mediaLoading: boolean
+  mediaFailed: boolean
+  onRetryMedia: () => void
+  peopleLoading: boolean
+  peopleFailed: boolean
+  onRetryPeople: () => void
   sort: ProfileBangerSort
   onSortChange: (sort: ProfileBangerSort) => void
   hasMore: boolean
@@ -176,17 +182,17 @@ export function Workspace({
             >
               Media
             </h3>
-            {sidebarLoading ? (
+            {mediaLoading ? (
               <div className="rounded-md border border-dashed border-border p-4 text-center text-xs text-muted-foreground">
                 Loading media…
               </div>
-            ) : sidebarFailed ? (
+            ) : mediaFailed ? (
               <button
                 type="button"
-                onClick={onRetrySidebar}
+                onClick={onRetryMedia}
                 className="w-full rounded-md border border-dashed border-border p-4 text-center text-xs font-semibold text-muted-foreground hover:bg-muted"
               >
-                Retry media and people
+                Retry media
               </button>
             ) : mediaTiles.length === 0 ? (
               <div className="rounded-md border border-dashed border-border p-4 text-center text-xs text-muted-foreground">
@@ -230,17 +236,21 @@ export function Workspace({
               {peopleTitle}
             </h3>
             <div className="flex flex-col gap-2.5">
-              {sidebarLoading && (
+              {peopleLoading && (
                 <div className="text-[13px] text-muted-foreground">
                   Loading people…
                 </div>
               )}
-              {!sidebarLoading && sidebarFailed && (
-                <div className="text-[13px] text-muted-foreground">
-                  Interactions are temporarily unavailable.
-                </div>
+              {!peopleLoading && peopleFailed && (
+                <button
+                  type="button"
+                  onClick={onRetryPeople}
+                  className="text-left text-[13px] font-semibold text-muted-foreground hover:text-foreground"
+                >
+                  Interactions are temporarily unavailable. Retry
+                </button>
               )}
-              {!sidebarLoading && !sidebarFailed && people.length === 0 && (
+              {!peopleLoading && !peopleFailed && people.length === 0 && (
                 <div className="text-[13px] text-muted-foreground">
                   No interactions found in this chapter.
                 </div>

--- a/src/lib/clickhouseAnalytics.test.ts
+++ b/src/lib/clickhouseAnalytics.test.ts
@@ -56,7 +56,7 @@ describe('getTopFollowedAccounts', () => {
           Accept: 'application/json',
           Authorization: 'Bearer test-token',
         },
-        next: { revalidate: 60 },
+        next: { revalidate: 86_400 },
       },
     )
   })

--- a/src/lib/clickhouseAnalytics.ts
+++ b/src/lib/clickhouseAnalytics.ts
@@ -39,7 +39,7 @@ export async function getTopFollowedAccounts(
         Accept: 'application/json',
         Authorization: `Bearer ${token}`,
       },
-      next: { revalidate: 60 },
+      next: { revalidate: 86_400 },
     },
   )
 

--- a/src/lib/clickhouseGateway.ts
+++ b/src/lib/clickhouseGateway.ts
@@ -81,7 +81,7 @@ export function analyticsGatewayRequestUrl(
     cleanPath[0] === 'user' &&
     /^[A-Za-z0-9_@]{1,80}$/.test(cleanPath[1])
   ) {
-    allowedParams = new Set(['limit'])
+    allowedParams = new Set(['limit', 'include_interactions'])
   } else if (
     cleanPath.length === 3 &&
     cleanPath[0] === 'user' &&
@@ -89,6 +89,20 @@ export function analyticsGatewayRequestUrl(
     cleanPath[2] === 'sidebar'
   ) {
     allowedParams = new Set(['year', 'media_limit', 'people_limit'])
+  } else if (
+    cleanPath.length === 3 &&
+    cleanPath[0] === 'user' &&
+    /^\d{1,20}$/.test(cleanPath[1]) &&
+    cleanPath[2] === 'media'
+  ) {
+    allowedParams = new Set(['year', 'limit'])
+  } else if (
+    cleanPath.length === 3 &&
+    cleanPath[0] === 'user' &&
+    /^\d{1,20}$/.test(cleanPath[1]) &&
+    cleanPath[2] === 'interactions'
+  ) {
+    allowedParams = new Set(['year', 'limit'])
   } else if (
     cleanPath.length === 2 &&
     cleanPath[0] === 'tweet' &&

--- a/src/lib/clickhouseLab.test.ts
+++ b/src/lib/clickhouseLab.test.ts
@@ -207,6 +207,36 @@ describe('ClickHouse staging lab guard', () => {
     ).toThrow('Unsupported ClickHouse analytics endpoint')
   })
 
+  test('allows a core user read to omit interactions', () => {
+    const target = analyticsGatewayRequestUrl(
+      ['user', 'alice'],
+      new URLSearchParams('limit=20&include_interactions=false&raw_sql=DROP'),
+      'https://stream.example/analytics',
+    )
+    expect(target.toString()).toBe(
+      'https://stream.example/analytics/user/alice?limit=20&include_interactions=false',
+    )
+  })
+
+  test('allows independently scoped profile enrichment reads', () => {
+    const media = analyticsGatewayRequestUrl(
+      ['user', '42', 'media'],
+      new URLSearchParams('year=2025&limit=6&people_limit=8'),
+      'https://stream.example/analytics',
+    )
+    const interactions = analyticsGatewayRequestUrl(
+      ['user', '42', 'interactions'],
+      new URLSearchParams('year=2025&limit=8&media_limit=6'),
+      'https://stream.example/analytics',
+    )
+    expect(media.toString()).toBe(
+      'https://stream.example/analytics/user/42/media?year=2025&limit=6',
+    )
+    expect(interactions.toString()).toBe(
+      'https://stream.example/analytics/user/42/interactions?year=2025&limit=8',
+    )
+  })
+
   test('allows bounded reverse-quote parameters for numeric tweet IDs', () => {
     const target = analyticsGatewayRequestUrl(
       ['quote-posts', '2085375983708692599'],

--- a/src/lib/clickhouseUserProfile.test.ts
+++ b/src/lib/clickhouseUserProfile.test.ts
@@ -61,6 +61,14 @@ test('maps a corpus account into the public profile contract', async () => {
       ],
     }),
   )
+  expect(fetchGateway).toHaveBeenCalledWith(
+    ['user', '42'],
+    new URLSearchParams({
+      limit: '20',
+      include_interactions: 'false',
+    }),
+    { revalidate: 300, timeoutMs: 8_000 },
+  )
 })
 
 test('degrades to not found for an unavailable or invalid account', async () => {

--- a/src/lib/clickhouseUserProfile.ts
+++ b/src/lib/clickhouseUserProfile.ts
@@ -84,7 +84,10 @@ export async function getClickHouseUserProfile(
   try {
     const response = await fetchAnalyticsGatewayJson<ClickHouseUserResponse>(
       ['user', identifier],
-      new URLSearchParams({ limit: '20' }),
+      new URLSearchParams({
+        limit: '20',
+        include_interactions: 'false',
+      }),
       { revalidate: 300, timeoutMs: 8_000 },
     )
     const account = response.data?.account

--- a/src/lib/metaTwitter/bangers.ts
+++ b/src/lib/metaTwitter/bangers.ts
@@ -23,6 +23,7 @@ export type { ProfileBangerSort } from './profilePagination'
 
 const PAGE_SIZE = 100
 const MIN_QUOTE_COUNT = 2
+const PROFILE_BANGERS_REVALIDATE_SECONDS = 86_400
 const ACCOUNT_ID_PATTERN = /^\d{1,20}$/
 const TWEET_ID_PATTERN = /^\d{1,20}$/
 
@@ -422,7 +423,7 @@ export async function fetchProfileBangers(
 const getCachedProfileBangers = unstable_cache(
   fetchProfileBangers,
   ['meta-twitter-profile-bangers-v3'],
-  { revalidate: 300 },
+  { revalidate: PROFILE_BANGERS_REVALIDATE_SECONDS },
 )
 
 const getCachedProfileBangersPage = unstable_cache(
@@ -434,7 +435,7 @@ const getCachedProfileBangersPage = unstable_cache(
     sort: ProfileBangerSort,
   ) => fetchProfileBangersPage(accountId, { limit, offset, year, sort }),
   ['meta-twitter-profile-bangers-page-v2'],
-  { revalidate: 300 },
+  { revalidate: PROFILE_BANGERS_REVALIDATE_SECONDS },
 )
 
 export async function getProfileBangersPage(

--- a/src/lib/metaTwitter/clickhouseSidebar.test.ts
+++ b/src/lib/metaTwitter/clickhouseSidebar.test.ts
@@ -1,5 +1,9 @@
 import type { AnalyticsGatewayFetcher } from '@/lib/clickhouseGateway'
-import { fetchClickHouseProfileSidebar } from './clickhouseSidebar'
+import {
+  fetchClickHouseProfileInteractions,
+  fetchClickHouseProfileMedia,
+  fetchClickHouseProfileSidebar,
+} from './clickhouseSidebar'
 
 const response = (year: number | null) => ({
   data: {
@@ -77,6 +81,32 @@ test('maps year-scoped ClickHouse media and interactions for the sidebar', async
       people_limit: '8',
       year: '2025',
     }),
+    { timeoutMs: 30_000 },
+  )
+})
+
+test('loads media and interactions through independent gateway resources', async () => {
+  const fetcher = jest.fn(async () =>
+    response(2025),
+  ) as unknown as AnalyticsGatewayFetcher
+
+  const [media, interactions] = await Promise.all([
+    fetchClickHouseProfileMedia('42', 2025, fetcher),
+    fetchClickHouseProfileInteractions('42', 2025, fetcher),
+  ])
+
+  expect(media).toMatchObject({ mediaCount: 7, media: [{ tweet_id: '501' }] })
+  expect(interactions).toMatchObject({
+    people: [{ user_id: '7', screen_name: 'bob', interactions: 9 }],
+  })
+  expect(fetcher).toHaveBeenCalledWith(
+    ['user', '42', 'media'],
+    new URLSearchParams({ limit: '6', year: '2025' }),
+    { timeoutMs: 30_000 },
+  )
+  expect(fetcher).toHaveBeenCalledWith(
+    ['user', '42', 'interactions'],
+    new URLSearchParams({ limit: '8', year: '2025' }),
     { timeoutMs: 30_000 },
   )
 })

--- a/src/lib/metaTwitter/clickhouseSidebar.ts
+++ b/src/lib/metaTwitter/clickhouseSidebar.ts
@@ -27,6 +27,29 @@ interface SidebarResponse {
   }
 }
 
+interface MediaResponse {
+  data?: {
+    media?: unknown
+    mediaCount?: unknown
+  }
+  query?: {
+    accountId?: unknown
+    year?: unknown
+    mediaLimit?: unknown
+  }
+}
+
+interface InteractionsResponse {
+  data?: {
+    people?: unknown
+  }
+  query?: {
+    accountId?: unknown
+    year?: unknown
+    peopleLimit?: unknown
+  }
+}
+
 interface SidebarMediaRow {
   tweetId?: unknown
   createdAt?: unknown
@@ -53,6 +76,24 @@ export interface ClickHouseProfileSidebar {
 
 export interface ClickHouseProfileSidebarState
   extends ClickHouseProfileSidebar {
+  available: boolean
+}
+
+export interface ClickHouseProfileMedia {
+  media: ArchiveMediaItem[]
+  mediaCount: number
+}
+
+export interface ClickHouseProfileMediaState extends ClickHouseProfileMedia {
+  available: boolean
+}
+
+export interface ClickHouseProfileInteractions {
+  people: ArchivePerson[]
+}
+
+export interface ClickHouseProfileInteractionsState
+  extends ClickHouseProfileInteractions {
   available: boolean
 }
 
@@ -127,6 +168,78 @@ const personItem = (value: unknown): ArchivePerson | null => {
   }
 }
 
+const profileParams = (year: number | undefined, limit: number) => {
+  const params = new URLSearchParams({ limit: String(limit) })
+  if (year !== undefined) params.set('year', String(year))
+  return params
+}
+
+export async function fetchClickHouseProfileMedia(
+  accountId: string,
+  year: number | undefined,
+  fetcher: AnalyticsGatewayFetcher = fetchAnalyticsGatewayJson,
+): Promise<ClickHouseProfileMedia> {
+  if (!ID_PATTERN.test(accountId)) {
+    throw new Error('Profile media requires a numeric account ID')
+  }
+  const response = await fetcher<MediaResponse>(
+    ['user', accountId, 'media'],
+    profileParams(year, MEDIA_LIMIT),
+    { timeoutMs: 30_000 },
+  )
+  if (
+    response.query?.accountId !== accountId ||
+    response.query?.year !== (year ?? null) ||
+    Number(response.query?.mediaLimit) !== MEDIA_LIMIT
+  ) {
+    throw new Error('ClickHouse returned mismatched profile media scope')
+  }
+  const media = response.data?.media
+  const mediaCount = safeCount(response.data?.mediaCount)
+  if (mediaCount === null || !Array.isArray(media)) {
+    throw new Error('ClickHouse returned invalid profile media')
+  }
+  return {
+    media: media.flatMap((value) => {
+      const item = mediaItem(value)
+      return item ? [item] : []
+    }),
+    mediaCount,
+  }
+}
+
+export async function fetchClickHouseProfileInteractions(
+  accountId: string,
+  year: number | undefined,
+  fetcher: AnalyticsGatewayFetcher = fetchAnalyticsGatewayJson,
+): Promise<ClickHouseProfileInteractions> {
+  if (!ID_PATTERN.test(accountId)) {
+    throw new Error('Profile interactions require a numeric account ID')
+  }
+  const response = await fetcher<InteractionsResponse>(
+    ['user', accountId, 'interactions'],
+    profileParams(year, PEOPLE_LIMIT),
+    { timeoutMs: 30_000 },
+  )
+  if (
+    response.query?.accountId !== accountId ||
+    response.query?.year !== (year ?? null) ||
+    Number(response.query?.peopleLimit) !== PEOPLE_LIMIT
+  ) {
+    throw new Error('ClickHouse returned mismatched profile interactions scope')
+  }
+  const people = response.data?.people
+  if (!Array.isArray(people)) {
+    throw new Error('ClickHouse returned invalid profile interactions')
+  }
+  return {
+    people: people.flatMap((value) => {
+      const item = personItem(value)
+      return item ? [item] : []
+    }),
+  }
+}
+
 export async function fetchClickHouseProfileSidebar(
   accountId: string,
   year: number | undefined,
@@ -180,11 +293,37 @@ const getCachedClickHouseProfileSidebar = unstable_cache(
   { revalidate: DAY },
 )
 
+const getCachedClickHouseProfileMedia = unstable_cache(
+  fetchClickHouseProfileMedia,
+  ['meta-twitter-clickhouse-profile-media-v1'],
+  { revalidate: DAY },
+)
+
+const getCachedClickHouseProfileInteractions = unstable_cache(
+  fetchClickHouseProfileInteractions,
+  ['meta-twitter-clickhouse-profile-interactions-v1'],
+  { revalidate: DAY },
+)
+
 export async function getClickHouseProfileSidebarOrThrow(
   accountId: string,
   year: number | undefined,
 ): Promise<ClickHouseProfileSidebar> {
   return getCachedClickHouseProfileSidebar(accountId, year)
+}
+
+export async function getClickHouseProfileMediaOrThrow(
+  accountId: string,
+  year: number | undefined,
+): Promise<ClickHouseProfileMedia> {
+  return getCachedClickHouseProfileMedia(accountId, year)
+}
+
+export async function getClickHouseProfileInteractionsOrThrow(
+  accountId: string,
+  year: number | undefined,
+): Promise<ClickHouseProfileInteractions> {
+  return getCachedClickHouseProfileInteractions(accountId, year)
 }
 
 export async function getClickHouseProfileSidebar(
@@ -203,5 +342,43 @@ export async function getClickHouseProfileSidebar(
       error,
     })
     return { media: [], mediaCount: 0, people: [], available: false }
+  }
+}
+
+export async function getClickHouseProfileMedia(
+  accountId: string,
+  year: number | undefined,
+): Promise<ClickHouseProfileMediaState> {
+  try {
+    return {
+      ...(await getClickHouseProfileMediaOrThrow(accountId, year)),
+      available: true,
+    }
+  } catch (error) {
+    devLog('metaTwitter getClickHouseProfileMedia error', {
+      accountId,
+      year,
+      error,
+    })
+    return { media: [], mediaCount: 0, available: false }
+  }
+}
+
+export async function getClickHouseProfileInteractions(
+  accountId: string,
+  year: number | undefined,
+): Promise<ClickHouseProfileInteractionsState> {
+  try {
+    return {
+      ...(await getClickHouseProfileInteractionsOrThrow(accountId, year)),
+      available: true,
+    }
+  } catch (error) {
+    devLog('metaTwitter getClickHouseProfileInteractions error', {
+      accountId,
+      year,
+      error,
+    })
+    return { people: [], available: false }
   }
 }

--- a/src/lib/profileRoutes.test.ts
+++ b/src/lib/profileRoutes.test.ts
@@ -1,14 +1,22 @@
 import { NextRequest } from 'next/server'
 import { GET as getBangers } from '@/app/api/profile/[account_id]/bangers/route'
+import { GET as getInteractions } from '@/app/api/profile/[account_id]/interactions/route'
+import { GET as getMedia } from '@/app/api/profile/[account_id]/media/route'
 import { GET as getSidebar } from '@/app/api/profile/[account_id]/sidebar/route'
 import { getProfileBangersPage } from '@/lib/metaTwitter/bangers'
-import { getClickHouseProfileSidebarOrThrow } from '@/lib/metaTwitter/clickhouseSidebar'
+import {
+  getClickHouseProfileInteractionsOrThrow,
+  getClickHouseProfileMediaOrThrow,
+  getClickHouseProfileSidebarOrThrow,
+} from '@/lib/metaTwitter/clickhouseSidebar'
 
 jest.mock('@/lib/metaTwitter/bangers', () => ({
   getProfileBangersPage: jest.fn(),
   PROFILE_BANGERS_PAGE_LIMIT: 10,
 }))
 jest.mock('@/lib/metaTwitter/clickhouseSidebar', () => ({
+  getClickHouseProfileInteractionsOrThrow: jest.fn(),
+  getClickHouseProfileMediaOrThrow: jest.fn(),
   getClickHouseProfileSidebarOrThrow: jest.fn(),
 }))
 
@@ -18,6 +26,14 @@ const getProfileBangersPageMock = getProfileBangersPage as jest.MockedFunction<
 const getClickHouseProfileSidebarOrThrowMock =
   getClickHouseProfileSidebarOrThrow as jest.MockedFunction<
     typeof getClickHouseProfileSidebarOrThrow
+  >
+const getClickHouseProfileMediaOrThrowMock =
+  getClickHouseProfileMediaOrThrow as jest.MockedFunction<
+    typeof getClickHouseProfileMediaOrThrow
+  >
+const getClickHouseProfileInteractionsOrThrowMock =
+  getClickHouseProfileInteractionsOrThrow as jest.MockedFunction<
+    typeof getClickHouseProfileInteractionsOrThrow
   >
 
 beforeEach(() => {
@@ -41,7 +57,9 @@ test('serves a bounded profile banger page', async () => {
   )
 
   expect(response.status).toBe(200)
-  expect(response.headers.get('cache-control')).toContain('s-maxage=300')
+  expect(response.headers.get('cache-control')).toBe(
+    'public, s-maxage=86400, stale-while-revalidate=604800',
+  )
   expect(getProfileBangersPageMock).toHaveBeenCalledWith('42', {
     limit: 2,
     offset: 2,
@@ -92,6 +110,39 @@ test('serves the cached year-scoped profile sidebar', async () => {
   expect(response.status).toBe(200)
   expect(response.headers.get('cache-control')).toContain('s-maxage=86400')
   expect(getClickHouseProfileSidebarOrThrowMock).toHaveBeenCalledWith(
+    '42',
+    2024,
+  )
+})
+
+test('serves independently cached profile media and interactions', async () => {
+  getClickHouseProfileMediaOrThrowMock.mockResolvedValue({
+    media: [],
+    mediaCount: 0,
+  })
+  getClickHouseProfileInteractionsOrThrowMock.mockResolvedValue({ people: [] })
+
+  const [media, interactions] = await Promise.all([
+    getMedia(
+      new NextRequest(
+        'https://community-archive.org/api/profile/42/media?year=2024',
+      ),
+      { params: { account_id: '42' } },
+    ),
+    getInteractions(
+      new NextRequest(
+        'https://community-archive.org/api/profile/42/interactions?year=2024',
+      ),
+      { params: { account_id: '42' } },
+    ),
+  ])
+
+  expect(media.status).toBe(200)
+  expect(interactions.status).toBe(200)
+  expect(media.headers.get('cache-control')).toContain('s-maxage=86400')
+  expect(interactions.headers.get('cache-control')).toContain('s-maxage=86400')
+  expect(getClickHouseProfileMediaOrThrowMock).toHaveBeenCalledWith('42', 2024)
+  expect(getClickHouseProfileInteractionsOrThrowMock).toHaveBeenCalledWith(
     '42',
     2024,
   )


### PR DESCRIPTION
## What changed

- tells the core profile adapter to omit the interaction aggregation it does not consume
- removes sidebar enrichment from the streamed server archive boundary
- loads media and top interactions through separate cacheable API resources with independent loading, failure, retry, and in-flight deduplication state
- caches profile banger pages and homepage top-followed accounts for one day, with seven-day HTTP stale windows on profile resources
- retains the existing combined sidebar path for compatibility

## Root cause and impact

The profile shell now streams from main, but the archive boundary still waited for a combined sidebar response whose media and interaction queries reached 4.82 and 8.95 seconds respectively. The core user request also repeated the interaction aggregation before the shell could resolve for ClickHouse-only accounts.

Media and interactions now settle independently after the archive content renders. A slow image-metadata query cannot block the people list, and a slow interaction query cannot block media or the core profile. Image bytes were never part of the measured gateway duration: tiles continue to use Next Image with a 94 px size hint, and merged PR #659 keeps list avatars on appropriately sized source variants.

## Validation

- focused server/client tests after rebasing: 8 suites / 47 tests passed
- full server/client suite before the conflict-free main rebase: 82 suites / 358 tests passed
- `pnpm type-check`
- focused Prettier check
- `pnpm build` completed successfully

## Dependency and rollout

The production gateway dependency is deployed and healthy at release 5a1cce4fbaf1, and [control-panel PR #70](https://github.com/TheExGenesis/community-archive-control-panel/pull/70) is merged. The new core, media, and interaction contracts all returned HTTP 200 through the public gateway before this frontend merge.

Tracking issue: [control-panel #69](https://github.com/TheExGenesis/community-archive-control-panel/issues/69)

