### PR TITLE
feat: carry recent context into digest generation

### DIFF
--- a/src/lib/digest/generation.test.ts
+++ b/src/lib/digest/generation.test.ts
@@ -135,6 +135,28 @@ describe('daily digest generation contract', () => {
     expect(prompt).toContain('"tweet_id": "1"')
   })
 
+  test('adds bounded published history for continuity without changing the current corpus', () => {
+    const prompt = renderDigestPrompt('{{candidate_json}}', {
+      digestDate: '2026-08-12',
+      windowStart: '2026-08-11T12:00:00.000Z',
+      windowEnd: '2026-08-12T12:00:00.000Z',
+      candidates,
+      priorDigests: [
+        {
+          digestDate: '2026-08-11',
+          executiveSummary: ['The community compared model taste.'],
+          storyTitles: ['Taste benchmarks became public rituals'],
+          keywords: ['taste'],
+        },
+      ],
+    })
+
+    expect(prompt).toContain('PAST PUBLISHED DIGESTS')
+    expect(prompt).toContain('"digest_date": "2026-08-11"')
+    expect(prompt).toContain('TODAY\'S CURRENT CANDIDATE CORPUS')
+    expect(prompt.match(/"tweet_id": "1"/g)).toHaveLength(1)
+  })
+
   test('indexes all bangers before reply and quote context', () => {
     const corpus = buildDigestPromptCorpus([
       { ...candidates[0], replyTweetIds: ['11'] },

--- a/src/lib/digest/generation.ts
+++ b/src/lib/digest/generation.ts
@@ -42,6 +42,13 @@ export interface DigestPromptCorpusRow {
   tweet: PortalTweet
 }
 
+export interface DigestContinuityContext {
+  digestDate: string
+  executiveSummary: string[]
+  storyTitles: string[]
+  keywords: string[]
+}
+
 export function selectDailyDigestBangers(tweets: PortalTweet[]): PortalTweet[] {
   return tweets.filter((tweet) => (tweet.quoteCount ?? 0) >= 2).slice(0, 50)
 }
@@ -280,6 +287,7 @@ export function renderDigestPrompt(
     windowStart: string
     windowEnd: string
     candidates: EnrichedDigestCandidate[]
+    priorDigests?: DigestContinuityContext[]
   },
 ): string {
   const corpus = buildDigestPromptCorpus(input.candidates)
@@ -306,11 +314,22 @@ export function renderDigestPrompt(
     null,
     2,
   )
-  return template
+  const rendered = template
     .replaceAll('{{digest_date}}', input.digestDate)
     .replaceAll('{{window_start}}', input.windowStart)
     .replaceAll('{{window_end}}', input.windowEnd)
     .replaceAll('{{candidate_json}}', candidateJson)
+
+  if (!input.priorDigests?.length) return rendered
+
+  const continuityContext = input.priorDigests.map((digest) => ({
+    digest_date: digest.digestDate,
+    executive_summary: digest.executiveSummary,
+    story_titles: digest.storyTitles,
+    keywords: digest.keywords,
+  }))
+
+  return `${rendered}\n\nPAST PUBLISHED DIGESTS (CONTINUITY CONTEXT)\n${JSON.stringify(continuityContext, null, 2)}\n\nUse this history only to preserve continuity, identify genuinely continuing threads, and avoid repetitive framing. Every factual claim and every selected tweet in today's digest must still be grounded in TODAY'S CURRENT CANDIDATE CORPUS above.`
 }
 
 export function renderDigestRevisionPrompt(input: {

--- a/src/workflows/digestGeneration.ts
+++ b/src/workflows/digestGeneration.ts
@@ -1,7 +1,12 @@
 import type { TweetData } from '@/components/TweetComponent'
 import { fetchClickHouseQuotePosts } from '@/lib/clickhouseQuotePosts'
 import { fetchDigestReplies } from '@/lib/digest/context'
-import { mapDigestRun, mapPromptVersion, toJson } from '@/lib/digest/data'
+import {
+  mapDigestEdition,
+  mapDigestRun,
+  mapPromptVersion,
+  toJson,
+} from '@/lib/digest/data'
 import { createDigestAdminClient } from '@/lib/digest/database'
 import {
   assembleDigestEditionContent,
@@ -222,11 +227,44 @@ async function executeDigestGeneration(runId: string) {
     ),
   ]
 
+  const { data: priorEditionRows, error: priorEditionsError } = await admin
+    .from('digest_editions')
+    .select('*')
+    .eq('status', 'published')
+    .lt('digest_date', run.digestDate)
+    .order('digest_date', { ascending: false })
+    .order('version', { ascending: false })
+    .limit(7)
+  if (priorEditionsError) throw priorEditionsError
+
+  const priorDigests = (priorEditionRows ?? []).flatMap((row) => {
+    const edition = mapDigestEdition(row)
+    return edition
+      ? [
+          {
+            digestDate: edition.digestDate,
+            executiveSummary: edition.content.executiveSummary,
+            storyTitles: edition.content.stories.map(({ title }) => title),
+            keywords: edition.content.keywords,
+          },
+        ]
+      : []
+  })
+  events.push(
+    event(
+      'commentary',
+      'completed',
+      `Loaded ${priorDigests.length} published digest${priorDigests.length === 1 ? '' : 's'} for continuity.`,
+      { past_digest_count: priorDigests.length },
+    ),
+  )
+
   const baseUserPrompt = renderDigestPrompt(prompt.userPromptTemplate, {
     digestDate: run.digestDate,
     windowStart: run.windowStart,
     windowEnd: run.windowEnd,
     candidates: enrichedCandidates,
+    priorDigests,
   })
   const userPrompt =
     revisionBase && run.revisionInstruction
@@ -240,6 +278,7 @@ async function executeDigestGeneration(runId: string) {
     promptVersion: prompt,
     renderedUserPrompt: userPrompt,
     candidateSnapshot: enrichedCandidates,
+    continuityContext: priorDigests,
     ...(revisionBase && run.revisionInstruction
       ? {
           revision: {


### PR DESCRIPTION
## Summary\n- load up to seven previously published digest editions\n- add their summaries, story titles, and keywords as compact continuity context\n- explicitly keep current digest facts and tweets grounded in the current corpus\n\n## Validation\n- pnpm test -- --runInBand src/lib/digest/generation.test.ts\n- pnpm type-check\n- pnpm lint\n\nCloses #680