### PR TITLE
Polish upload flow and homepage quick fixes

### DIFF
--- a/src/app/about/page.test.tsx
+++ b/src/app/about/page.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, within } from '@testing-library/react'
 import AboutPage from './page'
 
 describe('AboutPage contributors', () => {
-  it('shows the current and past contributors with their X accounts', () => {
+  it('links current and past contributors to their Archive profiles', () => {
     render(<AboutPage />)
 
     const currentHeading = screen.getByRole('heading', {
@@ -14,7 +14,7 @@ describe('AboutPage contributors', () => {
     const xiqLink = within(currentSection!).getByRole('link', {
       name: 'Francisco Carvalho (Xiq)',
     })
-    expect(xiqLink).toHaveAttribute('href', 'https://x.com/exgenesis')
+    expect(xiqLink).toHaveAttribute('href', '/user/exgenesis')
     expect(xiqLink).toHaveTextContent('Francisco Carvalho (Xiq)')
     expect(within(xiqLink).getByText('(Xiq)')).toHaveClass(
       'text-muted-foreground',
@@ -22,7 +22,7 @@ describe('AboutPage contributors', () => {
     expect(within(currentSection!).getByText('Founder')).toBeInTheDocument()
     expect(
       within(currentSection!).getByRole('link', { name: 'Christine Shiba' }),
-    ).toHaveAttribute('href', 'https://x.com/christineist')
+    ).toHaveAttribute('href', '/user/christineist')
 
     const xiqCard = xiqLink.closest('.rounded-lg')
     expect(xiqCard?.querySelector('svg')).toBeNull()
@@ -34,12 +34,12 @@ describe('AboutPage contributors', () => {
     expect(pastSection).not.toBeNull()
     expect(
       within(pastSection!).getByRole('link', { name: '@DefenderOfBasic' }),
-    ).toHaveAttribute('href', 'https://x.com/DefenderOfBasic')
+    ).toHaveAttribute('href', '/user/DefenderOfBasic')
     expect(
       within(pastSection!).getByRole('link', {
         name: 'Alexandre Variengien',
       }),
-    ).toHaveAttribute('href', 'https://x.com/A_Variengien')
+    ).toHaveAttribute('href', '/user/A_Variengien')
     expect(
       within(pastSection!).queryByText('Christine Shiba'),
     ).not.toBeInTheDocument()

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -5,6 +5,7 @@ import {
   currentProjectContributors,
   pastProjectContributors,
 } from '@/lib/projectContributors'
+import { userProfileHref } from '@/lib/navigation'
 
 export default function AboutPage() {
   return (
@@ -36,10 +37,8 @@ export default function AboutPage() {
               className="rounded-lg bg-muted p-4 dark:bg-card"
             >
               <h3 className="mb-1 text-xl font-semibold">
-                <a
-                  href={`https://x.com/${contributor.username}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
+                <Link
+                  href={userProfileHref(contributor.username)}
                   className="transition-colors hover:text-brand"
                 >
                   {contributor.name}
@@ -49,7 +48,7 @@ export default function AboutPage() {
                       ({contributor.qualifier})
                     </span>
                   ) : null}
-                </a>
+                </Link>
               </h3>
               {contributor.role && (
                 <p className="text-muted-foreground">{contributor.role}</p>
@@ -72,14 +71,12 @@ export default function AboutPage() {
               className="rounded-lg bg-muted p-4 dark:bg-card"
             >
               <h3 className="text-lg font-semibold">
-                <a
-                  href={`https://x.com/${contributor.username}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
+                <Link
+                  href={userProfileHref(contributor.username)}
                   className="transition-colors hover:text-brand"
                 >
                   {contributor.name}
-                </a>
+                </Link>
               </h3>
             </div>
           ))}

--- a/src/components/file-upload-dialog.test.tsx
+++ b/src/components/file-upload-dialog.test.tsx
@@ -1,0 +1,88 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FileUploadDialog } from './file-upload-dialog'
+import { uploadArchive } from '@/lib/upload-archive/uploadArchive'
+import type { Archive } from '@/lib/types'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '@/database-types'
+
+jest.mock('@/lib/upload-archive/uploadArchive', () => ({
+  uploadArchive: jest.fn(),
+}))
+jest.mock('@/lib/posthog', () => ({ capturePostHogEvent: jest.fn() }))
+
+const archive: Archive = {
+  profile: [
+    {
+      profile: {
+        description: { bio: '', website: '', location: '' },
+        avatarMediaUrl: '',
+        headerMediaUrl: '',
+      },
+    },
+  ],
+  account: [
+    {
+      account: {
+        createdVia: 'web',
+        username: 'alice',
+        accountId: '42',
+        createdAt: '2020-01-01T00:00:00.000Z',
+        accountDisplayName: 'Alice',
+      },
+    },
+  ],
+  tweets: [
+    {
+      tweet: {
+        id: '1',
+        id_str: '1',
+        source: 'web',
+        entities: {},
+        favorite_count: 0,
+        retweet_count: 0,
+        created_at: '2026-08-01T00:00:00.000Z',
+        favorited: false,
+        full_text: 'Hello',
+      },
+    },
+  ],
+  follower: [],
+  following: [],
+  'community-tweet': [],
+  like: [],
+}
+
+test('shows one concise upload status while progress is active', async () => {
+  jest
+    .mocked(uploadArchive)
+    .mockImplementation(
+      (
+        _supabase,
+        onProgress: (progress: { phase: string; percent: number }) => void,
+      ) => {
+        onProgress({ phase: 'Uploading archive to storage', percent: 0 })
+        return new Promise(() => {})
+      },
+    )
+  const user = userEvent.setup()
+
+  render(
+    <FileUploadDialog
+      supabase={{} as SupabaseClient<Database>}
+      isOpen
+      onClose={jest.fn()}
+      archive={archive}
+    />,
+  )
+  await user.click(screen.getByRole('button', { name: 'Upload' }))
+
+  expect(
+    screen.getByRole('heading', { name: 'Upload in progress' }),
+  ).toBeVisible()
+  expect(
+    await screen.findByText('Uploading archive to storage: 0.00%'),
+  ).toBeVisible()
+  expect(screen.getAllByText(/uploading/i)).toHaveLength(1)
+})

--- a/src/components/file-upload-dialog.tsx
+++ b/src/components/file-upload-dialog.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -106,8 +107,10 @@ export function FileUploadDialog({
     capturePostHogEvent('archive_upload_started', {
       includes_likes: options.uploadLikes,
       date_filter_applied:
-        dateInputs.start !== format(new Date(archiveStats.earliestTweetDate), 'yyyy-MM-dd') ||
-        dateInputs.end !== format(new Date(archiveStats.latestTweetDate), 'yyyy-MM-dd'),
+        dateInputs.start !==
+          format(new Date(archiveStats.earliestTweetDate), 'yyyy-MM-dd') ||
+        dateInputs.end !==
+          format(new Date(archiveStats.latestTweetDate), 'yyyy-MM-dd'),
     })
 
     try {
@@ -163,13 +166,22 @@ export function FileUploadDialog({
         <DialogHeader>
           <DialogTitle>
             {state.uploadStatus === 'uploading'
-              ? 'Uploading...'
+              ? 'Upload in progress'
               : state.uploadStatus === 'completed'
                 ? 'Upload Successful'
                 : state.error
                   ? 'Upload Error'
                   : 'Upload Confirmation'}
           </DialogTitle>
+          <DialogDescription className="sr-only">
+            {state.uploadStatus === 'uploading'
+              ? 'Your archive is being transferred. Keep this window open.'
+              : state.uploadStatus === 'completed'
+                ? 'Your archive upload finished successfully.'
+                : state.error
+                  ? 'The archive upload could not be completed.'
+                  : 'Review your archive details and choose what to upload.'}
+          </DialogDescription>
         </DialogHeader>
         {state.error ? (
           <div className="grid gap-4 py-4">
@@ -324,7 +336,6 @@ export function FileUploadDialog({
           </div>
         ) : state.uploadStatus === 'uploading' ? (
           <div className="grid gap-4 py-4">
-            <p className="mb-2 text-sm">Uploading your archive...</p>
             {state.progress && (
               <div>
                 <p className="mb-1">

--- a/src/lib/portal/stream.test.ts
+++ b/src/lib/portal/stream.test.ts
@@ -69,4 +69,15 @@ describe('portal stream selection', () => {
       likes: 250,
     })
   })
+
+  test('excludes @bot from the homepage selection only', () => {
+    const now = new Date('2026-08-07T12:00:00.000Z')
+    const bot = tweet('102', '2026-08-07T11:59:00.000Z', {
+      username: 'BoT',
+      likes: 10_000,
+    })
+    const human = tweet('101', '2026-08-07T11:58:00.000Z')
+
+    expect(selectHomepageStream([bot, human], 2, now)).toEqual([human])
+  })
 })

--- a/src/lib/portal/stream.ts
+++ b/src/lib/portal/stream.ts
@@ -1,6 +1,7 @@
 import type { PortalTweet } from './types'
 
 const HOMEPAGE_RECENCY_QUOTA = 4
+const HOMEPAGE_EXCLUDED_USERNAMES = new Set(['bot'])
 
 function compareTweetIdsDescending(left: string, right: string): number {
   return right.length - left.length || right.localeCompare(left)
@@ -52,6 +53,7 @@ export function selectHomepageStream(
   const safeLimit = Math.max(1, Math.min(100, Math.trunc(limit)))
   const byId = new Map<string, PortalTweet>()
   for (const tweet of tweets) {
+    if (HOMEPAGE_EXCLUDED_USERNAMES.has(tweet.username.toLowerCase())) continue
     const createdAt = new Date(tweet.createdAt)
     if (Number.isNaN(createdAt.getTime())) continue
     const previous = byId.get(tweet.id)


### PR DESCRIPTION
## Summary

- collapse the active upload dialog to one concise progress message and add an accessible dialog description
- link current and past contributor names to their Community Archive profiles
- exclude the exact `@bot` account from homepage stream selection without changing the full live stream

## Validation

- focused upload-dialog and About-page component tests passed
- focused homepage stream-selection tests passed
- TypeScript type check passed
- focused ESLint and diff checks passed

Closes #625
Closes #643
Closes #672
