### PR TITLE
Fix live stream freshness and hide trend panels

### DIFF
--- a/src/app/api/portal/stream/route.ts
+++ b/src/app/api/portal/stream/route.ts
@@ -63,6 +63,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json(
         {
           tweets,
+          backlogTruncated: tweets.length === 100,
           updateCursor: edge
             ? { observedAt: edge.observedAt, id: edge.id }
             : null,
@@ -91,7 +92,9 @@ export async function GET(request: NextRequest) {
       },
       {
         headers: {
-          'Cache-Control': 'public, s-maxage=15, stale-while-revalidate=30',
+          'Cache-Control': pageCursor
+            ? 'public, s-maxage=15, stale-while-revalidate=30'
+            : 'private, no-store',
         },
       },
     )

--- a/src/components/portal/Portal.test.tsx
+++ b/src/components/portal/Portal.test.tsx
@@ -263,3 +263,88 @@ describe('portal component failures', () => {
     expect(screen.queryByText('Explore the archive')).not.toBeInTheDocument()
   })
 })
+
+describe('portal stream page', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.setSystemTime(Date.parse('2026-08-07T13:00:00.000Z'))
+    Object.defineProperty(global, 'IntersectionObserver', {
+      configurable: true,
+      value: jest.fn(() => ({
+        disconnect: jest.fn(),
+        observe: jest.fn(),
+        takeRecords: jest.fn(),
+        unobserve: jest.fn(),
+      })),
+    })
+  })
+
+  afterEach(() => {
+    jest.clearAllTimers()
+    jest.useRealTimers()
+    jest.restoreAllMocks()
+    Reflect.deleteProperty(global, 'IntersectionObserver')
+  })
+
+  test('keeps trend analysis off the live stream page', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ tweets: [], updateCursor: null }),
+    } as Response)
+
+    const { unmount } = render(<Portal data={data} view="stream" />)
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(screen.queryByText('Trends in ideas')).not.toBeInTheDocument()
+    expect(screen.queryByText('Rising this week')).not.toBeInTheDocument()
+    expect(screen.queryByText('Cooling this week')).not.toBeInTheDocument()
+
+    unmount()
+  })
+
+  test('jumps a truncated update backlog to the current stream head', async () => {
+    const backlog = Array.from({ length: 100 }, (_, index) => ({
+      ...seedTweet,
+      id: String(500 + index),
+      text: `backlog tweet ${index + 1}`,
+      observedAt: new Date(
+        Date.parse('2026-08-07T12:00:01.000Z') + index,
+      ).toISOString(),
+    }))
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          tweets: backlog,
+          backlogTruncated: true,
+          updateCursor: {
+            observedAt: backlog.at(-1)?.observedAt,
+            id: backlog.at(-1)?.id,
+          },
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tweets: [freshTweet], hasMore: true }),
+      } as Response)
+
+    const { unmount } = render(<Portal data={data} view="stream" />)
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(String(fetchMock.mock.calls[1][0])).toBe('/api/portal/stream')
+    expect(screen.getByText('fresh tweet')).toBeInTheDocument()
+    expect(screen.queryByText('seed tweet')).not.toBeInTheDocument()
+    expect(screen.queryByText('backlog tweet 1')).not.toBeInTheDocument()
+
+    unmount()
+  })
+})

--- a/src/components/portal/Portal.tsx
+++ b/src/components/portal/Portal.tsx
@@ -94,30 +94,6 @@ function oldestPageCursor(tweets: PortalTweet[]) {
   return oldest ? { createdAt: oldest.createdAt, id: oldest.id } : null
 }
 
-function Chip({
-  active,
-  onClick,
-  children,
-}: {
-  active: boolean
-  onClick: () => void
-  children: React.ReactNode
-}) {
-  return (
-    <button
-      onClick={onClick}
-      aria-pressed={active}
-      className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-[5px] text-[12.5px] font-semibold transition-colors ${
-        active
-          ? 'bg-brand/15 border-brand text-blue-600 dark:text-blue-300'
-          : `border-zinc-300 bg-white dark:border-[#2c2c30] dark:bg-[#1b1b1e] ${MUTED} hover:border-zinc-400 dark:hover:border-[#3f3f46]`
-      }`}
-    >
-      {children}
-    </button>
-  )
-}
-
 function PanelHeader({
   title,
   action,
@@ -388,11 +364,41 @@ export default function Portal({
   useEffect(() => {
     const controller = new AbortController()
     let polling = false
+    const applyHead = (tweets: PortalTweet[], nextHasMore: boolean) => {
+      const head = [...tweets].sort(comparePortalTweetChronology)
+      updateCursor.current = newestCursor(head)
+      pageCursor.current = oldestPageCursor(head)
+      if (view === 'stream') {
+        setHasMore(nextHasMore && pageCursor.current !== null)
+      }
+      setVisible((current) => {
+        const next =
+          view === 'home'
+            ? selectHomepageStream([...head, ...current], 30)
+            : head
+        seenIds.current = new Set(next.map((tweet) => tweet.id))
+        return next
+      })
+    }
+    const fetchHead = async () => {
+      const response = await fetch('/api/portal/stream', {
+        signal: controller.signal,
+        cache: 'no-store',
+      })
+      if (!response.ok) return false
+      const payload = (await response.json()) as {
+        tweets: PortalTweet[]
+        hasMore?: boolean
+      }
+      applyHead(payload.tweets, payload.hasMore ?? false)
+      return true
+    }
     const poll = async () => {
       if (polling) return
       polling = true
       try {
         const params = new URLSearchParams()
+        const requestedHead = updateCursor.current === null
         if (updateCursor.current) {
           params.set('after', updateCursor.current.observedAt)
           params.set('afterId', updateCursor.current.id)
@@ -406,11 +412,25 @@ export default function Portal({
           return
         }
         setStreamUnavailable(false)
-        const { tweets, updateCursor: nextUpdateCursor } =
-          (await res.json()) as {
-            tweets: PortalTweet[]
-            updateCursor?: { observedAt: string; id: string } | null
-          }
+        const {
+          tweets,
+          updateCursor: nextUpdateCursor,
+          hasMore: nextHasMore,
+          backlogTruncated,
+        } = (await res.json()) as {
+          tweets: PortalTweet[]
+          updateCursor?: { observedAt: string; id: string } | null
+          hasMore?: boolean
+          backlogTruncated?: boolean
+        }
+        if (requestedHead) {
+          applyHead(tweets, nextHasMore ?? false)
+          return
+        }
+        if (backlogTruncated) {
+          if (!(await fetchHead())) setStreamUnavailable(true)
+          return
+        }
         const responseCursor = nextUpdateCursor ?? newestCursor(tweets)
         if (responseCursor) updateCursor.current = responseCursor
         const fresh = tweets
@@ -470,31 +490,6 @@ export default function Portal({
   )
   const weeklyBars = weeklyRanked.slice(0, 6)
   const maxWeekly = Math.max(...weeklyBars.map((w) => w.last7), 1)
-  const withDelta = useMemo(
-    () =>
-      trends.weekly.filter(
-        (w) => w.deltaPct !== null && w.prev7 >= 5,
-      ) as (TermWeek & {
-        deltaPct: number
-      })[],
-    [trends.weekly],
-  )
-  const risers = useMemo(
-    () =>
-      [...withDelta]
-        .filter((w) => w.deltaPct > 0)
-        .sort((a, b) => b.deltaPct - a.deltaPct)
-        .slice(0, 4),
-    [withDelta],
-  )
-  const fallers = useMemo(
-    () =>
-      [...withDelta]
-        .filter((w) => w.deltaPct < 0)
-        .sort((a, b) => a.deltaPct - b.deltaPct)
-        .slice(0, 4),
-    [withDelta],
-  )
 
   const recentBanger = data.recentBangers[0] ?? null
   const historicalBanger = data.historicalBangers[0] ?? null
@@ -869,71 +864,53 @@ export default function Portal({
 
       {/* ------------------------------------------------ Stream -------- */}
       {view === 'stream' && (
-        <div className="mx-auto max-w-[1320px] px-4 py-6 sm:px-6">
-          <div className="grid grid-cols-1 items-start gap-6 lg:grid-cols-[1.5fr_1fr]">
-            <div>
-              <Link
-                href="/"
-                className={`mb-2 inline-flex items-center text-[12.5px] font-semibold ${MUTED} hover:text-brand`}
-              >
-                ← Dashboard
-              </Link>
-              <LiveStreamHeading
-                stats={stats}
-                unavailable={data.failures.liveAnalytics}
+        <div className="mx-auto max-w-[900px] px-4 py-6 sm:px-6">
+          <Link
+            href="/"
+            className={`mb-2 inline-flex items-center text-[12.5px] font-semibold ${MUTED} hover:text-brand`}
+          >
+            ← Dashboard
+          </Link>
+          <LiveStreamHeading
+            stats={stats}
+            unavailable={data.failures.liveAnalytics}
+          />
+          <div className={`mb-3.5 text-[13px] ${MUTED}`}>
+            Tweets arriving from the browser-extension firehose, as contributors
+            read their timelines.
+          </div>
+          <div className={`${CARD} overflow-hidden`}>
+            {visible.map((t, i) => (
+              <TweetCard
+                key={t.id}
+                tweet={t}
+                animate={i === 0}
+                showArchivedBadge
+                origin="stream"
+                returnTo="/stream"
               />
-              <div className={`mb-3.5 text-[13px] ${MUTED}`}>
-                Tweets arriving from the browser-extension firehose, as
-                contributors read their timelines.
+            ))}
+            {visible.length === 0 && streamUnavailable && (
+              <PanelUnavailable message="Live stream is temporarily unavailable." />
+            )}
+            {visible.length === 0 && !streamUnavailable && (
+              <div className={`px-4 py-8 text-center text-[13px] ${MUTED}`}>
+                Waiting for the firehose…
               </div>
-              <div className={`${CARD} overflow-hidden`}>
-                {visible.map((t, i) => (
-                  <TweetCard
-                    key={t.id}
-                    tweet={t}
-                    animate={i === 0}
-                    showArchivedBadge
-                    origin="stream"
-                    returnTo="/stream"
-                  />
-                ))}
-                {visible.length === 0 && streamUnavailable && (
-                  <PanelUnavailable message="Live stream is temporarily unavailable." />
-                )}
-                {visible.length === 0 && !streamUnavailable && (
-                  <div className={`px-4 py-8 text-center text-[13px] ${MUTED}`}>
-                    Waiting for the firehose…
-                  </div>
-                )}
-              </div>
-              <div
-                ref={loadMoreTarget}
-                aria-live="polite"
-                className={`py-5 text-center text-[12.5px] ${MUTED}`}
-              >
-                {isLoadingMore
-                  ? 'Loading older tweets…'
-                  : hasMore
-                    ? 'Scroll for older tweets'
-                    : visible.length > 0
-                      ? 'You’ve reached the end.'
-                      : ''}
-              </div>
-            </div>
-            <div id="trends" className="scroll-mt-32">
-              {data.failures.trends ? (
-                <>
-                  <h2 className="mb-3 text-[18px] font-semibold" style={SERIF}>
-                    Trends in ideas
-                  </h2>
-                  <div className={CARD}>
-                    <PanelUnavailable message="Trends are temporarily unavailable." />
-                  </div>
-                </>
-              ) : (
-                <TrendsView trends={trends} risers={risers} fallers={fallers} />
-              )}
-            </div>
+            )}
+          </div>
+          <div
+            ref={loadMoreTarget}
+            aria-live="polite"
+            className={`py-5 text-center text-[12.5px] ${MUTED}`}
+          >
+            {isLoadingMore
+              ? 'Loading older tweets…'
+              : hasMore
+                ? 'Scroll for older tweets'
+                : visible.length > 0
+                  ? 'You’ve reached the end.'
+                  : ''}
           </div>
         </div>
       )}
@@ -963,164 +940,6 @@ function StatCard({
         {value}
       </div>
       <div className={`mt-0.5 text-[12px] ${noteClass ?? MUTED}`}>{note}</div>
-    </div>
-  )
-}
-
-// ---------------------------------------------------------------------------
-// Trends view
-// ---------------------------------------------------------------------------
-
-function TrendsView({
-  trends,
-  risers,
-  fallers,
-}: {
-  trends: PortalData['trends']
-  risers: (TermWeek & { deltaPct: number })[]
-  fallers: (TermWeek & { deltaPct: number })[]
-}) {
-  const [enabled, setEnabled] = useState<Record<string, boolean>>(() =>
-    Object.fromEntries(trends.series.map((s, i) => [s.term, i < 4])),
-  )
-
-  const activeSeries = trends.series.filter((s) => enabled[s.term])
-  const maxVal = Math.max(5, ...activeSeries.flatMap((s) => s.perYear))
-  const niceMax = Math.ceil(maxVal / 3) * 3
-
-  const W = 480
-  const H = 270
-  const X0 = 44
-  const X1 = 448
-  const Y0 = 244
-  const Y1 = 24
-  const xs = trends.years.map(
-    (_, i) => X0 + (i * (X1 - X0)) / Math.max(trends.years.length - 1, 1),
-  )
-  const yOf = (v: number) => Y0 - (v / niceMax) * (Y0 - Y1)
-  const gridVals = [0, niceMax / 3, (2 * niceMax) / 3, niceMax]
-
-  return (
-    <div>
-      <h2 className="mb-3 text-[18px] font-semibold" style={SERIF}>
-        Trends in ideas
-      </h2>
-      <div className={`${CARD} mb-4 p-4`}>
-        <svg viewBox={`0 0 ${W} ${H}`} className="block w-full">
-          {gridVals.map((v) => (
-            <g key={v}>
-              <line
-                x1={X0 - 4}
-                y1={yOf(v)}
-                x2={X1}
-                y2={yOf(v)}
-                className="stroke-zinc-200 dark:stroke-[#202023]"
-                strokeWidth={1}
-              />
-              <text
-                x={X0 - 8}
-                y={yOf(v) + 4}
-                textAnchor="end"
-                fontSize={10}
-                className="fill-zinc-400 dark:fill-[#6d6d78]"
-              >
-                {Math.round(v)}
-              </text>
-            </g>
-          ))}
-          {trends.years.map((y, i) => (
-            <text
-              key={y}
-              x={xs[i]}
-              y={262}
-              textAnchor="middle"
-              fontSize={11}
-              className="fill-zinc-400 dark:fill-[#6d6d78]"
-            >
-              {y}
-            </text>
-          ))}
-          {activeSeries.map((s) => (
-            <polyline
-              key={s.term}
-              fill="none"
-              stroke={s.color}
-              strokeWidth={2.5}
-              strokeLinejoin="round"
-              strokeLinecap="round"
-              points={s.perYear
-                .map((v, i) => `${xs[i]},${yOf(v).toFixed(1)}`)
-                .join(' ')}
-            />
-          ))}
-        </svg>
-      </div>
-      <div className="mb-4 flex flex-wrap gap-1.5">
-        {trends.series.map((s) => (
-          <Chip
-            key={s.term}
-            active={!!enabled[s.term]}
-            onClick={() => setEnabled((e) => ({ ...e, [s.term]: !e[s.term] }))}
-          >
-            <span
-              className="h-[9px] w-[9px] rounded-full"
-              style={{
-                background: s.color,
-                opacity: enabled[s.term] ? 1 : 0.35,
-              }}
-            />
-            {s.term}
-          </Chip>
-        ))}
-      </div>
-      <div className={`mb-4 text-[13px] leading-normal ${BODY}`}>
-        Term frequency per 100k tweets, {trends.years[0]}–
-        {trends.years[trends.years.length - 1]}. An ngram viewer for the
-        vocabulary of one corner of the internet. Recomputed daily from the full
-        corpus.
-      </div>
-      <div className="grid grid-cols-1 gap-4">
-        <DeltaPanel title="Rising this week" items={risers} positive />
-        <DeltaPanel title="Cooling this week" items={fallers} />
-      </div>
-    </div>
-  )
-}
-
-function DeltaPanel({
-  title,
-  items,
-  positive,
-}: {
-  title: string
-  items: (TermWeek & { deltaPct: number })[]
-  positive?: boolean
-}) {
-  return (
-    <div className={CARD}>
-      <PanelHeader title={title} />
-      {items.length === 0 && (
-        <div className={`px-4 py-6 text-center text-[13px] ${MUTED}`}>
-          Nothing moving fast this week.
-        </div>
-      )}
-      {items.map((m) => (
-        <div
-          key={m.term}
-          className="flex items-center justify-between border-b border-zinc-100 px-4 py-2.5 last:border-b-0 dark:border-[#202023]"
-        >
-          <span className="text-[13.5px] font-semibold">{m.term}</span>
-          <span
-            className={`text-[13px] font-bold tabular-nums ${
-              positive
-                ? 'text-[#16a34a] dark:text-[#2acf80]'
-                : 'text-[#dc2626] dark:text-[#f87171]'
-            }`}
-          >
-            {fmtDelta(m)}
-          </span>
-        </div>
-      ))}
     </div>
   )
 }

--- a/src/lib/portal/data.test.ts
+++ b/src/lib/portal/data.test.ts
@@ -254,6 +254,15 @@ describe('portal page resilience', () => {
     expect(fetchPortalRecentBangersMock).toHaveBeenCalledWith(50, 168)
   })
 
+  test('does not load trend analysis for the live stream page', async () => {
+    await expect(getPortalData('stream')).resolves.toMatchObject({
+      trends: { years: [], series: [], weekly: [], computedAt: '' },
+      failures: { trends: false },
+    })
+
+    expect(fetchPortalTrendsMock).not.toHaveBeenCalled()
+  })
+
   test('preserves other components when the trends request fails', async () => {
     fetchPortalTrendsMock.mockRejectedValueOnce(
       new Error('trend snapshot unavailable'),

--- a/src/lib/portal/data.ts
+++ b/src/lib/portal/data.ts
@@ -755,11 +755,6 @@ const getCachedJoinedThisWeek = unstable_cache(
   ['portal-joined-this-week-v1'],
   { revalidate: 300 },
 )
-const getCachedInitialStream = unstable_cache(
-  async (_sourceKey: string) => getPortalStreamPage(30),
-  ['portal-initial-stream-v6'],
-  { revalidate: 60 },
-)
 const getCachedHomepageStreamCandidates = unstable_cache(
   async (_sourceKey: string) => getPortalStreamPage(100),
   ['portal-home-stream-candidates-v1'],
@@ -1051,45 +1046,64 @@ export async function getPortalData(
     recentBangers,
     historicalBangers,
   ] = await Promise.all([
-    loadPortalComponentData(
-      'trends',
-      () => getCachedTrendsSnapshot(sourceKey),
-      { years: [], series: [], weekly: [], computedAt: '' },
-    ),
-    loadPortalComponentData(
-      'corpus-range',
-      () => getCachedCorpusRange(sourceKey),
-      { firstYear: 0, currentYear: 0 },
-    ),
+    view === 'home'
+      ? loadPortalComponentData(
+          'trends',
+          () => getCachedTrendsSnapshot(sourceKey),
+          { years: [], series: [], weekly: [], computedAt: '' },
+        )
+      : Promise.resolve({
+          data: { years: [], series: [], weekly: [], computedAt: '' },
+          failed: false,
+        }),
+    view === 'home'
+      ? loadPortalComponentData(
+          'corpus-range',
+          () => getCachedCorpusRange(sourceKey),
+          { firstYear: 0, currentYear: 0 },
+        )
+      : Promise.resolve({
+          data: { firstYear: 0, currentYear: 0 },
+          failed: false,
+        }),
     loadPortalComponentData(
       'corpus-stats',
       () => getCachedCorpusStats(sourceKey),
       { totalTweets: 0, generatedAt: new Date().toISOString() },
     ),
-    loadPortalComponentData(
-      'live-analytics',
-      () => getCachedLiveAnalytics(sourceKey),
-      {
-        streamedLast24Hours: 0,
-        latestObservedAt: null,
-      },
-    ),
-    loadPortalComponentData(
-      'member-count',
-      () => getCachedMemberCount(sourceKey),
-      0,
-    ),
-    loadPortalComponentData(
-      'joined-this-week',
-      () => getCachedJoinedThisWeek(sourceKey),
-      0,
-    ),
+    view === 'home'
+      ? loadPortalComponentData(
+          'live-analytics',
+          () => getCachedLiveAnalytics(sourceKey),
+          {
+            streamedLast24Hours: 0,
+            latestObservedAt: null,
+          },
+        )
+      : Promise.resolve({
+          data: { streamedLast24Hours: 0, latestObservedAt: null },
+          failed: false,
+        }),
+    view === 'home'
+      ? loadPortalComponentData(
+          'member-count',
+          () => getCachedMemberCount(sourceKey),
+          0,
+        )
+      : Promise.resolve({ data: 0, failed: false }),
+    view === 'home'
+      ? loadPortalComponentData(
+          'joined-this-week',
+          () => getCachedJoinedThisWeek(sourceKey),
+          0,
+        )
+      : Promise.resolve({ data: 0, failed: false }),
     loadPortalComponentData(
       'initial-stream',
       () =>
         view === 'home'
           ? getCachedHomepageStreamCandidates(sourceKey)
-          : getCachedInitialStream(sourceKey),
+          : getPortalStreamPage(30),
       [],
     ),
     view === 'home'

--- a/src/lib/portalStreamRoute.test.ts
+++ b/src/lib/portalStreamRoute.test.ts
@@ -47,12 +47,41 @@ describe('portal stream route', () => {
     })
     await expect(response.json()).resolves.toEqual(
       expect.objectContaining({
+        backlogTruncated: false,
         updateCursor: {
           observedAt: '2026-08-07T12:01:00.000Z',
           id: '123',
         },
       }),
     )
+  })
+
+  test('marks a full observation page as a truncated backlog', async () => {
+    getPortalStreamUpdatesMock.mockResolvedValue(
+      Array.from({ length: 100 }, (_, index) => ({
+        id: String(1_000 + index),
+        username: 'alice',
+        name: 'Alice',
+        avatar: null,
+        text: `update ${index}`,
+        observedAt: new Date(
+          Date.parse('2026-08-07T12:01:00.000Z') + index,
+        ).toISOString(),
+        createdAt: '2026-08-07T11:00:00.000Z',
+        likes: 1,
+        rts: 0,
+      })),
+    )
+
+    const response = await GET(
+      new NextRequest(
+        'https://community-archive.org/api/portal/stream?after=2026-08-07T12%3A00%3A00.000Z&afterId=100',
+      ),
+    )
+
+    await expect(response.json()).resolves.toMatchObject({
+      backlogTruncated: true,
+    })
   })
 
   test('returns an older authored-time page and its continuation cursor', async () => {
@@ -79,6 +108,9 @@ describe('portal stream route', () => {
       createdAt: '2026-08-07T12:00:00.000Z',
       id: '201',
     })
+    expect(response.headers.get('cache-control')).toBe(
+      'public, s-maxage=15, stale-while-revalidate=30',
+    )
     await expect(response.json()).resolves.toMatchObject({
       tweets: expect.arrayContaining([expect.objectContaining({ id: '200' })]),
       nextCursor: {
@@ -87,6 +119,16 @@ describe('portal stream route', () => {
       },
       hasMore: true,
     })
+  })
+
+  test('does not cache the current stream head', async () => {
+    getPortalStreamPageMock.mockResolvedValue([])
+
+    const response = await GET(
+      new NextRequest('https://community-archive.org/api/portal/stream'),
+    )
+
+    expect(response.headers.get('cache-control')).toBe('private, no-store')
   })
 
   test('rejects malformed cursors before reading data', async () => {


### PR DESCRIPTION
## What changed

- remove Trends in ideas, Rising this week, and Cooling this week from the live stream page
- read the initial live stream directly instead of through the stale last-good cache
- skip unrelated homepage analytics when rendering the stream
- mark capped update pages as truncated and jump the client to an uncached current head
- keep older authored-time pagination cacheable while making current-head reads `no-store`

## Why

The dedicated stream could render an 18-hour-old cached snapshot while the homepage widget used a separate, healthy cache. Its observation-cursor polling then replayed at most 100 historical arrivals per minute, so it could remain far behind the firehose.

## Impact

The stream now renders only the feed, starts from a direct current snapshot, and self-recovers to the current head if its cursor falls behind. Homepage trends and the homepage live-stream widget are unchanged.

## Validation

- `pnpm test:client -- --runInBand src/components/portal/Portal.test.tsx`
- `pnpm test:server -- --runInBand src/lib/portal/data.test.ts src/lib/portalStreamRoute.test.ts`
- `pnpm type-check`
- `pnpm exec eslint` on all changed files
- Prettier and `git diff --check`