### PR TITLE
Add undo for hidden profile items

### DIFF
--- a/src/app/user/[account_id]/actions.ts
+++ b/src/app/user/[account_id]/actions.ts
@@ -18,6 +18,7 @@ interface CurationTarget {
 
 type ProfileCurationMutation =
   | (CurationTarget & { action: 'dismiss'; itemId: string })
+  | (CurationTarget & { action: 'restore-item'; itemId: string })
   | (CurationTarget & { action: 'toggle-feature'; itemId: string })
   | (CurationTarget & { action: 'reorder'; itemIds: string[] })
   | (CurationTarget & { action: 'restore' })
@@ -99,6 +100,18 @@ export async function mutateProfileCuration(input: ProfileCurationMutation) {
   }
 
   if (!idPattern.test(input.itemId)) throw new Error('Invalid profile item')
+
+  if (input.action === 'restore-item') {
+    const { error } = await supabase
+      .from('profile_curation')
+      .upsert(
+        { ...target, item_id: input.itemId, is_hidden: false },
+        { onConflict: 'account_id,section,item_id' },
+      )
+    if (error) throw error
+    revalidateProfile(input.accountId)
+    return { ok: true as const }
+  }
 
   if (input.action === 'dismiss') {
     const { error } = await supabase

--- a/src/components/metaTwitter/ProfileArchive.test.tsx
+++ b/src/components/metaTwitter/ProfileArchive.test.tsx
@@ -188,6 +188,19 @@ test('shows owner-only curation controls and persists section edits', async () =
     }),
   )
   expect(screen.queryByText('Banger 1')).not.toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'Undo' })).toBeVisible()
+
+  await user.click(screen.getByRole('button', { name: 'Undo' }))
+  await waitFor(() =>
+    expect(mockMutateProfileCuration).toHaveBeenCalledWith({
+      action: 'restore-item',
+      accountId: '42',
+      section: 'bangers',
+      itemId: '1',
+    }),
+  )
+  await waitFor(() => expect(screen.getByText('Banger 1')).toBeVisible())
+  expect(screen.queryByRole('button', { name: 'Undo' })).not.toBeInTheDocument()
 
   mockMutateProfileCuration.mockResolvedValueOnce({
     ok: true,

--- a/src/components/metaTwitter/ProfileArchive.tsx
+++ b/src/components/metaTwitter/ProfileArchive.tsx
@@ -41,6 +41,11 @@ interface FeedState {
   available: boolean
 }
 
+interface DismissedItem {
+  itemId: string
+  section: ProfileCurationSection
+}
+
 const scopeKey = (year: number | null) => year?.toString() ?? 'overall'
 const feedKey = (year: number | null, sort: ProfileBangerSort) =>
   `${scopeKey(year)}:${sort}`
@@ -124,6 +129,7 @@ export function ProfileArchive({
   )
   const { editing, editSaving, setEditing, setEditSaving } = useProfileEditing()
   const [editError, setEditError] = useState<string | null>(null)
+  const [dismissedItem, setDismissedItem] = useState<DismissedItem | null>(null)
   const feedsRef = useRef(feeds)
   const mediaRef = useRef(mediaByScope)
   const peopleRef = useRef(peopleByScope)
@@ -132,6 +138,12 @@ export function ProfileArchive({
   const peopleRequests = useRef(new Map<string, Promise<void>>())
   const automaticallyFilledFeeds = useRef(new Set<string>())
   const loadMoreRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!dismissedItem) return
+    const timeout = window.setTimeout(() => setDismissedItem(null), 10_000)
+    return () => window.clearTimeout(timeout)
+  }, [dismissedItem])
 
   const updateFeeds = useCallback(
     (
@@ -489,6 +501,8 @@ export function ProfileArchive({
       })
       if (!result) return
 
+      setDismissedItem({ section, itemId })
+
       if (section === 'bangers') {
         const prefix = `${activeScopeKey}:`
         updateFeeds((current) =>
@@ -521,6 +535,52 @@ export function ProfileArchive({
     },
     [accountId, activeScopeKey, runEditMutation, updateFeeds, updatePeople],
   )
+
+  const undoDismissItem = useCallback(async () => {
+    if (!dismissedItem) return
+    setDismissedItem(null)
+    const result = await runEditMutation({
+      action: 'restore-item',
+      accountId,
+      section: dismissedItem.section,
+      itemId: dismissedItem.itemId,
+    })
+    if (!result) {
+      setDismissedItem(dismissedItem)
+      return
+    }
+
+    if (dismissedItem.section === 'bangers') {
+      const prefix = `${activeScopeKey}:`
+      const nextFeeds = Object.fromEntries(
+        Object.entries(feedsRef.current).filter(
+          ([key]) => !key.startsWith(prefix),
+        ),
+      )
+      feedsRef.current = nextFeeds
+      setFeeds(nextFeeds)
+      automaticallyFilledFeeds.current.delete(activeKey)
+      await loadFeedPage(activeYear, sort, 0, PROFILE_BANGERS_PRELOAD_LIMIT)
+      return
+    }
+
+    const nextPeople = { ...peopleRef.current }
+    delete nextPeople[activeScopeKey]
+    peopleRef.current = nextPeople
+    setPeopleByScope(nextPeople)
+    peopleRequests.current.delete(activeScopeKey)
+    await loadPeople(activeYear)
+  }, [
+    accountId,
+    activeKey,
+    activeScopeKey,
+    activeYear,
+    dismissedItem,
+    loadFeedPage,
+    loadPeople,
+    runEditMutation,
+    sort,
+  ])
 
   const toggleFeature = useCallback(
     async (section: ProfileCurationSection, itemId: string) => {
@@ -759,6 +819,8 @@ export function ProfileArchive({
         editing={editing && activeYear === null}
         editSaving={editSaving}
         editError={editError}
+        undoDismissAvailable={dismissedItem !== null}
+        onUndoDismiss={() => void undoDismissItem()}
         onDismiss={(section, itemId) => void dismissItem(section, itemId)}
         onToggleFeature={(section, itemId) =>
           void toggleFeature(section, itemId)

--- a/src/components/metaTwitter/Workspace.tsx
+++ b/src/components/metaTwitter/Workspace.tsx
@@ -59,6 +59,8 @@ export function Workspace({
   editing = false,
   editSaving = false,
   editError = null,
+  undoDismissAvailable = false,
+  onUndoDismiss,
   onDismiss,
   onToggleFeature,
   onMove,
@@ -89,6 +91,8 @@ export function Workspace({
   editing?: boolean
   editSaving?: boolean
   editError?: string | null
+  undoDismissAvailable?: boolean
+  onUndoDismiss?: () => void
   onDismiss?: (section: 'bangers' | 'people', itemId: string) => void
   onToggleFeature?: (section: 'bangers' | 'people', itemId: string) => void
   onMove?: (
@@ -161,6 +165,23 @@ export function Workspace({
           className="rounded-lg border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm text-destructive"
         >
           {editError}
+        </div>
+      )}
+
+      {undoDismissAvailable && (
+        <div
+          role="status"
+          className="flex items-center justify-between gap-3 rounded-lg border border-border bg-card px-3 py-2 text-sm shadow-sm"
+        >
+          <span>Hidden from your profile.</span>
+          <button
+            type="button"
+            onClick={onUndoDismiss}
+            disabled={editSaving}
+            className="font-semibold text-primary hover:underline disabled:opacity-60"
+          >
+            Undo
+          </button>
         </div>
       )}
 

--- a/src/lib/profileCurationActions.test.ts
+++ b/src/lib/profileCurationActions.test.ts
@@ -68,6 +68,30 @@ describe('owner profile server actions', () => {
     expect(mockRevalidatePath).toHaveBeenCalledWith('/user/42')
   })
 
+  test('restores only the requested hidden profile item', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { app_metadata: { provider_id: '42' } } },
+      error: null,
+    })
+
+    await mutateProfileCuration({
+      action: 'restore-item',
+      accountId: '42',
+      section: 'bangers',
+      itemId: '100',
+    })
+
+    expect(mockUpsert).toHaveBeenCalledWith(
+      {
+        account_id: '42',
+        section: 'bangers',
+        item_id: '100',
+        is_hidden: false,
+      },
+      { onConflict: 'account_id,section,item_id' },
+    )
+  })
+
   test('keeps Download Archive visible unless the owner turns it off', async () => {
     mockGetUser.mockResolvedValue({
       data: { user: { app_metadata: { provider_id: '42' } } },


### PR DESCRIPTION
Closes #682

## Summary
- add an owner-authorized restore-one-item curation mutation
- show a ten-second Undo affordance after hiding a profile post or person
- refresh only the affected profile section after an undo
- keep the existing restore-entire-section action separate

## Verification
- 11 profile archive UI tests
- 4 owner profile server-action tests
- TypeScript type check
- Next.js lint (one unrelated existing no-img-element warning)