### PR TITLE
Refine contributor labels

### DIFF
--- a/src/app/about/page.test.tsx
+++ b/src/app/about/page.test.tsx
@@ -12,11 +12,16 @@ describe('AboutPage contributors', () => {
     expect(currentSection).not.toBeNull()
 
     const xiqLink = within(currentSection!).getByRole('link', {
-      name: 'Francisco Carvalho, or Xiq',
+      name: 'Francisco Carvalho (Xiq)',
     })
     expect(xiqLink).toHaveAttribute('href', 'https://x.com/exgenesis')
+    expect(xiqLink).toHaveTextContent('Francisco Carvalho (Xiq)')
+    expect(within(xiqLink).getByText('(Xiq)')).toHaveClass(
+      'text-muted-foreground',
+    )
+    expect(within(currentSection!).getByText('Founder')).toBeInTheDocument()
     expect(
-      within(currentSection!).getByRole('link', { name: 'Christine' }),
+      within(currentSection!).getByRole('link', { name: 'Christine Shiba' }),
     ).toHaveAttribute('href', 'https://x.com/christineist')
 
     const xiqCard = xiqLink.closest('.rounded-lg')
@@ -28,7 +33,7 @@ describe('AboutPage contributors', () => {
     const pastSection = pastHeading.closest('section')
     expect(pastSection).not.toBeNull()
     expect(
-      within(pastSection!).getByRole('link', { name: 'Defender' }),
+      within(pastSection!).getByRole('link', { name: '@DefenderOfBasic' }),
     ).toHaveAttribute('href', 'https://x.com/DefenderOfBasic')
     expect(
       within(pastSection!).getByRole('link', {
@@ -36,7 +41,7 @@ describe('AboutPage contributors', () => {
       }),
     ).toHaveAttribute('href', 'https://x.com/A_Variengien')
     expect(
-      within(pastSection!).queryByText('Christine'),
+      within(pastSection!).queryByText('Christine Shiba'),
     ).not.toBeInTheDocument()
   })
 

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -43,6 +43,12 @@ export default function AboutPage() {
                   className="transition-colors hover:text-brand"
                 >
                   {contributor.name}
+                  {contributor.qualifier ? (
+                    <span className="text-muted-foreground">
+                      {' '}
+                      ({contributor.qualifier})
+                    </span>
+                  ) : null}
                 </a>
               </h3>
               {contributor.role && (

--- a/src/lib/projectContributors.ts
+++ b/src/lib/projectContributors.ts
@@ -2,16 +2,18 @@ export type ProjectContributor = {
   name: string
   username: string
   role?: string
+  qualifier?: string
 }
 
 export const currentProjectContributors: ProjectContributor[] = [
   {
-    name: 'Francisco Carvalho, or Xiq',
+    name: 'Francisco Carvalho',
     username: 'exgenesis',
-    role: 'Creator & Lead',
+    role: 'Founder',
+    qualifier: 'Xiq',
   },
   {
-    name: 'Christine',
+    name: 'Christine Shiba',
     username: 'christineist',
     role: 'Contributor',
   },
@@ -19,7 +21,7 @@ export const currentProjectContributors: ProjectContributor[] = [
 
 export const pastProjectContributors: ProjectContributor[] = [
   { name: '@IaimforGOAT', username: 'IaimforGOAT' },
-  { name: 'Defender', username: 'DefenderOfBasic' },
+  { name: '@DefenderOfBasic', username: 'DefenderOfBasic' },
   { name: 'Alexandre Variengien', username: 'A_Variengien' },
 ]
 


### PR DESCRIPTION
## Summary

- display `Francisco Carvalho` with a muted `(Xiq)` qualifier
- change Francisco's role to `Founder`
- show Christine's full name as `Christine Shiba`
- display Defender by the requested `@DefenderOfBasic` handle

## Why

This follows up on #616 with the final contributor naming and presentation requested from the rendered preview.

## Validation

- `pnpm exec jest --selectProjects client --runInBand src/app/about/page.test.tsx`
- `pnpm type-check`
- focused `next lint` on the changed files
