### PR TITLE
Fix Trends defaults, layout, and media hydration

### DIFF
--- a/src/components/portal/TrendsExplorer.tsx
+++ b/src/components/portal/TrendsExplorer.tsx
@@ -67,6 +67,13 @@ const SERIES_COLORS = [
 ]
 const DEFAULT_TREND_TERMS = CHART_TERMS.map(({ term }) => term)
 
+function isDefaultTrendSet(terms: string[]): boolean {
+  return (
+    terms.length === DEFAULT_TREND_TERMS.length &&
+    terms.every((term, index) => term === DEFAULT_TREND_TERMS[index])
+  )
+}
+
 type TrendsExplorerAction =
   | 'chart_series_toggled'
   | 'evidence_filter_toggled'
@@ -590,7 +597,12 @@ export default function TrendsExplorer({
     const existing = new Set(configuredTerms)
     const alreadyPresent = requested.filter((term) => existing.has(term))
     const newTerms = requested.filter((term) => !existing.has(term))
-    if (configuredTerms.length + newTerms.length > MAX_SERIES) {
+    const replaceDefaults =
+      newTerms.length > 0 && isDefaultTrendSet(configuredTerms)
+    const nextConfiguredTerms = replaceDefaults
+      ? [...alreadyPresent, ...newTerms]
+      : [...configuredTerms, ...newTerms]
+    if (nextConfiguredTerms.length > MAX_SERIES) {
       setAddError(`Show up to ${MAX_SERIES} trends at once.`)
       return
     }
@@ -617,35 +629,50 @@ export default function TrendsExplorer({
     try {
       const body = await requestTrendSeries(newTerms, granularity)
 
-      const firstColorIndex = series.length
+      const retainedSeries = replaceDefaults
+        ? series.filter(({ term }) => alreadyPresent.includes(term))
+        : series
+      const firstColorIndex = retainedSeries.length
       const additions = body.series.map((item, index) => ({
         ...item,
         color: SERIES_COLORS[(firstColorIndex + index) % SERIES_COLORS.length],
       }))
+      const nextSeries = [...retainedSeries, ...additions]
       setBuckets(body.buckets)
-      setSeries((current) => [...current, ...additions])
-      setConfiguredTerms((current) => [...current, ...newTerms])
-      setChartEnabled((current) => ({
-        ...current,
-        ...Object.fromEntries(additions.map(({ term }) => [term, true])),
-      }))
-      setFeedFilters((current) => ({
-        ...current,
-        ...Object.fromEntries(
-          additions.map(({ term }) => [term, 'include' as const]),
-        ),
-      }))
-      const nextEnabled = new Set([
-        ...enabledSeries.map(({ term }) => term),
-        ...alreadyPresent,
-        ...additions.map(({ term }) => term),
-      ])
-      const nextIncluded = new Set([
-        ...includeTerms,
-        ...additions.map(({ term }) => term),
-      ])
+      setSeries(nextSeries)
+      setConfiguredTerms(nextConfiguredTerms)
+      setChartEnabled((current) =>
+        replaceDefaults
+          ? Object.fromEntries(nextConfiguredTerms.map((term) => [term, true]))
+          : {
+              ...current,
+              ...Object.fromEntries(additions.map(({ term }) => [term, true])),
+            },
+      )
+      setFeedFilters((current) =>
+        replaceDefaults
+          ? Object.fromEntries(
+              nextConfiguredTerms.map((term) => [term, 'include' as const]),
+            )
+          : {
+              ...current,
+              ...Object.fromEntries(
+                additions.map(({ term }) => [term, 'include' as const]),
+              ),
+            },
+      )
+      const nextEnabled = replaceDefaults
+        ? new Set(nextConfiguredTerms)
+        : new Set([
+            ...enabledSeries.map(({ term }) => term),
+            ...alreadyPresent,
+            ...additions.map(({ term }) => term),
+          ])
+      const nextIncluded = replaceDefaults
+        ? new Set(nextConfiguredTerms)
+        : new Set([...includeTerms, ...additions.map(({ term }) => term)])
       captureExplorerAction('terms_added', {
-        seriesCount: series.length + additions.length,
+        seriesCount: nextSeries.length,
         enabledSeriesCount: nextEnabled.size,
         includedSeriesCount: nextIncluded.size,
       })
@@ -814,7 +841,7 @@ export default function TrendsExplorer({
   }
 
   return (
-    <main className="min-h-screen bg-zinc-100/80 dark:bg-transparent">
+    <main className="flex-1 bg-zinc-100/80 dark:bg-transparent">
       <div className="mx-auto max-w-[1480px] px-4 py-6 sm:px-6">
         <Link
           href="/"

--- a/src/lib/portal/TrendsExplorerResilience.test.tsx
+++ b/src/lib/portal/TrendsExplorerResilience.test.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import TrendsExplorer from '@/components/portal/TrendsExplorer'
-import { emptyPortalTrends } from './trendConfig'
+import { CHART_TERMS, emptyPortalTrends } from './trendConfig'
 import type { PortalTrends } from './types'
 import { capturePostHogEvent } from '@/lib/posthog'
 ;(globalThis as typeof globalThis & { React: typeof React }).React = React
@@ -44,6 +44,16 @@ const twoTrends: PortalTrends = {
       perYear: [50, 80],
     },
   ],
+}
+
+const defaultTrends: PortalTrends = {
+  ...successfulTrends,
+  series: CHART_TERMS.map(({ term, color }, index) => ({
+    term,
+    color,
+    tweetsPerYear: [index + 1, index + 2],
+    perYear: [(index + 1) * 10, (index + 2) * 10],
+  })),
 }
 
 function feedTweet(id: string, year: number) {
@@ -203,6 +213,72 @@ describe('TrendsExplorer request isolation', () => {
       screen.queryByRole('button', { name: 'Remove tpot trend' }),
     ).not.toBeInTheDocument()
     expect(screen.getByText('0/12 trends')).toBeVisible()
+  })
+
+  test('replaces defaults with the first custom trend, then preserves later additions', async () => {
+    const user = userEvent.setup()
+    jest.spyOn(global, 'fetch').mockImplementation(async (url) => {
+      const requestUrl = new URL(String(url), 'https://example.com')
+      if (requestUrl.searchParams.get('view') === 'series') {
+        const terms = requestUrl.searchParams.getAll('q')
+        return {
+          ok: true,
+          json: async () => ({
+            granularity: 'year',
+            buckets: ['2025', '2026'],
+            series: terms.map((term) => ({
+              term,
+              color: '#3b82f6',
+              tweetsPerBucket: [1, 2],
+              perBucket: [10, 20],
+            })),
+          }),
+        } as Response
+      }
+      return {
+        ok: true,
+        json: async () => ({ tweets: [] }),
+      } as Response
+    })
+
+    render(<TrendsExplorer initialTrends={defaultTrends} />)
+    const input = screen.getByLabelText('Words or phrases to chart')
+
+    await user.type(input, 'custom idea')
+    await user.click(screen.getByRole('button', { name: 'Add trends' }))
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Remove custom idea trend' }),
+      ).toBeVisible(),
+    )
+    expect(
+      screen.queryByRole('button', { name: 'Remove tpot trend' }),
+    ).not.toBeInTheDocument()
+    expect(screen.getByText('1/12 trends')).toBeVisible()
+
+    await user.type(input, 'second idea')
+    await user.click(screen.getByRole('button', { name: 'Add trends' }))
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Remove second idea trend' }),
+      ).toBeVisible(),
+    )
+    expect(
+      screen.getByRole('button', { name: 'Remove custom idea trend' }),
+    ).toBeVisible()
+    expect(screen.getByText('2/12 trends')).toBeVisible()
+  })
+
+  test('lets the root layout own the viewport height without extra page length', () => {
+    jest
+      .spyOn(global, 'fetch')
+      .mockImplementation(() => new Promise<Response>(() => undefined))
+
+    render(<TrendsExplorer initialTrends={successfulTrends} />)
+
+    const main = screen.getByRole('main')
+    expect(main).toHaveClass('flex-1')
+    expect(main).not.toHaveClass('min-h-screen')
   })
 
   test('loads only a newly included term when prior term evidence is cached', async () => {

--- a/src/lib/portal/analytics.test.ts
+++ b/src/lib/portal/analytics.test.ts
@@ -234,6 +234,17 @@ describe('ClickHouse-backed portal analytics', () => {
       username: 'alice',
       accountDisplayName: 'Alice',
       avatarMediaUrl: null,
+      media:
+        tweetId === '102'
+          ? [
+              {
+                mediaUrl: 'https://pbs.twimg.com/media/evidence.jpg',
+                mediaType: 'photo',
+                width: 1200,
+                height: 800,
+              },
+            ]
+          : [],
     })
     const fetcherMock = jest.fn(
       async (_path: string[], params: URLSearchParams) => ({
@@ -279,6 +290,14 @@ describe('ClickHouse-backed portal analytics', () => {
       createdAt: '2026-08-07T12:00:00.000Z',
       likes: 3,
       rts: 1,
+      media: [
+        {
+          url: 'https://pbs.twimg.com/media/evidence.jpg',
+          type: 'photo',
+          width: 1200,
+          height: 800,
+        },
+      ],
     })
   })
 
@@ -336,12 +355,7 @@ describe('ClickHouse-backed portal analytics', () => {
       new URLSearchParams({ limit: '50', hours: '168' }),
       { timeoutMs: 30_000, revalidate: 1_800 },
     )
-    await fetchPortalRecentBangers(
-      50,
-      24,
-      fetcher,
-      '2026-08-12T07:00:00.000Z',
-    )
+    await fetchPortalRecentBangers(50, 24, fetcher, '2026-08-12T07:00:00.000Z')
     expect(fetcher).toHaveBeenLastCalledWith(
       ['recent-bangers'],
       new URLSearchParams({

--- a/src/lib/portal/analytics.ts
+++ b/src/lib/portal/analytics.ts
@@ -62,6 +62,12 @@ interface ClickHouseSearchTweet {
   username: string | null
   accountDisplayName: string | null
   avatarMediaUrl: string | null
+  media?: Array<{
+    mediaUrl: string
+    mediaType: string
+    width: number | null
+    height: number | null
+  }>
 }
 
 interface ClickHouseSearchResponse {
@@ -371,6 +377,22 @@ export async function fetchPortalTrendEvidence(
       }
       const username = row.username || 'unknown'
       const createdAt = safeTimestamp(row.createdAt, 'trend tweet timestamp')
+      const media = row.media?.flatMap((item) =>
+        typeof item.mediaUrl === 'string' && typeof item.mediaType === 'string'
+          ? [
+              {
+                url: item.mediaUrl,
+                type: item.mediaType,
+                ...(typeof item.width === 'number'
+                  ? { width: item.width }
+                  : {}),
+                ...(typeof item.height === 'number'
+                  ? { height: item.height }
+                  : {}),
+              },
+            ]
+          : [],
+      )
       unique.set(row.tweetId, {
         id: row.tweetId,
         accountId: row.accountId,
@@ -382,6 +404,7 @@ export async function fetchPortalTrendEvidence(
         createdAt,
         likes: safeCount(row.favoriteCount, 'trend tweet favorite count'),
         rts: safeCount(row.retweetCount, 'trend tweet repost count'),
+        ...(media ? { media } : {}),
       })
     }
   }

--- a/src/lib/portal/data.test.ts
+++ b/src/lib/portal/data.test.ts
@@ -22,6 +22,7 @@ import {
   getPortalData,
   getPortalStreamPage,
   getPortalStreamUpdates,
+  enrichPortalTweets,
   loadOptionalPortalData,
   loadPortalComponentData,
   portalDataSourceKey,
@@ -320,6 +321,95 @@ describe('portal reads', () => {
     process.env.CLICKHOUSE_ANALYTICS_API_URL =
       'https://analytics.community-archive.org/analytics'
     process.env.CLICKHOUSE_ANALYTICS_API_TOKEN = 'test-token'
+  })
+
+  test('preserves hydrated own media while still checking quote relations', async () => {
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockImplementation(async (input) => {
+        const url = new URL(String(input))
+        if (url.pathname.endsWith('/quote_tweets')) {
+          return new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          })
+        }
+        throw new Error(`Unexpected test request: ${url}`)
+      })
+    const tweet: PortalTweet = {
+      id: '42',
+      accountId: '7',
+      username: 'alice',
+      name: 'Alice',
+      avatar: null,
+      text: 'Hydrated evidence',
+      observedAt: '2026-08-07T20:00:00.000Z',
+      createdAt: '2026-08-07T19:00:00.000Z',
+      likes: 3,
+      rts: 2,
+      media: [
+        {
+          url: 'https://pbs.twimg.com/media/evidence.jpg',
+          type: 'photo',
+          width: 1200,
+          height: 800,
+        },
+      ],
+    }
+
+    await expect(enrichPortalTweets([tweet])).resolves.toEqual([tweet])
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain('/quote_tweets?')
+  })
+
+  test('falls back to own-media enrichment for partially hydrated rows', async () => {
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockImplementation(async (input) => {
+        const url = new URL(String(input))
+        const rows = url.pathname.endsWith('/tweet_media')
+          ? [
+              {
+                tweet_id: '42',
+                media_url: 'https://pbs.twimg.com/media/fallback.jpg',
+                media_type: 'photo',
+                width: 1200,
+                height: 800,
+              },
+            ]
+          : []
+        return new Response(JSON.stringify(rows), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      })
+    const tweet: PortalTweet = {
+      id: '42',
+      accountId: '7',
+      username: 'alice',
+      name: 'Alice',
+      avatar: null,
+      text: 'Partial gateway evidence',
+      observedAt: '2026-08-07T20:00:00.000Z',
+      createdAt: '2026-08-07T19:00:00.000Z',
+      likes: 3,
+      rts: 2,
+    }
+
+    await expect(enrichPortalTweets([tweet])).resolves.toEqual([
+      {
+        ...tweet,
+        media: [
+          {
+            url: 'https://pbs.twimg.com/media/fallback.jpg',
+            type: 'photo',
+            width: 1200,
+            height: 800,
+          },
+        ],
+      },
+    ])
+    expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
   test('reads the homepage corpus total from ClickHouse', async () => {

--- a/src/lib/portal/data.ts
+++ b/src/lib/portal/data.ts
@@ -524,17 +524,20 @@ export async function enrichPortalTweets(
 ): Promise<PortalTweet[]> {
   const tweetIdFilter = portalIdFilter(tweets.map(({ id }) => id))
   if (!tweetIdFilter) return tweets
+  const needsOwnMedia = tweets.some((tweet) => tweet.media === undefined)
 
   const [mediaRows, quoteRelations] = await Promise.all([
-    optionalPortalRestRows<PortalMediaRow>(
-      'tweet_media',
-      new URLSearchParams({
-        select: 'tweet_id,media_url,media_type,width,height',
-        tweet_id: tweetIdFilter,
-        order: 'media_id.asc',
-      }),
-      'media',
-    ),
+    needsOwnMedia
+      ? optionalPortalRestRows<PortalMediaRow>(
+          'tweet_media',
+          new URLSearchParams({
+            select: 'tweet_id,media_url,media_type,width,height',
+            tweet_id: tweetIdFilter,
+            order: 'media_id.asc',
+          }),
+          'media',
+        )
+      : Promise.resolve([]),
     optionalPortalRestRows<PortalQuoteRelationRow>(
       'quote_tweets',
       new URLSearchParams({


### PR DESCRIPTION
Closes #670
Closes #678
Closes #632

## Summary
- replace the seeded Trends set when the first custom term is added while preserving subsequent custom additions
- let the shared page shell own viewport height so the footer no longer leaves an extra empty screen
- map gateway evidence media directly and skip the redundant Supabase own-media read when the batch is fully hydrated
- preserve quoted-tweet enrichment and partial gateway fallback behavior

## Verification
- 12 Trends explorer resilience tests
- 34 portal analytics/data tests
- TypeScript type check
- Next.js lint (one unrelated existing no-img-element warning)

## Preview follow-up
- confirm a warmed authenticated range top-up settles within one second after the existing 1.2-second debounce; the local browser session redirects to login, so that production-like timing check is not reproducible anonymously