### PR TITLE
Document Supabase preview seed invariant

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,10 @@ Staging synchronization is automatic; production synchronization is not:
   pushes to `main` that touch `supabase/**` or the sync script.
 - The workflow serializes staging updates and regenerates database types on PR
   branches. Fork PRs are skipped because they cannot access staging secrets.
+- Supabase's managed PR preview may rerun `supabase/seed.sql` against the same
+  preview database after a new commit, including the workflow's generated-types
+  bot commit. Keep seed inserts idempotent and, when schema or seed data changes,
+  verify that the seed loads twice without a database reset.
 - Editing only `supabase/schemas/` is insufficient. Generate and commit the
   migration that the workflow can apply.
 - Before merging a PR with migrations, run the read-only


### PR DESCRIPTION
## What changed

- Document that Supabase's managed PR preview can rerun `supabase/seed.sql`
  against an already-seeded preview database after a new commit, including the
  generated-types bot commit.
- Require idempotent seed inserts and a two-load validation when schema or seed
  data changes.

## Why

The owner-profile schema PR exposed this recurring workflow behavior: its
migration succeeded, then the generated-types commit caused the preview
integration to seed the same branch database again. A non-idempotent seed failed
on existing primary keys even though the schema was valid.

## Impact

Future schema PRs have the invariant in the always-loaded project guidance,
next to the staging synchronization workflow it qualifies. This is
documentation-only and does not change production state.

## Validation

- `git diff --check`
- Prettier check for `AGENTS.md`
