### PR TITLE
Preview X Articles from syndication metadata

### DIFF
--- a/src/lib/linkPreviews.test.ts
+++ b/src/lib/linkPreviews.test.ts
@@ -3,9 +3,12 @@ import {
   assertSafeRemoteUrl,
   fetchLinkPreviewMetadata,
   fetchSafeRemoteResource,
+  fetchXArticleSyndicationMetadata,
   isPublicIpAddress,
   isXArticleUrl,
   normalizePreviewUrl,
+  shouldRefreshCachedPreview,
+  xArticleIdFromUrl,
 } from './linkPreviews'
 
 const publicResolver = async () => [{ address: '1.1.1.1', family: 4 }]
@@ -18,6 +21,8 @@ describe('link preview safety and metadata', () => {
     expect(isXArticleUrl('https://x.com/i/article/123')).toBe(true)
     expect(isXArticleUrl('https://twitter.com/alice/article/123')).toBe(true)
     expect(isXArticleUrl('https://x.com/alice/status/123')).toBe(false)
+    expect(xArticleIdFromUrl('https://x.com/i/article/123')).toBe('123')
+    expect(xArticleIdFromUrl('https://x.com/i/article/not-a-number')).toBeNull()
   })
 
   test('rejects literal and resolved private destinations', async () => {
@@ -96,6 +101,77 @@ describe('link preview safety and metadata', () => {
       siteName: 'X',
       isXArticle: true,
     })
+  })
+
+  test('extracts an X Article preview from its parent tweet syndication data', async () => {
+    const fetcher = jest.fn().mockResolvedValue({
+      article: {
+        article_id: '2051411546757324800',
+        title: 'Social traits &amp; wholesome online interactions',
+        preview_text: 'A useful teaser from the article.',
+        cover_media_url: 'https://pbs.twimg.com/media/cover.jpg',
+      },
+    })
+
+    const metadata = await fetchXArticleSyndicationMetadata(
+      'http://x.com/i/article/2051411546757324800',
+      '2054372105223913761',
+      fetcher,
+    )
+
+    expect(fetcher).toHaveBeenCalledWith('2054372105223913761')
+    expect(metadata).toEqual({
+      canonicalUrl: 'https://x.com/i/article/2051411546757324800',
+      title: 'Social traits & wholesome online interactions',
+      description: 'A useful teaser from the article.',
+      imageUrl: 'https://pbs.twimg.com/media/cover.jpg',
+      siteName: 'X',
+      contentType: 'application/json',
+      isXArticle: true,
+    })
+  })
+
+  test('rejects syndication metadata for a different X Article', async () => {
+    await expect(
+      fetchXArticleSyndicationMetadata(
+        'https://x.com/i/article/123',
+        '456',
+        async () => ({
+          article: {
+            article_id: '999',
+            title: 'Wrong article',
+          },
+        }),
+      ),
+    ).resolves.toBeNull()
+  })
+
+  test('refreshes legacy X Article fallbacks once without retrying new fallbacks immediately', () => {
+    const now = Date.parse('2026-08-14T23:00:00.000Z')
+    const url = 'http://x.com/i/article/2051411546757324800'
+
+    expect(
+      shouldRefreshCachedPreview(
+        url,
+        {
+          title: 'X Article',
+          image_url: null,
+          expires_at: '2026-09-13T23:00:00.000Z',
+        },
+        now,
+      ),
+    ).toBe(true)
+    expect(
+      shouldRefreshCachedPreview(
+        url,
+        {
+          title: 'X Article',
+          image_url: null,
+          expires_at: '2026-08-15T05:00:00.000Z',
+        },
+        now,
+      ),
+    ).toBe(false)
   })
 
   test('rejects oversized responses before reading the body', async () => {

--- a/src/lib/linkPreviews.ts
+++ b/src/lib/linkPreviews.ts
@@ -6,6 +6,10 @@ import { BlockList, isIP, type LookupFunction } from 'net'
 import { Agent, fetch as undiciFetch } from 'undici'
 import { createServerServiceRoleClient } from '@/utils/supabase'
 import type { TweetLinkPreview } from './linkPreviewTypes'
+import {
+  fetchSyndicatedTweet,
+  type SyndicatedArticle,
+} from './twitterSyndication'
 
 const MAX_URL_LENGTH = 2048
 const MAX_HTML_BYTES = 512 * 1024
@@ -135,16 +139,21 @@ export const previewUrlHash = (url: string) =>
   createHash('sha256').update(normalizePreviewUrl(url)).digest('hex')
 
 export function isXArticleUrl(rawUrl: string): boolean {
+  return xArticleIdFromUrl(rawUrl) !== null
+}
+
+export function xArticleIdFromUrl(rawUrl: string): string | null {
   try {
     const url = new URL(rawUrl)
     const host = url.hostname.toLowerCase().replace(/^www\./, '')
+    if (host !== 'x.com' && host !== 'twitter.com') return null
     return (
-      (host === 'x.com' || host === 'twitter.com') &&
-      (/^\/i\/article(?:\/|$)/.test(url.pathname) ||
-        /^\/[^/]+\/article\//.test(url.pathname))
+      url.pathname.match(/^\/i\/article\/(\d+)(?:\/|$)/)?.[1] ??
+      url.pathname.match(/^\/[^/]+\/article\/(\d+)(?:\/|$)/)?.[1] ??
+      null
     )
   } catch {
-    return false
+    return null
   }
 }
 
@@ -425,6 +434,46 @@ export async function fetchLinkPreviewMetadata(
   }
 }
 
+type SyndicatedArticleFetcher = (
+  tweetId: string,
+) => Promise<{ article?: SyndicatedArticle } | null>
+
+export async function fetchXArticleSyndicationMetadata(
+  rawUrl: string,
+  tweetId: string,
+  fetcher: SyndicatedArticleFetcher = fetchSyndicatedTweet,
+): Promise<PreviewMetadata | null> {
+  const expectedArticleId = xArticleIdFromUrl(rawUrl)
+  if (!expectedArticleId) return null
+
+  const syndicated = await fetcher(tweetId)
+  const article = syndicated?.article
+  if (!article || article.article_id !== expectedArticleId) return null
+
+  const title = cleanText(article.title, 240)
+  if (!title) return null
+
+  let imageUrl: string | null = null
+  if (article.cover_media_url) {
+    try {
+      imageUrl = normalizePreviewUrl(article.cover_media_url)
+    } catch {
+      imageUrl = null
+    }
+  }
+
+  return {
+    canonicalUrl: `https://x.com/i/article/${expectedArticleId}`,
+    title,
+    description:
+      cleanText(article.preview_text, 500) ?? 'Read the full article on X.',
+    imageUrl,
+    siteName: 'X',
+    contentType: 'application/json',
+    isXArticle: true,
+  }
+}
+
 const fallbackXArticle = (url: string): PreviewMetadata => ({
   canonicalUrl: normalizePreviewUrl(url),
   title: 'X Article',
@@ -451,6 +500,25 @@ function rowToPreview(row: CachedPreviewRow): TweetLinkPreview | null {
   }
 }
 
+export function shouldRefreshCachedPreview(
+  url: string,
+  cached: Pick<CachedPreviewRow, 'expires_at' | 'title' | 'image_url'>,
+  now = Date.now(),
+) {
+  const expiresAt = new Date(cached.expires_at).getTime()
+  if (expiresAt <= now) return true
+
+  // Article fallbacks created before syndication enrichment shipped were
+  // cached for 30 days. Refresh those once immediately; new fallbacks get
+  // the shorter failed-preview TTL and therefore remain bounded.
+  return (
+    isXArticleUrl(url) &&
+    cached.title === 'X Article' &&
+    !cached.image_url &&
+    expiresAt > now + FAILED_TTL_MS
+  )
+}
+
 const previewCandidate = (rawUrl: string) => {
   const normalized = normalizePreviewUrl(rawUrl)
   const url = new URL(normalized)
@@ -467,7 +535,10 @@ const previewCandidate = (rawUrl: string) => {
   return normalized
 }
 
-async function refreshPreview(url: string): Promise<CachedPreviewRow | null> {
+async function refreshPreview(
+  url: string,
+  tweetId?: string,
+): Promise<CachedPreviewRow | null> {
   const supabase = createServerServiceRoleClient()
   const urlHash = previewUrlHash(url)
   const fetchedAt = new Date()
@@ -475,10 +546,14 @@ async function refreshPreview(url: string): Promise<CachedPreviewRow | null> {
   let metadata: PreviewMetadata | null = null
   let expiresAt = new Date(fetchedAt.getTime() + READY_TTL_MS)
   try {
-    metadata = await fetchLinkPreviewMetadata(url)
+    if (tweetId && isXArticleUrl(url)) {
+      metadata = await fetchXArticleSyndicationMetadata(url, tweetId)
+    }
+    metadata ??= await fetchLinkPreviewMetadata(url)
   } catch (error) {
     if (isXArticleUrl(url)) {
       metadata = fallbackXArticle(url)
+      expiresAt = new Date(fetchedAt.getTime() + FAILED_TTL_MS)
     } else if (error instanceof UnsafePreviewUrlError) {
       status = 'unsafe'
       expiresAt = new Date(fetchedAt.getTime() + UNSAFE_TTL_MS)
@@ -536,6 +611,7 @@ export async function getTweetLinkPreviews(tweetIds: string[]) {
 
   const candidatesByTweet = new Map<string, string[]>()
   const allCandidates = new Set<string>()
+  const sourceTweetByCandidate = new Map<string, string>()
   for (const row of urlRows ?? []) {
     try {
       const candidate = previewCandidate(row.expanded_url || row.url)
@@ -548,6 +624,9 @@ export async function getTweetLinkPreviews(tweetIds: string[]) {
         current.push(candidate)
         candidatesByTweet.set(row.tweet_id, current)
         allCandidates.add(candidate)
+        if (!sourceTweetByCandidate.has(candidate)) {
+          sourceTweetByCandidate.set(candidate, row.tweet_id)
+        }
       }
     } catch {
       // Invalid archive URL: retain the ordinary tweet text and omit the card.
@@ -574,11 +653,13 @@ export async function getTweetLinkPreviews(tweetIds: string[]) {
   const refreshCandidates = Array.from(allCandidates)
     .filter((url) => {
       const cached = rowsByUrl.get(url)
-      return !cached || new Date(cached.expires_at).getTime() <= now
+      return !cached || shouldRefreshCachedPreview(url, cached, now)
     })
     .slice(0, MAX_ENRICHMENTS_PER_REQUEST)
   const refreshed = await Promise.allSettled(
-    refreshCandidates.map(refreshPreview),
+    refreshCandidates.map((url) =>
+      refreshPreview(url, sourceTweetByCandidate.get(url)),
+    ),
   )
   refreshed.forEach((entry, index) => {
     if (entry.status === 'fulfilled' && entry.value) {

--- a/src/lib/twitterSyndication.test.ts
+++ b/src/lib/twitterSyndication.test.ts
@@ -1,0 +1,54 @@
+import { fetchSyndicatedTweet } from './twitterSyndication'
+
+describe('Twitter syndication', () => {
+  const originalFetch = global.fetch
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    jest.restoreAllMocks()
+  })
+
+  test('normalizes X Article metadata attached to a syndicated tweet', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          __typename: 'Tweet',
+          id_str: '2054372105223913761',
+          text: 'https://t.co/OIbtLZ7231',
+          created_at: 'Wed May 13 01:24:12 +0000 2026',
+          favorite_count: 152,
+          conversation_count: 18,
+          user: {
+            id_str: '826134955549790208',
+            screen_name: 'christineist',
+            name: 'christine',
+          },
+          article: {
+            rest_id: '2051411546757324800',
+            title: 'Social traits for wholesome online interactions',
+            preview_text: 'A particularly wholesome part of the internet.',
+            cover_media: {
+              media_info: {
+                original_img_url:
+                  'https://pbs.twimg.com/media/HHgY_ltaIAAsDDV.jpg',
+              },
+            },
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    ) as jest.MockedFunction<typeof fetch>
+
+    await expect(
+      fetchSyndicatedTweet('2054372105223913761'),
+    ).resolves.toMatchObject({
+      tweet_id: '2054372105223913761',
+      article: {
+        article_id: '2051411546757324800',
+        title: 'Social traits for wholesome online interactions',
+        preview_text: 'A particularly wholesome part of the internet.',
+        cover_media_url: 'https://pbs.twimg.com/media/HHgY_ltaIAAsDDV.jpg',
+      },
+    })
+  })
+})

--- a/src/lib/twitterSyndication.ts
+++ b/src/lib/twitterSyndication.ts
@@ -6,7 +6,9 @@
  * stale.
  *
  * Hard rules:
- * - Never persist the response to our DB.
+ * - Never persist hydrated tweet content to our DB. The link-preview subsystem may
+ *   separately cache the bounded title, teaser, and cover image that X publishes for
+ *   an Article linked by an archived tweet.
  * - Never include hydrated tweet content in search results, profile listings, or any
  *   other query path. Avatar recovery is render-only and is never persisted.
  * - Caller decides whether to render with a "(from Twitter)" marker.
@@ -19,15 +21,20 @@
 const SYNDICATION_BASE = 'https://cdn.syndication.twimg.com/tweet-result'
 
 const computeToken = (id: string): string =>
-  ((Number(id) / 1e15) * Math.PI)
-    .toString(6 ** 2)
-    .replace(/(0+|\.)/g, '')
+  ((Number(id) / 1e15) * Math.PI).toString(6 ** 2).replace(/(0+|\.)/g, '')
 
 export interface SyndicatedMedia {
   media_url: string
   media_type: string
   width?: number
   height?: number
+}
+
+export interface SyndicatedArticle {
+  article_id: string
+  title: string
+  preview_text?: string
+  cover_media_url?: string
 }
 
 export interface SyndicatedTweet {
@@ -41,6 +48,7 @@ export interface SyndicatedTweet {
   favorite_count: number
   avatar_media_url?: string
   media?: SyndicatedMedia[]
+  article?: SyndicatedArticle
   reply_to_tweet_id: string | null
   reply_to_username: string | null
   reply_to_user_id: string | null
@@ -103,6 +111,28 @@ export async function fetchSyndicatedTweet(
       }))
     : []
 
+  const rawArticle = data.article
+  const article: SyndicatedArticle | undefined =
+    rawArticle &&
+    typeof rawArticle.rest_id === 'string' &&
+    /^\d+$/.test(rawArticle.rest_id) &&
+    typeof rawArticle.title === 'string' &&
+    rawArticle.title.trim()
+      ? {
+          article_id: rawArticle.rest_id,
+          title: rawArticle.title,
+          preview_text:
+            typeof rawArticle.preview_text === 'string'
+              ? rawArticle.preview_text
+              : undefined,
+          cover_media_url:
+            typeof rawArticle.cover_media?.media_info?.original_img_url ===
+            'string'
+              ? rawArticle.cover_media.media_info.original_img_url
+              : undefined,
+        }
+      : undefined
+
   return {
     tweet_id: data.id_str,
     account_id: data.user?.id_str ?? '',
@@ -111,11 +141,14 @@ export async function fetchSyndicatedTweet(
     created_at: data.created_at ?? '',
     full_text: data.text ?? '',
     retweet_count:
-      typeof data.conversation_count === 'number' ? data.conversation_count : null,
+      typeof data.conversation_count === 'number'
+        ? data.conversation_count
+        : null,
     favorite_count:
       typeof data.favorite_count === 'number' ? data.favorite_count : 0,
     avatar_media_url: data.user?.profile_image_url_https,
     media: media.length > 0 ? media : undefined,
+    article,
     reply_to_tweet_id: data.in_reply_to_status_id_str ?? null,
     reply_to_username: data.in_reply_to_screen_name ?? null,
     reply_to_user_id: data.in_reply_to_user_id_str ?? null,
@@ -133,6 +166,8 @@ export async function fetchSyndicatedTweets(
   { limit = 12 }: { limit?: number } = {},
 ): Promise<Map<string, SyndicatedTweet | null>> {
   const unique = Array.from(new Set(ids)).slice(0, limit)
-  const results = await Promise.all(unique.map((id) => fetchSyndicatedTweet(id)))
+  const results = await Promise.all(
+    unique.map((id) => fetchSyndicatedTweet(id)),
+  )
   return new Map(unique.map((id, i) => [id, results[i]]))
 }


### PR DESCRIPTION
## What changed

- normalize X Article title, teaser, and cover image from the parent post's syndication response
- prefer that metadata in the existing cached link-preview pipeline while retaining the generic card as a fallback
- immediately refresh legacy generic Article cards that were cached for 30 days, while bounding failed retry traffic to the existing six-hour failure TTL
- validate that the syndicated Article ID matches the linked Article URL before caching metadata

## Why

X Article pages do not expose usable Open Graph metadata to the current server-side fetch, so Article links fell back to a generic “X Article” card. The public tweet syndication response already includes a bounded `article` object with the missing display metadata, but the existing normalizer discarded it.

## User impact

Archived posts linking to an X Article can show the Article's real title, teaser, and cover image. If syndication is unavailable or changes shape, the current generic card remains available.

## Validation

- `pnpm jest --runInBand --selectProjects server --runTestsByPath src/lib/linkPreviews.test.ts src/lib/twitterSyndication.test.ts src/lib/avatarSyndicationRoute.test.ts src/lib/getTweetPageData.test.ts src/lib/portal/TweetRow.test.tsx` (18 tests passed)
- `pnpm type-check`
- `pnpm lint` (passes with one pre-existing `<img>` warning in `UnifiedTweetList.test.tsx`)
- live read-only probe of tweet `2054372105223913761` confirmed the expected title, teaser, and cover URL; the cover returned `image/jpeg`

## Preview verification

- Vercel deployment and GitHub pull-request workflow passed
- the protected preview profile and link-preview route returned `200`
- the exact Christine card cannot be populated on the PR host because Preview intentionally points writes and service-role reads at isolated staging Supabase, which does not contain production tweet `2054372105223913761` or its `tweet_urls` row; the profile itself is supplied by the separate read-only portal source
- production behavior is covered by the live syndication probe plus the focused normalization, cache-refresh, and shared tweet-renderer tests above
