### PR TITLE
Show Digest in signed-in navigation

### DIFF
--- a/src/lib/navigation.test.ts
+++ b/src/lib/navigation.test.ts
@@ -26,6 +26,7 @@ describe('member navigation', () => {
   it('uses the requested primary order without a redundant Home link', () => {
     expect(getPrimaryNav(true)).toEqual([
       { href: '/bangers?period=all', label: 'Bangers' },
+      { href: '/digest', label: 'Digest' },
       { href: '/user-dir', label: 'Users' },
       { href: '/trends', label: 'Trends' },
       { href: '/stream', label: 'Live stream' },
@@ -36,6 +37,7 @@ describe('member navigation', () => {
         { href: '/user-dir', label: 'Users' },
         { href: '/stream', label: 'Live stream' },
         { href: '/bangers?period=all', label: 'Bangers' },
+        { href: '/digest', label: 'Digest' },
         { href: '/search', label: 'Search' },
       ]),
     )
@@ -78,6 +80,7 @@ describe('member navigation', () => {
     }
     expect(getPrimaryNav(true, true)).toEqual([
       { href: '/bangers?period=all', label: 'Bangers' },
+      { href: '/digest', label: 'Digest' },
       { href: '/user-dir', label: 'Users' },
       { href: '/trends', label: 'Trends' },
       { href: '/stream', label: 'Live stream' },

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -140,6 +140,7 @@ export const getPrimaryNav = (isMember: boolean, isAdmin = false): NavItem[] =>
   isMember || isAdmin
     ? [
         { href: BANGERS_ALL_TIME_HREF, label: 'Bangers' },
+        { href: '/digest', label: 'Digest' },
         { href: '/user-dir', label: 'Users' },
         { href: '/trends', label: 'Trends' },
         { href: '/stream', label: 'Live stream' },


### PR DESCRIPTION
## Summary

- add Digest to the signed-in primary navigation
- place it immediately after Bangers on desktop and mobile
- keep the signed-out navigation unchanged

## Why

Digest was discoverable while signed out but disappeared from the signed-in workspace navigation. Signed-in members should retain direct access to the same page.

## User impact

Signed-in members and admins now see Bangers, then Digest, followed by the rest of their audience-specific navigation. No route permissions or Digest behavior change.

## Validation

- `pnpm exec jest --selectProjects server --runInBand --runTestsByPath src/lib/navigation.test.ts` — 7 tests passed
- `pnpm type-check`
- `pnpm lint` (passes with one pre-existing `<img>` warning in `UnifiedTweetList.test.tsx`)
- `git diff --check`
