### PR TITLE
Add admin-only social graph full refresh

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,7 @@ ALLOW_STAGING_ADMIN_ON_PROD_SUPABASE=false
 CLICKHOUSE_ANALYTICS_API_URL=https://analytics.community-archive.org/analytics
 CLICKHOUSE_SEARCH_API_URL=https://analytics.community-archive.org
 CLICKHOUSE_ANALYTICS_API_TOKEN=<shared-gateway-token>
+CLICKHOUSE_ANALYTICS_ADMIN_TOKEN=<separate-social-graph-admin-token>
 ENABLE_CLICKHOUSE_READS=false
 NEXT_PUBLIC_ENABLE_CLICKHOUSE_SEARCH=false
 

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -34,6 +34,7 @@ ENABLE_CLICKHOUSE_LAB=true
 CLICKHOUSE_ANALYTICS_API_URL=https://analytics.community-archive.org/analytics
 CLICKHOUSE_SEARCH_API_URL=https://analytics.community-archive.org
 CLICKHOUSE_ANALYTICS_API_TOKEN=<shared-staging-gateway-token>
+CLICKHOUSE_ANALYTICS_ADMIN_TOKEN=<separate-social-graph-admin-token>
 
 # Opt-in application reads. Leave false until the dedicated /search endpoint is deployed.
 ENABLE_CLICKHOUSE_READS=false
@@ -150,6 +151,8 @@ For PR-created Vercel Preview deployments, add the values from `.env.staging.gen
 - `CLICKHOUSE_SEARCH_API_URL` (the standalone mirror-search gateway; falls
   back to `CLICKHOUSE_ANALYTICS_API_URL` only when omitted)
 - `CLICKHOUSE_ANALYTICS_API_TOKEN`
+- `CLICKHOUSE_ANALYTICS_ADMIN_TOKEN` (server-only; required for the admin-only
+  social-graph full refresh control)
 - `ENABLE_CLICKHOUSE_READS=false` (set true when testing homepage/search reads)
 - `NEXT_PUBLIC_ENABLE_CLICKHOUSE_SEARCH=false` (set true in the same build that
   should try ClickHouse text search)

--- a/src/app/social-graph/SocialGraphAdminControls.test.tsx
+++ b/src/app/social-graph/SocialGraphAdminControls.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { requestFullSocialGraphRebuild } from './actions'
+import { SocialGraphAdminControls } from './SocialGraphAdminControls'
+
+jest.mock('./actions', () => ({
+  requestFullSocialGraphRebuild: jest.fn(),
+}))
+
+const requestRebuildMock = jest.mocked(requestFullSocialGraphRebuild)
+
+describe('SocialGraphAdminControls', () => {
+  it('queues a full refresh and reports the background handoff', async () => {
+    requestRebuildMock.mockResolvedValue({
+      ok: true,
+      message: 'Full refresh queued.',
+    })
+    const user = userEvent.setup()
+    render(<SocialGraphAdminControls />)
+
+    await user.click(screen.getByRole('button', { name: 'Run full refresh' }))
+
+    expect(requestRebuildMock).toHaveBeenCalledTimes(1)
+    expect(await screen.findByRole('status')).toHaveTextContent(
+      'Full refresh queued.',
+    )
+  })
+})

--- a/src/app/social-graph/SocialGraphAdminControls.tsx
+++ b/src/app/social-graph/SocialGraphAdminControls.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { RefreshCw } from 'lucide-react'
+import { useState } from 'react'
+import { requestFullSocialGraphRebuild } from './actions'
+
+export function SocialGraphAdminControls() {
+  const [pending, setPending] = useState(false)
+  const [message, setMessage] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const requestRebuild = async () => {
+    setPending(true)
+    setMessage(null)
+    setError(null)
+    try {
+      const result = await requestFullSocialGraphRebuild()
+      if (result.ok) setMessage(result.message)
+      else setError(result.error)
+    } catch {
+      setError('The full refresh could not be queued.')
+    } finally {
+      setPending(false)
+    }
+  }
+
+  return (
+    <div className="flex max-w-sm flex-col items-end gap-1.5">
+      <button
+        type="button"
+        onClick={requestRebuild}
+        disabled={pending}
+        className="inline-flex items-center gap-1.5 rounded-[4px] border border-amber-300 bg-amber-50 px-2.5 py-1.5 text-[11px] font-medium text-amber-950 transition-colors hover:bg-amber-100 disabled:cursor-wait disabled:opacity-60 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100 dark:hover:bg-amber-950/70"
+      >
+        <RefreshCw className={`h-3.5 w-3.5 ${pending ? 'animate-spin' : ''}`} />
+        {pending ? 'Queueing full refresh…' : 'Run full refresh'}
+      </button>
+      {message ? (
+        <p
+          role="status"
+          className="text-right text-[11px] text-emerald-700 dark:text-emerald-300"
+        >
+          {message}
+        </p>
+      ) : null}
+      {error ? (
+        <p
+          role="alert"
+          className="text-right text-[11px] text-red-700 dark:text-red-300"
+        >
+          {error}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/src/app/social-graph/actions.ts
+++ b/src/app/social-graph/actions.ts
@@ -1,0 +1,27 @@
+'use server'
+
+import { requireAdmin } from '@/app/admin/data'
+import { requestSocialGraphFullRebuild } from '@/lib/socialGraphAdmin'
+
+export type SocialGraphRebuildActionResult =
+  | { ok: true; message: string }
+  | { ok: false; error: string }
+
+export async function requestFullSocialGraphRebuild(): Promise<SocialGraphRebuildActionResult> {
+  await requireAdmin()
+  try {
+    await requestSocialGraphFullRebuild()
+    return {
+      ok: true,
+      message:
+        'Full refresh queued. The snapshot timestamp will update after the background build finishes.',
+    }
+  } catch (error) {
+    console.error('[social graph admin] full rebuild request failed:', error)
+    return {
+      ok: false,
+      error:
+        'The full refresh could not be queued. Try again or check the gateway service.',
+    }
+  }
+}

--- a/src/app/social-graph/page.tsx
+++ b/src/app/social-graph/page.tsx
@@ -3,6 +3,8 @@ import { redirect } from 'next/navigation'
 import { getIsMember } from '@/lib/portal/auth'
 import { getSocialGraphSnapshot } from '@/lib/socialGraph'
 import { MUTED, SERIF } from '@/components/portal/styles'
+import { checkIsAdmin } from '@/app/admin/data'
+import { SocialGraphAdminControls } from './SocialGraphAdminControls'
 
 const SocialGraphExplorer = dynamic(() => import('./SocialGraphExplorer'), {
   ssr: false,
@@ -14,7 +16,8 @@ const SocialGraphExplorer = dynamic(() => import('./SocialGraphExplorer'), {
 export const metadata = { title: 'Social graph · Community Archive' }
 
 export default async function SocialGraphPage() {
-  if (!(await getIsMember())) redirect('/login?redirect=/social-graph')
+  const [isMember, isAdmin] = await Promise.all([getIsMember(), checkIsAdmin()])
+  if (!isMember) redirect('/login?redirect=/social-graph')
 
   let snapshot
   try {
@@ -32,6 +35,11 @@ export default async function SocialGraphPage() {
             database query runs from this page, so it will recover when the next
             snapshot is published.
           </p>
+          {isAdmin ? (
+            <div className="mt-4 flex justify-start">
+              <SocialGraphAdminControls />
+            </div>
+          ) : null}
         </div>
       </main>
     )
@@ -51,9 +59,12 @@ export default async function SocialGraphPage() {
               interactions.
             </p>
           </div>
-          <p className={`text-[11px] ${MUTED}`}>
-            Snapshot {new Date(snapshot.generatedAt).toLocaleString()}
-          </p>
+          <div className="flex flex-col items-end gap-2">
+            <p className={`text-[11px] ${MUTED}`}>
+              Snapshot {new Date(snapshot.generatedAt).toLocaleString()}
+            </p>
+            {isAdmin ? <SocialGraphAdminControls /> : null}
+          </div>
         </div>
         <SocialGraphExplorer snapshot={snapshot} />
       </div>

--- a/src/lib/socialGraphAdmin.test.ts
+++ b/src/lib/socialGraphAdmin.test.ts
@@ -1,0 +1,50 @@
+import {
+  requestSocialGraphFullRebuild,
+  socialGraphFullRebuildUrl,
+} from './socialGraphAdmin'
+
+describe('social graph full rebuild request', () => {
+  it('uses the dedicated admin credential on the bounded gateway route', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ accepted: true, status: 'queued' }), {
+        status: 202,
+      }),
+    )
+
+    await expect(
+      requestSocialGraphFullRebuild({
+        fetchImpl: fetchMock,
+        baseUrl: 'https://analytics.example/analytics',
+        gatewayToken: 'gateway-secret',
+        adminToken: 'admin-secret',
+      }),
+    ).resolves.toEqual({ accepted: true, status: 'queued' })
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL('https://analytics.example/analytics/admin/social-graph/rebuild'),
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer gateway-secret',
+          'X-Community-Archive-Admin-Token': 'admin-secret',
+        },
+        cache: 'no-store',
+      }),
+    )
+  })
+
+  it('fails closed without both server-only credentials', async () => {
+    await expect(
+      requestSocialGraphFullRebuild({
+        baseUrl: 'https://analytics.example/analytics',
+        gatewayToken: 'gateway-secret',
+        adminToken: '',
+      }),
+    ).rejects.toThrow('credentials are not configured')
+  })
+
+  it('keeps the rebuild path under the configured analytics base', () => {
+    expect(
+      socialGraphFullRebuildUrl('https://analytics.example/analytics/').href,
+    ).toBe('https://analytics.example/analytics/admin/social-graph/rebuild')
+  })
+})

--- a/src/lib/socialGraphAdmin.ts
+++ b/src/lib/socialGraphAdmin.ts
@@ -1,0 +1,59 @@
+import 'server-only'
+import { clickHouseAnalyticsGatewayBaseUrl } from './clickhouseGateway'
+
+interface FullRebuildOptions {
+  fetchImpl?: typeof fetch
+  baseUrl?: string
+  gatewayToken?: string
+  adminToken?: string
+}
+
+export function socialGraphFullRebuildUrl(
+  baseUrl = clickHouseAnalyticsGatewayBaseUrl(),
+): URL {
+  if (!baseUrl) {
+    throw new Error('CLICKHOUSE_ANALYTICS_API_URL is not configured')
+  }
+  const base = new URL(baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`)
+  return new URL('admin/social-graph/rebuild', base)
+}
+
+export async function requestSocialGraphFullRebuild(
+  options: FullRebuildOptions = {},
+): Promise<{ accepted: true; status: 'queued' }> {
+  const gatewayToken =
+    options.gatewayToken ?? process.env.CLICKHOUSE_ANALYTICS_API_TOKEN
+  const adminToken =
+    options.adminToken ?? process.env.CLICKHOUSE_ANALYTICS_ADMIN_TOKEN
+  if (!gatewayToken || !adminToken) {
+    throw new Error('Social graph rebuild credentials are not configured')
+  }
+  const response = await (options.fetchImpl ?? fetch)(
+    socialGraphFullRebuildUrl(options.baseUrl),
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${gatewayToken}`,
+        'X-Community-Archive-Admin-Token': adminToken,
+      },
+      cache: 'no-store',
+      signal: AbortSignal.timeout(15_000),
+    },
+  )
+  const body = await response.text()
+  if (!response.ok) {
+    throw new Error(
+      `Social graph full rebuild request failed (${response.status})`,
+    )
+  }
+  let result: { accepted?: unknown; status?: unknown }
+  try {
+    result = JSON.parse(body) as { accepted?: unknown; status?: unknown }
+  } catch {
+    throw new Error('Social graph full rebuild returned invalid JSON')
+  }
+  if (result.accepted !== true || result.status !== 'queued') {
+    throw new Error('Social graph full rebuild was not accepted')
+  }
+  return { accepted: true, status: 'queued' }
+}


### PR DESCRIPTION
## What changed

- render a full-refresh control on /social-graph only for the existing immutable admin identity
- re-authorize in a server action before calling the gateway
- keep both the normal gateway token and separate rebuild token server-side
- report queued and error states without blocking the page
- document the new Preview environment variable

## Why

Routine graph builds now use a cached seven-day overlap. A complete historical rebuild should be deliberate and available only to the administrator.

## Validation

- TypeScript check passes
- focused Next lint passes with no warnings
- 3 server helper tests pass
- 1 client interaction test passes
- React best-practices review confirms parallel auth checks and server-side re-authorization

The pre-commit wrapper is not generated in the isolated worktree, and its underlying Supabase type-generation step cannot run without the local Supabase environment. No database types changed; the normal TypeScript, lint, and focused tests pass.