### PR TITLE
Add a paged profile media gallery

### DIFF
--- a/src/app/api/profile/[account_id]/media/route.ts
+++ b/src/app/api/profile/[account_id]/media/route.ts
@@ -31,10 +31,30 @@ export async function GET(
       )
     }
   }
+  const limitValue = request.nextUrl.searchParams.get('limit')
+  const offsetValue = request.nextUrl.searchParams.get('offset')
+  const limit = limitValue === null ? 6 : Number(limitValue)
+  const offset = offsetValue === null ? 0 : Number(offsetValue)
+  if (
+    !Number.isInteger(limit) ||
+    limit < 1 ||
+    limit > 50 ||
+    !Number.isInteger(offset) ||
+    offset < 0 ||
+    offset > 5_000
+  ) {
+    return NextResponse.json(
+      { error: 'Invalid profile media pagination' },
+      { status: 400, headers: { 'Cache-Control': 'private, no-store' } },
+    )
+  }
 
   try {
     return NextResponse.json(
-      await getClickHouseProfileMediaOrThrow(params.account_id, year),
+      await getClickHouseProfileMediaOrThrow(params.account_id, year, {
+        limit,
+        offset,
+      }),
       {
         headers: {
           'Cache-Control':

--- a/src/components/metaTwitter/ProfileArchive.tsx
+++ b/src/components/metaTwitter/ProfileArchive.tsx
@@ -17,6 +17,7 @@ import type {
 import { mutateProfileCuration } from '@/app/user/[account_id]/actions'
 import type { ProfileCurationSection } from '@/lib/profileCurationState'
 import { useProfileEditing } from './ProfileEditingContext'
+import { ProfileMediaGallery } from './ProfileMediaGallery'
 
 interface SidebarData {
   media: ArchiveMediaItem[]
@@ -124,6 +125,7 @@ export function ProfileArchive({
   )
   const { editing, editSaving, setEditing, setEditSaving } = useProfileEditing()
   const [editError, setEditError] = useState<string | null>(null)
+  const [mediaGalleryOpen, setMediaGalleryOpen] = useState(false)
   const feedsRef = useRef(feeds)
   const mediaRef = useRef(mediaByScope)
   const peopleRef = useRef(peopleByScope)
@@ -434,6 +436,7 @@ export function ProfileArchive({
     (year: number | null) => {
       if (year === activeYear) return
       setEditing(false)
+      setMediaGalleryOpen(false)
       setSort('quotes')
       setActiveYear(year)
       window.history.pushState(null, '', archiveChapterHref(basePath, year))
@@ -741,6 +744,7 @@ export function ProfileArchive({
         }
         mediaFailed={activeMediaFailed}
         onRetryMedia={() => void loadMedia(activeYear)}
+        onOpenMediaGallery={() => setMediaGalleryOpen(true)}
         peopleLoading={
           activePeopleLoading || (!activePeople && !activePeopleFailed)
         }
@@ -768,6 +772,16 @@ export function ProfileArchive({
         }
         onRestore={(section) => void restoreSection(section)}
       />
+      {mediaGalleryOpen && activeMedia && (
+        <ProfileMediaGallery
+          accountId={accountId}
+          initialMedia={activeMedia.media}
+          mediaCount={activeMedia.mediaCount}
+          onOpenChange={setMediaGalleryOpen}
+          returnTo={returnTo}
+          year={activeYear}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/metaTwitter/ProfileMediaGallery.test.tsx
+++ b/src/components/metaTwitter/ProfileMediaGallery.test.tsx
@@ -1,0 +1,113 @@
+import type { ImgHTMLAttributes, ReactNode } from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ProfileMediaGallery } from './ProfileMediaGallery'
+import type { ArchiveMediaItem } from '@/lib/metaTwitter/types'
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: ({
+    alt = '',
+    fill: _fill,
+    ...props
+  }: ImgHTMLAttributes<HTMLImageElement> & { fill?: boolean }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={alt} {...props} />
+  ),
+}))
+
+jest.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children }: { children: ReactNode }) => (
+    <section>{children}</section>
+  ),
+  DialogDescription: ({ children }: { children: ReactNode }) => (
+    <p>{children}</p>
+  ),
+  DialogHeader: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}))
+
+const mediaItem = (index: number): ArchiveMediaItem => ({
+  tweet_id: String(100 + index),
+  created_at: '2026-08-01T00:00:00.000Z',
+  favorite_count: 10,
+  media_url: `https://pbs.twimg.com/media/${index}.jpg`,
+  media_type: 'photo',
+  width: 1200,
+  height: 800,
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+test('loads bounded gallery pages until every profile photo is reachable', async () => {
+  const user = userEvent.setup()
+  const initialMedia = Array.from({ length: 6 }, (_, index) => mediaItem(index))
+  const secondPage = Array.from({ length: 24 }, (_, index) =>
+    mediaItem(index + 6),
+  )
+  const fetchMock = jest
+    .spyOn(global, 'fetch')
+    .mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          media: secondPage,
+          mediaCount: 31,
+          nextOffset: 30,
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    )
+    .mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          media: [mediaItem(30)],
+          mediaCount: 31,
+          nextOffset: null,
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    )
+
+  render(
+    <ProfileMediaGallery
+      accountId="42"
+      initialMedia={initialMedia}
+      mediaCount={31}
+      onOpenChange={jest.fn()}
+      returnTo="/user/alice"
+      year={2026}
+    />,
+  )
+
+  await waitFor(() =>
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/profile/42/media?limit=24&offset=6&year=2026',
+    ),
+  )
+  expect(
+    await screen.findByText(
+      'Showing 30 of 31 archived photos. Open one to view its post.',
+    ),
+  ).toBeVisible()
+
+  await user.click(screen.getByRole('button', { name: 'Load 1 more photos' }))
+  await waitFor(() =>
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      '/api/profile/42/media?limit=24&offset=30&year=2026',
+    ),
+  )
+  expect(
+    await screen.findByText(
+      'Showing 31 of 31 archived photos. Open one to view its post.',
+    ),
+  ).toBeVisible()
+  expect(
+    screen.queryByRole('button', { name: /more photos/i }),
+  ).not.toBeInTheDocument()
+  expect(screen.getAllByAltText('Archived post media')).toHaveLength(31)
+})

--- a/src/components/metaTwitter/ProfileMediaGallery.tsx
+++ b/src/components/metaTwitter/ProfileMediaGallery.tsx
@@ -1,0 +1,145 @@
+'use client'
+
+import Image from 'next/image'
+import Link from 'next/link'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { formatNumber } from '@/lib/formatNumber'
+import { tweetPermalinkHref } from '@/lib/navigation'
+import {
+  PROFILE_MEDIA_PAGE_LIMIT,
+  type ProfileMediaPageState,
+} from '@/lib/metaTwitter/profileMediaPagination'
+import type { ArchiveMediaItem } from '@/lib/metaTwitter/types'
+
+const mergeMedia = (
+  current: ArchiveMediaItem[],
+  incoming: ArchiveMediaItem[],
+) => {
+  const seen = new Set(current.map((item) => item.media_url))
+  return [
+    ...current,
+    ...incoming.filter((item) => {
+      if (seen.has(item.media_url)) return false
+      seen.add(item.media_url)
+      return true
+    }),
+  ]
+}
+
+export function ProfileMediaGallery({
+  accountId,
+  initialMedia,
+  mediaCount,
+  onOpenChange,
+  returnTo,
+  year,
+}: {
+  accountId: string
+  initialMedia: ArchiveMediaItem[]
+  mediaCount: number
+  onOpenChange: (open: boolean) => void
+  returnTo: string
+  year: number | null
+}) {
+  const [media, setMedia] = useState(initialMedia)
+  const [nextOffset, setNextOffset] = useState<number | null>(
+    initialMedia.length < mediaCount ? initialMedia.length : null,
+  )
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const initialRequestStarted = useRef(false)
+
+  const loadMore = useCallback(async () => {
+    if (nextOffset === null || isLoading) return
+    setIsLoading(true)
+    setError(null)
+    const params = new URLSearchParams({
+      limit: String(PROFILE_MEDIA_PAGE_LIMIT),
+      offset: String(nextOffset),
+    })
+    if (year !== null) params.set('year', String(year))
+    try {
+      const response = await fetch(
+        `/api/profile/${encodeURIComponent(accountId)}/media?${params}`,
+      )
+      if (!response.ok) throw new Error('Profile media request failed')
+      const page = (await response.json()) as ProfileMediaPageState
+      if (!Array.isArray(page.media)) {
+        throw new Error('Profile media response was invalid')
+      }
+      setMedia((current) => mergeMedia(current, page.media))
+      setNextOffset(page.nextOffset)
+    } catch {
+      setError('More photos could not be loaded.')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [accountId, isLoading, nextOffset, year])
+
+  useEffect(() => {
+    if (initialRequestStarted.current || nextOffset === null) return
+    initialRequestStarted.current = true
+    void loadMore()
+  }, [loadMore, nextOffset])
+
+  const remaining = Math.max(0, mediaCount - media.length)
+
+  return (
+    <Dialog open onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[88vh] max-w-5xl overflow-y-auto p-4 sm:p-6">
+        <DialogHeader>
+          <DialogTitle>Profile media</DialogTitle>
+          <DialogDescription>
+            Showing {formatNumber(media.length)} of {formatNumber(mediaCount)}{' '}
+            archived photos. Open one to view its post.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
+          {media.map((item) => (
+            <Link
+              key={item.media_url}
+              href={tweetPermalinkHref(item.tweet_id, 'profile', returnTo)}
+              className="relative aspect-square overflow-hidden rounded-lg bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <Image
+                src={item.media_url}
+                alt="Archived post media"
+                fill
+                sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 240px"
+                className="object-cover transition-transform hover:scale-[1.02]"
+              />
+            </Link>
+          ))}
+        </div>
+
+        {error && (
+          <p role="alert" className="text-center text-sm text-destructive">
+            {error}
+          </p>
+        )}
+        {nextOffset !== null && (
+          <button
+            type="button"
+            onClick={() => void loadMore()}
+            disabled={isLoading}
+            className="mx-auto rounded-full border border-border px-4 py-2 text-sm font-semibold hover:bg-muted disabled:cursor-wait disabled:opacity-60"
+          >
+            {isLoading
+              ? 'Loading more photos…'
+              : error
+                ? 'Retry loading photos'
+                : `Load ${formatNumber(Math.min(PROFILE_MEDIA_PAGE_LIMIT, remaining))} more photos`}
+          </button>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/metaTwitter/Workspace.test.tsx
+++ b/src/components/metaTwitter/Workspace.test.tsx
@@ -71,6 +71,7 @@ const tweets: BangerTweet[] = Array.from({ length: 13 }, (_, index) => ({
 test('shows the initial canonical banger cards with media and profile return links', async () => {
   const user = userEvent.setup()
   const onLoadMore = jest.fn()
+  const onOpenMediaGallery = jest.fn()
   render(
     <Workspace
       avatarUrl={null}
@@ -78,13 +79,22 @@ test('shows the initial canonical banger cards with media and profile return lin
       tweets={tweets.slice(0, 2)}
       bangersAvailable
       bangersLoading={false}
-      media={[]}
-      mediaCount={0}
+      media={Array.from({ length: 6 }, (_, index) => ({
+        tweet_id: String(300 + index),
+        created_at: '2026-08-01T00:00:00.000Z',
+        favorite_count: 10,
+        media_url: `https://example.com/media-${index}.jpg`,
+        media_type: 'photo',
+        width: 1200,
+        height: 800,
+      }))}
+      mediaCount={325}
       people={[]}
       peopleTitle="Top people"
       mediaLoading={false}
       mediaFailed={false}
       onRetryMedia={jest.fn()}
+      onOpenMediaGallery={onOpenMediaGallery}
       peopleLoading={false}
       peopleFailed={false}
       onRetryPeople={jest.fn()}
@@ -166,4 +176,8 @@ test('shows the initial canonical banger cards with media and profile return lin
   await user.click(screen.getByRole('button', { name: 'Load more bangers' }))
 
   expect(onLoadMore).toHaveBeenCalledTimes(1)
+  await user.click(
+    screen.getByRole('button', { name: 'View 319 more profile photos' }),
+  )
+  expect(onOpenMediaGallery).toHaveBeenCalledTimes(1)
 })

--- a/src/components/metaTwitter/Workspace.tsx
+++ b/src/components/metaTwitter/Workspace.tsx
@@ -46,6 +46,7 @@ export function Workspace({
   mediaLoading,
   mediaFailed,
   onRetryMedia,
+  onOpenMediaGallery,
   peopleLoading,
   peopleFailed,
   onRetryPeople,
@@ -76,6 +77,7 @@ export function Workspace({
   mediaLoading: boolean
   mediaFailed: boolean
   onRetryMedia: () => void
+  onOpenMediaGallery?: () => void
   peopleLoading: boolean
   peopleFailed: boolean
   onRetryPeople: () => void
@@ -310,30 +312,47 @@ export function Workspace({
               </div>
             ) : (
               <div className="grid grid-cols-3 gap-1">
-                {mediaTiles.map((item, index) => (
-                  <Link
-                    key={item.media_url}
-                    href={tweetPermalinkHref(
-                      item.tweet_id,
-                      'profile',
-                      returnTo,
-                    )}
-                    className="relative block aspect-square overflow-hidden rounded-md bg-muted"
-                  >
-                    <Image
-                      src={item.media_url}
-                      alt=""
-                      fill
-                      sizes="94px"
-                      className="object-cover"
-                    />
-                    {index === 5 && mediaOverflow > 0 && (
-                      <span className="absolute inset-0 grid place-items-center bg-black/50 text-xs font-semibold text-white">
-                        +{formatNumber(mediaOverflow)}
-                      </span>
-                    )}
-                  </Link>
-                ))}
+                {mediaTiles.map((item, index) => {
+                  const tile = (
+                    <>
+                      <Image
+                        src={item.media_url}
+                        alt=""
+                        fill
+                        sizes="94px"
+                        className="object-cover"
+                      />
+                      {index === 5 && mediaOverflow > 0 && (
+                        <span className="absolute inset-0 grid place-items-center bg-black/50 text-xs font-semibold text-white">
+                          +{formatNumber(mediaOverflow)}
+                        </span>
+                      )}
+                    </>
+                  )
+                  return index === 5 && mediaOverflow > 0 ? (
+                    <button
+                      key={item.media_url}
+                      type="button"
+                      aria-label={`View ${formatNumber(mediaOverflow)} more profile photos`}
+                      onClick={onOpenMediaGallery}
+                      className="relative block aspect-square overflow-hidden rounded-md bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    >
+                      {tile}
+                    </button>
+                  ) : (
+                    <Link
+                      key={item.media_url}
+                      href={tweetPermalinkHref(
+                        item.tweet_id,
+                        'profile',
+                        returnTo,
+                      )}
+                      className="relative block aspect-square overflow-hidden rounded-md bg-muted"
+                    >
+                      {tile}
+                    </Link>
+                  )
+                })}
               </div>
             )}
           </section>

--- a/src/lib/metaTwitter/clickhouseSidebar.test.ts
+++ b/src/lib/metaTwitter/clickhouseSidebar.test.ts
@@ -20,6 +20,7 @@ const response = (year: number | null) => ({
       },
     ],
     mediaCount: '7',
+    nextOffset: 1,
     people: [
       {
         accountId: '7',
@@ -38,6 +39,7 @@ const response = (year: number | null) => ({
     accountId: '42',
     year,
     mediaLimit: 6,
+    mediaOffset: 0,
     peopleLimit: 8,
   },
 })
@@ -91,17 +93,21 @@ test('loads media and interactions through independent gateway resources', async
   ) as unknown as AnalyticsGatewayFetcher
 
   const [media, interactions] = await Promise.all([
-    fetchClickHouseProfileMedia('42', 2025, fetcher),
+    fetchClickHouseProfileMedia('42', 2025, {}, fetcher),
     fetchClickHouseProfileInteractions('42', 2025, fetcher),
   ])
 
-  expect(media).toMatchObject({ mediaCount: 7, media: [{ tweet_id: '501' }] })
+  expect(media).toMatchObject({
+    mediaCount: 7,
+    nextOffset: 1,
+    media: [{ tweet_id: '501' }],
+  })
   expect(interactions).toMatchObject({
     people: [{ user_id: '7', screen_name: 'bob', interactions: 9 }],
   })
   expect(fetcher).toHaveBeenCalledWith(
     ['user', '42', 'media'],
-    new URLSearchParams({ limit: '6', year: '2025' }),
+    new URLSearchParams({ limit: '6', offset: '0', year: '2025' }),
     { timeoutMs: 30_000 },
   )
   expect(fetcher).toHaveBeenCalledWith(

--- a/src/lib/metaTwitter/clickhouseSidebar.ts
+++ b/src/lib/metaTwitter/clickhouseSidebar.ts
@@ -7,6 +7,7 @@ import {
 } from '@/lib/clickhouseGateway'
 import { devLog } from '@/lib/devLog'
 import type { ArchiveMediaItem, ArchivePerson } from './types'
+import type { ProfileMediaPageState } from './profileMediaPagination'
 
 const DAY = 86_400
 const MEDIA_LIMIT = 6
@@ -31,11 +32,13 @@ interface MediaResponse {
   data?: {
     media?: unknown
     mediaCount?: unknown
+    nextOffset?: unknown
   }
   query?: {
     accountId?: unknown
     year?: unknown
     mediaLimit?: unknown
+    mediaOffset?: unknown
   }
 }
 
@@ -79,10 +82,7 @@ export interface ClickHouseProfileSidebarState
   available: boolean
 }
 
-export interface ClickHouseProfileMedia {
-  media: ArchiveMediaItem[]
-  mediaCount: number
-}
+export interface ClickHouseProfileMedia extends ProfileMediaPageState {}
 
 export interface ClickHouseProfileMediaState extends ClickHouseProfileMedia {
   available: boolean
@@ -168,35 +168,58 @@ const personItem = (value: unknown): ArchivePerson | null => {
   }
 }
 
-const profileParams = (year: number | undefined, limit: number) => {
+const profileParams = (
+  year: number | undefined,
+  limit: number,
+  offset?: number,
+) => {
   const params = new URLSearchParams({ limit: String(limit) })
+  if (offset !== undefined) params.set('offset', String(offset))
   if (year !== undefined) params.set('year', String(year))
   return params
+}
+
+interface ProfileMediaPageOptions {
+  limit?: number
+  offset?: number
 }
 
 export async function fetchClickHouseProfileMedia(
   accountId: string,
   year: number | undefined,
+  options: ProfileMediaPageOptions = {},
   fetcher: AnalyticsGatewayFetcher = fetchAnalyticsGatewayJson,
 ): Promise<ClickHouseProfileMedia> {
   if (!ID_PATTERN.test(accountId)) {
     throw new Error('Profile media requires a numeric account ID')
   }
+  const limit = Math.max(
+    1,
+    Math.min(50, Math.trunc(options.limit ?? MEDIA_LIMIT)),
+  )
+  const offset = Math.max(0, Math.min(5_000, Math.trunc(options.offset ?? 0)))
   const response = await fetcher<MediaResponse>(
     ['user', accountId, 'media'],
-    profileParams(year, MEDIA_LIMIT),
+    profileParams(year, limit, offset),
     { timeoutMs: 30_000 },
   )
   if (
     response.query?.accountId !== accountId ||
     response.query?.year !== (year ?? null) ||
-    Number(response.query?.mediaLimit) !== MEDIA_LIMIT
+    Number(response.query?.mediaLimit) !== limit ||
+    Number(response.query?.mediaOffset) !== offset
   ) {
     throw new Error('ClickHouse returned mismatched profile media scope')
   }
   const media = response.data?.media
   const mediaCount = safeCount(response.data?.mediaCount)
-  if (mediaCount === null || !Array.isArray(media)) {
+  const rawNextOffset = response.data?.nextOffset
+  const nextOffset = rawNextOffset === null ? null : safeCount(rawNextOffset)
+  if (
+    mediaCount === null ||
+    !Array.isArray(media) ||
+    (rawNextOffset !== null && nextOffset === null)
+  ) {
     throw new Error('ClickHouse returned invalid profile media')
   }
   return {
@@ -205,6 +228,7 @@ export async function fetchClickHouseProfileMedia(
       return item ? [item] : []
     }),
     mediaCount,
+    nextOffset,
   }
 }
 
@@ -295,7 +319,7 @@ const getCachedClickHouseProfileSidebar = unstable_cache(
 
 const getCachedClickHouseProfileMedia = unstable_cache(
   fetchClickHouseProfileMedia,
-  ['meta-twitter-clickhouse-profile-media-v1'],
+  ['meta-twitter-clickhouse-profile-media-v2'],
   { revalidate: DAY },
 )
 
@@ -315,8 +339,9 @@ export async function getClickHouseProfileSidebarOrThrow(
 export async function getClickHouseProfileMediaOrThrow(
   accountId: string,
   year: number | undefined,
+  options: ProfileMediaPageOptions = {},
 ): Promise<ClickHouseProfileMedia> {
-  return getCachedClickHouseProfileMedia(accountId, year)
+  return getCachedClickHouseProfileMedia(accountId, year, options)
 }
 
 export async function getClickHouseProfileInteractionsOrThrow(
@@ -348,10 +373,11 @@ export async function getClickHouseProfileSidebar(
 export async function getClickHouseProfileMedia(
   accountId: string,
   year: number | undefined,
+  options: ProfileMediaPageOptions = {},
 ): Promise<ClickHouseProfileMediaState> {
   try {
     return {
-      ...(await getClickHouseProfileMediaOrThrow(accountId, year)),
+      ...(await getClickHouseProfileMediaOrThrow(accountId, year, options)),
       available: true,
     }
   } catch (error) {
@@ -360,7 +386,7 @@ export async function getClickHouseProfileMedia(
       year,
       error,
     })
-    return { media: [], mediaCount: 0, available: false }
+    return { media: [], mediaCount: 0, nextOffset: null, available: false }
   }
 }
 

--- a/src/lib/metaTwitter/profileMediaPagination.ts
+++ b/src/lib/metaTwitter/profileMediaPagination.ts
@@ -1,0 +1,9 @@
+import type { ArchiveMediaItem } from './types'
+
+export const PROFILE_MEDIA_PAGE_LIMIT = 24
+
+export interface ProfileMediaPageState {
+  media: ArchiveMediaItem[]
+  mediaCount: number
+  nextOffset: number | null
+}

--- a/src/lib/profileRoutes.test.ts
+++ b/src/lib/profileRoutes.test.ts
@@ -117,13 +117,14 @@ test('serves independently cached profile media and interactions', async () => {
   getClickHouseProfileMediaOrThrowMock.mockResolvedValue({
     media: [],
     mediaCount: 0,
+    nextOffset: null,
   })
   getClickHouseProfileInteractionsOrThrowMock.mockResolvedValue({ people: [] })
 
   const [media, interactions] = await Promise.all([
     getMedia(
       new NextRequest(
-        'https://community-archive.org/api/profile/42/media?year=2024',
+        'https://community-archive.org/api/profile/42/media?year=2024&offset=24&limit=24',
       ),
       { params: { account_id: '42' } },
     ),
@@ -139,11 +140,30 @@ test('serves independently cached profile media and interactions', async () => {
   expect(interactions.status).toBe(200)
   expect(media.headers.get('cache-control')).toContain('s-maxage=86400')
   expect(interactions.headers.get('cache-control')).toBe('private, no-store')
-  expect(getClickHouseProfileMediaOrThrowMock).toHaveBeenCalledWith('42', 2024)
+  expect(getClickHouseProfileMediaOrThrowMock).toHaveBeenCalledWith(
+    '42',
+    2024,
+    {
+      limit: 24,
+      offset: 24,
+    },
+  )
   expect(getClickHouseProfileInteractionsOrThrowMock).toHaveBeenCalledWith(
     '42',
     2024,
   )
+})
+
+test('rejects invalid profile media pagination before calling ClickHouse', async () => {
+  const response = await getMedia(
+    new NextRequest(
+      'https://community-archive.org/api/profile/42/media?offset=-1&limit=100',
+    ),
+    { params: { account_id: '42' } },
+  )
+
+  expect(response.status).toBe(400)
+  expect(getClickHouseProfileMediaOrThrowMock).not.toHaveBeenCalled()
 })
 
 test('does not cache a transient profile sidebar failure as empty data', async () => {


### PR DESCRIPTION
Closes #642

Depends on TheExGenesis/community-archive-control-panel#81.

## Summary
- turn the +N profile media tile into an accessible gallery trigger
- open a responsive modal with links back to each archived post
- automatically load the first bounded 24-photo page
- let people continue loading bounded pages until every photo is reachable
- reject invalid media offsets and preserve year-scoped galleries

## Verification
- 2 focused gallery/workspace UI tests
- 10 profile route and gateway-mapping tests
- TypeScript type check
- Next.js lint (one unrelated existing no-img-element warning)

## Rollout gate
Keep this draft and unmerged. The gateway pagination PR must be reviewed, deployed, and smoke-tested before this website gallery can be made ready.