### PR TITLE
Document archive text fidelity boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,14 @@ The upload path is:
 4. `services/process_archive/` claims the upload, marks it `committing`, writes
    the normalized PostgreSQL records, and marks it `completed` or `failed`.
 
+Text fidelity has a separate source-of-truth boundary: the uploaded archive
+JSON in Supabase Storage preserves the original tweet text, while
+`public.tweets.full_text` is a normalized projection. The archive processor's
+text sanitization can remove control characters such as line feeds, so a
+flattened database value is not sufficient evidence that the original archive
+had no line breaks. For fidelity-sensitive diagnosis or recovery, compare the
+stored archive object before considering any external text source.
+
 Important locations:
 
 - `src/app/`: pages, server actions, and API routes.


### PR DESCRIPTION
## Summary

- document that uploaded archive JSON is the fidelity source for tweet text
- note that normalized `public.tweets.full_text` may lose control characters such as line feeds during processing

This is a learning-only documentation update from the archive text-fidelity investigation. No product behavior or production data changed.

Validation: `git diff --check`.