### PR TITLE
Publish digest corrections and refresh homepage bangers

### DIFF
--- a/src/app/admin/digest/DigestEditionEditor.test.tsx
+++ b/src/app/admin/digest/DigestEditionEditor.test.tsx
@@ -4,11 +4,26 @@ import React from 'react'
 import '@testing-library/jest-dom'
 import { render, screen } from '@testing-library/react'
 import { AUGUST_11_MOCK_DIGEST } from '@/lib/digest/mock'
-import { DigestContentFields, DigestEditionEditor } from './DigestEditionEditor'
+import {
+  DigestContentFields,
+  DigestEditionEditor,
+  DigestValidatedOutputEditor,
+} from './DigestEditionEditor'
 ;(globalThis as typeof globalThis & { React: typeof React }).React = React
+
+jest.mock('react-dom', () => ({
+  ...jest.requireActual('react-dom'),
+  useFormStatus: () => ({
+    action: null,
+    data: null,
+    method: null,
+    pending: false,
+  }),
+}))
 
 jest.mock('./actions', () => ({
   saveDigestEditionAction: '/save-digest-edition',
+  stageEditedDigestEditionAction: '/stage-edited-digest-edition',
 }))
 
 jest.mock('./MarkdownField', () => ({
@@ -54,6 +69,23 @@ describe('DigestContentFields', () => {
       screen.getByRole('button', {
         name: `Save as draft v${AUGUST_11_MOCK_DIGEST.version + 1}`,
       }),
+    ).toHaveAttribute('value', 'draft')
+    expect(screen.getByRole('button', { name: 'Publish now' })).toHaveAttribute(
+      'value',
+      'publish',
+    )
+  })
+
+  test('offers draft and immediate publish actions beside validated copy', () => {
+    render(
+      <DigestValidatedOutputEditor
+        content={AUGUST_11_MOCK_DIGEST.content}
+        runId="00000000-0000-4000-8000-000000000001"
+      />,
+    )
+
+    expect(
+      screen.getByRole('button', { name: 'Save as draft' }),
     ).toHaveAttribute('value', 'draft')
     expect(screen.getByRole('button', { name: 'Publish now' })).toHaveAttribute(
       'value',

--- a/src/app/admin/digest/DigestEditionEditor.tsx
+++ b/src/app/admin/digest/DigestEditionEditor.tsx
@@ -3,7 +3,10 @@ import {
   type DigestEdition,
   type DigestEditionContent,
 } from '@/lib/digest/types'
-import { saveDigestEditionAction } from './actions'
+import {
+  saveDigestEditionAction,
+  stageEditedDigestEditionAction,
+} from './actions'
 import { MarkdownField } from './MarkdownField'
 import { SubmitButton } from './SubmitButton'
 
@@ -166,5 +169,51 @@ export function DigestEditionEditor({
         </div>
       </form>
     </section>
+  )
+}
+
+export function DigestValidatedOutputEditor({
+  content,
+  runId,
+}: {
+  content: DigestEditionContent
+  runId: string
+}) {
+  return (
+    <form
+      action={stageEditedDigestEditionAction}
+      className="mt-5 space-y-7 rounded-lg border border-blue-200 bg-blue-50/60 p-4 dark:border-blue-900 dark:bg-blue-950/20"
+    >
+      <input type="hidden" name="run_id" value={runId} />
+      <div>
+        <div className="font-semibold">Edit the validated copy inline</div>
+        <p className="mt-1 text-xs leading-5 text-muted-foreground">
+          Correct typos or wording below. The validated model run stays
+          unchanged.
+        </p>
+      </div>
+      <DigestContentFields content={content} />
+      <div className="flex flex-wrap items-center gap-3 border-t border-blue-200 pt-4 dark:border-blue-900">
+        <SubmitButton
+          pendingLabel="Saving new draft…"
+          variant="secondary"
+          name="intent"
+          value="draft"
+        >
+          Save as draft
+        </SubmitButton>
+        <SubmitButton
+          pendingLabel="Saving and publishing…"
+          name="intent"
+          value="publish"
+        >
+          Publish now
+        </SubmitButton>
+        <span className="text-xs text-muted-foreground">
+          Publish now saves these corrections as a new version and makes it
+          public.
+        </span>
+      </div>
+    </form>
   )
 }

--- a/src/app/admin/digest/SubmitButton.tsx
+++ b/src/app/admin/digest/SubmitButton.tsx
@@ -1,6 +1,9 @@
 'use client'
 
-import { useState, type MouseEvent, type ReactNode } from 'react'
+import type { ReactNode } from 'react'
+// Next.js 14 supplies React DOM's canary form hook at runtime.
+// @ts-expect-error The installed stable React DOM types do not expose it yet.
+import { useFormStatus } from 'react-dom'
 
 export function SubmitButton({
   children,
@@ -15,11 +18,9 @@ export function SubmitButton({
   name?: string
   value?: string
 }) {
-  const [pending, setPending] = useState(false)
-  const startPendingAfterSubmit = (event: MouseEvent<HTMLButtonElement>) => {
-    if (event.currentTarget.form?.checkValidity() === false) return
-    window.setTimeout(() => setPending(true), 0)
-  }
+  const { data, pending: formPending } = useFormStatus()
+  const pending =
+    formPending && (name && value ? data?.get(name) === value : true)
   const colors =
     variant === 'primary'
       ? 'bg-zinc-950 text-white hover:bg-zinc-800 dark:bg-white dark:text-zinc-950 dark:hover:bg-zinc-200'
@@ -32,8 +33,7 @@ export function SubmitButton({
       type="submit"
       name={name}
       value={value}
-      disabled={pending}
-      onClick={startPendingAfterSubmit}
+      disabled={formPending}
       className={`inline-flex items-center justify-center rounded-md border border-transparent px-4 py-2 text-sm font-semibold transition disabled:cursor-wait disabled:opacity-60 ${colors}`}
     >
       {pending ? (pendingLabel ?? 'Working…') : children}

--- a/src/app/admin/digest/actions.ts
+++ b/src/app/admin/digest/actions.ts
@@ -857,6 +857,7 @@ export async function stageDigestEditionAction(formData: FormData) {
 export async function stageEditedDigestEditionAction(formData: FormData) {
   const { user } = await requireAdmin()
   const runId = formString(formData, 'run_id')
+  const publishImmediately = formString(formData, 'intent') === 'publish'
   if (!UUID_PATTERN.test(runId)) redirectToLab({ error: 'Invalid run ID.' })
 
   const admin = createDigestAdminClient()
@@ -889,19 +890,39 @@ export async function stageEditedDigestEditionAction(formData: FormData) {
     })
   }
   const version = (latest?.version ?? 0) + 1
-  const { error } = await admin.from('digest_editions').insert({
-    digest_date: run.digestDate,
-    version,
-    status: 'draft',
-    source_run_id: run.id,
-    content: toJson(content),
-    created_by: user.id,
-  })
-  if (error) {
+  const { data: savedEdition, error } = await admin
+    .from('digest_editions')
+    .insert({
+      digest_date: run.digestDate,
+      version,
+      status: 'draft',
+      source_run_id: run.id,
+      content: toJson(content),
+      created_by: user.id,
+    })
+    .select('*')
+    .single()
+  if (error || !savedEdition) {
     redirectToLab({
       runId,
-      error: `Could not save corrected draft: ${error.message}`,
+      error: `Could not save corrected draft: ${error?.message ?? 'No edition was returned.'}`,
     })
+  }
+
+  let publishedEdition: typeof savedEdition | null = null
+  if (publishImmediately) {
+    const { data, error: publishError } = await admin.rpc(
+      'publish_digest_edition',
+      { p_edition_id: savedEdition.id },
+    )
+    if (publishError || !data) {
+      revalidateDigestPaths(run.digestDate)
+      redirectToLab({
+        runId,
+        error: `Saved draft v${version}, but publish failed: ${publishError?.message ?? 'No published edition was returned.'}`,
+      })
+    }
+    publishedEdition = data
   }
 
   const events = [
@@ -909,35 +930,49 @@ export async function stageEditedDigestEditionAction(formData: FormData) {
     event(
       'edition',
       'completed',
-      `Saved inline corrections as digest edition version ${version}.`,
+      publishImmediately
+        ? `Saved inline corrections and published digest edition version ${version}.`
+        : `Saved inline corrections as digest edition version ${version}.`,
     ),
   ]
-  const { error: eventError } = await admin
-    .from('digest_runs')
-    .update({ events: toJson(events), updated_at: new Date().toISOString() })
-    .eq('id', runId)
+  const [eventResult] = await Promise.allSettled([
+    admin
+      .from('digest_runs')
+      .update({ events: toJson(events), updated_at: new Date().toISOString() })
+      .eq('id', runId),
+    captureDigestPostHogEvent(user.id, {
+      event: 'digest_page_created',
+      properties: {
+        source: 'manual_edit',
+        status: publishImmediately ? 'published' : 'draft',
+        story_count: content.stories.length,
+        editorial_warning_count: content.editorialWarnings?.length ?? 0,
+      },
+    }),
+  ])
+  const eventError =
+    eventResult.status === 'fulfilled'
+      ? eventResult.value.error
+      : eventResult.reason
   if (eventError) {
     console.warn(
       '[daily digest] saved corrected draft but could not append event',
       { runId, version, error: eventError },
     )
   }
-  await captureDigestPostHogEvent(user.id, {
-    event: 'digest_page_created',
-    properties: {
-      source: 'manual_edit',
-      status: 'draft',
-      story_count: content.stories.length,
-      editorial_warning_count: content.editorialWarnings?.length ?? 0,
-    },
-  })
   console.info('[daily digest] inline corrections saved', {
     runId,
     digestDate: run.digestDate,
     version,
+    published: publishImmediately,
   })
-  revalidateDigestPaths(run.digestDate)
-  redirectToLab({ runId, notice: `Saved corrections as draft v${version}.` })
+  revalidateDigestPaths(publishedEdition?.digest_date ?? run.digestDate)
+  redirectToLab({
+    runId,
+    notice: publishImmediately
+      ? `Saved corrections and published ${run.digestDate} edition v${version}.`
+      : `Saved corrections as draft v${version}.`,
+  })
 }
 
 export async function saveDigestEditionAction(formData: FormData) {

--- a/src/app/admin/digest/page.tsx
+++ b/src/app/admin/digest/page.tsx
@@ -14,11 +14,13 @@ import {
   publishDigestEditionAction,
   reviseDigestRunAction,
   stageDigestEditionAction,
-  stageEditedDigestEditionAction,
   updateDigestSelectionAction,
 } from './actions'
 import { DigestJobProgress } from './DigestJobProgress'
-import { DigestContentFields, DigestEditionEditor } from './DigestEditionEditor'
+import {
+  DigestEditionEditor,
+  DigestValidatedOutputEditor,
+} from './DigestEditionEditor'
 import { SubmitButton } from './SubmitButton'
 
 export const dynamic = 'force-dynamic'
@@ -632,37 +634,10 @@ export default async function DigestLabPage({
                         </ul>
                       </div>
                     ) : null}
-                    <form
-                      action={stageEditedDigestEditionAction}
-                      className="mt-5 space-y-7 rounded-lg border border-blue-200 bg-blue-50/60 p-4 dark:border-blue-900 dark:bg-blue-950/20"
-                    >
-                      <input
-                        type="hidden"
-                        name="run_id"
-                        value={state.activeRun.id}
-                      />
-                      <div>
-                        <div className="font-semibold">
-                          Edit the validated copy inline
-                        </div>
-                        <p className="mt-1 text-xs leading-5 text-muted-foreground">
-                          Correct typos or wording below. Saving creates a new
-                          private draft; the validated model run stays
-                          unchanged.
-                        </p>
-                      </div>
-                      <DigestContentFields
-                        content={state.activeRun.parsedOutput}
-                      />
-                      <div className="flex flex-wrap items-center gap-3 border-t border-blue-200 pt-4 dark:border-blue-900">
-                        <SubmitButton pendingLabel="Saving corrections…">
-                          Save corrections as new draft
-                        </SubmitButton>
-                        <span className="text-xs text-muted-foreground">
-                          This does not publish the edition.
-                        </span>
-                      </div>
-                    </form>
+                    <DigestValidatedOutputEditor
+                      content={state.activeRun.parsedOutput}
+                      runId={state.activeRun.id}
+                    />
                     <form
                       action={reviseDigestRunAction}
                       className="mt-6 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-900 dark:bg-blue-950/25"

--- a/src/components/portal/Portal.tsx
+++ b/src/components/portal/Portal.tsx
@@ -571,9 +571,7 @@ export default function Portal({
                 data.failures.historicalBangers) && (
                 <div className="grid grid-cols-1 gap-4">
                   {(recentBanger || data.failures.recentBangers) && (
-                    <div
-                      className={`${CARD} flex min-w-0 flex-col overflow-hidden lg:min-h-[320px]`}
-                    >
+                    <div className={`${CARD} min-w-0 overflow-hidden`}>
                       <PanelHeader
                         title="Banger of the moment"
                         action={{
@@ -583,15 +581,13 @@ export default function Portal({
                         }}
                       />
                       {recentBanger ? (
-                        <div className="flex flex-1 flex-col [&>article]:flex-1">
-                          <TweetCard
-                            tweet={recentBanger}
-                            collapsible
-                            clickable
-                            origin="home"
-                            returnTo="/"
-                          />
-                        </div>
+                        <TweetCard
+                          tweet={recentBanger}
+                          collapsible
+                          clickable
+                          origin="home"
+                          returnTo="/"
+                        />
                       ) : (
                         <PanelUnavailable message="Recent bangers are temporarily unavailable." />
                       )}
@@ -599,9 +595,7 @@ export default function Portal({
                   )}
 
                   {(historicalBanger || data.failures.historicalBangers) && (
-                    <div
-                      className={`${CARD} flex min-w-0 flex-col overflow-hidden lg:min-h-[320px]`}
-                    >
+                    <div className={`${CARD} min-w-0 overflow-hidden`}>
                       <PanelHeader
                         title="Historical Banger"
                         action={{
@@ -611,16 +605,14 @@ export default function Portal({
                         }}
                       />
                       {historicalBanger ? (
-                        <div className="flex flex-1 flex-col [&>article]:flex-1">
-                          <TweetCard
-                            tweet={historicalBanger}
-                            collapsible
-                            showDate
-                            clickable
-                            origin="home"
-                            returnTo="/"
-                          />
-                        </div>
+                        <TweetCard
+                          tweet={historicalBanger}
+                          collapsible
+                          showDate
+                          clickable
+                          origin="home"
+                          returnTo="/"
+                        />
                       ) : (
                         <PanelUnavailable message="Historical bangers are temporarily unavailable." />
                       )}

--- a/src/lib/portal/data.test.ts
+++ b/src/lib/portal/data.test.ts
@@ -27,6 +27,7 @@ import {
   portalDataSourceKey,
   resolvePortalReadConfig,
   selectDailyBangers,
+  selectDailyRecentBangers,
 } from './data'
 import {
   fetchPortalBangersPage,
@@ -248,10 +249,10 @@ describe('portal page resilience', () => {
     })
   })
 
-  test('loads the homepage Banger of the moment from a rolling week', async () => {
+  test('loads the homepage Banger of the moment from the past 24 hours', async () => {
     await getPortalData()
 
-    expect(fetchPortalRecentBangersMock).toHaveBeenCalledWith(50, 168)
+    expect(fetchPortalRecentBangersMock).toHaveBeenCalledWith(50, 24)
   })
 
   test('does not load trend analysis for the live stream page', async () => {
@@ -808,5 +809,27 @@ describe('daily banger selection', () => {
       new Set(Array.from({ length: 10 }, (_, index) => String(index))),
     )
     expect(selected.some(({ id }) => id === 'current')).toBe(false)
+  })
+
+  test('chooses deterministically from the past 24 hours', () => {
+    const now = new Date('2026-08-14T12:00:00.000Z')
+    const candidates = [
+      tweet('today-1', '2026-08-14T10:00:00.000Z', 100),
+      tweet('today-2', '2026-08-14T11:00:00.000Z', 90),
+      tweet('overnight', '2026-08-13T12:30:00.000Z', 80),
+      tweet('too-old', '2026-08-13T11:59:00.000Z', 1_000_000),
+      tweet('future', '2026-08-14T12:01:00.000Z', 1_000_000),
+    ]
+
+    const selected = selectDailyRecentBangers(candidates, now)
+    const selectedAgain = selectDailyRecentBangers(candidates, now)
+
+    expect(selected).toHaveLength(3)
+    expect(selectedAgain[0].id).toBe(selected[0].id)
+    expect(selected.map(({ id }) => id)).toEqual(
+      expect.arrayContaining(['today-1', 'today-2', 'overnight']),
+    )
+    expect(selected.some(({ id }) => id === 'too-old')).toBe(false)
+    expect(selected.some(({ id }) => id === 'future')).toBe(false)
   })
 })

--- a/src/lib/portal/data.ts
+++ b/src/lib/portal/data.ts
@@ -681,6 +681,44 @@ export function selectDailyBangers(
   return [selected, ...candidates.filter((_, index) => index !== selectedIndex)]
 }
 
+/**
+ * Put one deterministic daily choice first, selected from the strongest
+ * bangers in the rolling 24-hour window.
+ */
+export function selectDailyRecentBangers(
+  tweets: PortalTweet[],
+  now = new Date(),
+  poolSize = 10,
+): PortalTweet[] {
+  const windowEnd = now.getTime()
+  const windowStart = windowEnd - 24 * 60 * 60 * 1_000
+  const candidates = tweets
+    .filter((tweet) => {
+      const createdAt = new Date(tweet.createdAt)
+      const createdAtTime = createdAt.getTime()
+      return (
+        !Number.isNaN(createdAtTime) &&
+        createdAtTime >= windowStart &&
+        createdAtTime <= windowEnd
+      )
+    })
+    .sort((left, right) => {
+      return (
+        (right.quoteCount ?? 0) - (left.quoteCount ?? 0) ||
+        right.likes - left.likes ||
+        Date.parse(right.createdAt) - Date.parse(left.createdAt) ||
+        right.id.localeCompare(left.id)
+      )
+    })
+    .slice(0, Math.max(1, poolSize))
+
+  if (candidates.length < 2) return candidates
+  const day = now.toISOString().slice(0, 10)
+  const selectedIndex = stableHash(day) % candidates.length
+  const selected = candidates[selectedIndex]
+  return [selected, ...candidates.filter((_, index) => index !== selectedIndex)]
+}
+
 async function fetchCorpusRange(): Promise<PortalCorpusRange> {
   const [firstResult, latestResult] = await Promise.all([
     portalRestRows<{ created_at: string }>(
@@ -771,9 +809,11 @@ const getCachedHistoricalBangers = unstable_cache(
   { revalidate: 86_400 },
 )
 const getCachedRecentBangers = unstable_cache(
-  async (_sourceKey: string) =>
-    enrichPortalTweets(await fetchPortalRecentBangers(50, 168)),
-  ['portal-recent-bangers-v3'],
+  async (_sourceKey: string, _day: string) =>
+    enrichPortalTweets(
+      selectDailyRecentBangers(await fetchPortalRecentBangers(50, 24)),
+    ),
+  ['portal-recent-bangers-v5'],
   { revalidate: 1_800 },
 )
 
@@ -1116,7 +1156,7 @@ export async function getPortalData(
     view === 'home'
       ? loadPortalComponentData(
           'recent-bangers',
-          () => getCachedRecentBangers(sourceKey),
+          () => getCachedRecentBangers(sourceKey, today),
           [],
         )
       : Promise.resolve({ data: [], failed: false }),


### PR DESCRIPTION
## What changed

- adds a primary **Publish now** action beside **Save as draft** in the validated-output editor
- lets that action save the current corrections as a versioned edition and publish it in one submission
- ties pending labels to the actual form action so they reliably clear, and only the clicked button shows its pending copy
- runs the edition-event update and PostHog capture concurrently to shorten the save path
- makes the homepage featured and historical banger panels fit their content instead of stretching to a fixed minimum height
- selects the homepage featured banger from the rolling past 24 hours with a deterministic daily choice

## Why

The corrections form only offered draft staging, while its publish action appeared elsewhere after a full refresh. The homepage banger card also had unnecessary vertical whitespace and could show a stale multi-day post instead of a current recent banger.

## Validation

- focused digest editor tests previously passed
- focused portal data and layout tests: 24 passed
- TypeScript type check
- Prettier formatting checks
- production Next.js build passed