### PR TITLE
Polish profile header actions and contributor badges

### DIFF
--- a/src/app/user/[account_id]/page.tsx
+++ b/src/app/user/[account_id]/page.tsx
@@ -5,6 +5,7 @@ import { ProfileHeader } from '@/components/metaTwitter/ProfileHeader'
 import type { NavChapter } from '@/components/metaTwitter/ArchiveNav'
 import { ProfileArchive } from '@/components/metaTwitter/ProfileArchive'
 import { ProfileArchiveSkeleton } from '@/components/metaTwitter/ProfilePageSkeleton'
+import { ProfileEditingProvider } from '@/components/metaTwitter/ProfileEditingContext'
 import { getClickHouseUserProfile } from '@/lib/clickhouseUserProfile'
 import { userProfileHref } from '@/lib/navigation'
 import {
@@ -86,14 +87,12 @@ async function ProfileArchiveContent({
   basePath,
   candidateYear,
   displayName,
-  isOwner,
 }: {
   accountId: string
   avatarUrl: string | null
   basePath: string
   candidateYear: number | null
   displayName: string
-  isOwner: boolean
 }) {
   const candidatePage = await getCuratedProfileBangersPage(accountId, {
     limit: PROFILE_BANGERS_INITIAL_LIMIT,
@@ -119,7 +118,6 @@ async function ProfileArchiveContent({
       displayName={displayName}
       initialYear={year}
       initialPage={initialPage}
-      isOwner={isOwner}
     />
   )
 }
@@ -173,28 +171,30 @@ export default async function UserPage({ params, searchParams }: PageProps) {
   return (
     <div className="flex justify-center px-4 pb-8 pt-4 sm:px-6">
       <div className="h-fit w-full max-w-[1220px] overflow-hidden rounded-2xl border border-border bg-card shadow-[0_2px_16px_rgba(0,0,0,0.06)]">
-        <ProfileHeader
-          profile={profile}
-          downloadArchiveVisible={settings.downloadArchiveVisible}
-          archivedAt={null}
-          archivedAtSlot={
-            profile.has_archive ? (
-              <Suspense fallback={null}>
-                <ProfileArchivedAt accountId={accountId} />
-              </Suspense>
-            ) : null
-          }
-        />
-        <Suspense fallback={<ProfileArchiveSkeleton />}>
-          <ProfileArchiveContent
-            accountId={accountId}
-            avatarUrl={profile.avatar_media_url}
-            basePath={canonicalProfilePath}
-            candidateYear={candidateYear}
-            displayName={profile.account_display_name}
+        <ProfileEditingProvider>
+          <ProfileHeader
+            profile={profile}
+            downloadArchiveVisible={settings.downloadArchiveVisible}
+            archivedAt={null}
+            archivedAtSlot={
+              profile.has_archive ? (
+                <Suspense fallback={null}>
+                  <ProfileArchivedAt accountId={accountId} />
+                </Suspense>
+              ) : null
+            }
             isOwner={isOwner}
           />
-        </Suspense>
+          <Suspense fallback={<ProfileArchiveSkeleton />}>
+            <ProfileArchiveContent
+              accountId={accountId}
+              avatarUrl={profile.avatar_media_url}
+              basePath={canonicalProfilePath}
+              candidateYear={candidateYear}
+              displayName={profile.account_display_name}
+            />
+          </Suspense>
+        </ProfileEditingProvider>
       </div>
     </div>
   )

--- a/src/components/ProjectContributorBadge.test.tsx
+++ b/src/components/ProjectContributorBadge.test.tsx
@@ -11,18 +11,18 @@ describe('ProjectContributorBadge', () => {
   ])('identifies %s as a project contributor', (username) => {
     render(<ProjectContributorBadge username={username} />)
 
-    expect(screen.getByText('Project contributor')).toBeInTheDocument()
+    expect(screen.getByText('Archive contributor')).toBeInTheDocument()
   })
 
   it('matches contributor usernames case-insensitively', () => {
     render(<ProjectContributorBadge username="@CHRISTINEIST" />)
 
-    expect(screen.getByText('Project contributor')).toBeInTheDocument()
+    expect(screen.getByText('Archive contributor')).toBeInTheDocument()
   })
 
   it('does not badge other archive members', () => {
     render(<ProjectContributorBadge username="archive_member" />)
 
-    expect(screen.queryByText('Project contributor')).not.toBeInTheDocument()
+    expect(screen.queryByText('Archive contributor')).not.toBeInTheDocument()
   })
 })

--- a/src/components/ProjectContributorBadge.tsx
+++ b/src/components/ProjectContributorBadge.tsx
@@ -11,7 +11,7 @@ export function ProjectContributorBadge({ username }: { username: string }) {
       className="gap-1.5 border-brand/40 bg-brand/10 text-brand"
     >
       <Award aria-hidden="true" className="h-3.5 w-3.5" />
-      Project contributor
+      Archive contributor
     </Badge>
   )
 }

--- a/src/components/metaTwitter/ArchiveNav.tsx
+++ b/src/components/metaTwitter/ArchiveNav.tsx
@@ -66,7 +66,7 @@ export function ArchiveNav({
             : 'text-foreground hover:bg-muted'
         }`}
       >
-        Overall — Bangers
+        All time
       </Link>
       {chapters.map((chapter) => {
         const active = activeYear === chapter.year

--- a/src/components/metaTwitter/ProfileArchive.test.tsx
+++ b/src/components/metaTwitter/ProfileArchive.test.tsx
@@ -1,7 +1,10 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactElement } from 'react'
 import userEvent from '@testing-library/user-event'
 import { archiveChapterHref } from './ArchiveNav'
 import { ProfileArchive } from './ProfileArchive'
+import { ProfileEditButton } from './ProfileEditButton'
+import { ProfileEditingProvider } from './ProfileEditingContext'
 import type { BangerTweet } from '@/lib/metaTwitter/types'
 import { mutateProfileCuration } from '@/app/user/[account_id]/actions'
 
@@ -68,6 +71,17 @@ const deferredResponse = () => {
   return { promise, resolve }
 }
 
+const renderProfileArchive = (
+  archive: ReactElement,
+  { withEditButton = false }: { withEditButton?: boolean } = {},
+) =>
+  render(
+    <ProfileEditingProvider>
+      {withEditButton ? <ProfileEditButton /> : null}
+      {archive}
+    </ProfileEditingProvider>,
+  )
+
 class TestIntersectionObserver {
   static callbacks: IntersectionObserverCallback[] = []
   readonly root = null
@@ -126,7 +140,7 @@ test('shows owner-only curation controls and persists section edits', async () =
     return Promise.resolve(jsonResponse({ people: [] }))
   })
 
-  render(
+  renderProfileArchive(
     <ProfileArchive
       accountId="42"
       avatarUrl={null}
@@ -153,10 +167,13 @@ test('shows owner-only curation controls and persists section edits', async () =
           },
         ],
       }}
-      isOwner
     />,
+    { withEditButton: true },
   )
 
+  expect(
+    screen.getByRole('link', { name: 'All time', current: 'page' }),
+  ).toBeVisible()
   await user.click(screen.getByRole('button', { name: 'Edit profile' }))
   expect(screen.getByRole('button', { name: 'Restore Bangers' })).toBeVisible()
   expect(screen.getByRole('button', { name: 'Restore' })).toBeVisible()
@@ -194,12 +211,65 @@ test('shows owner-only curation controls and persists section edits', async () =
   expect(fetchMock).toHaveBeenCalledWith('/api/profile/42/interactions')
 
   await user.click(screen.getByRole('link', { name: '2025 4' }))
-  expect(
-    screen.queryByRole('button', { name: 'Edit profile' }),
-  ).not.toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'Edit profile' })).toBeVisible()
   expect(
     screen.queryByRole('button', { name: /dismiss banger/i }),
   ).not.toBeInTheDocument()
+})
+
+test('returns to all time when edit mode starts from a year chapter', async () => {
+  const user = userEvent.setup()
+  jest.spyOn(global, 'fetch').mockImplementation((input) => {
+    const url = new URL(String(input), 'https://community-archive.org')
+    if (url.pathname.endsWith('/bangers')) {
+      return Promise.resolve(
+        jsonResponse({
+          tweets: [banger(1, 2025)],
+          yearCounts: chapters,
+          total: 1,
+          nextOffset: null,
+          available: true,
+        }),
+      )
+    }
+    if (url.pathname.endsWith('/media')) {
+      return Promise.resolve(jsonResponse({ media: [], mediaCount: 0 }))
+    }
+    return Promise.resolve(jsonResponse({ people: [] }))
+  })
+
+  renderProfileArchive(
+    <ProfileArchive
+      accountId="42"
+      avatarUrl={null}
+      basePath="/user/alice"
+      chapters={chapters}
+      displayName="Alice"
+      initialYear={2025}
+      initialPage={{
+        tweets: [banger(1, 2025)],
+        yearCounts: chapters,
+        total: 1,
+        nextOffset: null,
+        available: true,
+      }}
+      initialSidebar={initialSidebar}
+    />,
+    { withEditButton: true },
+  )
+
+  expect(
+    screen.getByRole('link', { name: '2025 4', current: 'page' }),
+  ).toBeVisible()
+  await user.click(screen.getByRole('button', { name: 'Edit profile' }))
+
+  await waitFor(() =>
+    expect(
+      screen.getByRole('link', { name: 'All time', current: 'page' }),
+    ).toBeVisible(),
+  )
+  expect(window.location.pathname + window.location.search).toBe('/user/alice')
+  expect(screen.getByRole('button', { name: 'Restore Bangers' })).toBeVisible()
 })
 
 test('switches chapters immediately while their small data requests are pending', async () => {
@@ -208,7 +278,7 @@ test('switches chapters immediately while their small data requests are pending'
     .spyOn(global, 'fetch')
     .mockImplementation(() => new Promise(() => {}))
 
-  render(
+  renderProfileArchive(
     <ProfileArchive
       accountId="42"
       avatarUrl={null}
@@ -264,7 +334,7 @@ test('preserves modified-click behavior on chapter links', async () => {
   const fetchMock = jest
     .spyOn(global, 'fetch')
     .mockImplementation(() => new Promise(() => {}))
-  render(
+  renderProfileArchive(
     <ProfileArchive
       accountId="42"
       avatarUrl={null}
@@ -307,7 +377,7 @@ test('restores the selected chapter from browser history', async () => {
   const fetchMock = jest
     .spyOn(global, 'fetch')
     .mockImplementation(() => new Promise(() => {}))
-  render(
+  renderProfileArchive(
     <ProfileArchive
       accountId="42"
       avatarUrl={null}
@@ -369,7 +439,7 @@ test('fills the active feed, preloads shallow chapter pages, and continues at th
     return Promise.resolve({ ok: true, json: async () => page } as Response)
   })
 
-  render(
+  renderProfileArchive(
     <ProfileArchive
       accountId="42"
       avatarUrl={null}
@@ -439,7 +509,7 @@ test('stops automatic infinite-scroll retries after a failed page', async () => 
     )
   })
 
-  render(
+  renderProfileArchive(
     <ProfileArchive
       accountId="42"
       avatarUrl={null}
@@ -495,7 +565,7 @@ test('can retry an unavailable initial banger page from offset zero', async () =
     )
   })
 
-  render(
+  renderProfileArchive(
     <ProfileArchive
       accountId="42"
       avatarUrl={null}
@@ -552,7 +622,7 @@ test('retries failed media without blocking successful interactions', async () =
     )
   })
 
-  render(
+  renderProfileArchive(
     <ProfileArchive
       accountId="42"
       avatarUrl={null}
@@ -608,7 +678,7 @@ test('does not start a stale chapter preload over an in-flight active feed', asy
     )
   })
 
-  render(
+  renderProfileArchive(
     <ProfileArchive
       accountId="42"
       avatarUrl={null}

--- a/src/components/metaTwitter/ProfileArchive.tsx
+++ b/src/components/metaTwitter/ProfileArchive.tsx
@@ -16,6 +16,7 @@ import type {
 } from '@/lib/metaTwitter/types'
 import { mutateProfileCuration } from '@/app/user/[account_id]/actions'
 import type { ProfileCurationSection } from '@/lib/profileCurationState'
+import { useProfileEditing } from './ProfileEditingContext'
 
 interface SidebarData {
   media: ArchiveMediaItem[]
@@ -72,7 +73,6 @@ export function ProfileArchive({
   initialYear,
   initialPage,
   initialSidebar,
-  isOwner = false,
 }: {
   accountId: string
   avatarUrl: string | null
@@ -82,7 +82,6 @@ export function ProfileArchive({
   initialYear: number | null
   initialPage: ProfileBangersPageState
   initialSidebar?: SidebarData
-  isOwner?: boolean
 }) {
   const initialFeedKey = feedKey(initialYear, 'quotes')
   const initialScopeKey = scopeKey(initialYear)
@@ -123,8 +122,7 @@ export function ProfileArchive({
   const [loadingPeople, setLoadingPeople] = useState<Record<string, boolean>>(
     {},
   )
-  const [editing, setEditing] = useState(false)
-  const [editSaving, setEditSaving] = useState(false)
+  const { editing, editSaving, setEditing, setEditSaving } = useProfileEditing()
   const [editError, setEditError] = useState<string | null>(null)
   const feedsRef = useRef(feeds)
   const mediaRef = useRef(mediaByScope)
@@ -440,8 +438,15 @@ export function ProfileArchive({
       setActiveYear(year)
       window.history.pushState(null, '', archiveChapterHref(basePath, year))
     },
-    [activeYear, basePath],
+    [activeYear, basePath, setEditing],
   )
+
+  useEffect(() => {
+    if (!editing || activeYear === null) return
+    setSort('quotes')
+    setActiveYear(null)
+    window.history.pushState(null, '', archiveChapterHref(basePath, null))
+  }, [activeYear, basePath, editing])
 
   const selectSort = useCallback((nextSort: ProfileBangerSort) => {
     setSort(nextSort)
@@ -471,7 +476,7 @@ export function ProfileArchive({
         setEditSaving(false)
       }
     },
-    [],
+    [setEditSaving],
   )
 
   const dismissItem = useCallback(
@@ -751,11 +756,9 @@ export function ProfileArchive({
         onLoadMore={() => void loadMore()}
         loadMoreRef={loadMoreRef}
         returnTo={returnTo}
-        isOwner={isOwner && activeYear === null}
         editing={editing && activeYear === null}
         editSaving={editSaving}
         editError={editError}
-        onEditingChange={setEditing}
         onDismiss={(section, itemId) => void dismissItem(section, itemId)}
         onToggleFeature={(section, itemId) =>
           void toggleFeature(section, itemId)

--- a/src/components/metaTwitter/ProfileEditButton.tsx
+++ b/src/components/metaTwitter/ProfileEditButton.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import { useProfileEditing } from './ProfileEditingContext'
+
+export function ProfileEditButton() {
+  const { editing, editSaving, setEditing } = useProfileEditing()
+
+  return (
+    <button
+      type="button"
+      onClick={() => setEditing((current) => !current)}
+      disabled={editSaving}
+      className="border-brand/35 hover:border-brand/55 rounded-full border bg-brand/5 px-4 py-[7px] text-sm font-semibold text-brand transition-colors hover:bg-brand/10 disabled:opacity-60"
+    >
+      {editing ? 'Done editing' : 'Edit profile'}
+    </button>
+  )
+}

--- a/src/components/metaTwitter/ProfileEditingContext.tsx
+++ b/src/components/metaTwitter/ProfileEditingContext.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import {
+  createContext,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+  useContext,
+  useMemo,
+  useState,
+} from 'react'
+
+interface ProfileEditingState {
+  editing: boolean
+  editSaving: boolean
+  setEditing: Dispatch<SetStateAction<boolean>>
+  setEditSaving: Dispatch<SetStateAction<boolean>>
+}
+
+const ProfileEditingContext = createContext<ProfileEditingState | null>(null)
+
+export function ProfileEditingProvider({ children }: { children: ReactNode }) {
+  const [editing, setEditing] = useState(false)
+  const [editSaving, setEditSaving] = useState(false)
+  const value = useMemo(
+    () => ({ editing, editSaving, setEditing, setEditSaving }),
+    [editing, editSaving],
+  )
+
+  return (
+    <ProfileEditingContext.Provider value={value}>
+      {children}
+    </ProfileEditingContext.Provider>
+  )
+}
+
+export function useProfileEditing() {
+  const context = useContext(ProfileEditingContext)
+  if (!context) {
+    throw new Error(
+      'useProfileEditing must be used within a ProfileEditingProvider',
+    )
+  }
+  return context
+}

--- a/src/components/metaTwitter/ProfileHeader.test.tsx
+++ b/src/components/metaTwitter/ProfileHeader.test.tsx
@@ -1,6 +1,8 @@
 import '@testing-library/jest-dom'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { ProfileHeader } from './ProfileHeader'
+import { ProfileEditingProvider } from './ProfileEditingContext'
 import type { ProfileHeaderData } from '@/lib/metaTwitter/types'
 
 type MockImageProps = React.ComponentProps<'img'> & {
@@ -48,7 +50,8 @@ test('does not label a non-member or offer an archive download', () => {
   )
 
   expect(screen.queryByText('Archive contributor')).not.toBeInTheDocument()
-  expect(screen.queryByText('Community member')).not.toBeInTheDocument()
+  expect(screen.queryByText('Archived tweets')).not.toBeInTheDocument()
+  expect(screen.queryByText('Opted in')).not.toBeInTheDocument()
   expect(
     screen.queryByRole('link', { name: 'Download archive' }),
   ).not.toBeInTheDocument()
@@ -62,7 +65,7 @@ test('does not label a non-member or offer an archive download', () => {
   ).toHaveAttribute('href', '/settings')
 })
 
-test('labels an opted-in non-uploader without offering a download', () => {
+test('labels an opted-in non-uploader without treating them as a contributor', () => {
   render(
     <ProfileHeader
       profile={profile({ has_archive: false, is_opted_in: true })}
@@ -70,7 +73,7 @@ test('labels an opted-in non-uploader without offering a download', () => {
     />,
   )
 
-  expect(screen.getByText('Community member')).toBeVisible()
+  expect(screen.getByText('Opted in')).toBeVisible()
   expect(screen.queryByText('Archive contributor')).not.toBeInTheDocument()
   expect(
     screen.queryByRole('link', { name: 'Download archive' }),
@@ -80,7 +83,7 @@ test('labels an opted-in non-uploader without offering a download', () => {
   ).not.toBeInTheDocument()
 })
 
-test('labels an uploader and exposes the archive download', () => {
+test('labels an uploader without treating them as a contributor', () => {
   render(
     <ProfileHeader
       profile={profile({ has_archive: true, is_opted_in: false })}
@@ -88,7 +91,8 @@ test('labels an uploader and exposes the archive download', () => {
     />,
   )
 
-  expect(screen.getByText('Archive contributor')).toBeVisible()
+  expect(screen.getByText('Archived tweets')).toBeVisible()
+  expect(screen.queryByText('Archive contributor')).not.toBeInTheDocument()
   expect(
     screen.getByRole('link', { name: 'Download archive' }),
   ).toHaveAttribute(
@@ -98,6 +102,46 @@ test('labels an uploader and exposes the archive download', () => {
   expect(
     screen.queryByRole('note', { name: 'Limited profile' }),
   ).not.toBeInTheDocument()
+})
+
+test('gives rostered contributors a distinct blue award badge', () => {
+  render(
+    <ProfileHeader
+      profile={{
+        ...profile({ has_archive: true, is_opted_in: false }),
+        username: 'exgenesis',
+      }}
+      archivedAt={null}
+    />,
+  )
+
+  expect(screen.getByText('Archive contributor')).toHaveClass(
+    'border-brand/40',
+    'bg-brand/10',
+    'text-brand',
+  )
+  expect(screen.getByText('Archived tweets')).toBeVisible()
+})
+
+test('puts the owner edit control immediately before the subtle X link', async () => {
+  const user = userEvent.setup()
+  render(
+    <ProfileEditingProvider>
+      <ProfileHeader
+        profile={profile({ has_archive: true, is_opted_in: false })}
+        archivedAt={null}
+        isOwner
+      />
+    </ProfileEditingProvider>,
+  )
+
+  const editButton = screen.getByRole('button', { name: 'Edit profile' })
+  const xLink = screen.getByRole('link', { name: 'View on X' })
+  expect(editButton.nextElementSibling).toBe(xLink)
+  expect(xLink).toHaveClass('bg-transparent', 'text-muted-foreground')
+
+  await user.click(editButton)
+  expect(screen.getByRole('button', { name: 'Done editing' })).toBeVisible()
 })
 
 test('honors an owner setting that hides the archive download', () => {

--- a/src/components/metaTwitter/ProfileHeader.tsx
+++ b/src/components/metaTwitter/ProfileHeader.tsx
@@ -4,7 +4,9 @@ import type { ReactNode } from 'react'
 import { PiInfo } from 'react-icons/pi'
 import { formatNumber } from '@/lib/formatNumber'
 import type { ProfileHeaderData } from '@/lib/metaTwitter/types'
+import { ProjectContributorBadge } from '@/components/ProjectContributorBadge'
 import { ProfileAvatar } from './ProfileAvatar'
+import { ProfileEditButton } from './ProfileEditButton'
 
 const monthYear = (iso: string) =>
   new Date(iso).toLocaleDateString('en-US', {
@@ -26,11 +28,13 @@ export function ProfileHeader({
   archivedAt,
   archivedAtSlot,
   downloadArchiveVisible = true,
+  isOwner = false,
 }: {
   profile: ProfileHeaderData
   archivedAt: string | null
   archivedAtSlot?: ReactNode
   downloadArchiveVisible?: boolean
+  isOwner?: boolean
 }) {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
   const archiveUrl =
@@ -73,13 +77,14 @@ export function ProfileHeader({
                 Download archive
               </a>
             )}
+            {isOwner ? <ProfileEditButton /> : null}
             <a
               href={`https://x.com/${profile.username}`}
               target="_blank"
               rel="noopener noreferrer"
-              className="rounded-full bg-foreground px-4 py-[7px] text-sm font-semibold text-background hover:opacity-90"
+              className="rounded-full border border-border/70 bg-transparent px-4 py-[7px] text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
             >
-              Follow on X
+              View on X
             </a>
           </div>
         </div>
@@ -88,9 +93,10 @@ export function ProfileHeader({
           <h1 className="text-xl font-extrabold">
             {profile.account_display_name}
           </h1>
+          <ProjectContributorBadge username={profile.username} />
           {(profile.has_archive || profile.is_opted_in) && (
             <span className="rounded-full bg-muted px-2 py-0.5 text-[11px] font-semibold text-muted-foreground">
-              {profile.has_archive ? 'Archive contributor' : 'Community member'}
+              {profile.has_archive ? 'Archived tweets' : 'Opted in'}
             </span>
           )}
         </div>

--- a/src/components/metaTwitter/Workspace.tsx
+++ b/src/components/metaTwitter/Workspace.tsx
@@ -31,8 +31,7 @@ const sharesFeaturedGroup = (
   left: { curation?: { is_featured: boolean } } | undefined,
   right: { curation?: { is_featured: boolean } } | undefined,
 ) =>
-  Boolean(left?.curation?.is_featured) ===
-  Boolean(right?.curation?.is_featured)
+  Boolean(left?.curation?.is_featured) === Boolean(right?.curation?.is_featured)
 
 export function Workspace({
   avatarUrl,
@@ -57,11 +56,9 @@ export function Workspace({
   onLoadMore,
   loadMoreRef,
   returnTo,
-  isOwner = false,
   editing = false,
   editSaving = false,
   editError = null,
-  onEditingChange,
   onDismiss,
   onToggleFeature,
   onMove,
@@ -89,11 +86,9 @@ export function Workspace({
   onLoadMore: () => void
   loadMoreRef: RefObject<HTMLDivElement>
   returnTo: string
-  isOwner?: boolean
   editing?: boolean
   editSaving?: boolean
   editError?: string | null
-  onEditingChange?: (editing: boolean) => void
   onDismiss?: (section: 'bangers' | 'people', itemId: string) => void
   onToggleFeature?: (section: 'bangers' | 'people', itemId: string) => void
   onMove?: (
@@ -141,16 +136,6 @@ export function Workspace({
             >
               <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />
               Restore Bangers
-            </button>
-          )}
-          {isOwner && (
-            <button
-              type="button"
-              onClick={() => onEditingChange?.(!editing)}
-              disabled={editSaving}
-              className="rounded-full border border-border px-3 py-1.5 text-[13px] font-semibold hover:bg-muted disabled:opacity-60"
-            >
-              {editing ? 'Done editing' : 'Edit profile'}
             </button>
           )}
           <label className="flex shrink-0 items-center gap-2 text-[13px] text-muted-foreground">


### PR DESCRIPTION
## Summary

- move the owner-only edit control into the profile header immediately before a subtler **View on X** action
- rename the overall chapter to **All time**
- reserve the blue **Archive contributor** award badge for the canonical current/past contributor roster
- show archive participation separately as **Archived tweets** or **Opted in**

## Validation

- `pnpm type-check`
- targeted ESLint on the edited profile files
- 26 focused client tests across the profile header, archive workspace, and contributor badge

Follow-up polish for #667.
