### PR TITLE
Gate social graph to admins and apply curated defaults

### DIFF
--- a/src/app/admin/data.ts
+++ b/src/app/admin/data.ts
@@ -191,13 +191,15 @@ export async function checkIsAdmin(): Promise<boolean> {
   return isAdminUser(user)
 }
 
-export async function requireAdmin() {
+export async function requireAdmin(
+  loginReturnPath: '/admin' | '/social-graph' = '/admin',
+) {
   // getCurrentUser is request-cached, so the root layout, page, and streamed
   // admin sections share one Supabase Auth round trip.
   const user = await getCurrentUser()
 
   if (!user) {
-    redirect('/login?redirect=/admin')
+    redirect(`/login?redirect=${loginReturnPath}`)
   }
 
   // The staging allowance is now baked into isAdminUser (specific

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -55,9 +55,9 @@ export default async function RootLayout({
 }) {
   const [isAdmin, isMember] = await Promise.all([checkIsAdmin(), getIsMember()])
   const showClickHouseLab = isAdmin && isClickHouseLabEnvironmentEnabled()
-  const primaryNav = getPrimaryNav(isMember)
+  const primaryNav = getPrimaryNav(isMember, isAdmin)
   const utilityNav = getUtilityNav(isMember)
-  const mobileNav = getMobileNav(isMember)
+  const mobileNav = getMobileNav(isMember, isAdmin)
   return (
     <html
       lang="en"

--- a/src/app/social-graph/SocialGraphExplorer.test.tsx
+++ b/src/app/social-graph/SocialGraphExplorer.test.tsx
@@ -1,0 +1,161 @@
+/** @jest-environment jsdom */
+
+import '@testing-library/jest-dom'
+import { render, screen, waitFor } from '@testing-library/react'
+import type { SocialGraphSnapshot } from '@/lib/socialGraph'
+import SocialGraphExplorer from './SocialGraphExplorer'
+
+jest.mock('next-themes', () => ({
+  useTheme: () => ({ resolvedTheme: 'dark' }),
+}))
+
+jest.mock('sigma', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    on: jest.fn(),
+    kill: jest.fn(),
+    setSetting: jest.fn(),
+    refresh: jest.fn(),
+  })),
+}))
+
+const workerInstances: MockWorker[] = []
+
+class MockWorker {
+  addEventListener = jest.fn()
+  postMessage = jest.fn()
+  terminate = jest.fn()
+
+  constructor() {
+    workerInstances.push(this)
+  }
+}
+
+const originalWorker = globalThis.Worker
+
+const snapshot = {
+  version: 2,
+  generatedAt: '2026-08-14T23:15:21.000Z',
+  semantics: {
+    interactions: ['reply', 'quote'],
+    directedStrength: 'directed',
+    mutualStrength: 'mutual',
+    mutualInteractions: 'minimum',
+    clusterPolicy: 'stable',
+    timeWindow: 'yearly',
+  },
+  temporal: { minYear: 2006, maxYear: 2026 },
+  stats: {
+    nodeCount: 3,
+    edgeCount: 1,
+    totalMutualEdgeCount: 1,
+    clusterCount: 1,
+    maxFollowers: 100_000,
+    maxStrength: 3,
+    suggestedMinStrength: 0,
+    edgePayloadTruncated: false,
+  },
+  clusters: [
+    { id: 'stable', label: 'Stable community', color: '#2acf80', nodeCount: 3 },
+  ],
+  nodes: [
+    {
+      id: 'a',
+      accountId: 'a',
+      username: 'alpha',
+      label: 'Alpha',
+      followers: 1_000,
+      cluster: 'stable',
+      x: 0,
+      y: 0,
+      degree: 1,
+      totalInteractions: 3,
+    },
+    {
+      id: 'b',
+      accountId: 'b',
+      username: 'beta',
+      label: 'Beta',
+      followers: 600,
+      cluster: 'stable',
+      x: 1,
+      y: 1,
+      degree: 1,
+      totalInteractions: 3,
+    },
+    {
+      id: 'c',
+      accountId: 'c',
+      username: 'gamma',
+      label: 'Gamma',
+      followers: 100,
+      cluster: 'stable',
+      x: 2,
+      y: 2,
+      degree: 0,
+      totalInteractions: 0,
+    },
+  ],
+  edges: [
+    {
+      source: 'a',
+      target: 'b',
+      strength: 3,
+      mutualInteractions: 3,
+      yearlyInteractions: [[2021, 3, 3, 100, 100]],
+    },
+  ],
+} as SocialGraphSnapshot
+
+describe('SocialGraphExplorer defaults', () => {
+  beforeAll(() => {
+    Object.defineProperty(globalThis, 'Worker', {
+      configurable: true,
+      writable: true,
+      value: MockWorker,
+    })
+  })
+
+  beforeEach(() => {
+    workerInstances.length = 0
+  })
+
+  afterAll(() => {
+    Object.defineProperty(globalThis, 'Worker', {
+      configurable: true,
+      writable: true,
+      value: originalWorker,
+    })
+  })
+
+  it('loads the curated filters and automatically adapts the visible graph', async () => {
+    render(<SocialGraphExplorer snapshot={snapshot} />)
+
+    expect(screen.getByText('517')).toBeInTheDocument()
+    expect(screen.getByText('0.30 per 100')).toBeInTheDocument()
+    expect(screen.getByText('20%')).toBeInTheDocument()
+    expect(
+      screen.getByRole('slider', { name: 'Interaction start year' }),
+    ).toHaveAttribute('aria-valuenow', '2021')
+    expect(
+      screen.getByRole('slider', { name: 'Interaction end year' }),
+    ).toHaveAttribute('aria-valuenow', '2026')
+
+    await waitFor(() => {
+      expect(workerInstances).toHaveLength(1)
+      expect(workerInstances[0].postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nodes: [
+            expect.objectContaining({ id: 'a' }),
+            expect.objectContaining({ id: 'b' }),
+          ],
+          edges: [expect.objectContaining({ source: 'a', target: 'b' })],
+          options: {
+            clustering: 'louvain',
+            layout: 'clustered-force',
+          },
+        }),
+      )
+    })
+  })
+})

--- a/src/app/social-graph/SocialGraphExplorer.tsx
+++ b/src/app/social-graph/SocialGraphExplorer.tsx
@@ -1,6 +1,13 @@
 'use client'
 
-import { useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { UndirectedGraph } from 'graphology'
 import Sigma from 'sigma'
 import type { NodeHoverDrawingFunction } from 'sigma/rendering'
@@ -23,6 +30,7 @@ import type {
 } from '@/lib/socialGraph'
 import {
   filterSocialGraph,
+  followerCountToSlider,
   followerSliderToCount,
 } from '@/lib/socialGraphFilter'
 import type { AdaptiveGraphResult } from '@/lib/socialGraphAdaptive'
@@ -30,7 +38,12 @@ import type {
   SocialGraphWorkerRequest,
   SocialGraphWorkerResponse,
 } from '@/workers/socialGraph.worker'
-import { nodeIdsForLabelCoverage, updateYearRange } from '@/lib/socialGraphView'
+import {
+  getSocialGraphDefaultSettings,
+  nodeIdsForLabelCoverage,
+  SOCIAL_GRAPH_DEFAULTS,
+  updateYearRange,
+} from '@/lib/socialGraphView'
 import { MUTED, SERIF } from '@/components/portal/styles'
 
 interface NodeAttributes {
@@ -51,8 +64,6 @@ interface EdgeAttributes {
   strength: number
 }
 
-const DEFAULT_MAX_VISIBLE_NODES = 650
-const DEFAULT_LABEL_PERCENTAGE = 20
 const NODE_HOVER_DELAY_MS = 1_000
 const STRENGTH_SLIDER_MAX = 3
 const ADAPTIVE_PALETTE = [
@@ -368,27 +379,34 @@ export default function SocialGraphExplorer({
   const hoverCandidateRef = useRef<string | null>(null)
   const { resolvedTheme } = useTheme()
   const isDark = resolvedTheme !== 'light'
+  const defaultSettings = useMemo(
+    () =>
+      getSocialGraphDefaultSettings({
+        minYear: snapshot.temporal.minYear,
+        maxYear: snapshot.temporal.maxYear,
+        maxFollowers: snapshot.stats.maxFollowers,
+        nodeCount: snapshot.stats.nodeCount,
+      }),
+    [snapshot.stats, snapshot.temporal],
+  )
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null)
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null)
   const [selectedCommunityId, setSelectedCommunityId] = useState<string | null>(
     null,
   )
   const [query, setQuery] = useState('')
-  const [labelPercentage, setLabelPercentage] = useState(
-    DEFAULT_LABEL_PERCENTAGE,
+  const [labelPercentage, setLabelPercentage] = useState<number>(
+    defaultSettings.labelPercentage,
   )
-  const [followerSlider, setFollowerSlider] = useState(0)
-  const [startYear, setStartYear] = useState(snapshot.temporal.minYear)
-  const [endYear, setEndYear] = useState(snapshot.temporal.maxYear)
-  const [minimumStrength, setMinimumStrength] = useState(
-    Math.min(
-      STRENGTH_SLIDER_MAX,
-      Math.round(snapshot.stats.suggestedMinStrength / 0.05) * 0.05,
-    ),
+  const [minimumFollowers, setMinimumFollowers] = useState(
+    defaultSettings.minimumFollowers,
   )
-  const [maximumNodes, setMaximumNodes] = useState(
-    Math.min(DEFAULT_MAX_VISIBLE_NODES, snapshot.stats.nodeCount),
+  const [startYear, setStartYear] = useState(defaultSettings.startYear)
+  const [endYear, setEndYear] = useState(defaultSettings.endYear)
+  const [minimumStrength, setMinimumStrength] = useState<number>(
+    defaultSettings.minimumStrength,
   )
+  const [maximumNodes, setMaximumNodes] = useState(defaultSettings.maximumNodes)
   const [adaptiveResult, setAdaptiveResult] =
     useState<AdaptiveGraphResult | null>(null)
   const [adaptiveSignature, setAdaptiveSignature] = useState<string | null>(
@@ -396,19 +414,15 @@ export default function SocialGraphExplorer({
   )
   const [isAdapting, setIsAdapting] = useState(false)
   const [adaptiveError, setAdaptiveError] = useState<string | null>(null)
-  const deferredFollowerSlider = useDeferredValue(followerSlider)
+  const deferredMinimumFollowers = useDeferredValue(minimumFollowers)
   const deferredMinimumStrength = useDeferredValue(minimumStrength)
   const deferredMaximumNodes = useDeferredValue(maximumNodes)
-  const minimumFollowers = followerSliderToCount(
-    followerSlider,
-    snapshot.stats.maxFollowers,
-  )
-  const appliedMinimumFollowers = followerSliderToCount(
-    deferredFollowerSlider,
+  const followerSlider = followerCountToSlider(
+    minimumFollowers,
     snapshot.stats.maxFollowers,
   )
   const isPending =
-    deferredFollowerSlider !== followerSlider ||
+    deferredMinimumFollowers !== minimumFollowers ||
     deferredMinimumStrength !== minimumStrength ||
     deferredMaximumNodes !== maximumNodes
   const clusters = useMemo(() => clusterMap(snapshot.clusters), [snapshot])
@@ -419,7 +433,7 @@ export default function SocialGraphExplorer({
   const filtered = useMemo(
     () =>
       filterSocialGraph(snapshot, {
-        minimumFollowers: appliedMinimumFollowers,
+        minimumFollowers: deferredMinimumFollowers,
         minimumStrength: deferredMinimumStrength,
         maximumNodes: deferredMaximumNodes,
         startYear,
@@ -427,7 +441,7 @@ export default function SocialGraphExplorer({
       }),
     [
       snapshot,
-      appliedMinimumFollowers,
+      deferredMinimumFollowers,
       deferredMinimumStrength,
       deferredMaximumNodes,
       endYear,
@@ -439,7 +453,37 @@ export default function SocialGraphExplorer({
       `${filtered.nodes.map((node) => node.id).join(',')}|${filtered.edges.map((edge) => `${edge.source}:${edge.target}:${edge.strength}`).join(',')}`,
     [filtered.edges, filtered.nodes],
   )
-  const adaptiveRunSignature = `${filteredSignature}|louvain|clustered-force`
+  const adaptiveRunSignature = `${filteredSignature}|${SOCIAL_GRAPH_DEFAULTS.clustering}|${SOCIAL_GRAPH_DEFAULTS.layout}`
+  const adaptiveInputRef = useRef({
+    signature: adaptiveRunSignature,
+    nodes: filtered.nodes,
+    edges: filtered.edges,
+  })
+  adaptiveInputRef.current = {
+    signature: adaptiveRunSignature,
+    nodes: filtered.nodes,
+    edges: filtered.edges,
+  }
+  const requestAdaptiveGraph = useCallback((workerOverride?: Worker) => {
+    const worker = workerOverride ?? workerRef.current
+    const input = adaptiveInputRef.current
+    if (!worker || input.nodes.length < 2) return
+    const id = workerRequestRef.current + 1
+    workerRequestRef.current = id
+    workerSignatureRef.current = input.signature
+    setIsAdapting(true)
+    setAdaptiveError(null)
+    const request: SocialGraphWorkerRequest = {
+      id,
+      nodes: input.nodes,
+      edges: input.edges,
+      options: {
+        clustering: SOCIAL_GRAPH_DEFAULTS.clustering,
+        layout: SOCIAL_GRAPH_DEFAULTS.layout,
+      },
+    }
+    worker.postMessage(request)
+  }, [])
   const adaptiveIsCurrent = adaptiveSignature === adaptiveRunSignature
   const adaptiveLegendClusters = useMemo(() => {
     if (!adaptiveResult) return []
@@ -662,11 +706,12 @@ export default function SocialGraphExplorer({
       setIsAdapting(false)
       setAdaptiveError('Adaptive graph worker failed')
     })
+    requestAdaptiveGraph(worker)
     return () => {
       worker.terminate()
-      workerRef.current = null
+      if (workerRef.current === worker) workerRef.current = null
     }
-  }, [])
+  }, [requestAdaptiveGraph])
 
   useEffect(() => {
     const renderer = rendererRef.current
@@ -795,26 +840,6 @@ export default function SocialGraphExplorer({
     })
   }
 
-  const adaptGraph = () => {
-    const worker = workerRef.current
-    if (!worker) return
-    const id = workerRequestRef.current + 1
-    workerRequestRef.current = id
-    workerSignatureRef.current = adaptiveRunSignature
-    setIsAdapting(true)
-    setAdaptiveError(null)
-    const request: SocialGraphWorkerRequest = {
-      id,
-      nodes: filtered.nodes,
-      edges: filtered.edges,
-      options: {
-        clustering: 'louvain',
-        layout: 'clustered-force',
-      },
-    }
-    worker.postMessage(request)
-  }
-
   return (
     <div className="grid gap-3 lg:grid-cols-[300px_minmax(0,1fr)]">
       <aside className="space-y-4 rounded-[4px] border border-zinc-200 bg-white p-4 dark:border-[#26262a] dark:bg-[#1b1b1e]">
@@ -859,7 +884,11 @@ export default function SocialGraphExplorer({
           min={0}
           max={100}
           step={1}
-          onChange={setFollowerSlider}
+          onChange={(nextSlider) =>
+            setMinimumFollowers(
+              followerSliderToCount(nextSlider, snapshot.stats.maxFollowers),
+            )
+          }
         />
         <DualRangeSlider
           label="Interaction years"
@@ -919,8 +948,8 @@ export default function SocialGraphExplorer({
                   Adaptive structure
                 </h2>
                 <p className={`mt-1 text-[10px] leading-relaxed ${MUTED}`}>
-                  Recluster and lay out only the graph that survives these
-                  filters.
+                  Applied automatically on first load. Rerun after changing
+                  filters to adapt the surviving graph.
                 </p>
               </div>
               <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-[11px]">
@@ -931,7 +960,7 @@ export default function SocialGraphExplorer({
               </dl>
               <button
                 type="button"
-                onClick={adaptGraph}
+                onClick={() => requestAdaptiveGraph()}
                 disabled={isAdapting || filtered.nodes.length < 2}
                 className="flex h-8 w-full items-center justify-center gap-1.5 rounded-[3px] bg-brand px-3 text-[11px] font-semibold text-zinc-950 disabled:cursor-wait disabled:opacity-60"
               >
@@ -1117,8 +1146,9 @@ export default function SocialGraphExplorer({
             all replies + quotes from that account, then multiplied by 100. The
             edge uses the weaker direction. Counts and denominators are
             recomputed for the selected years. The node limit keeps the highest
-            weighted-degree accounts in that active graph. The stable server
-            layout stays fixed until you explicitly run an adaptive layout.
+            weighted-degree accounts in that active graph. The default filters
+            are reclustered and laid out automatically; after filter changes,
+            the current layout stays fixed until you rerun it.
           </p>
         </details>
 

--- a/src/app/social-graph/page.test.tsx
+++ b/src/app/social-graph/page.test.tsx
@@ -1,0 +1,41 @@
+/** @jest-environment jsdom */
+
+import { requireAdmin } from '@/app/admin/data'
+import { getSocialGraphSnapshot } from '@/lib/socialGraph'
+import SocialGraphPage from './page'
+
+jest.mock('next/dynamic', () => ({
+  __esModule: true,
+  default: () => () => null,
+}))
+
+jest.mock('@/app/admin/data', () => ({
+  requireAdmin: jest.fn(),
+}))
+
+jest.mock('@/lib/socialGraph', () => ({
+  getSocialGraphSnapshot: jest.fn(),
+}))
+
+jest.mock('./SocialGraphAdminControls', () => ({
+  SocialGraphAdminControls: () => null,
+}))
+
+const requireAdminMock = jest.mocked(requireAdmin)
+const getSocialGraphSnapshotMock = jest.mocked(getSocialGraphSnapshot)
+
+describe('SocialGraphPage access', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('enforces admin access before loading graph data', async () => {
+    const denial = new Error('not authorized')
+    requireAdminMock.mockRejectedValue(denial)
+
+    await expect(SocialGraphPage()).rejects.toBe(denial)
+
+    expect(requireAdminMock).toHaveBeenCalledWith('/social-graph')
+    expect(getSocialGraphSnapshotMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/social-graph/page.tsx
+++ b/src/app/social-graph/page.tsx
@@ -1,9 +1,7 @@
 import dynamic from 'next/dynamic'
-import { redirect } from 'next/navigation'
-import { getIsMember } from '@/lib/portal/auth'
 import { getSocialGraphSnapshot } from '@/lib/socialGraph'
 import { MUTED, SERIF } from '@/components/portal/styles'
-import { checkIsAdmin } from '@/app/admin/data'
+import { requireAdmin } from '@/app/admin/data'
 import { SocialGraphAdminControls } from './SocialGraphAdminControls'
 
 const SocialGraphExplorer = dynamic(() => import('./SocialGraphExplorer'), {
@@ -16,8 +14,7 @@ const SocialGraphExplorer = dynamic(() => import('./SocialGraphExplorer'), {
 export const metadata = { title: 'Social graph · Community Archive' }
 
 export default async function SocialGraphPage() {
-  const [isMember, isAdmin] = await Promise.all([getIsMember(), checkIsAdmin()])
-  if (!isMember) redirect('/login?redirect=/social-graph')
+  await requireAdmin('/social-graph')
 
   let snapshot
   try {
@@ -35,11 +32,9 @@ export default async function SocialGraphPage() {
             database query runs from this page, so it will recover when the next
             snapshot is published.
           </p>
-          {isAdmin ? (
-            <div className="mt-4 flex justify-start">
-              <SocialGraphAdminControls />
-            </div>
-          ) : null}
+          <div className="mt-4 flex justify-start">
+            <SocialGraphAdminControls />
+          </div>
         </div>
       </main>
     )
@@ -63,7 +58,7 @@ export default async function SocialGraphPage() {
             <p className={`text-[11px] ${MUTED}`}>
               Snapshot {new Date(snapshot.generatedAt).toLocaleString()}
             </p>
-            {isAdmin ? <SocialGraphAdminControls /> : null}
+            <SocialGraphAdminControls />
           </div>
         </div>
         <SocialGraphExplorer snapshot={snapshot} />

--- a/src/components/HeaderNavigation.test.tsx
+++ b/src/components/HeaderNavigation.test.tsx
@@ -1,0 +1,24 @@
+/** @jest-environment jsdom */
+
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import HeaderNavigation from './HeaderNavigation'
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/',
+}))
+
+describe('HeaderNavigation', () => {
+  it('renders muted navigation items with a darker tint', () => {
+    render(
+      <HeaderNavigation
+        items={[{ href: '/social-graph', label: 'Graph', tone: 'muted' }]}
+      />,
+    )
+
+    expect(screen.getByRole('link', { name: 'Graph' })).toHaveClass(
+      'bg-muted/70',
+      'text-muted-foreground',
+    )
+  })
+})

--- a/src/components/HeaderNavigation.tsx
+++ b/src/components/HeaderNavigation.tsx
@@ -27,6 +27,9 @@ export default function HeaderNavigation({ items }: { items: NavItem[] }) {
                   className={cn(
                     navigationMenuTriggerStyle(),
                     'px-2.5 text-xs transition-colors duration-150 hover:bg-accent 2xl:px-4 2xl:text-sm',
+                    item.tone === 'muted'
+                      ? 'bg-muted/70 text-muted-foreground hover:bg-muted hover:text-foreground'
+                      : '',
                     isActive ? 'bg-muted font-semibold' : '',
                   )}
                 >

--- a/src/components/MobileNavigation.tsx
+++ b/src/components/MobileNavigation.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 
 import { isNavItemActive, NavItem } from '@/lib/navigation'
+import { cn } from '@/utils/tailwind'
 
 export default function MobileNavigation({ items }: { items: NavItem[] }) {
   const pathname = usePathname()
@@ -41,9 +42,13 @@ export default function MobileNavigation({ items }: { items: NavItem[] }) {
               <Link
                 href={item.href}
                 aria-current={isActive ? 'page' : undefined}
-                className={`cursor-pointer py-2.5 ${
-                  isActive ? 'bg-muted font-medium' : ''
-                }`}
+                className={cn(
+                  'cursor-pointer py-2.5',
+                  item.tone === 'muted'
+                    ? 'bg-muted/70 text-muted-foreground focus:bg-muted focus:text-foreground'
+                    : '',
+                  isActive ? 'bg-muted font-medium' : '',
+                )}
               >
                 {item.label}
               </Link>

--- a/src/lib/navigation.test.ts
+++ b/src/lib/navigation.test.ts
@@ -23,25 +23,19 @@ describe('user profile navigation', () => {
 })
 
 describe('member navigation', () => {
-  it('uses explicit Users, Live stream, Bangers, and Search destinations', () => {
-    expect(getPrimaryNav(true)).toContainEqual({
-      href: '/user-dir',
-      label: 'Users',
-    })
-    expect(getPrimaryNav(true)).toContainEqual({
-      href: '/stream',
-      label: 'Live stream',
-    })
-    expect(getPrimaryNav(true)).toContainEqual({
-      href: '/bangers?period=all',
-      label: 'Bangers',
-    })
+  it('uses the requested primary order without a redundant Home link', () => {
+    expect(getPrimaryNav(true)).toEqual([
+      { href: '/bangers?period=all', label: 'Bangers' },
+      { href: '/user-dir', label: 'Users' },
+      { href: '/trends', label: 'Trends' },
+      { href: '/stream', label: 'Live stream' },
+      { href: '/research', label: 'Research' },
+    ])
     expect(getMobileNav(true)).toEqual(
       expect.arrayContaining([
         { href: '/user-dir', label: 'Users' },
         { href: '/stream', label: 'Live stream' },
         { href: '/bangers?period=all', label: 'Bangers' },
-        { href: '/digest', label: 'Digest' },
         { href: '/search', label: 'Search' },
       ]),
     )
@@ -67,6 +61,31 @@ describe('member navigation', () => {
       href: '/trends',
       label: 'Trends',
     })
+  })
+
+  it('shows the muted Graph shortcut only to admins', () => {
+    expect(getPrimaryNav(true)).not.toContainEqual(
+      expect.objectContaining({ href: '/social-graph' }),
+    )
+    expect(getMobileNav(true)).not.toContainEqual(
+      expect.objectContaining({ href: '/social-graph' }),
+    )
+
+    const adminGraphItem = {
+      href: '/social-graph',
+      label: 'Graph',
+      tone: 'muted',
+    }
+    expect(getPrimaryNav(true, true)).toEqual([
+      { href: '/bangers?period=all', label: 'Bangers' },
+      { href: '/user-dir', label: 'Users' },
+      { href: '/trends', label: 'Trends' },
+      { href: '/stream', label: 'Live stream' },
+      adminGraphItem,
+      { href: '/research', label: 'Research' },
+    ])
+    expect(getMobileNav(true, true)).toContainEqual(adminGraphItem)
+    expect(getPrimaryNav(false, true)).toContainEqual(adminGraphItem)
   })
 })
 

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -4,6 +4,7 @@ import { isTwitterUsername } from './apiInputValidation'
 export interface NavItem {
   href: string
   label: string
+  tone?: 'muted'
 }
 
 export type TweetOrigin =
@@ -135,16 +136,18 @@ export function getTweetBackLink(searchParams?: {
  * built on it, and how to contribute.
  * Logged in: the portal workspace — the member's daily views of the data.
  */
-export const getPrimaryNav = (isMember: boolean): NavItem[] =>
-  isMember
+export const getPrimaryNav = (isMember: boolean, isAdmin = false): NavItem[] =>
+  isMember || isAdmin
     ? [
-        { href: '/', label: 'Home' },
-        { href: '/user-dir', label: 'Users' },
-        { href: '/stream', label: 'Live stream' },
         { href: BANGERS_ALL_TIME_HREF, label: 'Bangers' },
-        { href: '/digest', label: 'Digest' },
+        { href: '/user-dir', label: 'Users' },
         { href: '/trends', label: 'Trends' },
-        { href: '/social-graph', label: 'Graph' },
+        { href: '/stream', label: 'Live stream' },
+        ...(isAdmin
+          ? ([
+              { href: '/social-graph', label: 'Graph', tone: 'muted' },
+            ] satisfies NavItem[])
+          : []),
         { href: '/research', label: 'Research' },
       ]
     : [
@@ -160,8 +163,8 @@ export const getUtilityNav = (isMember: boolean): NavItem[] =>
   isMember ? [{ href: '/docs', label: 'Docs' }] : []
 
 /** Everything the mobile hamburger shows: primary + utilities + search. */
-export const getMobileNav = (isMember: boolean): NavItem[] => [
-  ...getPrimaryNav(isMember),
+export const getMobileNav = (isMember: boolean, isAdmin = false): NavItem[] => [
+  ...getPrimaryNav(isMember, isAdmin),
   ...getUtilityNav(isMember),
   { href: '/search', label: 'Search' },
 ]

--- a/src/lib/socialGraphView.test.ts
+++ b/src/lib/socialGraphView.test.ts
@@ -1,6 +1,48 @@
-import { nodeIdsForLabelCoverage, updateYearRange } from './socialGraphView'
+import {
+  getSocialGraphDefaultSettings,
+  nodeIdsForLabelCoverage,
+  updateYearRange,
+} from './socialGraphView'
 
 describe('social graph view controls', () => {
+  it('uses the curated graph defaults from the admin view', () => {
+    expect(
+      getSocialGraphDefaultSettings({
+        minYear: 2006,
+        maxYear: 2026,
+        maxFollowers: 1_000_000,
+        nodeCount: 2_000,
+      }),
+    ).toEqual({
+      minimumFollowers: 517,
+      startYear: 2021,
+      endYear: 2026,
+      minimumStrength: 0.3,
+      maximumNodes: 720,
+      labelPercentage: 20,
+      clustering: 'louvain',
+      layout: 'clustered-force',
+    })
+  })
+
+  it('clamps curated defaults to smaller snapshots', () => {
+    expect(
+      getSocialGraphDefaultSettings({
+        minYear: 2024,
+        maxYear: 2025,
+        maxFollowers: 100,
+        nodeCount: 50,
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        minimumFollowers: 100,
+        startYear: 2024,
+        endYear: 2025,
+        maximumNodes: 50,
+      }),
+    )
+  })
+
   it('keeps the two year handles ordered', () => {
     expect(updateYearRange(2020, 2024, 'start', 2026)).toEqual([2024, 2024])
     expect(updateYearRange(2020, 2024, 'end', 2018)).toEqual([2020, 2020])

--- a/src/lib/socialGraphView.ts
+++ b/src/lib/socialGraphView.ts
@@ -1,5 +1,46 @@
 export type YearRangeHandle = 'start' | 'end'
 
+export const SOCIAL_GRAPH_DEFAULTS = {
+  minimumFollowers: 517,
+  startYear: 2021,
+  endYear: 2026,
+  minimumStrength: 0.3,
+  maximumNodes: 720,
+  labelPercentage: 20,
+  clustering: 'louvain',
+  layout: 'clustered-force',
+} as const
+
+export function getSocialGraphDefaultSettings(bounds: {
+  minYear: number
+  maxYear: number
+  maxFollowers: number
+  nodeCount: number
+}) {
+  const startYear = Math.max(
+    bounds.minYear,
+    Math.min(bounds.maxYear, SOCIAL_GRAPH_DEFAULTS.startYear),
+  )
+  const endYear = Math.max(
+    startYear,
+    Math.min(bounds.maxYear, SOCIAL_GRAPH_DEFAULTS.endYear),
+  )
+
+  return {
+    ...SOCIAL_GRAPH_DEFAULTS,
+    minimumFollowers: Math.min(
+      SOCIAL_GRAPH_DEFAULTS.minimumFollowers,
+      Math.max(0, bounds.maxFollowers),
+    ),
+    startYear,
+    endYear,
+    maximumNodes: Math.min(
+      SOCIAL_GRAPH_DEFAULTS.maximumNodes,
+      Math.max(0, bounds.nodeCount),
+    ),
+  }
+}
+
 export function updateYearRange(
   startYear: number,
   endYear: number,


### PR DESCRIPTION
## Summary

- restrict `/social-graph` to the existing server-side admin gate
- hide Graph from regular-member desktop and mobile navigation
- reorder the member navigation to Bangers, Users, Trends, Live stream, Graph (admin only), Research
- remove the redundant Home and Digest entries from the signed-in primary navigation
- render the admin-only Graph link with a subdued darker tint
- make 517 followers, 2021–2026, 0.30 strength, 720 nodes, and 20% labels the curated Graph defaults
- automatically apply Louvain clustering and the community force-directed layout on first load

## Why

The social graph is temporarily an admin-only surface. Its navigation entry and direct route access should follow the same audience rule, while the signed-in navigation should prioritize the current product order and rely on the logo for Home. The curated admin view should also open directly into the useful filtered, clustered layout instead of requiring manual setup and an initial button click.

## User impact

Regular members no longer see or directly access Graph. Anonymous visitors who open the route are sent through sign-in, while signed-in non-admins receive the existing not-found response used by private admin surfaces. Admins retain a visually muted Graph shortcut in the requested position. When Graph loads, the curated filters are preselected and its worker immediately reclusters and lays out the surviving graph; the existing manual rerun remains available after filter changes. Defaults clamp safely for smaller or narrower snapshots.

## Validation

- focused Jest suites: 6 passed, 19 tests
- `pnpm type-check`
- `pnpm lint` (passes with one pre-existing `<img>` warning in `UnifiedTweetList.test.tsx`)
- `git diff --check`

The repository pre-commit hook was also attempted, but its generated-type step requires a running local Supabase instance and `SUPABASE_AUTH_TWITTER_CLIENT_ID`, which are not available in this isolated worktree. Remote preview/build checks are left to the draft PR.
