### PR TITLE
Fix X Article preview cover loading

### DIFF
--- a/src/components/TweetLinkPreviews.test.tsx
+++ b/src/components/TweetLinkPreviews.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react'
+import type { ImgHTMLAttributes } from 'react'
+import { TweetLinkPreviews } from './TweetLinkPreviews'
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: ({
+    alt = '',
+    fill: _fill,
+    unoptimized,
+    ...props
+  }: ImgHTMLAttributes<HTMLImageElement> & {
+    fill?: boolean
+    unoptimized?: boolean
+  }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={alt} {...props} data-unoptimized={String(unoptimized)} />
+  ),
+}))
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+test('loads Article covers directly from the authenticated image proxy', async () => {
+  jest.spyOn(global, 'fetch').mockResolvedValue(
+    new Response(
+      JSON.stringify({
+        previews: [
+          {
+            urlHash: 'a'.repeat(64),
+            url: 'https://x.com/i/article/123',
+            canonicalUrl: 'https://x.com/i/article/123',
+            title: 'Social traits for wholesome online interactions',
+            description: 'A useful teaser.',
+            imageUrl: 'https://pbs.twimg.com/media/article.jpg',
+            siteName: 'X',
+            isXArticle: true,
+          },
+        ],
+      }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    ),
+  )
+
+  const { container } = render(<TweetLinkPreviews tweetId="42" />)
+
+  expect(
+    await screen.findByText('Social traits for wholesome online interactions'),
+  ).toBeVisible()
+  const image = container.querySelector('img')
+  expect(image).toHaveAttribute(
+    'src',
+    `/api/link-preview/image?hash=${'a'.repeat(64)}`,
+  )
+  expect(image).toHaveAttribute('data-unoptimized', 'true')
+})

--- a/src/components/TweetLinkPreviews.tsx
+++ b/src/components/TweetLinkPreviews.tsx
@@ -50,6 +50,7 @@ export function TweetLinkPreviews({
                 src={`/api/link-preview/image?hash=${preview.urlHash}`}
                 alt=""
                 fill
+                unoptimized
                 sizes="144px"
                 className="object-cover"
               />


### PR DESCRIPTION
Closes #694

## Summary
- load cached Article covers directly from the same-origin authenticated image proxy
- bypass the redundant Next.js optimizer hop that produced the broken image placeholder
- retain responsive sizing and the existing safe remote-image proxy

## Avatar disposition
The other item in #694 is not currently reproducible. The reported @christineist profile rendered its stored avatar in production on 2026-08-15, and the client recovery route added in #657 remains active when stored avatar data is missing.

## Verification
- focused Article cover renderer test
- TypeScript type check
- focused lint clean; full lint has only the unrelated existing UnifiedTweetList test warning