### PR TITLE
Show three search previews and fast empty results

### DIFF
--- a/src/components/TweetList.test.tsx
+++ b/src/components/TweetList.test.tsx
@@ -5,7 +5,7 @@ import TweetList from './TweetList'
 import { fetchTweets } from '@/lib/queries/tweetQueries'
 import {
   canPreviewTweetSearch,
-  searchTweetPreviewWithClickHouse,
+  searchTweetPreviewsWithClickHouse,
 } from '@/lib/clickhouseSearch'
 
 jest.mock('@/utils/supabase', () => ({
@@ -18,14 +18,22 @@ jest.mock('@/lib/queries/tweetQueries', () => ({
 
 jest.mock('@/lib/clickhouseSearch', () => ({
   canPreviewTweetSearch: jest.fn(),
-  searchTweetPreviewWithClickHouse: jest.fn(),
+  searchTweetPreviewsWithClickHouse: jest.fn(),
 }))
 
 jest.mock('@/components/UnifiedTweetList', () => ({
   __esModule: true,
-  default: ({ tweets }: { tweets: Array<{ tweet_id: string }> }) => (
+  default: ({
+    tweets,
+    emptyMessage,
+  }: {
+    tweets: Array<{ tweet_id: string }>
+    emptyMessage: string
+  }) => (
     <div data-testid="tweet-ids">
-      {tweets.map((tweet) => tweet.tweet_id).join(',')}
+      {tweets.length > 0
+        ? tweets.map((tweet) => tweet.tweet_id).join(',')
+        : emptyMessage}
     </div>
   ),
 }))
@@ -44,6 +52,10 @@ const previewTweet = {
   },
   media: [],
 }
+
+const previewTweets = ['preview-1', 'preview-2', 'preview-3'].map(
+  (tweet_id) => ({ ...previewTweet, tweet_id }),
+)
 
 function deferred<T>() {
   let resolve!: (value: T) => void
@@ -76,9 +88,10 @@ describe('TweetList progressive search', () => {
       { ...previewTweet, tweet_id: 'canonical-2' },
     ]
     ;(canPreviewTweetSearch as jest.Mock).mockReturnValue(true)
-    ;(searchTweetPreviewWithClickHouse as jest.Mock).mockResolvedValue(
-      previewTweet,
-    )
+    ;(searchTweetPreviewsWithClickHouse as jest.Mock).mockResolvedValue({
+      tweets: previewTweets,
+      definitiveEmpty: false,
+    })
     ;(fetchTweets as jest.Mock).mockReturnValue(complete.promise)
 
     render(
@@ -91,7 +104,9 @@ describe('TweetList progressive search', () => {
       />,
     )
 
-    expect(await screen.findByTestId('tweet-ids')).toHaveTextContent('preview')
+    expect(await screen.findByTestId('tweet-ids')).toHaveTextContent(
+      'preview-1,preview-2,preview-3',
+    )
     expect(screen.getByRole('status')).toHaveTextContent(
       'Loading the remaining results…',
     )
@@ -111,7 +126,7 @@ describe('TweetList progressive search', () => {
 
   it('falls through to the canonical page when the preview fails', async () => {
     ;(canPreviewTweetSearch as jest.Mock).mockReturnValue(true)
-    ;(searchTweetPreviewWithClickHouse as jest.Mock).mockRejectedValue(
+    ;(searchTweetPreviewsWithClickHouse as jest.Mock).mockRejectedValue(
       new Error('preview unavailable'),
     )
     ;(fetchTweets as jest.Mock).mockResolvedValue({
@@ -134,5 +149,59 @@ describe('TweetList progressive search', () => {
       'canonical',
     )
     expect(fetchTweets).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls through when an empty preview is not marked definitive', async () => {
+    ;(canPreviewTweetSearch as jest.Mock).mockReturnValue(true)
+    ;(searchTweetPreviewsWithClickHouse as jest.Mock).mockResolvedValue({
+      tweets: [],
+      definitiveEmpty: false,
+    })
+    ;(fetchTweets as jest.Mock).mockResolvedValue({
+      tweets: [{ ...previewTweet, tweet_id: 'canonical' }],
+      totalCount: null,
+      error: null,
+    })
+
+    render(
+      <TweetList
+        filterCriteria={{
+          searchQuery: 'open & source',
+          rawSearchQuery: 'open source',
+          excludeRetweets: true,
+        }}
+      />,
+    )
+
+    expect(await screen.findByTestId('tweet-ids')).toHaveTextContent(
+      'canonical',
+    )
+    expect(fetchTweets).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows an immediate empty result without repeating a successful empty preview', async () => {
+    ;(canPreviewTweetSearch as jest.Mock).mockReturnValue(true)
+    ;(searchTweetPreviewsWithClickHouse as jest.Mock).mockResolvedValue({
+      tweets: [],
+      definitiveEmpty: true,
+    })
+
+    render(
+      <TweetList
+        filterCriteria={{
+          searchQuery: 'nothing',
+          rawSearchQuery: 'no results anywhere',
+          excludeRetweets: true,
+        }}
+      />,
+    )
+
+    expect(
+      await screen.findByText('No tweets to display for the current filters.'),
+    ).toBeVisible()
+    expect(fetchTweets).not.toHaveBeenCalled()
+    expect(
+      screen.queryByText('Loading the remaining results…'),
+    ).not.toBeInTheDocument()
   })
 })

--- a/src/components/TweetList.tsx
+++ b/src/components/TweetList.tsx
@@ -15,7 +15,7 @@ import {
 } from '@/lib/queries/tweetQueries'
 import {
   canPreviewTweetSearch,
-  searchTweetPreviewWithClickHouse,
+  searchTweetPreviewsWithClickHouse,
 } from '@/lib/clickhouseSearch'
 import { AlertCircle, Loader2 } from 'lucide-react'
 import type { TweetOrigin } from '@/lib/navigation'
@@ -79,9 +79,17 @@ export default function TweetList({
       try {
         if (pageToLoad === 1 && canPreviewTweetSearch(criteria)) {
           try {
-            const preview = await searchTweetPreviewWithClickHouse(criteria)
-            if (preview) {
-              setTweets([preview])
+            const preview = await searchTweetPreviewsWithClickHouse(criteria)
+            if (preview.definitiveEmpty) {
+              setTweets([])
+              setIsLoading(false)
+              setLastFetchCount(0)
+              setTotalCount(0)
+              setCurrentPage(1)
+              return
+            }
+            if (preview.tweets.length > 0) {
+              setTweets(preview.tweets)
               setIsLoading(false)
               setIsCompletingPreview(true)
             }

--- a/src/lib/clickhouseSearch.test.ts
+++ b/src/lib/clickhouseSearch.test.ts
@@ -1,6 +1,6 @@
 import {
   canPreviewTweetSearch,
-  searchTweetPreviewWithClickHouse,
+  searchTweetPreviewsWithClickHouse,
   searchTweetsWithClickHouse,
 } from './clickhouseSearch'
 
@@ -96,35 +96,33 @@ describe('searchTweetsWithClickHouse', () => {
     expect(fetchImpl).not.toHaveBeenCalled()
   })
 
-  test('requests one newest non-retweet as a progressive preview', async () => {
+  test('requests three newest non-retweets as a progressive preview', async () => {
     const fetchImpl = jest.fn().mockResolvedValue({
       ok: true,
       status: 200,
       text: jest.fn().mockResolvedValue(
         JSON.stringify({
           data: {
-            tweets: [
-              {
-                tweetId: '123',
-                accountId: '42',
-                createdAt: '2026-08-13 00:00:00.000',
-                fullText: 'Open source matters',
-                replyToTweetId: null,
-                favoriteCount: '4',
-                retweetCount: '2',
-                username: 'alice',
-                accountDisplayName: 'Alice',
-                avatarMediaUrl: null,
-                media: [],
-              },
-            ],
+            tweets: ['123', '122', '121'].map((tweetId) => ({
+              tweetId,
+              accountId: '42',
+              createdAt: '2026-08-13 00:00:00.000',
+              fullText: 'Open source matters',
+              replyToTweetId: null,
+              favoriteCount: '4',
+              retweetCount: '2',
+              username: 'alice',
+              accountDisplayName: 'Alice',
+              avatarMediaUrl: null,
+              media: [],
+            })),
             nextOffset: null,
           },
         }),
       ),
     })
 
-    const tweet = await searchTweetPreviewWithClickHouse(
+    const tweets = await searchTweetPreviewsWithClickHouse(
       {
         rawSearchQuery: 'Open source',
         excludeRetweets: true,
@@ -133,10 +131,15 @@ describe('searchTweetsWithClickHouse', () => {
     )
 
     expect(fetchImpl).toHaveBeenCalledWith(
-      '/api/tweet-search?q=Open+source&mode=phrase&limit=1&offset=0&preview=true&exclude_retweets=true',
+      '/api/tweet-search?q=Open+source&mode=phrase&limit=3&offset=0&preview=true&exclude_retweets=true',
       { cache: 'no-store' },
     )
-    expect(tweet?.tweet_id).toBe('123')
+    expect(tweets.definitiveEmpty).toBe(false)
+    expect(tweets.tweets.map((tweet) => tweet.tweet_id)).toEqual([
+      '123',
+      '122',
+      '121',
+    ])
   })
 
   test('only enables previews for ClickHouse newest text searches', () => {

--- a/src/lib/clickhouseSearch.ts
+++ b/src/lib/clickhouseSearch.ts
@@ -24,7 +24,13 @@ interface ClickHouseSearchResponse {
   data: {
     tweets: ClickHouseSearchTweet[]
     nextOffset: number | null
+    definitiveEmpty?: boolean
   }
+}
+
+interface MappedClickHouseSearchResponse {
+  tweets: TimelineTweet[]
+  definitiveEmpty: boolean
 }
 
 interface ClickHouseSearchRequestOptions {
@@ -59,20 +65,20 @@ function mapSearchTweets(result: ClickHouseSearchResponse): TimelineTweet[] {
   }))
 }
 
-async function requestClickHouseTweets(
+async function requestClickHouseSearch(
   criteria: FilterCriteria,
   page: number,
   pageSize: number,
   fetchImpl: typeof fetch,
   options: ClickHouseSearchRequestOptions = {},
-): Promise<TimelineTweet[]> {
+): Promise<MappedClickHouseSearchResponse> {
   const query = criteria.rawSearchQuery?.trim()
   if (!query) {
     throw new Error('ClickHouse text search requires the raw search query')
   }
 
   const offset = (page - 1) * pageSize
-  if (offset > 5_000) return []
+  if (offset > 5_000) return { tweets: [], definitiveEmpty: false }
 
   const params = new URLSearchParams({
     q: query,
@@ -111,7 +117,22 @@ async function requestClickHouseTweets(
     throw new Error('ClickHouse tweet search returned an invalid response')
   }
 
-  return mapSearchTweets(result)
+  return {
+    tweets: mapSearchTweets(result),
+    definitiveEmpty: result.data.definitiveEmpty === true,
+  }
+}
+
+async function requestClickHouseTweets(
+  criteria: FilterCriteria,
+  page: number,
+  pageSize: number,
+  fetchImpl: typeof fetch,
+  options: ClickHouseSearchRequestOptions = {},
+): Promise<TimelineTweet[]> {
+  return (
+    await requestClickHouseSearch(criteria, page, pageSize, fetchImpl, options)
+  ).tweets
 }
 
 export async function searchTweetsWithClickHouse(
@@ -134,13 +155,12 @@ export function canPreviewTweetSearch(
   )
 }
 
-export async function searchTweetPreviewWithClickHouse(
+export async function searchTweetPreviewsWithClickHouse(
   criteria: FilterCriteria,
   fetchImpl: typeof fetch = fetch,
-): Promise<TimelineTweet | null> {
-  const tweets = await requestClickHouseTweets(criteria, 1, 1, fetchImpl, {
+): Promise<MappedClickHouseSearchResponse> {
+  return requestClickHouseSearch(criteria, 1, 3, fetchImpl, {
     preview: true,
     excludeRetweets: criteria.excludeRetweets,
   })
-  return tweets[0] || null
 }


### PR DESCRIPTION
Closes #644
Closes #693

Depends on TheExGenesis/community-archive-control-panel#80.

## Summary
- request and render the three newest progressive search results
- preserve their order while the complete page loads
- show an immediate empty result only when the gateway marks its completed scan definitive
- continue to the canonical search after preview failures or non-definitive empty hydration

## Verification
- 4 progressive search UI tests
- 4 ClickHouse search client tests
- TypeScript type check
- Next.js lint (one unrelated existing no-img-element warning)

## Rollout gate
Keep this draft and unmerged. The gateway dependency must be reviewed, deployed, and verified for preview latency and first-three ID/order parity before this website change can be made ready.