### PR TITLE
Add user profile link previews

### DIFF
--- a/src/app/user/[account_id]/opengraph-image.tsx
+++ b/src/app/user/[account_id]/opengraph-image.tsx
@@ -1,0 +1,322 @@
+import { ImageResponse } from 'next/og'
+import { notFound } from 'next/navigation'
+import { getHighResolutionAvatarUrl } from '@/lib/avatar'
+import { formatNumber } from '@/lib/formatNumber'
+import {
+  getProfilePreviewStats,
+  resolveProfile,
+  type ProfilePreviewStats,
+} from '@/lib/metaTwitter/profile'
+import type { ProfileHeaderData } from '@/lib/metaTwitter/types'
+
+export const alt = 'Community Archive user profile'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+export const revalidate = 3600
+
+const colors = {
+  brand: '#25aadf',
+  card: '#ffffff',
+  foreground: '#111113',
+  muted: '#777780',
+  border: '#e1e1e5',
+}
+
+const truncate = (value: string, maximum: number) =>
+  value.length > maximum ? `${value.slice(0, maximum - 1).trimEnd()}…` : value
+
+const safeTwitterImageUrl = (value: string | null | undefined) => {
+  if (!value) return null
+  try {
+    const url = new URL(value)
+    return url.protocol === 'https:' && url.hostname === 'pbs.twimg.com'
+      ? url.toString()
+      : null
+  } catch {
+    return null
+  }
+}
+
+const headerImageUrl = (value: string | null) => {
+  const safeUrl = safeTwitterImageUrl(value)
+  if (!safeUrl) return null
+  const url = new URL(safeUrl)
+  url.pathname = `${url.pathname.replace(/\/$/, '')}/1500x500`
+  url.search = ''
+  url.hash = ''
+  return url.toString()
+}
+
+const avatarImageUrl = (value: string | null) =>
+  safeTwitterImageUrl(getHighResolutionAvatarUrl(value))
+
+function ArchiveMark() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="72"
+      height="72"
+      viewBox="0 0 72 72"
+      fill="none"
+    >
+      <path
+        d="M13 24h46l-4 39H17l-4-39Z"
+        fill="white"
+        stroke="white"
+        strokeWidth="3"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M18 23c1-8 7-13 18-13s17 5 18 13"
+        stroke="white"
+        strokeWidth="5"
+        strokeLinecap="round"
+      />
+      <circle cx="23" cy="12" r="4" fill="white" />
+      <circle cx="36" cy="8" r="4" fill="white" />
+      <circle cx="49" cy="12" r="4" fill="white" />
+      <path d="M24 38h24v5H24zM28 48h16v5H28z" fill={colors.brand} />
+    </svg>
+  )
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={{ alignItems: 'baseline', display: 'flex' }}>
+      <span style={{ fontSize: 26, fontWeight: 800 }}>{value}</span>
+      <span style={{ color: colors.muted, fontSize: 26, marginLeft: 7 }}>
+        {label}
+      </span>
+    </div>
+  )
+}
+
+function ProfilePreview({
+  profile,
+  stats,
+}: {
+  profile: ProfileHeaderData
+  stats: ProfilePreviewStats | null
+}) {
+  const headerUrl = headerImageUrl(profile.header_media_url)
+  const avatarUrl = avatarImageUrl(profile.avatar_media_url)
+  const bio = profile.bio?.replace(/\s+/g, ' ').trim() ?? ''
+
+  return (
+    <div
+      style={{
+        background: '#f4f4f5',
+        display: 'flex',
+        height: '100%',
+        width: '100%',
+      }}
+    >
+      <div
+        style={{
+          background: colors.card,
+          border: `1px solid ${colors.border}`,
+          borderRadius: 32,
+          color: colors.foreground,
+          display: 'flex',
+          flexDirection: 'column',
+          fontFamily: 'sans-serif',
+          height: '100%',
+          overflow: 'hidden',
+          position: 'relative',
+          width: '100%',
+        }}
+      >
+        <div
+          style={{
+            alignItems: 'center',
+            background: colors.brand,
+            color: '#ffffff',
+            display: 'flex',
+            flexShrink: 0,
+            height: 120,
+            padding: '0 48px',
+            width: '100%',
+          }}
+        >
+          <ArchiveMark />
+          <span
+            style={{
+              fontFamily: 'serif',
+              fontSize: 48,
+              fontWeight: 700,
+              letterSpacing: '-0.01em',
+              marginLeft: 24,
+            }}
+          >
+            Community Archive
+          </span>
+          <span
+            style={{
+              fontSize: 24,
+              fontWeight: 600,
+              marginLeft: 'auto',
+              opacity: 0.9,
+            }}
+          >
+            community-archive.org
+          </span>
+        </div>
+
+        <div
+          style={{
+            background:
+              'linear-gradient(135deg, #d9f1fa 0%, #9fdcf0 52%, #60c4e8 100%)',
+            display: 'flex',
+            flexShrink: 0,
+            height: 190,
+            overflow: 'hidden',
+            width: '100%',
+          }}
+        >
+          {headerUrl ? (
+            // ImageResponse renders remote assets directly; next/image is not
+            // available inside the generated image renderer.
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              alt=""
+              src={headerUrl}
+              style={{ height: '100%', objectFit: 'cover', width: '100%' }}
+            />
+          ) : null}
+        </div>
+
+        <div
+          style={{
+            alignItems: 'center',
+            background: colors.card,
+            border: `8px solid ${colors.card}`,
+            borderRadius: 999,
+            display: 'flex',
+            height: 196,
+            justifyContent: 'center',
+            left: 64,
+            overflow: 'hidden',
+            position: 'absolute',
+            top: 212,
+            width: 196,
+          }}
+        >
+          {avatarUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              alt=""
+              src={avatarUrl}
+              style={{ height: '100%', objectFit: 'cover', width: '100%' }}
+            />
+          ) : (
+            <span
+              style={{
+                alignItems: 'center',
+                background: '#e8e8eb',
+                display: 'flex',
+                fontFamily: 'serif',
+                fontSize: 72,
+                fontWeight: 800,
+                height: '100%',
+                justifyContent: 'center',
+                width: '100%',
+              }}
+            >
+              {profile.account_display_name.charAt(0).toUpperCase()}
+            </span>
+          )}
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            flex: 1,
+            flexDirection: 'column',
+            justifyContent: 'flex-end',
+            padding: '28px 64px 44px',
+          }}
+        >
+          <div style={{ alignItems: 'baseline', display: 'flex' }}>
+            <span
+              style={{
+                fontFamily: 'serif',
+                fontSize: 52,
+                fontWeight: 700,
+                lineHeight: 1,
+                maxWidth: 680,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {truncate(profile.account_display_name, 42)}
+            </span>
+            <span
+              style={{
+                color: colors.muted,
+                fontSize: 28,
+                marginLeft: 16,
+              }}
+            >
+              @{truncate(profile.username, 30)}
+            </span>
+          </div>
+
+          <div
+            style={{
+              fontSize: 25,
+              lineHeight: 1.4,
+              marginTop: 18,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              width: '100%',
+            }}
+          >
+            {bio ? truncate(bio, 145) : 'A profile in the Community Archive'}
+          </div>
+
+          <div
+            style={{
+              alignItems: 'center',
+              display: 'flex',
+              marginTop: 18,
+            }}
+          >
+            <Metric
+              value={stats ? formatNumber(stats.bangers) : '—'}
+              label="Bangers"
+            />
+            <div style={{ display: 'flex', marginLeft: 40 }}>
+              <Metric
+                value={stats ? formatNumber(stats.archivedQuotes) : '—'}
+                label="Archived quotes"
+              />
+            </div>
+            <div style={{ display: 'flex', marginLeft: 40 }}>
+              <Metric
+                value={stats ? formatNumber(stats.yearsArchived) : '—'}
+                label="Years archived"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default async function Image({
+  params,
+}: {
+  params: { account_id: string }
+}) {
+  const resolved = await resolveProfile(params.account_id)
+  if (!resolved) notFound()
+  const stats = await getProfilePreviewStats(resolved.accountId)
+
+  return new ImageResponse(
+    <ProfilePreview profile={resolved.profile} stats={stats} />,
+    size,
+  )
+}

--- a/src/app/user/[account_id]/page.tsx
+++ b/src/app/user/[account_id]/page.tsx
@@ -1,4 +1,4 @@
-import { cache, Suspense } from 'react'
+import { Suspense } from 'react'
 import type { Metadata } from 'next'
 import { notFound, redirect } from 'next/navigation'
 import { ProfileHeader } from '@/components/metaTwitter/ProfileHeader'
@@ -6,7 +6,6 @@ import type { NavChapter } from '@/components/metaTwitter/ArchiveNav'
 import { ProfileArchive } from '@/components/metaTwitter/ProfileArchive'
 import { ProfileArchiveSkeleton } from '@/components/metaTwitter/ProfilePageSkeleton'
 import { ProfileEditingProvider } from '@/components/metaTwitter/ProfileEditingContext'
-import { getClickHouseUserProfile } from '@/lib/clickhouseUserProfile'
 import { userProfileHref } from '@/lib/navigation'
 import {
   getCuratedProfileBangersPage,
@@ -17,67 +16,43 @@ import {
   PROFILE_BANGERS_INITIAL_LIMIT,
   resolveProfileChapterYear,
 } from '@/lib/metaTwitter/profilePagination'
-import {
-  getCachedArchivedAt,
-  getCachedProfileHeader,
-  resolveAccountId,
-} from '@/lib/metaTwitter/data'
-import type { ProfileHeaderData } from '@/lib/metaTwitter/types'
+import { getCachedArchivedAt } from '@/lib/metaTwitter/data'
+import { resolveProfile } from '@/lib/metaTwitter/profile'
 
 interface PageProps {
   params: { account_id: string }
   searchParams: { chapter?: string; username?: string }
 }
 
-interface ResolvedProfile {
-  accountId: string
-  profile: ProfileHeaderData
-}
-
-const resolveProfile = cache(
-  async (param: string): Promise<ResolvedProfile | null> => {
-    const archiveAccountId = await resolveAccountId(param)
-    if (archiveAccountId) {
-      const profile = await getCachedProfileHeader(archiveAccountId)
-      if (profile) return { accountId: archiveAccountId, profile }
-    }
-
-    const clickHouseProfile = await getClickHouseUserProfile(param)
-    const accountId = clickHouseProfile?.user.account_id
-    if (!clickHouseProfile || !accountId) return null
-    const user = clickHouseProfile.user
-    return {
-      accountId,
-      profile: {
-        account_id: accountId,
-        username: user.username,
-        account_display_name: user.account_display_name,
-        created_at: user.created_at,
-        num_tweets: user.num_tweets,
-        num_followers: user.num_followers,
-        num_following: user.num_following,
-        num_likes: user.num_likes,
-        has_archive: user.has_archive,
-        is_opted_in: user.is_opted_in,
-        bio: user.bio,
-        website: user.website,
-        location: user.location,
-        avatar_media_url: user.avatar_media_url,
-        header_media_url: user.header_media_url ?? null,
-      },
-    }
-  },
-)
-
 export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
   const resolved = await resolveProfile(params.account_id)
   if (!resolved) return { title: 'User not found' }
-  const { profile } = resolved
+  const { accountId, profile } = resolved
+  const title = `${profile.account_display_name} (@${profile.username}) — Community Archive`
+  const normalizedBio = profile.bio?.replace(/\s+/g, ' ').trim()
+  const description = normalizedBio
+    ? normalizedBio.length > 200
+      ? `${normalizedBio.slice(0, 199).trimEnd()}…`
+      : normalizedBio
+    : `Explore @${profile.username}'s archived posts on Community Archive.`
+  const canonicalPath = userProfileHref(profile.username, accountId)
   return {
-    title: `${profile.account_display_name} (@${profile.username}) — Community Archive`,
-    description: profile.bio ?? undefined,
+    title,
+    description,
+    alternates: { canonical: canonicalPath },
+    openGraph: {
+      type: 'website',
+      url: canonicalPath,
+      title,
+      description,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+    },
   }
 }
 

--- a/src/lib/metaTwitter/profile.test.ts
+++ b/src/lib/metaTwitter/profile.test.ts
@@ -1,0 +1,123 @@
+const resolveAccountIdMock = jest.fn()
+const getCachedProfileHeaderMock = jest.fn()
+const getClickHouseUserProfileMock = jest.fn()
+const getProfileBangersMock = jest.fn()
+
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  cache: (callback: unknown) => callback,
+}))
+
+jest.mock('@/lib/metaTwitter/data', () => ({
+  resolveAccountId: (...args: unknown[]) => resolveAccountIdMock(...args),
+  getCachedProfileHeader: (...args: unknown[]) =>
+    getCachedProfileHeaderMock(...args),
+}))
+
+jest.mock('@/lib/clickhouseUserProfile', () => ({
+  getClickHouseUserProfile: (...args: unknown[]) =>
+    getClickHouseUserProfileMock(...args),
+}))
+
+jest.mock('@/lib/metaTwitter/bangers', () => ({
+  getProfileBangers: (...args: unknown[]) => getProfileBangersMock(...args),
+}))
+
+import { getProfilePreviewStats, resolveProfile } from './profile'
+
+const archivedProfile = {
+  account_id: '42',
+  username: 'alice',
+  account_display_name: 'Alice',
+  created_at: null,
+  num_tweets: 10,
+  num_followers: 20,
+  num_following: 30,
+  num_likes: 40,
+  has_archive: true,
+  is_opted_in: false,
+  bio: 'Archived profile',
+  website: null,
+  location: null,
+  avatar_media_url: null,
+  header_media_url: null,
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('prefers the authoritative archived profile', async () => {
+  resolveAccountIdMock.mockResolvedValue('42')
+  getCachedProfileHeaderMock.mockResolvedValue(archivedProfile)
+
+  await expect(resolveProfile('alice')).resolves.toEqual({
+    accountId: '42',
+    profile: archivedProfile,
+  })
+  expect(getClickHouseUserProfileMock).not.toHaveBeenCalled()
+})
+
+test('maps the analytical fallback to the shared profile shape', async () => {
+  resolveAccountIdMock.mockResolvedValue(null)
+  getClickHouseUserProfileMock.mockResolvedValue({
+    user: {
+      ...archivedProfile,
+      account_id: '77',
+      username: 'bob',
+      account_display_name: 'Bob',
+      has_archive: false,
+      is_opted_in: false,
+      bio: 'Analytical profile',
+      header_media_url: undefined,
+    },
+    topTweets: [],
+  })
+
+  await expect(resolveProfile('bob')).resolves.toMatchObject({
+    accountId: '77',
+    profile: {
+      account_id: '77',
+      username: 'bob',
+      account_display_name: 'Bob',
+      bio: 'Analytical profile',
+      header_media_url: null,
+    },
+  })
+})
+
+test('returns null when neither profile source can resolve the user', async () => {
+  resolveAccountIdMock.mockResolvedValue(null)
+  getClickHouseUserProfileMock.mockResolvedValue(null)
+
+  await expect(resolveProfile('missing')).resolves.toBeNull()
+})
+
+test('summarizes the profile collection for the preview card', async () => {
+  getProfileBangersMock.mockResolvedValue({
+    available: true,
+    total: 3,
+    yearCounts: [
+      { year: 2024, count: 2 },
+      { year: 2023, count: 1 },
+    ],
+    tweets: [{ quote_count: 5 }, { quote_count: 8 }, { quote_count: 2 }],
+  })
+
+  await expect(getProfilePreviewStats('42')).resolves.toEqual({
+    archivedQuotes: 15,
+    bangers: 3,
+    yearsArchived: 2,
+  })
+})
+
+test('omits preview stats when the analytical collection is unavailable', async () => {
+  getProfileBangersMock.mockResolvedValue({
+    available: false,
+    total: 0,
+    yearCounts: [],
+    tweets: [],
+  })
+
+  await expect(getProfilePreviewStats('42')).resolves.toBeNull()
+})

--- a/src/lib/metaTwitter/profile.ts
+++ b/src/lib/metaTwitter/profile.ts
@@ -1,0 +1,76 @@
+import 'server-only'
+
+import { cache } from 'react'
+import { getClickHouseUserProfile } from '@/lib/clickhouseUserProfile'
+import { getProfileBangers } from '@/lib/metaTwitter/bangers'
+import {
+  getCachedProfileHeader,
+  resolveAccountId,
+} from '@/lib/metaTwitter/data'
+import type { ProfileHeaderData } from '@/lib/metaTwitter/types'
+
+export interface ResolvedProfile {
+  accountId: string
+  profile: ProfileHeaderData
+}
+
+export interface ProfilePreviewStats {
+  archivedQuotes: number
+  bangers: number
+  yearsArchived: number
+}
+
+/**
+ * Resolves either a stable account ID or a username to the shared profile
+ * payload used by the page, its metadata, and its social preview image.
+ */
+export const resolveProfile = cache(
+  async (param: string): Promise<ResolvedProfile | null> => {
+    const archiveAccountId = await resolveAccountId(param)
+    if (archiveAccountId) {
+      const profile = await getCachedProfileHeader(archiveAccountId)
+      if (profile) return { accountId: archiveAccountId, profile }
+    }
+
+    const clickHouseProfile = await getClickHouseUserProfile(param)
+    const accountId = clickHouseProfile?.user.account_id
+    if (!clickHouseProfile || !accountId) return null
+    const user = clickHouseProfile.user
+    return {
+      accountId,
+      profile: {
+        account_id: accountId,
+        username: user.username,
+        account_display_name: user.account_display_name,
+        created_at: user.created_at,
+        num_tweets: user.num_tweets,
+        num_followers: user.num_followers,
+        num_following: user.num_following,
+        num_likes: user.num_likes,
+        has_archive: user.has_archive,
+        is_opted_in: user.is_opted_in,
+        bio: user.bio,
+        website: user.website,
+        location: user.location,
+        avatar_media_url: user.avatar_media_url,
+        header_media_url: user.header_media_url ?? null,
+      },
+    }
+  },
+)
+
+export const getProfilePreviewStats = cache(
+  async (accountId: string): Promise<ProfilePreviewStats | null> => {
+    const collection = await getProfileBangers(accountId)
+    if (!collection.available) return null
+
+    return {
+      archivedQuotes: collection.tweets.reduce(
+        (total, tweet) => total + tweet.quote_count,
+        0,
+      ),
+      bangers: collection.total,
+      yearsArchived: collection.yearCounts.length,
+    }
+  },
+)


### PR DESCRIPTION
## Summary

- add a dynamic 1200×630 Open Graph image for every user profile
- match the supplied Community Archive card design with the branded masthead, banner/avatar overlap, profile copy, and archive stats
- add canonical, Open Graph, and Twitter card metadata so messaging apps can discover the preview
- share profile resolution between the page, metadata, and image route

## Validation

- `pnpm type-check`
- focused Next.js lint on the changed files
- focused Jest profile resolver/stat tests (5 passing)
- production Next.js build
- fetched profile metadata as Twitterbot and verified the generated PNG is 1200×630
- visually inspected the rendered Christine profile card

The production build retains the repository pre-existing dynamic-route build notices and UnifiedTweetList test-image lint warning.