### PR TITLE
Reuse user status icons on profile headers

### DIFF
--- a/src/app/user-dir/page.tsx
+++ b/src/app/user-dir/page.tsx
@@ -2,15 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
-import {
-  Archive,
-  ArrowDown,
-  ArrowUp,
-  ArrowUpDown,
-  Loader2,
-  Radio,
-  Search,
-} from 'lucide-react'
+import { ArrowDown, ArrowUp, ArrowUpDown, Loader2, Search } from 'lucide-react'
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Button } from '@/components/ui/button'
@@ -23,12 +15,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
+import { MembershipStatusIcon } from '@/components/MembershipStatusIcon'
 import { formatNumber } from '@/lib/formatNumber'
 import {
   fetchUsers,
@@ -329,50 +316,12 @@ export default function UserDirectoryPage() {
                         </time>
                       </TableCell>
                       <TableCell className="pr-4">
-                        <TooltipProvider delayDuration={150}>
-                          <div className="flex justify-end gap-0.5">
-                            {user.has_archive && (
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <span
-                                    role="img"
-                                    tabIndex={0}
-                                    aria-label="Archive"
-                                    className="inline-flex h-7 w-7 items-center justify-center rounded-md text-brand/60 outline-none transition-colors hover:bg-brand/5 hover:text-brand focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 dark:focus-visible:ring-offset-background"
-                                  >
-                                    <Archive
-                                      aria-hidden="true"
-                                      className="h-3.5 w-3.5"
-                                    />
-                                  </span>
-                                </TooltipTrigger>
-                                <TooltipContent side="top">
-                                  Archive
-                                </TooltipContent>
-                              </Tooltip>
-                            )}
-                            {!user.has_archive && user.is_opted_in && (
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <span
-                                    role="img"
-                                    tabIndex={0}
-                                    aria-label="Opted in"
-                                    className="inline-flex h-7 w-7 items-center justify-center rounded-md text-brand/60 outline-none transition-colors hover:bg-brand/5 hover:text-brand focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 dark:focus-visible:ring-offset-background"
-                                  >
-                                    <Radio
-                                      aria-hidden="true"
-                                      className="h-3.5 w-3.5"
-                                    />
-                                  </span>
-                                </TooltipTrigger>
-                                <TooltipContent side="top">
-                                  Opted in
-                                </TooltipContent>
-                              </Tooltip>
-                            )}
-                          </div>
-                        </TooltipProvider>
+                        <div className="flex justify-end gap-0.5">
+                          <MembershipStatusIcon
+                            hasArchive={user.has_archive}
+                            isOptedIn={user.is_opted_in}
+                          />
+                        </div>
                       </TableCell>
                     </TableRow>
                   )

--- a/src/components/MembershipStatusIcon.test.tsx
+++ b/src/components/MembershipStatusIcon.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MembershipStatusIcon } from './MembershipStatusIcon'
+
+test.each([
+  { hasArchive: true, isOptedIn: false, label: 'Archive uploaded' },
+  { hasArchive: false, isOptedIn: true, label: 'Opted in' },
+])('shows the $label icon and tooltip', async (status) => {
+  const user = userEvent.setup()
+  render(<MembershipStatusIcon {...status} />)
+
+  const icon = screen.getByRole('img', { name: status.label })
+  expect(icon).toHaveClass(
+    status.hasArchive ? 'text-[#25AADF]/70' : 'text-brand/60',
+  )
+
+  await user.hover(icon)
+  expect(await screen.findByRole('tooltip')).toHaveTextContent(status.label)
+})
+
+test('renders no status for a non-member', () => {
+  const { container } = render(
+    <MembershipStatusIcon hasArchive={false} isOptedIn={false} />,
+  )
+
+  expect(container).toBeEmptyDOMElement()
+})

--- a/src/components/MembershipStatusIcon.tsx
+++ b/src/components/MembershipStatusIcon.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { Archive, Radio } from 'lucide-react'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+
+export function MembershipStatusIcon({
+  hasArchive,
+  isOptedIn,
+}: {
+  hasArchive: boolean
+  isOptedIn: boolean
+}) {
+  const label = hasArchive ? 'Archive uploaded' : isOptedIn ? 'Opted in' : null
+  const Icon = hasArchive ? Archive : Radio
+  if (!label) return null
+  const colorClassName = hasArchive
+    ? 'text-[#25AADF]/70 hover:bg-[#25AADF]/5 hover:text-[#25AADF] focus-visible:ring-[#25AADF]'
+    : 'text-brand/60 hover:bg-brand/5 hover:text-brand focus-visible:ring-brand'
+
+  return (
+    <TooltipProvider delayDuration={150}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            role="img"
+            tabIndex={0}
+            aria-label={label}
+            className={`inline-flex h-7 w-7 items-center justify-center rounded-md outline-none transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-background ${colorClassName}`}
+          >
+            <Icon aria-hidden="true" className="h-3.5 w-3.5" />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top">{label}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}

--- a/src/components/metaTwitter/ProfileHeader.test.tsx
+++ b/src/components/metaTwitter/ProfileHeader.test.tsx
@@ -50,8 +50,9 @@ test('does not label a non-member or offer an archive download', () => {
   )
 
   expect(screen.queryByText('Archive contributor')).not.toBeInTheDocument()
-  expect(screen.queryByText('Archived tweets')).not.toBeInTheDocument()
-  expect(screen.queryByText('Opted in')).not.toBeInTheDocument()
+  expect(
+    screen.queryByRole('img', { name: /archive|opted in/i }),
+  ).not.toBeInTheDocument()
   expect(
     screen.queryByRole('link', { name: 'Download archive' }),
   ).not.toBeInTheDocument()
@@ -65,7 +66,7 @@ test('does not label a non-member or offer an archive download', () => {
   ).toHaveAttribute('href', '/settings')
 })
 
-test('labels an opted-in non-uploader without treating them as a contributor', () => {
+test('shows the opted-in icon without treating the user as a contributor', () => {
   render(
     <ProfileHeader
       profile={profile({ has_archive: false, is_opted_in: true })}
@@ -73,7 +74,7 @@ test('labels an opted-in non-uploader without treating them as a contributor', (
     />,
   )
 
-  expect(screen.getByText('Opted in')).toBeVisible()
+  expect(screen.getByRole('img', { name: 'Opted in' })).toBeVisible()
   expect(screen.queryByText('Archive contributor')).not.toBeInTheDocument()
   expect(
     screen.queryByRole('link', { name: 'Download archive' }),
@@ -83,7 +84,7 @@ test('labels an opted-in non-uploader without treating them as a contributor', (
   ).not.toBeInTheDocument()
 })
 
-test('labels an uploader without treating them as a contributor', () => {
+test('shows the archive icon without treating the user as a contributor', () => {
   render(
     <ProfileHeader
       profile={profile({ has_archive: true, is_opted_in: false })}
@@ -91,7 +92,7 @@ test('labels an uploader without treating them as a contributor', () => {
     />,
   )
 
-  expect(screen.getByText('Archived tweets')).toBeVisible()
+  expect(screen.getByRole('img', { name: 'Archive uploaded' })).toBeVisible()
   expect(screen.queryByText('Archive contributor')).not.toBeInTheDocument()
   expect(
     screen.getByRole('link', { name: 'Download archive' }),
@@ -120,7 +121,10 @@ test('gives rostered contributors a distinct blue award badge', () => {
     'bg-brand/10',
     'text-brand',
   )
-  expect(screen.getByText('Archived tweets')).toBeVisible()
+  expect(screen.getByRole('img', { name: 'Archive uploaded' })).toBeVisible()
+  expect(screen.getByText('Archive contributor').parentElement).toHaveClass(
+    'ml-2',
+  )
 })
 
 test('puts the owner edit control immediately before the subtle X link', async () => {

--- a/src/components/metaTwitter/ProfileHeader.tsx
+++ b/src/components/metaTwitter/ProfileHeader.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react'
 import { PiInfo } from 'react-icons/pi'
 import { formatNumber } from '@/lib/formatNumber'
 import type { ProfileHeaderData } from '@/lib/metaTwitter/types'
+import { MembershipStatusIcon } from '@/components/MembershipStatusIcon'
 import { ProjectContributorBadge } from '@/components/ProjectContributorBadge'
 import { ProfileAvatar } from './ProfileAvatar'
 import { ProfileEditButton } from './ProfileEditButton'
@@ -89,16 +90,17 @@ export function ProfileHeader({
           </div>
         </div>
 
-        <div className="mt-2.5 flex flex-wrap items-center gap-1.5">
+        <div className="mt-2.5 flex flex-wrap items-center">
           <h1 className="text-xl font-extrabold">
             {profile.account_display_name}
           </h1>
-          <ProjectContributorBadge username={profile.username} />
-          {(profile.has_archive || profile.is_opted_in) && (
-            <span className="rounded-full bg-muted px-2 py-0.5 text-[11px] font-semibold text-muted-foreground">
-              {profile.has_archive ? 'Archived tweets' : 'Opted in'}
-            </span>
-          )}
+          <div className="ml-2 flex flex-wrap items-center gap-1.5">
+            <ProjectContributorBadge username={profile.username} />
+            <MembershipStatusIcon
+              hasArchive={profile.has_archive}
+              isOptedIn={profile.is_opted_in}
+            />
+          </div>
         </div>
         <div className="text-[15px] text-muted-foreground">
           @{profile.username}


### PR DESCRIPTION
## Summary

- reuse the user-directory archive and opt-in icons on profile headers, including their accessible tooltips
- label the archive state **Archive uploaded** and render it in CA blue (`#25AADF`)
- add more space between the display name and its badge/status group

## Validation

- `pnpm type-check`
- targeted ESLint on the edited components
- 29 focused client tests across membership status, profile header, profile archive, workspace, and contributor badge

Follow-up polish for #674.
