### PR TITLE
Fix recent tweet rendering and profile link quick wins

### DIFF
--- a/src/app/tweets/[tweet_id]/page.tsx
+++ b/src/app/tweets/[tweet_id]/page.tsx
@@ -62,7 +62,11 @@ export default async function TweetPage({
               <ThreadView tree={threadTree} highlightTweetId={tweet_id} />
             ) : (
               <article className="rounded-xl border border-border bg-card p-5 shadow-sm sm:p-6">
-                <TweetComponent key={tweet.tweet_id} tweet={tweet} />
+                <TweetComponent
+                  key={tweet.tweet_id}
+                  tweet={tweet}
+                  isPermalinkPage
+                />
               </article>
             )}
 

--- a/src/components/ThreadView.test.tsx
+++ b/src/components/ThreadView.test.tsx
@@ -5,8 +5,16 @@ import type { ConversationTree, ThreadTweet } from '@/lib/threadUtils'
 
 jest.mock('./TweetComponent', () => ({
   __esModule: true,
-  default: ({ tweet }: { tweet: { full_text: string } }) => (
-    <div>{tweet.full_text}</div>
+  default: ({
+    tweet,
+    isPermalinkPage,
+  }: {
+    tweet: { full_text: string }
+    isPermalinkPage?: boolean
+  }) => (
+    <div>
+      {tweet.full_text} {isPermalinkPage ? '(permalink)' : ''}
+    </div>
   ),
 }))
 
@@ -52,5 +60,21 @@ describe('ThreadView', () => {
     expect(containers[1]).toHaveClass('border-l-2', 'pl-3')
     expect(containers[2]).not.toHaveClass('border-l-2', 'pl-3')
     expect(containers[3]).not.toHaveClass('border-l-2', 'pl-3')
+  })
+
+  test('marks only the highlighted tweet as the current permalink', () => {
+    const tree: ConversationTree = {
+      root: '1',
+      roots: ['1'],
+      tweets: { '1': tweet('1', null), '2': tweet('2', '1') },
+      children: { '1': ['2'], '2': [] },
+      parents: { '2': '1' },
+      paths: { '2': ['1', '2'] },
+    }
+
+    render(<ThreadView tree={tree} highlightTweetId="2" />)
+
+    expect(screen.getByText('tweet 1')).toBeVisible()
+    expect(screen.getByText('tweet 2 (permalink)')).toBeVisible()
   })
 })

--- a/src/components/ThreadView.tsx
+++ b/src/components/ThreadView.tsx
@@ -66,7 +66,10 @@ export const ThreadView: React.FC<ThreadViewProps> = ({
                 from Twitter · not archived
               </span>
             )}
-            <TweetComponent tweet={convertToTweetData(tweet)} />
+            <TweetComponent
+              tweet={convertToTweetData(tweet)}
+              isPermalinkPage={isHighlighted}
+            />
           </div>
         )}
 

--- a/src/components/TweetCard.test.tsx
+++ b/src/components/TweetCard.test.tsx
@@ -13,8 +13,22 @@ jest.mock('@/components/TweetAvatarImage', () => ({
 }))
 jest.mock('@/components/ImageLightbox', () => ({
   __esModule: true,
-  default: ({ src, alt }: { src: string; alt: string }) => (
-    <span data-testid="tweet-image" data-src={src} aria-label={alt} />
+  default: ({
+    src,
+    alt,
+    className,
+  }: {
+    src: string
+    alt: string
+    className?: string
+  }) => (
+    <button
+      type="button"
+      data-testid="tweet-image"
+      data-src={src}
+      aria-label={`Enlarge ${alt.toLowerCase()}`}
+      className={className}
+    />
   ),
 }))
 
@@ -82,6 +96,41 @@ describe('TweetCard', () => {
     )
   })
 
+  test.each([1, 2, 3, 4])(
+    'renders %i quoted images in a keyboard-accessible compact grid',
+    (imageCount) => {
+      const media = Array.from({ length: imageCount }, (_, index) => ({
+        url: `https://example.com/quoted-${index + 1}.jpg`,
+        type: 'photo' as const,
+      }))
+      render(
+        <TweetCard
+          compact
+          tweet={{
+            ...tweet,
+            media: [],
+            quotedTweet: { ...tweet.quotedTweet!, media },
+          }}
+        />,
+      )
+
+      const grid = screen.getByRole('group', { name: 'Quoted tweet media' })
+      expect(grid).toHaveClass(
+        'grid',
+        imageCount > 1 ? 'grid-cols-2' : 'grid-cols-1',
+      )
+      const images = screen.getAllByRole('button', {
+        name: /Enlarge quoted tweet image/i,
+      })
+      expect(images).toHaveLength(imageCount)
+      images.forEach((image) =>
+        expect(image).toHaveClass(
+          imageCount > 1 ? 'aspect-square' : 'aspect-video',
+        ),
+      )
+    },
+  )
+
   test('can summarize only the repeated quoted tweet marker', () => {
     render(<TweetCard tweet={tweet} quotedTweetDisplay="summary" />)
 
@@ -92,6 +141,20 @@ describe('TweetCard', () => {
       screen.getAllByTestId('tweet-image').map((image) => image.dataset.src),
     ).toEqual(['https://example.com/tweet.jpg'])
     expect(screen.queryByText('8 likes')).not.toBeInTheDocument()
+  })
+
+  test('uses an unavailable tombstone when a quoted tweet cannot be shown', () => {
+    render(
+      <TweetCard
+        tweet={{
+          ...tweet,
+          quotedTweet: { ...tweet.quotedTweet!, isDeleted: true },
+        }}
+      />,
+    )
+
+    expect(screen.getByText('Quoted tweet unavailable')).toBeVisible()
+    expect(screen.queryByText('Quoted tweet deleted')).not.toBeInTheDocument()
   })
 
   test('can disable text clamping independently of the card layout', () => {

--- a/src/components/TweetComponent.test.tsx
+++ b/src/components/TweetComponent.test.tsx
@@ -1,0 +1,67 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import TweetComponent, { type TweetData } from './TweetComponent'
+
+jest.mock('@/components/TweetAvatarImage', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+jest.mock('@/components/ImageLightbox', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+
+const tweet: TweetData = {
+  tweet_id: '123',
+  account_id: '456',
+  created_at: '2026-08-12T12:00:00.000Z',
+  full_text: 'A tweet',
+  retweet_count: 2,
+  favorite_count: 3,
+  reply_to_tweet_id: null,
+  quote_tweet_id: null,
+  retweeted_tweet_id: null,
+  avatar_media_url: null,
+  username: 'alice',
+  account_display_name: 'Alice',
+  media: [],
+  urls: [],
+}
+
+describe('TweetComponent', () => {
+  test('removes its self-link and shows an icon-only external link on a permalink page', () => {
+    render(<TweetComponent tweet={tweet} isPermalinkPage />)
+
+    expect(screen.queryByText('Archive')).not.toBeInTheDocument()
+    expect(screen.queryByText('Twitter')).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('link', {
+        name: 'View on Twitter (opens in a new tab)',
+      }),
+    ).toHaveAttribute('href', 'https://twitter.com/alice/status/123')
+  })
+
+  test('labels missing quoted tweets as unavailable', () => {
+    render(
+      <TweetComponent
+        tweet={{
+          ...tweet,
+          quote_tweet_id: '789',
+          quoted_tweet: {
+            tweet_id: '789',
+            account_id: '987',
+            created_at: '2026-08-11T12:00:00.000Z',
+            full_text: '',
+            retweet_count: 0,
+            favorite_count: 0,
+            username: 'bob',
+            account_display_name: 'Bob',
+            is_deleted: true,
+          },
+        }}
+      />,
+    )
+
+    expect(screen.getByText('[Quoted tweet unavailable]')).toBeVisible()
+  })
+})

--- a/src/components/TweetComponent.tsx
+++ b/src/components/TweetComponent.tsx
@@ -101,6 +101,7 @@ interface TweetComponentProps {
   compact?: boolean
   permalinkOrigin?: TweetOrigin
   permalinkReturnTo?: string
+  isPermalinkPage?: boolean
 }
 
 export const compactTweetGridClass =
@@ -116,6 +117,7 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
   compact = false,
   permalinkOrigin,
   permalinkReturnTo,
+  isPermalinkPage = false,
 }) => {
   const [isTextExpanded, setIsTextExpanded] = React.useState(false)
   // Support both interface formats for backwards compatibility
@@ -287,15 +289,13 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
     if (!isQuoteTweet || !tweet.quoted_tweet) return null
 
     const quotedTweet = tweet.quoted_tweet
-    // The fetchers set is_deleted=true when the quote relationship exists but the
-    // target tweet has been deleted. Render a muted tombstone instead of trying to
-    // show an empty card.
+    // A missing quote can be deleted, private, or otherwise inaccessible.
     if (quotedTweet.is_deleted) {
       return (
         <div
           className={`${compact ? 'mt-2 p-2 text-xs' : 'mt-3 p-3 text-sm'} rounded-lg border border-dashed border-border bg-muted italic text-muted-foreground dark:bg-card`}
         >
-          [Quoted tweet deleted]
+          [Quoted tweet unavailable]
         </div>
       )
     }
@@ -705,27 +705,34 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
         </div>
         <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
           <span>{new Date(tweet.created_at).toLocaleDateString()}</span>
-          <a
-            href={tweetPermalinkHref(
-              tweet.tweet_id,
-              permalinkOrigin,
-              permalinkReturnTo,
-            )}
-            className="inline-flex items-center gap-1 transition-colors hover:text-foreground"
-            title="Permalink"
-          >
-            <FaExternalLinkAlt className="h-3 w-3" />
-            Archive
-          </a>
+          {!isPermalinkPage && (
+            <a
+              href={tweetPermalinkHref(
+                tweet.tweet_id,
+                permalinkOrigin,
+                permalinkReturnTo,
+              )}
+              className="inline-flex items-center gap-1 transition-colors hover:text-foreground"
+              title="Permalink"
+            >
+              <FaExternalLinkAlt className="h-3 w-3" />
+              Archive
+            </a>
+          )}
           <a
             href={`https://twitter.com/${displayUsername}/status/${tweet.tweet_id}`}
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center gap-1 transition-colors hover:text-foreground"
+            aria-label={
+              isPermalinkPage
+                ? 'View on Twitter (opens in a new tab)'
+                : undefined
+            }
             title="View on Twitter"
           >
             <FaExternalLinkAlt className="h-3 w-3" />
-            Twitter
+            {!isPermalinkPage && 'Twitter'}
           </a>
         </div>
       </div>

--- a/src/components/metaTwitter/ProfileHeader.test.tsx
+++ b/src/components/metaTwitter/ProfileHeader.test.tsx
@@ -175,3 +175,37 @@ test('requests a high-resolution avatar for the profile header', () => {
     'https://pbs.twimg.com/profile_images/42/avatar_400x400.jpg',
   )
 })
+
+test('shows resolved, clickable profile bio and website links', () => {
+  render(
+    <ProfileHeader
+      profile={{
+        ...profile({ has_archive: true, is_opted_in: false }),
+        bio: 'Building https://t.co/bio',
+        website: 'https://t.co/site',
+        profile_links: [
+          {
+            original_url: 'https://t.co/bio',
+            expanded_url: 'https://www.community-archive.org/',
+            display_url: 'community-archive.org',
+          },
+          {
+            original_url: 'https://t.co/site',
+            expanded_url: 'https://xiqo.substack.com/',
+            display_url: 'xiqo.substack.com',
+          },
+        ],
+      }}
+      archivedAt={null}
+    />,
+  )
+
+  expect(
+    screen.getByRole('link', { name: 'community-archive.org' }),
+  ).toHaveAttribute('href', 'https://www.community-archive.org/')
+  expect(
+    screen.getByRole('link', { name: 'xiqo.substack.com' }),
+  ).toHaveAttribute('href', 'https://xiqo.substack.com/')
+  expect(screen.queryByText('https://t.co/bio')).not.toBeInTheDocument()
+  expect(screen.queryByText('https://t.co/site')).not.toBeInTheDocument()
+})

--- a/src/components/metaTwitter/ProfileHeader.tsx
+++ b/src/components/metaTwitter/ProfileHeader.tsx
@@ -3,7 +3,10 @@ import Link from 'next/link'
 import type { ReactNode } from 'react'
 import { PiInfo } from 'react-icons/pi'
 import { formatNumber } from '@/lib/formatNumber'
-import type { ProfileHeaderData } from '@/lib/metaTwitter/types'
+import type {
+  ProfileHeaderData,
+  ResolvedProfileLink,
+} from '@/lib/metaTwitter/types'
 import { MembershipStatusIcon } from '@/components/MembershipStatusIcon'
 import { ProjectContributorBadge } from '@/components/ProjectContributorBadge'
 import { ProfileAvatar } from './ProfileAvatar'
@@ -23,6 +26,32 @@ const Stat = ({ value, label }: { value: number | null; label: string }) =>
       <span className="text-muted-foreground">{label}</span>
     </span>
   )
+
+const urlPattern = /(https?:\/\/[^\s]+)/g
+
+function ProfileText({
+  text,
+  links,
+}: {
+  text: string
+  links: Map<string, ResolvedProfileLink>
+}) {
+  return text.split(urlPattern).map((part, index) => {
+    if (!/^https?:\/\/[^\s]+$/.test(part)) return part
+    const link = links.get(part)
+    return (
+      <a
+        key={`${part}-${index}`}
+        href={link?.expanded_url ?? part}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="break-all text-brand underline-offset-2 hover:underline"
+      >
+        {link?.display_url ?? part.replace(/^https?:\/\//, '')}
+      </a>
+    )
+  })
+}
 
 export function ProfileHeader({
   profile,
@@ -45,6 +74,9 @@ export function ProfileHeader({
   const headerUrl = profile.header_media_url
     ? `${profile.header_media_url.replace(/\/$/, '')}/1500x500`
     : null
+  const profileLinks = new Map(
+    (profile.profile_links ?? []).map((link) => [link.original_url, link]),
+  )
 
   return (
     <header>
@@ -115,8 +147,16 @@ export function ProfileHeader({
                   : 'hidden lg:block'
               }
             >
-              {profile.bio}
+              {profile.bio ? (
+                <ProfileText text={profile.bio} links={profileLinks} />
+              ) : null}
             </div>
+
+            {profile.website ? (
+              <div className="mt-1 text-sm">
+                <ProfileText text={profile.website} links={profileLinks} />
+              </div>
+            ) : null}
 
             {!profile.has_archive && !profile.is_opted_in ? (
               <div

--- a/src/components/portal/TweetRow.tsx
+++ b/src/components/portal/TweetRow.tsx
@@ -121,16 +121,18 @@ function imageMedia(media: PortalMedia[] | undefined): PortalMedia[] {
 function TweetImages({
   media,
   compact,
+  compactGrid = false,
   label,
 }: {
   media: PortalMedia[] | undefined
   compact: boolean
+  compactGrid?: boolean
   label: string
 }) {
   const images = imageMedia(media)
   if (images.length === 0) return null
 
-  if (compact) {
+  if (compact && !compactGrid) {
     return (
       <div className="mt-2 flex gap-1.5 overflow-x-auto pb-0.5">
         {images.slice(0, 4).map((item, index) => (
@@ -151,6 +153,8 @@ function TweetImages({
 
   return (
     <div
+      role={compactGrid ? 'group' : undefined}
+      aria-label={compactGrid ? 'Quoted tweet media' : undefined}
       className={`mt-2 grid gap-1.5 ${images.length > 1 ? 'grid-cols-2' : 'grid-cols-1'}`}
     >
       {images.slice(0, 4).map((item, index) => (
@@ -165,8 +169,8 @@ function TweetImages({
               ? '(max-width: 640px) 50vw, 320px'
               : '(max-width: 640px) 100vw, 640px'
           }
-          className="max-h-72 rounded-[4px] border border-zinc-200 bg-zinc-100 dark:border-[#303036] dark:bg-[#202023]"
-          imageClassName="h-full max-h-72 w-full object-cover transition-transform hover:scale-[1.01]"
+          className={`${compactGrid ? (images.length > 1 ? 'aspect-square' : 'aspect-video') : 'max-h-72'} rounded-[4px] border border-zinc-200 bg-zinc-100 dark:border-[#303036] dark:bg-[#202023]`}
+          imageClassName={`${compactGrid ? 'h-full' : 'h-full max-h-72'} w-full object-cover transition-transform hover:scale-[1.01]`}
         />
       ))}
     </div>
@@ -195,7 +199,7 @@ function QuotedTweet({
   if (tweet.isDeleted) {
     return (
       <div className="mt-2 rounded-[4px] border border-dashed border-zinc-300 bg-white px-3 py-2 text-[12px] italic text-zinc-500 dark:border-[#3a3a40] dark:bg-[#18181b] dark:text-[#a7a7b4]">
-        Quoted tweet deleted
+        Quoted tweet unavailable
       </div>
     )
   }
@@ -250,6 +254,7 @@ function QuotedTweet({
           <TweetImages
             media={tweet.media}
             compact={compact}
+            compactGrid
             label="Quoted tweet image"
           />
           {/https?:\/\//.test(tweet.text) && (
@@ -402,8 +407,8 @@ export function TweetRow({
   const tweetContent = (
     <div
       className={`${
-        isEditorial ? 'mt-2.5 whitespace-pre-wrap' : 'mt-0.5'
-      } break-words text-zinc-700 dark:text-[#d9d9de] ${
+        isEditorial ? 'mt-2.5' : 'mt-0.5'
+      } whitespace-pre-wrap break-words text-zinc-700 dark:text-[#d9d9de] ${
         isEditorial
           ? isFeatured
             ? 'text-[20px] leading-[1.55] [font-family:var(--font-petrona)] sm:text-[22px]'

--- a/src/lib/metaTwitter/data.ts
+++ b/src/lib/metaTwitter/data.ts
@@ -4,6 +4,7 @@ import { createClient, SupabaseClient } from '@supabase/supabase-js'
 import { unstable_cache } from 'next/cache'
 import { Database } from '@/database-types'
 import { devLog } from '@/lib/devLog'
+import { resolveProfileLinks } from '@/lib/profileLinks'
 import type {
   ArchiveMediaItem,
   ArchivePerson,
@@ -63,11 +64,15 @@ async function fetchProfileHeader(
   if (profileError) throw profileError
   if (membershipError) throw membershipError
   if (!account) return null
+  const bio = profile?.bio ?? null
+  const website = profile?.website ?? null
+  const profileLinks = await resolveProfileLinks([bio, website])
   return {
     ...account,
     account_display_name: account.account_display_name ?? account.username,
-    bio: profile?.bio ?? null,
-    website: profile?.website ?? null,
+    bio,
+    website,
+    profile_links: profileLinks,
     location: profile?.location ?? null,
     avatar_media_url: profile?.avatar_media_url ?? null,
     header_media_url: profile?.header_media_url ?? null,

--- a/src/lib/metaTwitter/types.ts
+++ b/src/lib/metaTwitter/types.ts
@@ -66,7 +66,14 @@ export interface ProfileHeaderData {
   is_opted_in: boolean
   bio: string | null
   website: string | null
+  profile_links?: ResolvedProfileLink[]
   location: string | null
   avatar_media_url: string | null
   header_media_url: string | null
+}
+
+export interface ResolvedProfileLink {
+  original_url: string
+  expanded_url: string
+  display_url: string
 }

--- a/src/lib/profileLinks.test.ts
+++ b/src/lib/profileLinks.test.ts
@@ -1,0 +1,52 @@
+jest.mock('server-only', () => ({}))
+
+import { resolveProfileLinks } from './profileLinks'
+
+describe('resolveProfileLinks', () => {
+  const originalFetch = global.fetch
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    jest.restoreAllMocks()
+  })
+
+  test('resolves unique t.co links and formats direct links without fetching them', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(null, {
+        status: 301,
+        headers: { location: 'https://www.community-archive.org/' },
+      }),
+    )
+
+    await expect(
+      resolveProfileLinks([
+        'Bio https://t.co/abc and https://example.com/about/',
+        'https://t.co/abc',
+      ]),
+    ).resolves.toEqual([
+      {
+        original_url: 'https://t.co/abc',
+        expanded_url: 'https://www.community-archive.org/',
+        display_url: 'community-archive.org',
+      },
+      {
+        original_url: 'https://example.com/about/',
+        expanded_url: 'https://example.com/about/',
+        display_url: 'example.com/about',
+      },
+    ])
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  test('falls back to the short link when resolution fails', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('network unavailable'))
+
+    await expect(resolveProfileLinks(['https://t.co/abc'])).resolves.toEqual([
+      {
+        original_url: 'https://t.co/abc',
+        expanded_url: 'https://t.co/abc',
+        display_url: 't.co/abc',
+      },
+    ])
+  })
+})

--- a/src/lib/profileLinks.ts
+++ b/src/lib/profileLinks.ts
@@ -1,0 +1,70 @@
+import 'server-only'
+
+import type { ResolvedProfileLink } from '@/lib/metaTwitter/types'
+
+const urlPattern = /https?:\/\/[^\s]+/g
+const tcoPattern = /^https:\/\/t\.co\/[A-Za-z0-9]+$/
+
+const displayUrl = (value: string) => {
+  try {
+    const parsed = new URL(value)
+    const host = parsed.hostname.replace(/^www\./, '')
+    const path =
+      parsed.pathname === '/' ? '' : parsed.pathname.replace(/\/$/, '')
+    return `${host}${path}${parsed.search}`
+  } catch {
+    return value.replace(/^https?:\/\//, '')
+  }
+}
+
+const safeRedirect = (shortUrl: string, location: string | null) => {
+  if (!location) return shortUrl
+  try {
+    const resolved = new URL(location, shortUrl)
+    return resolved.protocol === 'http:' || resolved.protocol === 'https:'
+      ? resolved.toString()
+      : shortUrl
+  } catch {
+    return shortUrl
+  }
+}
+
+async function resolveUrl(url: string): Promise<ResolvedProfileLink> {
+  if (!tcoPattern.test(url)) {
+    return {
+      original_url: url,
+      expanded_url: url,
+      display_url: displayUrl(url),
+    }
+  }
+
+  try {
+    const response = await fetch(url, {
+      method: 'HEAD',
+      redirect: 'manual',
+      signal: AbortSignal.timeout(2_000),
+      next: { revalidate: 604_800 },
+    })
+    const expandedUrl = safeRedirect(url, response.headers.get('location'))
+    return {
+      original_url: url,
+      expanded_url: expandedUrl,
+      display_url: displayUrl(expandedUrl),
+    }
+  } catch {
+    return {
+      original_url: url,
+      expanded_url: url,
+      display_url: displayUrl(url),
+    }
+  }
+}
+
+export async function resolveProfileLinks(
+  values: Array<string | null | undefined>,
+): Promise<ResolvedProfileLink[]> {
+  const urls = new Set(
+    values.flatMap((value) => value?.match(urlPattern) ?? []),
+  )
+  return Promise.all(Array.from(urls, resolveUrl))
+}


### PR DESCRIPTION
## Summary

- remove the self-referential Archive action from tweet permalink cards and reduce the X/Twitter action to an accessible outgoing-link icon
- preserve authored newlines in live-stream and other canonical TweetCard surfaces
- use “unavailable” for quoted-tweet tombstones
- render quoted media as a stable 1-up / 2-column grid with lightbox access for 1–4 images
- resolve profile bio and website t.co links into readable, clickable destinations with bounded, cached server lookups

## Root causes

- the legacy tweet renderer had no context indicating that it was already on the current permalink
- default TweetRow text lacked the whitespace-preserving class used by editorial cards
- missing quotes were treated as definitively deleted even though private or inaccessible posts look the same
- compact quoted media inherited the horizontal-strip layout
- archived profile data stores t.co tokens but not their expanded entity metadata

## Validation

- 26 focused client component tests passed
- 5 focused server/data tests passed
- TypeScript type check passed
- focused ESLint and diff checks passed
- live t.co HEAD checks confirmed the archived sample links expose redirect destinations

Closes #675
Closes #640
Closes #627
Closes #639
Closes #631
