### PR TITLE
Repair flattened newlines in profile tweets

### DIFF
--- a/src/app/user/[account_id]/AccountTopTweets.tsx
+++ b/src/app/user/[account_id]/AccountTopTweets.tsx
@@ -5,6 +5,7 @@ import { createServerClient } from '@/utils/supabase'
 import { cookies } from 'next/headers'
 import { devLog } from '@/lib/devLog'
 import { PopularTweet } from '@/lib/types'
+import { repairProfileTweetText } from '@/lib/profileTweetText'
 
 const AccountTopTweets = async ({ userData }: { userData: FormattedUser }) => {
   const cookieStore = cookies()
@@ -28,11 +29,24 @@ const AccountTopTweets = async ({ userData }: { userData: FormattedUser }) => {
     return <div>Invalid data format</div>
   }
 
+  const favorited = data.most_favorited_tweets as PopularTweet[]
+  const retweeted = data.most_retweeted_tweets as PopularTweet[]
+  const repaired = await repairProfileTweetText(
+    Array.from(
+      new Map(
+        [...favorited, ...retweeted].map((tweet) => [tweet.tweet_id, tweet]),
+      ).values(),
+    ),
+  )
+  const repairedById = new Map(repaired.map((tweet) => [tweet.tweet_id, tweet]))
+  const withRepairedText = (tweets: PopularTweet[]) =>
+    tweets.map((tweet) => repairedById.get(tweet.tweet_id) ?? tweet)
+
   const tweetData = {
     // liked: data.most_liked_tweets_by_archive_users,
     // replied: data.most_replied_tweets_by_archive_users,
-    favorited: data.most_favorited_tweets as PopularTweet[],
-    retweeted: data.most_retweeted_tweets as PopularTweet[],
+    favorited: withRepairedText(favorited),
+    retweeted: withRepairedText(retweeted),
   }
 
   return (

--- a/src/lib/profileTweetText.test.ts
+++ b/src/lib/profileTweetText.test.ts
@@ -1,0 +1,64 @@
+import { repairProfileTweetText } from './profileTweetText'
+import { fetchSyndicatedTweets } from './twitterSyndication'
+
+jest.mock('./twitterSyndication', () => ({
+  fetchSyndicatedTweets: jest.fn(),
+}))
+
+const mockFetchSyndicatedTweets = fetchSyndicatedTweets as jest.MockedFunction<
+  typeof fetchSyndicatedTweets
+>
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+test('uses syndication line breaks for flattened profile text', async () => {
+  mockFetchSyndicatedTweets.mockResolvedValue(
+    new Map([
+      [
+        '1636679643120951297',
+        {
+          tweet_id: '1636679643120951297',
+          full_text:
+            '*deep breath* \n\nART IS PRE-PARADIGMATIC SCIENCE\n\nand art is relevance realization',
+        } as any,
+      ],
+    ]),
+  )
+
+  const tweets = [
+    {
+      tweet_id: '1636679643120951297',
+      full_text:
+        '*deep breath* ART IS PRE-PARADIGMATIC SCIENCEand art is relevance realization',
+      favorite_count: 143,
+    },
+  ]
+
+  await expect(repairProfileTweetText(tweets)).resolves.toEqual([
+    {
+      ...tweets[0],
+      full_text:
+        '*deep breath* \n\nART IS PRE-PARADIGMATIC SCIENCE\n\nand art is relevance realization',
+    },
+  ])
+})
+
+test('keeps DB text when syndication has no line breaks', async () => {
+  mockFetchSyndicatedTweets.mockResolvedValue(
+    new Map([
+      [
+        '1',
+        {
+          tweet_id: '1',
+          full_text: 'same text',
+        } as any,
+      ],
+    ]),
+  )
+
+  const tweets = [{ tweet_id: '1', full_text: 'same text' }]
+  await expect(repairProfileTweetText(tweets)).resolves.toEqual(tweets)
+  expect(mockFetchSyndicatedTweets).not.toHaveBeenCalled()
+})

--- a/src/lib/profileTweetText.ts
+++ b/src/lib/profileTweetText.ts
@@ -1,0 +1,50 @@
+import 'server-only'
+
+import { fetchSyndicatedTweets } from './twitterSyndication'
+
+interface ProfileTweetText {
+  tweet_id: string
+  full_text: string
+}
+
+const likelyFlattenedText = (text: string) => {
+  if (text.includes('\n') || text.includes('\r')) return false
+
+  // Ignore URL host/path casing; the archive bug is the disappearance of a
+  // separator between adjacent words, which commonly leaves a case boundary.
+  const withoutUrls = text.replace(/https?:\/\/\S+/g, '')
+  return /[a-z][A-Z]|\b[A-Z]{2,}[a-z]/.test(withoutUrls)
+}
+
+/**
+ * Repair only the known archive-ingestion failure where control characters were
+ * stripped from a profile tweet's stored text. The database remains the source
+ * for every other field, and syndication failures leave the stored text intact.
+ */
+export async function repairProfileTweetText<T extends ProfileTweetText>(
+  tweets: T[],
+): Promise<T[]> {
+  if (tweets.length === 0) return tweets
+
+  const candidates = tweets.filter((tweet) =>
+    likelyFlattenedText(tweet.full_text),
+  )
+  if (candidates.length === 0) return tweets
+
+  const syndicated = await fetchSyndicatedTweets(
+    candidates.map((tweet) => tweet.tweet_id),
+    { limit: candidates.length },
+  )
+
+  return tweets.map((tweet) => {
+    const syndicatedTweet = syndicated.get(tweet.tweet_id)
+    if (syndicatedTweet?.tweet_id !== tweet.tweet_id) return tweet
+
+    const replacement = syndicatedTweet.full_text
+    if (!replacement?.includes('\n') && !replacement?.includes('\r')) {
+      return tweet
+    }
+
+    return { ...tweet, full_text: replacement }
+  })
+}

--- a/src/lib/twitterSyndication.ts
+++ b/src/lib/twitterSyndication.ts
@@ -9,8 +9,9 @@
  * - Never persist hydrated tweet content to our DB. The link-preview subsystem may
  *   separately cache the bounded title, teaser, and cover image that X publishes for
  *   an Article linked by an archived tweet.
- * - Never include hydrated tweet content in search results, profile listings, or any
- *   other query path. Avatar recovery is render-only and is never persisted.
+ * - Never use hydrated tweet content in search results or global feeds.
+ * - Profile pages may use the text-only repair path for archived profile cards;
+ *   that path only replaces flattened DB text when syndication supplies line breaks.
  * - Caller decides whether to render with a "(from Twitter)" marker.
  *
  * The endpoint requires a `token` query param derived from the tweet id. This is


### PR DESCRIPTION
## Summary

- repair flattened newline characters in archived profile Top Tweets cards
- fetch text-only replacements from the public syndication API at render time
- leave the database, search, and global feeds unchanged

## Root cause

Archive ingestion removes control characters from `tweets.full_text`, including line feeds. The original uploaded archive and syndication response retain the line breaks, but the normalized database value does not.

## Safety

- only profile Top Tweets cards use the repair path
- only likely flattened text is queried
- replacement requires a matching tweet ID and returned line breaks
- syndication failures fall back to the stored database text
- no syndication response is persisted

## Validation

- Prettier check passed
- TypeScript check passed in the original checkout
- 42 server suites passed (194 tests), including the new repair test
- `git diff --check` passed
