### PR TITLE
fix: stabilize social graph layout orientation

### DIFF
--- a/src/app/social-graph/SocialGraphExplorer.tsx
+++ b/src/app/social-graph/SocialGraphExplorer.tsx
@@ -34,6 +34,7 @@ import {
   followerSliderToCount,
 } from '@/lib/socialGraphFilter'
 import type { AdaptiveGraphResult } from '@/lib/socialGraphAdaptive'
+import { alignGraphLayout } from '@/lib/socialGraphProcrustes'
 import type {
   SocialGraphWorkerRequest,
   SocialGraphWorkerResponse,
@@ -377,6 +378,11 @@ export default function SocialGraphExplorer({
   const workerSignatureRef = useRef('')
   const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const hoverCandidateRef = useRef<string | null>(null)
+  const layoutReferenceRef = useRef(
+    Object.fromEntries(
+      snapshot.nodes.map((node) => [node.id, { x: node.x, y: node.y }]),
+    ),
+  )
   const { resolvedTheme } = useTheme()
   const isDark = resolvedTheme !== 'light'
   const defaultSettings = useMemo(
@@ -697,7 +703,15 @@ export default function SocialGraphExplorer({
           setAdaptiveError(event.data.error || 'Adaptive graph failed')
           return
         }
-        setAdaptiveResult(event.data.result)
+        const alignedPositions = alignGraphLayout(
+          layoutReferenceRef.current,
+          event.data.result.positions,
+        )
+        layoutReferenceRef.current = alignedPositions
+        setAdaptiveResult({
+          ...event.data.result,
+          positions: alignedPositions,
+        })
         setAdaptiveSignature(workerSignatureRef.current)
         setAdaptiveError(null)
       },

--- a/src/lib/socialGraphProcrustes.test.ts
+++ b/src/lib/socialGraphProcrustes.test.ts
@@ -1,0 +1,47 @@
+import { alignGraphLayout } from './socialGraphProcrustes'
+
+describe('social graph Procrustes alignment', () => {
+  test('removes translation, rotation, and scale from a new layout', () => {
+    const reference = {
+      a: { x: 0, y: 0 },
+      b: { x: 4, y: 0 },
+      c: { x: 0, y: 2 },
+    }
+    const candidate = {
+      a: { x: 10, y: -3 },
+      b: { x: 10, y: 5 },
+      c: { x: 6, y: -3 },
+      d: { x: 8, y: 1 },
+    }
+
+    const aligned = alignGraphLayout(reference, candidate)
+
+    expect(aligned.a.x).toBeCloseTo(0)
+    expect(aligned.a.y).toBeCloseTo(0)
+    expect(aligned.b.x).toBeCloseTo(4)
+    expect(aligned.b.y).toBeCloseTo(0)
+    expect(aligned.c.x).toBeCloseTo(0)
+    expect(aligned.c.y).toBeCloseTo(2)
+    expect(aligned.d.x).toBeCloseTo(2)
+    expect(aligned.d.y).toBeCloseTo(1)
+  })
+
+  test('can undo a mirrored layout and carries new nodes along', () => {
+    const reference = {
+      a: { x: -1, y: -1 },
+      b: { x: 1, y: -1 },
+      c: { x: -1, y: 1 },
+    }
+    const aligned = alignGraphLayout(reference, {
+      a: { x: -1, y: 1 },
+      b: { x: 1, y: 1 },
+      c: { x: -1, y: -1 },
+      d: { x: 1, y: -1 },
+    })
+
+    expect(aligned.a).toEqual(reference.a)
+    expect(aligned.b).toEqual(reference.b)
+    expect(aligned.c).toEqual(reference.c)
+    expect(aligned.d).toEqual({ x: 1, y: 1 })
+  })
+})

--- a/src/lib/socialGraphProcrustes.ts
+++ b/src/lib/socialGraphProcrustes.ts
@@ -1,0 +1,134 @@
+export interface GraphPosition {
+  x: number
+  y: number
+}
+
+type GraphPositions = Record<string, GraphPosition>
+
+interface SimilarityTransform {
+  scale: number
+  cos: number
+  sin: number
+  reflectY: boolean
+  candidateCenter: GraphPosition
+  referenceCenter: GraphPosition
+}
+
+const center = (positions: GraphPositions, ids: string[]): GraphPosition => {
+  const total = ids.reduce(
+    (sum, id) => ({
+      x: sum.x + positions[id].x,
+      y: sum.y + positions[id].y,
+    }),
+    { x: 0, y: 0 },
+  )
+  return { x: total.x / ids.length, y: total.y / ids.length }
+}
+
+function fitTransform(
+  reference: GraphPositions,
+  candidate: GraphPositions,
+  ids: string[],
+  reflectY: boolean,
+): SimilarityTransform {
+  const referenceCenter = center(reference, ids)
+  const candidateCenter = center(candidate, ids)
+  let dot = 0
+  let cross = 0
+  let candidateEnergy = 0
+
+  for (const id of ids) {
+    const candidateX = candidate[id].x - candidateCenter.x
+    const rawCandidateY = candidate[id].y - candidateCenter.y
+    const candidateY = reflectY ? -rawCandidateY : rawCandidateY
+    const referenceX = reference[id].x - referenceCenter.x
+    const referenceY = reference[id].y - referenceCenter.y
+    dot += candidateX * referenceX + candidateY * referenceY
+    cross += candidateX * referenceY - candidateY * referenceX
+    candidateEnergy += candidateX ** 2 + candidateY ** 2
+  }
+
+  const magnitude = Math.hypot(dot, cross)
+  return {
+    scale: candidateEnergy > 0 ? magnitude / candidateEnergy : 1,
+    cos: magnitude > 0 ? dot / magnitude : 1,
+    sin: magnitude > 0 ? cross / magnitude : 0,
+    reflectY,
+    candidateCenter,
+    referenceCenter,
+  }
+}
+
+function applyTransform(
+  point: GraphPosition,
+  transform: SimilarityTransform,
+): GraphPosition {
+  const centeredX = point.x - transform.candidateCenter.x
+  const rawCenteredY = point.y - transform.candidateCenter.y
+  const centeredY = transform.reflectY ? -rawCenteredY : rawCenteredY
+  return {
+    x:
+      transform.referenceCenter.x +
+      transform.scale *
+        (transform.cos * centeredX - transform.sin * centeredY),
+    y:
+      transform.referenceCenter.y +
+      transform.scale *
+        (transform.sin * centeredX + transform.cos * centeredY),
+  }
+}
+
+const squaredError = (
+  reference: GraphPositions,
+  candidate: GraphPositions,
+  ids: string[],
+  transform: SimilarityTransform,
+) =>
+  ids.reduce((total, id) => {
+    const aligned = applyTransform(candidate[id], transform)
+    return (
+      total +
+      (aligned.x - reference[id].x) ** 2 +
+      (aligned.y - reference[id].y) ** 2
+    )
+  }, 0)
+
+/**
+ * Align a fresh graph layout to the last visible one with a 2D similarity
+ * Procrustes transform. Rotation, reflection, scale, and translation are
+ * removed while the internal shape of the new layout is preserved.
+ */
+export function alignGraphLayout(
+  reference: GraphPositions,
+  candidate: GraphPositions,
+): GraphPositions {
+  const sharedIds = Object.keys(candidate).filter((id) => reference[id])
+  if (sharedIds.length === 0) return candidate
+
+  if (sharedIds.length === 1) {
+    const id = sharedIds[0]
+    const offsetX = reference[id].x - candidate[id].x
+    const offsetY = reference[id].y - candidate[id].y
+    return Object.fromEntries(
+      Object.entries(candidate).map(([candidateId, point]) => [
+        candidateId,
+        { x: point.x + offsetX, y: point.y + offsetY },
+      ]),
+    )
+  }
+
+  const direct = fitTransform(reference, candidate, sharedIds, false)
+  const reflected = fitTransform(reference, candidate, sharedIds, true)
+  const transform =
+    squaredError(reference, candidate, sharedIds, reflected) <
+    squaredError(reference, candidate, sharedIds, direct)
+      ? reflected
+      : direct
+
+  return Object.fromEntries(
+    Object.entries(candidate).map(([id, point]) => [
+      id,
+      applyTransform(point, transform),
+    ]),
+  )
+}


### PR DESCRIPTION
## Summary\n- align each newly calculated layout to the prior visible positions using similarity Procrustes analysis\n- support rotation, reflection, uniform scale, and translation without changing graph topology\n- cover unchanged, rotated, reflected, and partial-overlap layouts\n\n## Validation\n- pnpm test -- --runInBand src/lib/socialGraphProcrustes.test.ts src/app/social-graph/SocialGraphExplorer.test.tsx\n- pnpm type-check\n- pnpm lint\n\nCloses #691