### PR TITLE
feat: let members delete their own tweets

### DIFF
--- a/src/app/profile/ProfileContent.test.tsx
+++ b/src/app/profile/ProfileContent.test.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import ProfileContent from './ProfileContent'
 
 const mockFetch = jest.fn()
 const originalFetch = global.fetch
 const mockLogInsert = jest.fn().mockResolvedValue({ error: null })
+const mockRpc = jest.fn()
 const mockUpdateDownloadArchiveVisibility = jest.fn()
 
 jest.mock('next/navigation', () => ({
@@ -20,6 +22,7 @@ jest.mock('@/hooks/useAuthAndArchive', () => ({
 jest.mock('@/utils/supabase', () => ({
   createBrowserClient: () => ({
     from: () => ({ insert: mockLogInsert }),
+    rpc: mockRpc,
     storage: { from: jest.fn() },
   }),
 }))
@@ -137,5 +140,45 @@ describe('ProfileContent opt-in preference', () => {
     expect(
       screen.getByText('Download Archive is hidden from your public profile'),
     ).toBeVisible()
+  })
+
+  it('lets the owner permanently delete one of their tweets', async () => {
+    const interaction = userEvent.setup()
+    jest.spyOn(window, 'confirm').mockReturnValue(true)
+    mockRpc.mockResolvedValue({
+      data: [{ deleted_tweets: 1 }],
+      error: null,
+    })
+
+    render(
+      <ProfileContent
+        user={user}
+        accountId="twitter-123"
+        initialOptInData={null}
+        archives={[]}
+        initialTweets={[
+          {
+            tweet_id: '1234567890',
+            created_at: '2026-08-15T00:00:00.000Z',
+            full_text: 'A tweet I can remove',
+            favorite_count: 3,
+            retweet_count: 1,
+          },
+        ]}
+      />,
+    )
+
+    await interaction.click(screen.getByRole('tab', { name: 'My Tweets' }))
+    await interaction.click(
+      screen.getByRole('button', { name: 'Delete tweet 1234567890' }),
+    )
+
+    await waitFor(() =>
+      expect(mockRpc).toHaveBeenCalledWith('delete_own_tweets', {
+        p_tweet_ids: ['1234567890'],
+      }),
+    )
+    expect(await screen.findByText('Tweet deleted permanently')).toBeVisible()
+    expect(screen.queryByText('A tweet I can remove')).not.toBeInTheDocument()
   })
 })

--- a/src/app/profile/ProfileContent.tsx
+++ b/src/app/profile/ProfileContent.tsx
@@ -40,6 +40,13 @@ interface ProfileContentProps {
   initialDownloadArchiveVisible?: boolean
   initialOptInData: any
   archives: any[]
+  initialTweets?: Array<{
+    tweet_id: string
+    created_at: string
+    full_text: string
+    favorite_count: number | null
+    retweet_count: number | null
+  }>
 }
 
 export default function ProfileContent({
@@ -48,6 +55,7 @@ export default function ProfileContent({
   initialDownloadArchiveVisible = true,
   initialOptInData,
   archives,
+  initialTweets = [],
 }: ProfileContentProps) {
   const router = useRouter()
   const { userMetadata } = useAuthAndArchive()
@@ -65,6 +73,8 @@ export default function ProfileContent({
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState<string | null>(null)
   const [deletingArchive, setDeletingArchive] = useState<string | null>(null)
+  const [deletingTweetId, setDeletingTweetId] = useState<string | null>(null)
+  const [ownTweets, setOwnTweets] = useState(initialTweets)
   const [showDeleteAllDialog, setShowDeleteAllDialog] = useState(false)
   const [showOptOutDialog, setShowOptOutDialog] = useState(false)
   const supabase = createBrowserClient()
@@ -363,6 +373,42 @@ export default function ProfileContent({
     }
   }
 
+  const handleDeleteTweet = async (tweetId: string) => {
+    if (
+      !confirm(
+        'Permanently delete this tweet and its archived media? This cannot be undone.',
+      )
+    ) {
+      return
+    }
+
+    setDeletingTweetId(tweetId)
+    setError(null)
+    setSuccess(null)
+
+    try {
+      const { data, error: deleteError } = await supabase.rpc(
+        'delete_own_tweets',
+        { p_tweet_ids: [tweetId] },
+      )
+      if (deleteError) throw deleteError
+      if (data?.[0]?.deleted_tweets !== 1) {
+        throw new Error('The tweet was not deleted')
+      }
+
+      setOwnTweets((tweets) =>
+        tweets.filter((tweet) => tweet.tweet_id !== tweetId),
+      )
+      setSuccess('Tweet deleted permanently')
+      capturePostHogEvent('own_tweet_deleted')
+      await logUserAction('delete_tweet', { tweet_id: tweetId })
+    } catch (err: any) {
+      setError(err.message || 'Failed to delete tweet')
+    } finally {
+      setDeletingTweetId(null)
+    }
+  }
+
   return (
     <div className="space-y-6">
       <Card>
@@ -385,9 +431,10 @@ export default function ProfileContent({
       </Card>
 
       <Tabs defaultValue="privacy" className="w-full">
-        <TabsList className="grid w-full grid-cols-2">
+        <TabsList className="grid w-full grid-cols-3">
           <TabsTrigger value="privacy">Privacy Settings</TabsTrigger>
           <TabsTrigger value="archives">My Archives</TabsTrigger>
+          <TabsTrigger value="tweets">My Tweets</TabsTrigger>
         </TabsList>
 
         <TabsContent value="privacy" className="space-y-4">
@@ -584,6 +631,58 @@ export default function ProfileContent({
                   data — including data from the scraper/extension.
                 </p>
               </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="tweets" className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>Your Tweets</CardTitle>
+              <CardDescription>
+                Permanently remove individual tweets from your archive. The most
+                recent 100 tweets are shown.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {ownTweets.length === 0 ? (
+                <div className="py-8 text-center text-muted-foreground">
+                  No archived tweets found.
+                </div>
+              ) : (
+                <div className="divide-y rounded-lg border">
+                  {ownTweets.map((tweet) => (
+                    <div
+                      key={tweet.tweet_id}
+                      className="flex items-start justify-between gap-4 p-4"
+                    >
+                      <div className="min-w-0 space-y-2">
+                        <p className="whitespace-pre-wrap break-words text-sm">
+                          {tweet.full_text}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          {new Date(tweet.created_at).toLocaleDateString()} ·{' '}
+                          {tweet.favorite_count || 0} likes ·{' '}
+                          {tweet.retweet_count || 0} reposts
+                        </p>
+                      </div>
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        className="flex-shrink-0"
+                        onClick={() => handleDeleteTweet(tweet.tweet_id)}
+                        disabled={deletingTweetId !== null}
+                        aria-label={`Delete tweet ${tweet.tweet_id}`}
+                      >
+                        <Trash2 className="mr-2 h-4 w-4" />
+                        {deletingTweetId === tweet.tweet_id
+                          ? 'Deleting...'
+                          : 'Delete'}
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              )}
             </CardContent>
           </Card>
         </TabsContent>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -38,13 +38,14 @@ export default async function SettingsPage() {
         .maybeSingle()
     : admin.from('optin').select('*').eq('user_id', user.id).maybeSingle()
 
-  const [optInResponse, archivesResponse, settings] = await Promise.all([
-    optInQuery,
-    twitterAccountId
-      ? supabase
-          .from('archive_upload')
-          .select(
-            `
+  const [optInResponse, archivesResponse, tweetsResponse, settings] =
+    await Promise.all([
+      optInQuery,
+      twitterAccountId
+        ? supabase
+            .from('archive_upload')
+            .select(
+              `
             id,
             account_id,
             upload_phase,
@@ -58,14 +59,24 @@ export default async function SettingsPage() {
               profile:all_profile(avatar_media_url)
             )
           `,
-          )
-          .eq('account_id', twitterAccountId)
-          .order('created_at', { ascending: false })
-      : Promise.resolve({ data: [], error: null }),
-    twitterAccountId
-      ? getPublicProfileSettings(twitterAccountId)
-      : Promise.resolve({ downloadArchiveVisible: true }),
-  ])
+            )
+            .eq('account_id', twitterAccountId)
+            .order('created_at', { ascending: false })
+        : Promise.resolve({ data: [], error: null }),
+      twitterAccountId
+        ? supabase
+            .from('tweets')
+            .select(
+              'tweet_id, created_at, full_text, favorite_count, retweet_count',
+            )
+            .eq('account_id', twitterAccountId)
+            .order('created_at', { ascending: false })
+            .limit(100)
+        : Promise.resolve({ data: [], error: null }),
+      twitterAccountId
+        ? getPublicProfileSettings(twitterAccountId)
+        : Promise.resolve({ downloadArchiveVisible: true }),
+    ])
 
   return (
     <main className="min-h-screen bg-card dark:bg-background">
@@ -76,6 +87,7 @@ export default async function SettingsPage() {
           initialDownloadArchiveVisible={settings.downloadArchiveVisible}
           initialOptInData={optInResponse.data}
           archives={archivesResponse.data || []}
+          initialTweets={tweetsResponse.data || []}
         />
       </div>
     </main>

--- a/src/database-types.ts
+++ b/src/database-types.ts
@@ -234,32 +234,32 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'all_profile_account_id_fkey'
-            columns: ['account_id']
+            foreignKeyName: "all_profile_account_id_fkey"
+            columns: ["account_id"]
             isOneToOne: true
-            referencedRelation: 'account'
-            referencedColumns: ['account_id']
+            referencedRelation: "account"
+            referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: 'all_profile_account_id_fkey'
-            columns: ['account_id']
+            foreignKeyName: "all_profile_account_id_fkey"
+            columns: ["account_id"]
             isOneToOne: true
-            referencedRelation: 'account_activity_summary'
-            referencedColumns: ['account_id']
+            referencedRelation: "account_activity_summary"
+            referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: 'all_profile_account_id_fkey'
-            columns: ['account_id']
+            foreignKeyName: "all_profile_account_id_fkey"
+            columns: ["account_id"]
             isOneToOne: true
-            referencedRelation: 'all_account'
-            referencedColumns: ['account_id']
+            referencedRelation: "all_account"
+            referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: 'all_profile_archive_upload_id_fkey'
-            columns: ['archive_upload_id']
+            foreignKeyName: "all_profile_archive_upload_id_fkey"
+            columns: ["archive_upload_id"]
             isOneToOne: false
-            referencedRelation: 'archive_upload'
-            referencedColumns: ['id']
+            referencedRelation: "archive_upload"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -273,7 +273,7 @@ export type Database = {
           keep_private: boolean | null
           start_date: string | null
           upload_likes: boolean | null
-          upload_phase: Database['public']['Enums']['upload_phase_enum'] | null
+          upload_phase: Database["public"]["Enums"]["upload_phase_enum"] | null
           username: string | null
         }
         Insert: {
@@ -285,7 +285,7 @@ export type Database = {
           keep_private?: boolean | null
           start_date?: string | null
           upload_likes?: boolean | null
-          upload_phase?: Database['public']['Enums']['upload_phase_enum'] | null
+          upload_phase?: Database["public"]["Enums"]["upload_phase_enum"] | null
           username?: string | null
         }
         Update: {
@@ -297,30 +297,30 @@ export type Database = {
           keep_private?: boolean | null
           start_date?: string | null
           upload_likes?: boolean | null
-          upload_phase?: Database['public']['Enums']['upload_phase_enum'] | null
+          upload_phase?: Database["public"]["Enums"]["upload_phase_enum"] | null
           username?: string | null
         }
         Relationships: [
           {
-            foreignKeyName: 'archive_upload_account_id_fkey'
-            columns: ['account_id']
+            foreignKeyName: "archive_upload_account_id_fkey"
+            columns: ["account_id"]
             isOneToOne: false
-            referencedRelation: 'account'
-            referencedColumns: ['account_id']
+            referencedRelation: "account"
+            referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: 'archive_upload_account_id_fkey'
-            columns: ['account_id']
+            foreignKeyName: "archive_upload_account_id_fkey"
+            columns: ["account_id"]
             isOneToOne: false
-            referencedRelation: 'account_activity_summary'
-            referencedColumns: ['account_id']
+            referencedRelation: "account_activity_summary"
+            referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: 'archive_upload_account_id_fkey'
-            columns: ['account_id']
+            foreignKeyName: "archive_upload_account_id_fkey"
+            columns: ["account_id"]
             isOneToOne: false
-            referencedRelation: 'all_account'
-            referencedColumns: ['account_id']
+            referencedRelation: "all_account"
+            referencedColumns: ["account_id"]
           },
         ]
       }
@@ -339,25 +339,25 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'conversations_tweet_id_fkey'
-            columns: ['tweet_id']
+            foreignKeyName: "conversations_tweet_id_fkey"
+            columns: ["tweet_id"]
             isOneToOne: true
-            referencedRelation: 'enriched_tweets'
-            referencedColumns: ['tweet_id']
+            referencedRelation: "enriched_tweets"
+            referencedColumns: ["tweet_id"]
           },
           {
-            foreignKeyName: 'conversations_tweet_id_fkey'
-            columns: ['tweet_id']
+            foreignKeyName: "conversations_tweet_id_fkey"
+            columns: ["tweet_id"]
             isOneToOne: true
-            referencedRelation: 'tweets'
-            referencedColumns: ['tweet_id']
+            referencedRelation: "tweets"
+            referencedColumns: ["tweet_id"]
           },
           {
-            foreignKeyName: 'conversations_tweet_id_fkey'
-            columns: ['tweet_id']
+            foreignKeyName: "conversations_tweet_id_fkey"
+            columns: ["tweet_id"]
             isOneToOne: true
-            referencedRelation: 'tweets_w_conversation_id'
-            referencedColumns: ['tweet_id']
+            referencedRelation: "tweets_w_conversation_id"
+            referencedColumns: ["tweet_id"]
           },
         ]
       }
@@ -403,11 +403,11 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'digest_editions_source_run_id_fkey'
-            columns: ['source_run_id']
+            foreignKeyName: "digest_editions_source_run_id_fkey"
+            columns: ["source_run_id"]
             isOneToOne: false
-            referencedRelation: 'digest_runs'
-            referencedColumns: ['id']
+            referencedRelation: "digest_runs"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -534,18 +534,18 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'digest_runs_parent_run_id_fkey'
-            columns: ['parent_run_id']
+            foreignKeyName: "digest_runs_parent_run_id_fkey"
+            columns: ["parent_run_id"]
             isOneToOne: false
-            referencedRelation: 'digest_runs'
-            referencedColumns: ['id']
+            referencedRelation: "digest_runs"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'digest_runs_prompt_version_id_fkey'
-            columns: ['prompt_version_id']
+            foreignKeyName: "digest_runs_prompt_version_id_fkey"
+            columns: ["prompt_version_id"]
             isOneToOne: false
-            referencedRelation: 'digest_prompt_versions'
-            referencedColumns: ['id']
+            referencedRelation: "digest_prompt_versions"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -573,32 +573,32 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'followers_account_id_fkey'
-            columns: ['account_id']
+            foreignKeyName: "followers_account_id_fkey"
+            columns: ["account_id"]
             isOneToOne: false
-            referencedRelation: 'account'
-            referencedColumns: ['account_id']
+            referencedRelation: "account"
+            referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: 'followers_account_id_fkey'
-            columns: ['account_id']
+            foreignKeyName: "followers_account_id_fkey"
+            columns: ["account_id"]
             isOneToOne: false
-            referencedRelation: 'account_activity_summary'
-            referencedColumns: ['account_id']
+            referencedRelation: "account_activity_summary"
+            referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: 'followers_account_id_fkey'
-            columns: ['account_id']
+            foreignKeyName: "followers_account_id_fkey"
+            columns: ["account_id"]
             isOneToOne: false
-            referencedRelation: 'all_account'
-            referencedColumns: ['account_id']
+            referencedRelation: "all_account"
+            referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: 'followers_archive_upload_id_fkey'
-            columns: ['archive_upload_id']
+            foreignKeyName: "followers_archive_upload_id_fkey"
+            columns: ["archive_upload_id"]
             isOneToOne: false
-            referencedRelation: 'archive_upload'
-            referencedColumns: ['id']
+            referencedRelation: "archive_upload"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -626,32 +626,32 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'following_account_id_fkey'
-            columns: ['account_id']
+            foreignKeyName: "following_account_id_fkey"
+            columns: ["account_id"]
             isOneToOne: false
-            referencedRelation: 'account'
-            referencedColumns: ['account_id']
+            referencedRelation: "account"
+            referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: 'following_account_id_fkey'
-            columns: ['account_id']
+            foreignKeyName: "following_account_id_fkey"
+            columns: ["account_id"]
             isOneToOne: false
-            referencedRelation: 'account_activity_summary'
-            referencedColumns: ['account_id']
+            referencedRelation: "account_activity_summary"
+            referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: 'following_account_id_fkey'
-            columns: ['account_id']
+            foreignKeyName: "following_account_id_fkey"
+            columns: ["account_id"]
             isOneToOne: false
-            referencedRelation: 'all_account'
-            referencedColumns: ['account_id']
+            referencedRelation: "all_account"
+            referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: 'following_archive_upload_id_fkey'
-            columns: ['archive_upload_id']
+            foreignKeyName: "following_archive_upload_id_fkey"
+            columns: ["archive_upload_id"]
             isOneToOne: false
-            referencedRelation: 'archive_upload'
-            referencedColumns: ['id']
+            referencedRelation: "archive_upload"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -697,39 +697,39 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'likes_account_id_fkey'
-            columns: ['account_id']
+            foreignKeyName: "likes_account_id_fkey"
+            columns: ["account_id"]
             isOneToOne: false
-            referencedRelation: 'account'
-            referencedColumns: ['account_id']
+            referencedRelation: "account"
+            referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: 'likes_account_id_fkey'
-            columns: ['account_id']
+            foreignKeyName: "likes_account_id_fkey"
+            columns: ["account_id"]
             isOneToOne: false
-            referencedRelation: 'account_activity_summary'
-            referencedColumns: ['account_id']
+            referencedRelation: "account_activity_summary"
+            referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: 'likes_account_id_fkey'
-            columns: ['account_id']
+            foreignKeyName: "likes_account_id_fkey"
+            columns: ["account_id"]
             isOneToOne: false
-            referencedRelation: 'all_account'
-            referencedColumns: ['account_id']
+            referencedRelation: "all_account"
+            referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: 'likes_archive_upload_id_fkey'
-            columns: ['archive_upload_id']
+            foreignKeyName: "likes_archive_upload_id_fkey"
+            columns: ["archive_upload_id"]
             isOneToOne: false
-            referencedRelation: 'archive_upload'
-            referencedColumns: ['id']
+            referencedRelation: "archive_upload"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'likes_liked_tweet_id_fkey'
-            columns: ['liked_tweet_id']
+            foreignKeyName: "likes_liked_tweet_id_fkey"
+            columns: ["liked_tweet_id"]
             isOneToOne: false
-            referencedRelation: 'liked_tweets'
-            referencedColumns: ['tweet_id']
+            referencedRelation: "liked_tweets"
+            referencedColumns: ["tweet_id"]
           },
         ]
       }
@@ -868,25 +868,25 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'fk_quote_tweets_tweet_id'
-            columns: ['tweet_id']
+            foreignKeyName: "fk_quote_tweets_tweet_id"
+            columns: ["tweet_id"]
             isOneToOne: false
-            referencedRelation: 'enriched_tweets'
-            referencedColumns: ['tweet_id']
+            referencedRelation: "enriched_tweets"
+            referencedColumns: ["tweet_id"]
           },
           {
-            foreignKeyName: 'fk_quote_tweets_tweet_id'
-            columns: ['tweet_id']
+            foreignKeyName: "fk_quote_tweets_tweet_id"
+            columns: ["tweet_id"]
             isOneToOne: false
-            referencedRelation: 'tweets'
-            referencedColumns: ['tweet_id']
+            referencedRelation: "tweets"
+            referencedColumns: ["tweet_id"]
           },
           {
-            foreignKeyName: 'fk_quote_tweets_tweet_id'
-            columns: ['tweet_id']
+            foreignKeyName: "fk_quote_tweets_tweet_id"
+            columns: ["tweet_id"]
             isOneToOne: false
-            referencedRelation: 'tweets_w_conversation_id'
-            referencedColumns: ['tweet_id']
+            referencedRelation: "tweets_w_conversation_id"
+            referencedColumns: ["tweet_id"]
           },
         ]
       }
@@ -905,46 +905,46 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'fk_retweets_retweeted_tweet_id'
-            columns: ['retweeted_tweet_id']
+            foreignKeyName: "fk_retweets_retweeted_tweet_id"
+            columns: ["retweeted_tweet_id"]
             isOneToOne: false
-            referencedRelation: 'enriched_tweets'
-            referencedColumns: ['tweet_id']
+            referencedRelation: "enriched_tweets"
+            referencedColumns: ["tweet_id"]
           },
           {
-            foreignKeyName: 'fk_retweets_retweeted_tweet_id'
-            columns: ['retweeted_tweet_id']
+            foreignKeyName: "fk_retweets_retweeted_tweet_id"
+            columns: ["retweeted_tweet_id"]
             isOneToOne: false
-            referencedRelation: 'tweets'
-            referencedColumns: ['tweet_id']
+            referencedRelation: "tweets"
+            referencedColumns: ["tweet_id"]
           },
           {
-            foreignKeyName: 'fk_retweets_retweeted_tweet_id'
-            columns: ['retweeted_tweet_id']
+            foreignKeyName: "fk_retweets_retweeted_tweet_id"
+            columns: ["retweeted_tweet_id"]
             isOneToOne: false
-            referencedRelation: 'tweets_w_conversation_id'
-            referencedColumns: ['tweet_id']
+            referencedRelation: "tweets_w_conversation_id"
+            referencedColumns: ["tweet_id"]
           },
           {
-            foreignKeyName: 'fk_retweets_tweet_id'
-            columns: ['tweet_id']
+            foreignKeyName: "fk_retweets_tweet_id"
+            columns: ["tweet_id"]
             isOneToOne: true
-            referencedRelation: 'enriched_tweets'
-            referencedColumns: ['tweet_id']
+            referencedRelation: "enriched_tweets"
+            referencedColumns: ["tweet_id"]
           },
           {
-            foreignKeyName: 'fk_retweets_tweet_id'
-            columns: ['tweet_id']
+            foreignKeyName: "fk_retweets_tweet_id"
+            columns: ["tweet_id"]
             isOneToOne: true
-            referencedRelation: 'tweets'
-            referencedColumns: ['tweet_id']
+            referencedRelation: "tweets"
+            referencedColumns: ["tweet_id"]
           },
           {
-            foreignKeyName: 'fk_retweets_tweet_id'
-            columns: ['tweet_id']
+            foreignKeyName: "fk_retweets_tweet_id"
+            columns: ["tweet_id"]
             isOneToOne: true
-            referencedRelation: 'tweets_w_conversation_id'
-            referencedColumns: ['tweet_id']
+            referencedRelation: "tweets_w_conversation_id"
+            referencedColumns: ["tweet_id"]
           },
         ]
       }
@@ -1041,32 +1041,32 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'tweet_media_archive_upload_id_fkey'
-            columns: ['archive_upload_id']
+            foreignKeyName: "tweet_media_archive_upload_id_fkey"
+            columns: ["archive_upload_id"]
             isOneToOne: false
-            referencedRelation: 'archive_upload'
-            referencedColumns: ['id']
+            referencedRelation: "archive_upload"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'tweet_media_tweet_id_fkey'
-            columns: ['tweet_id']
+            foreignKeyName: "tweet_media_tweet_id_fkey"
+            columns: ["tweet_id"]
             isOneToOne: false
-            referencedRelation: 'enriched_tweets'
-            referencedColumns: ['tweet_id']
+            referencedRelation: "enriched_tweets"
+            referencedColumns: ["tweet_id"]
           },
           {
-            foreignKeyName: 'tweet_media_tweet_id_fkey'
-            columns: ['tweet_id']
+            foreignKeyName: "tweet_media_tweet_id_fkey"
+            columns: ["tweet_id"]
             isOneToOne: false
-            referencedRelation: 'tweets'
-            referencedColumns: ['tweet_id']
+            referencedRelation: "tweets"
+            referencedColumns: ["tweet_id"]
           },
           {
-            foreignKeyName: 'tweet_media_tweet_id_fkey'
-            columns: ['tweet_id']
+            foreignKeyName: "tweet_media_tweet_id_fkey"
+            columns: ["tweet_id"]
             isOneToOne: false
-            referencedRelation: 'tweets_w_conversation_id'
-            referencedColumns: ['tweet_id']
+            referencedRelation: "tweets_w_conversation_id"
+            referencedColumns: ["tweet_id"]
           },
         ]
       }
@@ -1097,25 +1097,25 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'tweet_urls_tweet_id_fkey'
-            columns: ['tweet_id']
+            foreignKeyName: "tweet_urls_tweet_id_fkey"
+            columns: ["tweet_id"]
             isOneToOne: false
-            referencedRelation: 'enriched_tweets'
-            referencedColumns: ['tweet_id']
+            referencedRelation: "enriched_tweets"
+            referencedColumns: ["tweet_id"]
           },
           {
-            foreignKeyName: 'tweet_urls_tweet_id_fkey'
-            columns: ['tweet_id']
+            foreignKeyName: "tweet_urls_tweet_id_fkey"
+            columns: ["tweet_id"]
             isOneToOne: false
-            referencedRelation: 'tweets'
-            referencedColumns: ['tweet_id']
+            referencedRelation: "tweets"
+            referencedColumns: ["tweet_id"]
           },
           {
-            foreignKeyName: 'tweet_urls_tweet_id_fkey'
-            columns: ['tweet_id']
+            foreignKeyName: "tweet_urls_tweet_id_fkey"
+            columns: ["tweet_id"]
             isOneToOne: false
-            referencedRelation: 'tweets_w_conversation_id'
-            referencedColumns: ['tweet_id']
+            referencedRelation: "tweets_w_conversation_id"
+            referencedColumns: ["tweet_id"]
           },
         ]
       }
@@ -1164,32 +1164,32 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'tweets_account_id_fkey'
-            columns: ['account_id']
+            foreignKeyName: "tweets_account_id_fkey"
+            columns: ["account_id"]
             isOneToOne: false
-            referencedRelation: 'account'
-            referencedColumns: ['account_id']
+            referencedRelation: "account"
+            referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: 'tweets_account_id_fkey'
-            columns: ['account_id']
+            foreignKeyName: "tweets_account_id_fkey"
+            columns: ["account_id"]
             isOneToOne: false
-            referencedRelation: 'account_activity_summary'
-            referencedColumns: ['account_id']
+            referencedRelation: "account_activity_summary"
+            referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: 'tweets_account_id_fkey'
-            columns: ['account_id']
+            foreignKeyName: "tweets_account_id_fkey"
+            columns: ["account_id"]
             isOneToOne: false
-            referencedRelation: 'all_account'
-            referencedColumns: ['account_id']
+            referencedRelation: "all_account"
+            referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: 'tweets_archive_upload_id_fkey'
-            columns: ['archive_upload_id']
+            foreignKeyName: "tweets_archive_upload_id_fkey"
+            columns: ["archive_upload_id"]
             isOneToOne: false
-            referencedRelation: 'archive_upload'
-            referencedColumns: ['id']
+            referencedRelation: "archive_upload"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -1244,32 +1244,32 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'user_mentions_mentioned_user_id_fkey'
-            columns: ['mentioned_user_id']
+            foreignKeyName: "user_mentions_mentioned_user_id_fkey"
+            columns: ["mentioned_user_id"]
             isOneToOne: false
-            referencedRelation: 'mentioned_users'
-            referencedColumns: ['user_id']
+            referencedRelation: "mentioned_users"
+            referencedColumns: ["user_id"]
           },
           {
-            foreignKeyName: 'user_mentions_tweet_id_fkey'
-            columns: ['tweet_id']
+            foreignKeyName: "user_mentions_tweet_id_fkey"
+            columns: ["tweet_id"]
             isOneToOne: false
-            referencedRelation: 'enriched_tweets'
-            referencedColumns: ['tweet_id']
+            referencedRelation: "enriched_tweets"
+            referencedColumns: ["tweet_id"]
           },
           {
-            foreignKeyName: 'user_mentions_tweet_id_fkey'
-            columns: ['tweet_id']
+            foreignKeyName: "user_mentions_tweet_id_fkey"
+            columns: ["tweet_id"]
             isOneToOne: false
-            referencedRelation: 'tweets'
-            referencedColumns: ['tweet_id']
+            referencedRelation: "tweets"
+            referencedColumns: ["tweet_id"]
           },
           {
-            foreignKeyName: 'user_mentions_tweet_id_fkey'
-            columns: ['tweet_id']
+            foreignKeyName: "user_mentions_tweet_id_fkey"
+            columns: ["tweet_id"]
             isOneToOne: false
-            referencedRelation: 'tweets_w_conversation_id'
-            referencedColumns: ['tweet_id']
+            referencedRelation: "tweets_w_conversation_id"
+            referencedColumns: ["tweet_id"]
           },
         ]
       }
@@ -1325,32 +1325,32 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'tweets_account_id_fkey'
-            columns: ['account_id']
+            foreignKeyName: "tweets_account_id_fkey"
+            columns: ["account_id"]
             isOneToOne: false
-            referencedRelation: 'account'
-            referencedColumns: ['account_id']
+            referencedRelation: "account"
+            referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: 'tweets_account_id_fkey'
-            columns: ['account_id']
+            foreignKeyName: "tweets_account_id_fkey"
+            columns: ["account_id"]
             isOneToOne: false
-            referencedRelation: 'account_activity_summary'
-            referencedColumns: ['account_id']
+            referencedRelation: "account_activity_summary"
+            referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: 'tweets_account_id_fkey'
-            columns: ['account_id']
+            foreignKeyName: "tweets_account_id_fkey"
+            columns: ["account_id"]
             isOneToOne: false
-            referencedRelation: 'all_account'
-            referencedColumns: ['account_id']
+            referencedRelation: "all_account"
+            referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: 'tweets_archive_upload_id_fkey'
-            columns: ['archive_upload_id']
+            foreignKeyName: "tweets_archive_upload_id_fkey"
+            columns: ["archive_upload_id"]
             isOneToOne: false
-            referencedRelation: 'archive_upload'
-            referencedColumns: ['id']
+            referencedRelation: "archive_upload"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -1388,25 +1388,25 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'tweets_account_id_fkey'
-            columns: ['account_id']
+            foreignKeyName: "tweets_account_id_fkey"
+            columns: ["account_id"]
             isOneToOne: false
-            referencedRelation: 'account'
-            referencedColumns: ['account_id']
+            referencedRelation: "account"
+            referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: 'tweets_account_id_fkey'
-            columns: ['account_id']
+            foreignKeyName: "tweets_account_id_fkey"
+            columns: ["account_id"]
             isOneToOne: false
-            referencedRelation: 'account_activity_summary'
-            referencedColumns: ['account_id']
+            referencedRelation: "account_activity_summary"
+            referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: 'tweets_account_id_fkey'
-            columns: ['account_id']
+            foreignKeyName: "tweets_account_id_fkey"
+            columns: ["account_id"]
             isOneToOne: false
-            referencedRelation: 'all_account'
-            referencedColumns: ['account_id']
+            referencedRelation: "all_account"
+            referencedColumns: ["account_id"]
           },
         ]
       }
@@ -1422,32 +1422,32 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'all_profile_account_id_fkey'
-            columns: ['account_id']
+            foreignKeyName: "all_profile_account_id_fkey"
+            columns: ["account_id"]
             isOneToOne: true
-            referencedRelation: 'account'
-            referencedColumns: ['account_id']
+            referencedRelation: "account"
+            referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: 'all_profile_account_id_fkey'
-            columns: ['account_id']
+            foreignKeyName: "all_profile_account_id_fkey"
+            columns: ["account_id"]
             isOneToOne: true
-            referencedRelation: 'account_activity_summary'
-            referencedColumns: ['account_id']
+            referencedRelation: "account_activity_summary"
+            referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: 'all_profile_account_id_fkey'
-            columns: ['account_id']
+            foreignKeyName: "all_profile_account_id_fkey"
+            columns: ["account_id"]
             isOneToOne: true
-            referencedRelation: 'all_account'
-            referencedColumns: ['account_id']
+            referencedRelation: "all_account"
+            referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: 'all_profile_archive_upload_id_fkey'
-            columns: ['archive_upload_id']
+            foreignKeyName: "all_profile_archive_upload_id_fkey"
+            columns: ["archive_upload_id"]
             isOneToOne: false
-            referencedRelation: 'archive_upload'
-            referencedColumns: ['id']
+            referencedRelation: "archive_upload"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -1483,32 +1483,32 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'tweets_account_id_fkey'
-            columns: ['account_id']
+            foreignKeyName: "tweets_account_id_fkey"
+            columns: ["account_id"]
             isOneToOne: false
-            referencedRelation: 'account'
-            referencedColumns: ['account_id']
+            referencedRelation: "account"
+            referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: 'tweets_account_id_fkey'
-            columns: ['account_id']
+            foreignKeyName: "tweets_account_id_fkey"
+            columns: ["account_id"]
             isOneToOne: false
-            referencedRelation: 'account_activity_summary'
-            referencedColumns: ['account_id']
+            referencedRelation: "account_activity_summary"
+            referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: 'tweets_account_id_fkey'
-            columns: ['account_id']
+            foreignKeyName: "tweets_account_id_fkey"
+            columns: ["account_id"]
             isOneToOne: false
-            referencedRelation: 'all_account'
-            referencedColumns: ['account_id']
+            referencedRelation: "all_account"
+            referencedColumns: ["account_id"]
           },
           {
-            foreignKeyName: 'tweets_archive_upload_id_fkey'
-            columns: ['archive_upload_id']
+            foreignKeyName: "tweets_archive_upload_id_fkey"
+            columns: ["archive_upload_id"]
             isOneToOne: false
-            referencedRelation: 'archive_upload'
-            referencedColumns: ['id']
+            referencedRelation: "archive_upload"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -1648,14 +1648,7 @@ export type Database = {
           deleted_private_tweet_user: number
         }[]
       }
-      delete_single_archive: {
-        Args: {
-          p_account_id: string
-          p_archive_upload_id: number
-        }
-        Returns: undefined
-      }
-      delete_tweets: {
+      delete_own_tweets: {
         Args: {
           p_tweet_ids: string[]
         }
@@ -1668,7 +1661,14 @@ export type Database = {
           deleted_private_tweet_user: number
         }[]
       }
-      delete_own_tweets: {
+      delete_single_archive: {
+        Args: {
+          p_account_id: string
+          p_archive_upload_id: number
+        }
+        Returns: undefined
+      }
+      delete_tweets: {
         Args: {
           p_tweet_ids: string[]
         }
@@ -2123,31 +2123,31 @@ export type Database = {
       }
       gtrgm_compress: {
         Args: {
-          '': unknown
+          "": unknown
         }
         Returns: unknown
       }
       gtrgm_decompress: {
         Args: {
-          '': unknown
+          "": unknown
         }
         Returns: unknown
       }
       gtrgm_in: {
         Args: {
-          '': unknown
+          "": unknown
         }
         Returns: unknown
       }
       gtrgm_options: {
         Args: {
-          '': unknown
+          "": unknown
         }
         Returns: undefined
       }
       gtrgm_out: {
         Args: {
-          '': unknown
+          "": unknown
         }
         Returns: unknown
       }
@@ -2315,7 +2315,7 @@ export type Database = {
       }
       set_limit: {
         Args: {
-          '': number
+          "": number
         }
         Returns: number
       }
@@ -2325,7 +2325,7 @@ export type Database = {
       }
       show_trgm: {
         Args: {
-          '': string
+          "": string
         }
         Returns: string[]
       }
@@ -2352,11 +2352,11 @@ export type Database = {
     }
     Enums: {
       upload_phase_enum:
-        | 'uploading'
-        | 'ready_for_commit'
-        | 'committing'
-        | 'completed'
-        | 'failed'
+        | "uploading"
+        | "ready_for_commit"
+        | "committing"
+        | "completed"
+        | "failed"
     }
     CompositeTypes: {
       [_ in never]: never
@@ -2364,27 +2364,27 @@ export type Database = {
   }
 }
 
-type PublicSchema = Database[Extract<keyof Database, 'public'>]
+type PublicSchema = Database[Extract<keyof Database, "public">]
 
 export type Tables<
   PublicTableNameOrOptions extends
-    | keyof (PublicSchema['Tables'] & PublicSchema['Views'])
+    | keyof (PublicSchema["Tables"] & PublicSchema["Views"])
     | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof (Database[PublicTableNameOrOptions['schema']]['Tables'] &
-        Database[PublicTableNameOrOptions['schema']]['Views'])
+    ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+        Database[PublicTableNameOrOptions["schema"]]["Views"])
     : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? (Database[PublicTableNameOrOptions['schema']]['Tables'] &
-      Database[PublicTableNameOrOptions['schema']]['Views'])[TableName] extends {
+  ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+      Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
       Row: infer R
     }
     ? R
     : never
-  : PublicTableNameOrOptions extends keyof (PublicSchema['Tables'] &
-        PublicSchema['Views'])
-    ? (PublicSchema['Tables'] &
-        PublicSchema['Views'])[PublicTableNameOrOptions] extends {
+  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
+        PublicSchema["Views"])
+    ? (PublicSchema["Tables"] &
+        PublicSchema["Views"])[PublicTableNameOrOptions] extends {
         Row: infer R
       }
       ? R
@@ -2393,19 +2393,19 @@ export type Tables<
 
 export type TablesInsert<
   PublicTableNameOrOptions extends
-    | keyof PublicSchema['Tables']
+    | keyof PublicSchema["Tables"]
     | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicTableNameOrOptions['schema']]['Tables']
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions['schema']]['Tables'][TableName] extends {
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Insert: infer I
     }
     ? I
     : never
-  : PublicTableNameOrOptions extends keyof PublicSchema['Tables']
-    ? PublicSchema['Tables'][PublicTableNameOrOptions] extends {
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
         Insert: infer I
       }
       ? I
@@ -2414,19 +2414,19 @@ export type TablesInsert<
 
 export type TablesUpdate<
   PublicTableNameOrOptions extends
-    | keyof PublicSchema['Tables']
+    | keyof PublicSchema["Tables"]
     | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicTableNameOrOptions['schema']]['Tables']
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions['schema']]['Tables'][TableName] extends {
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Update: infer U
     }
     ? U
     : never
-  : PublicTableNameOrOptions extends keyof PublicSchema['Tables']
-    ? PublicSchema['Tables'][PublicTableNameOrOptions] extends {
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
         Update: infer U
       }
       ? U
@@ -2435,28 +2435,29 @@ export type TablesUpdate<
 
 export type Enums<
   PublicEnumNameOrOptions extends
-    | keyof PublicSchema['Enums']
+    | keyof PublicSchema["Enums"]
     | { schema: keyof Database },
   EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicEnumNameOrOptions['schema']]['Enums']
+    ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
     : never = never,
 > = PublicEnumNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicEnumNameOrOptions['schema']]['Enums'][EnumName]
-  : PublicEnumNameOrOptions extends keyof PublicSchema['Enums']
-    ? PublicSchema['Enums'][PublicEnumNameOrOptions]
+  ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
+    ? PublicSchema["Enums"][PublicEnumNameOrOptions]
     : never
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
-    | keyof PublicSchema['CompositeTypes']
+    | keyof PublicSchema["CompositeTypes"]
     | { schema: keyof Database },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
     schema: keyof Database
   }
-    ? keyof Database[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
+    ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
     : never = never,
 > = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes'][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof PublicSchema['CompositeTypes']
-    ? PublicSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
+  ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
+    ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never
+

--- a/src/database-types.ts
+++ b/src/database-types.ts
@@ -234,32 +234,32 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "all_profile_account_id_fkey"
-            columns: ["account_id"]
+            foreignKeyName: 'all_profile_account_id_fkey'
+            columns: ['account_id']
             isOneToOne: true
-            referencedRelation: "account"
-            referencedColumns: ["account_id"]
+            referencedRelation: 'account'
+            referencedColumns: ['account_id']
           },
           {
-            foreignKeyName: "all_profile_account_id_fkey"
-            columns: ["account_id"]
+            foreignKeyName: 'all_profile_account_id_fkey'
+            columns: ['account_id']
             isOneToOne: true
-            referencedRelation: "account_activity_summary"
-            referencedColumns: ["account_id"]
+            referencedRelation: 'account_activity_summary'
+            referencedColumns: ['account_id']
           },
           {
-            foreignKeyName: "all_profile_account_id_fkey"
-            columns: ["account_id"]
+            foreignKeyName: 'all_profile_account_id_fkey'
+            columns: ['account_id']
             isOneToOne: true
-            referencedRelation: "all_account"
-            referencedColumns: ["account_id"]
+            referencedRelation: 'all_account'
+            referencedColumns: ['account_id']
           },
           {
-            foreignKeyName: "all_profile_archive_upload_id_fkey"
-            columns: ["archive_upload_id"]
+            foreignKeyName: 'all_profile_archive_upload_id_fkey'
+            columns: ['archive_upload_id']
             isOneToOne: false
-            referencedRelation: "archive_upload"
-            referencedColumns: ["id"]
+            referencedRelation: 'archive_upload'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -273,7 +273,7 @@ export type Database = {
           keep_private: boolean | null
           start_date: string | null
           upload_likes: boolean | null
-          upload_phase: Database["public"]["Enums"]["upload_phase_enum"] | null
+          upload_phase: Database['public']['Enums']['upload_phase_enum'] | null
           username: string | null
         }
         Insert: {
@@ -285,7 +285,7 @@ export type Database = {
           keep_private?: boolean | null
           start_date?: string | null
           upload_likes?: boolean | null
-          upload_phase?: Database["public"]["Enums"]["upload_phase_enum"] | null
+          upload_phase?: Database['public']['Enums']['upload_phase_enum'] | null
           username?: string | null
         }
         Update: {
@@ -297,30 +297,30 @@ export type Database = {
           keep_private?: boolean | null
           start_date?: string | null
           upload_likes?: boolean | null
-          upload_phase?: Database["public"]["Enums"]["upload_phase_enum"] | null
+          upload_phase?: Database['public']['Enums']['upload_phase_enum'] | null
           username?: string | null
         }
         Relationships: [
           {
-            foreignKeyName: "archive_upload_account_id_fkey"
-            columns: ["account_id"]
+            foreignKeyName: 'archive_upload_account_id_fkey'
+            columns: ['account_id']
             isOneToOne: false
-            referencedRelation: "account"
-            referencedColumns: ["account_id"]
+            referencedRelation: 'account'
+            referencedColumns: ['account_id']
           },
           {
-            foreignKeyName: "archive_upload_account_id_fkey"
-            columns: ["account_id"]
+            foreignKeyName: 'archive_upload_account_id_fkey'
+            columns: ['account_id']
             isOneToOne: false
-            referencedRelation: "account_activity_summary"
-            referencedColumns: ["account_id"]
+            referencedRelation: 'account_activity_summary'
+            referencedColumns: ['account_id']
           },
           {
-            foreignKeyName: "archive_upload_account_id_fkey"
-            columns: ["account_id"]
+            foreignKeyName: 'archive_upload_account_id_fkey'
+            columns: ['account_id']
             isOneToOne: false
-            referencedRelation: "all_account"
-            referencedColumns: ["account_id"]
+            referencedRelation: 'all_account'
+            referencedColumns: ['account_id']
           },
         ]
       }
@@ -339,25 +339,25 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "conversations_tweet_id_fkey"
-            columns: ["tweet_id"]
+            foreignKeyName: 'conversations_tweet_id_fkey'
+            columns: ['tweet_id']
             isOneToOne: true
-            referencedRelation: "enriched_tweets"
-            referencedColumns: ["tweet_id"]
+            referencedRelation: 'enriched_tweets'
+            referencedColumns: ['tweet_id']
           },
           {
-            foreignKeyName: "conversations_tweet_id_fkey"
-            columns: ["tweet_id"]
+            foreignKeyName: 'conversations_tweet_id_fkey'
+            columns: ['tweet_id']
             isOneToOne: true
-            referencedRelation: "tweets"
-            referencedColumns: ["tweet_id"]
+            referencedRelation: 'tweets'
+            referencedColumns: ['tweet_id']
           },
           {
-            foreignKeyName: "conversations_tweet_id_fkey"
-            columns: ["tweet_id"]
+            foreignKeyName: 'conversations_tweet_id_fkey'
+            columns: ['tweet_id']
             isOneToOne: true
-            referencedRelation: "tweets_w_conversation_id"
-            referencedColumns: ["tweet_id"]
+            referencedRelation: 'tweets_w_conversation_id'
+            referencedColumns: ['tweet_id']
           },
         ]
       }
@@ -403,11 +403,11 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "digest_editions_source_run_id_fkey"
-            columns: ["source_run_id"]
+            foreignKeyName: 'digest_editions_source_run_id_fkey'
+            columns: ['source_run_id']
             isOneToOne: false
-            referencedRelation: "digest_runs"
-            referencedColumns: ["id"]
+            referencedRelation: 'digest_runs'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -534,18 +534,18 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "digest_runs_parent_run_id_fkey"
-            columns: ["parent_run_id"]
+            foreignKeyName: 'digest_runs_parent_run_id_fkey'
+            columns: ['parent_run_id']
             isOneToOne: false
-            referencedRelation: "digest_runs"
-            referencedColumns: ["id"]
+            referencedRelation: 'digest_runs'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "digest_runs_prompt_version_id_fkey"
-            columns: ["prompt_version_id"]
+            foreignKeyName: 'digest_runs_prompt_version_id_fkey'
+            columns: ['prompt_version_id']
             isOneToOne: false
-            referencedRelation: "digest_prompt_versions"
-            referencedColumns: ["id"]
+            referencedRelation: 'digest_prompt_versions'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -573,32 +573,32 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "followers_account_id_fkey"
-            columns: ["account_id"]
+            foreignKeyName: 'followers_account_id_fkey'
+            columns: ['account_id']
             isOneToOne: false
-            referencedRelation: "account"
-            referencedColumns: ["account_id"]
+            referencedRelation: 'account'
+            referencedColumns: ['account_id']
           },
           {
-            foreignKeyName: "followers_account_id_fkey"
-            columns: ["account_id"]
+            foreignKeyName: 'followers_account_id_fkey'
+            columns: ['account_id']
             isOneToOne: false
-            referencedRelation: "account_activity_summary"
-            referencedColumns: ["account_id"]
+            referencedRelation: 'account_activity_summary'
+            referencedColumns: ['account_id']
           },
           {
-            foreignKeyName: "followers_account_id_fkey"
-            columns: ["account_id"]
+            foreignKeyName: 'followers_account_id_fkey'
+            columns: ['account_id']
             isOneToOne: false
-            referencedRelation: "all_account"
-            referencedColumns: ["account_id"]
+            referencedRelation: 'all_account'
+            referencedColumns: ['account_id']
           },
           {
-            foreignKeyName: "followers_archive_upload_id_fkey"
-            columns: ["archive_upload_id"]
+            foreignKeyName: 'followers_archive_upload_id_fkey'
+            columns: ['archive_upload_id']
             isOneToOne: false
-            referencedRelation: "archive_upload"
-            referencedColumns: ["id"]
+            referencedRelation: 'archive_upload'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -626,32 +626,32 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "following_account_id_fkey"
-            columns: ["account_id"]
+            foreignKeyName: 'following_account_id_fkey'
+            columns: ['account_id']
             isOneToOne: false
-            referencedRelation: "account"
-            referencedColumns: ["account_id"]
+            referencedRelation: 'account'
+            referencedColumns: ['account_id']
           },
           {
-            foreignKeyName: "following_account_id_fkey"
-            columns: ["account_id"]
+            foreignKeyName: 'following_account_id_fkey'
+            columns: ['account_id']
             isOneToOne: false
-            referencedRelation: "account_activity_summary"
-            referencedColumns: ["account_id"]
+            referencedRelation: 'account_activity_summary'
+            referencedColumns: ['account_id']
           },
           {
-            foreignKeyName: "following_account_id_fkey"
-            columns: ["account_id"]
+            foreignKeyName: 'following_account_id_fkey'
+            columns: ['account_id']
             isOneToOne: false
-            referencedRelation: "all_account"
-            referencedColumns: ["account_id"]
+            referencedRelation: 'all_account'
+            referencedColumns: ['account_id']
           },
           {
-            foreignKeyName: "following_archive_upload_id_fkey"
-            columns: ["archive_upload_id"]
+            foreignKeyName: 'following_archive_upload_id_fkey'
+            columns: ['archive_upload_id']
             isOneToOne: false
-            referencedRelation: "archive_upload"
-            referencedColumns: ["id"]
+            referencedRelation: 'archive_upload'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -697,39 +697,39 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "likes_account_id_fkey"
-            columns: ["account_id"]
+            foreignKeyName: 'likes_account_id_fkey'
+            columns: ['account_id']
             isOneToOne: false
-            referencedRelation: "account"
-            referencedColumns: ["account_id"]
+            referencedRelation: 'account'
+            referencedColumns: ['account_id']
           },
           {
-            foreignKeyName: "likes_account_id_fkey"
-            columns: ["account_id"]
+            foreignKeyName: 'likes_account_id_fkey'
+            columns: ['account_id']
             isOneToOne: false
-            referencedRelation: "account_activity_summary"
-            referencedColumns: ["account_id"]
+            referencedRelation: 'account_activity_summary'
+            referencedColumns: ['account_id']
           },
           {
-            foreignKeyName: "likes_account_id_fkey"
-            columns: ["account_id"]
+            foreignKeyName: 'likes_account_id_fkey'
+            columns: ['account_id']
             isOneToOne: false
-            referencedRelation: "all_account"
-            referencedColumns: ["account_id"]
+            referencedRelation: 'all_account'
+            referencedColumns: ['account_id']
           },
           {
-            foreignKeyName: "likes_archive_upload_id_fkey"
-            columns: ["archive_upload_id"]
+            foreignKeyName: 'likes_archive_upload_id_fkey'
+            columns: ['archive_upload_id']
             isOneToOne: false
-            referencedRelation: "archive_upload"
-            referencedColumns: ["id"]
+            referencedRelation: 'archive_upload'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "likes_liked_tweet_id_fkey"
-            columns: ["liked_tweet_id"]
+            foreignKeyName: 'likes_liked_tweet_id_fkey'
+            columns: ['liked_tweet_id']
             isOneToOne: false
-            referencedRelation: "liked_tweets"
-            referencedColumns: ["tweet_id"]
+            referencedRelation: 'liked_tweets'
+            referencedColumns: ['tweet_id']
           },
         ]
       }
@@ -868,25 +868,25 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "fk_quote_tweets_tweet_id"
-            columns: ["tweet_id"]
+            foreignKeyName: 'fk_quote_tweets_tweet_id'
+            columns: ['tweet_id']
             isOneToOne: false
-            referencedRelation: "enriched_tweets"
-            referencedColumns: ["tweet_id"]
+            referencedRelation: 'enriched_tweets'
+            referencedColumns: ['tweet_id']
           },
           {
-            foreignKeyName: "fk_quote_tweets_tweet_id"
-            columns: ["tweet_id"]
+            foreignKeyName: 'fk_quote_tweets_tweet_id'
+            columns: ['tweet_id']
             isOneToOne: false
-            referencedRelation: "tweets"
-            referencedColumns: ["tweet_id"]
+            referencedRelation: 'tweets'
+            referencedColumns: ['tweet_id']
           },
           {
-            foreignKeyName: "fk_quote_tweets_tweet_id"
-            columns: ["tweet_id"]
+            foreignKeyName: 'fk_quote_tweets_tweet_id'
+            columns: ['tweet_id']
             isOneToOne: false
-            referencedRelation: "tweets_w_conversation_id"
-            referencedColumns: ["tweet_id"]
+            referencedRelation: 'tweets_w_conversation_id'
+            referencedColumns: ['tweet_id']
           },
         ]
       }
@@ -905,46 +905,46 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "fk_retweets_retweeted_tweet_id"
-            columns: ["retweeted_tweet_id"]
+            foreignKeyName: 'fk_retweets_retweeted_tweet_id'
+            columns: ['retweeted_tweet_id']
             isOneToOne: false
-            referencedRelation: "enriched_tweets"
-            referencedColumns: ["tweet_id"]
+            referencedRelation: 'enriched_tweets'
+            referencedColumns: ['tweet_id']
           },
           {
-            foreignKeyName: "fk_retweets_retweeted_tweet_id"
-            columns: ["retweeted_tweet_id"]
+            foreignKeyName: 'fk_retweets_retweeted_tweet_id'
+            columns: ['retweeted_tweet_id']
             isOneToOne: false
-            referencedRelation: "tweets"
-            referencedColumns: ["tweet_id"]
+            referencedRelation: 'tweets'
+            referencedColumns: ['tweet_id']
           },
           {
-            foreignKeyName: "fk_retweets_retweeted_tweet_id"
-            columns: ["retweeted_tweet_id"]
+            foreignKeyName: 'fk_retweets_retweeted_tweet_id'
+            columns: ['retweeted_tweet_id']
             isOneToOne: false
-            referencedRelation: "tweets_w_conversation_id"
-            referencedColumns: ["tweet_id"]
+            referencedRelation: 'tweets_w_conversation_id'
+            referencedColumns: ['tweet_id']
           },
           {
-            foreignKeyName: "fk_retweets_tweet_id"
-            columns: ["tweet_id"]
+            foreignKeyName: 'fk_retweets_tweet_id'
+            columns: ['tweet_id']
             isOneToOne: true
-            referencedRelation: "enriched_tweets"
-            referencedColumns: ["tweet_id"]
+            referencedRelation: 'enriched_tweets'
+            referencedColumns: ['tweet_id']
           },
           {
-            foreignKeyName: "fk_retweets_tweet_id"
-            columns: ["tweet_id"]
+            foreignKeyName: 'fk_retweets_tweet_id'
+            columns: ['tweet_id']
             isOneToOne: true
-            referencedRelation: "tweets"
-            referencedColumns: ["tweet_id"]
+            referencedRelation: 'tweets'
+            referencedColumns: ['tweet_id']
           },
           {
-            foreignKeyName: "fk_retweets_tweet_id"
-            columns: ["tweet_id"]
+            foreignKeyName: 'fk_retweets_tweet_id'
+            columns: ['tweet_id']
             isOneToOne: true
-            referencedRelation: "tweets_w_conversation_id"
-            referencedColumns: ["tweet_id"]
+            referencedRelation: 'tweets_w_conversation_id'
+            referencedColumns: ['tweet_id']
           },
         ]
       }
@@ -1041,32 +1041,32 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "tweet_media_archive_upload_id_fkey"
-            columns: ["archive_upload_id"]
+            foreignKeyName: 'tweet_media_archive_upload_id_fkey'
+            columns: ['archive_upload_id']
             isOneToOne: false
-            referencedRelation: "archive_upload"
-            referencedColumns: ["id"]
+            referencedRelation: 'archive_upload'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "tweet_media_tweet_id_fkey"
-            columns: ["tweet_id"]
+            foreignKeyName: 'tweet_media_tweet_id_fkey'
+            columns: ['tweet_id']
             isOneToOne: false
-            referencedRelation: "enriched_tweets"
-            referencedColumns: ["tweet_id"]
+            referencedRelation: 'enriched_tweets'
+            referencedColumns: ['tweet_id']
           },
           {
-            foreignKeyName: "tweet_media_tweet_id_fkey"
-            columns: ["tweet_id"]
+            foreignKeyName: 'tweet_media_tweet_id_fkey'
+            columns: ['tweet_id']
             isOneToOne: false
-            referencedRelation: "tweets"
-            referencedColumns: ["tweet_id"]
+            referencedRelation: 'tweets'
+            referencedColumns: ['tweet_id']
           },
           {
-            foreignKeyName: "tweet_media_tweet_id_fkey"
-            columns: ["tweet_id"]
+            foreignKeyName: 'tweet_media_tweet_id_fkey'
+            columns: ['tweet_id']
             isOneToOne: false
-            referencedRelation: "tweets_w_conversation_id"
-            referencedColumns: ["tweet_id"]
+            referencedRelation: 'tweets_w_conversation_id'
+            referencedColumns: ['tweet_id']
           },
         ]
       }
@@ -1097,25 +1097,25 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "tweet_urls_tweet_id_fkey"
-            columns: ["tweet_id"]
+            foreignKeyName: 'tweet_urls_tweet_id_fkey'
+            columns: ['tweet_id']
             isOneToOne: false
-            referencedRelation: "enriched_tweets"
-            referencedColumns: ["tweet_id"]
+            referencedRelation: 'enriched_tweets'
+            referencedColumns: ['tweet_id']
           },
           {
-            foreignKeyName: "tweet_urls_tweet_id_fkey"
-            columns: ["tweet_id"]
+            foreignKeyName: 'tweet_urls_tweet_id_fkey'
+            columns: ['tweet_id']
             isOneToOne: false
-            referencedRelation: "tweets"
-            referencedColumns: ["tweet_id"]
+            referencedRelation: 'tweets'
+            referencedColumns: ['tweet_id']
           },
           {
-            foreignKeyName: "tweet_urls_tweet_id_fkey"
-            columns: ["tweet_id"]
+            foreignKeyName: 'tweet_urls_tweet_id_fkey'
+            columns: ['tweet_id']
             isOneToOne: false
-            referencedRelation: "tweets_w_conversation_id"
-            referencedColumns: ["tweet_id"]
+            referencedRelation: 'tweets_w_conversation_id'
+            referencedColumns: ['tweet_id']
           },
         ]
       }
@@ -1164,32 +1164,32 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "tweets_account_id_fkey"
-            columns: ["account_id"]
+            foreignKeyName: 'tweets_account_id_fkey'
+            columns: ['account_id']
             isOneToOne: false
-            referencedRelation: "account"
-            referencedColumns: ["account_id"]
+            referencedRelation: 'account'
+            referencedColumns: ['account_id']
           },
           {
-            foreignKeyName: "tweets_account_id_fkey"
-            columns: ["account_id"]
+            foreignKeyName: 'tweets_account_id_fkey'
+            columns: ['account_id']
             isOneToOne: false
-            referencedRelation: "account_activity_summary"
-            referencedColumns: ["account_id"]
+            referencedRelation: 'account_activity_summary'
+            referencedColumns: ['account_id']
           },
           {
-            foreignKeyName: "tweets_account_id_fkey"
-            columns: ["account_id"]
+            foreignKeyName: 'tweets_account_id_fkey'
+            columns: ['account_id']
             isOneToOne: false
-            referencedRelation: "all_account"
-            referencedColumns: ["account_id"]
+            referencedRelation: 'all_account'
+            referencedColumns: ['account_id']
           },
           {
-            foreignKeyName: "tweets_archive_upload_id_fkey"
-            columns: ["archive_upload_id"]
+            foreignKeyName: 'tweets_archive_upload_id_fkey'
+            columns: ['archive_upload_id']
             isOneToOne: false
-            referencedRelation: "archive_upload"
-            referencedColumns: ["id"]
+            referencedRelation: 'archive_upload'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -1244,32 +1244,32 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "user_mentions_mentioned_user_id_fkey"
-            columns: ["mentioned_user_id"]
+            foreignKeyName: 'user_mentions_mentioned_user_id_fkey'
+            columns: ['mentioned_user_id']
             isOneToOne: false
-            referencedRelation: "mentioned_users"
-            referencedColumns: ["user_id"]
+            referencedRelation: 'mentioned_users'
+            referencedColumns: ['user_id']
           },
           {
-            foreignKeyName: "user_mentions_tweet_id_fkey"
-            columns: ["tweet_id"]
+            foreignKeyName: 'user_mentions_tweet_id_fkey'
+            columns: ['tweet_id']
             isOneToOne: false
-            referencedRelation: "enriched_tweets"
-            referencedColumns: ["tweet_id"]
+            referencedRelation: 'enriched_tweets'
+            referencedColumns: ['tweet_id']
           },
           {
-            foreignKeyName: "user_mentions_tweet_id_fkey"
-            columns: ["tweet_id"]
+            foreignKeyName: 'user_mentions_tweet_id_fkey'
+            columns: ['tweet_id']
             isOneToOne: false
-            referencedRelation: "tweets"
-            referencedColumns: ["tweet_id"]
+            referencedRelation: 'tweets'
+            referencedColumns: ['tweet_id']
           },
           {
-            foreignKeyName: "user_mentions_tweet_id_fkey"
-            columns: ["tweet_id"]
+            foreignKeyName: 'user_mentions_tweet_id_fkey'
+            columns: ['tweet_id']
             isOneToOne: false
-            referencedRelation: "tweets_w_conversation_id"
-            referencedColumns: ["tweet_id"]
+            referencedRelation: 'tweets_w_conversation_id'
+            referencedColumns: ['tweet_id']
           },
         ]
       }
@@ -1325,32 +1325,32 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "tweets_account_id_fkey"
-            columns: ["account_id"]
+            foreignKeyName: 'tweets_account_id_fkey'
+            columns: ['account_id']
             isOneToOne: false
-            referencedRelation: "account"
-            referencedColumns: ["account_id"]
+            referencedRelation: 'account'
+            referencedColumns: ['account_id']
           },
           {
-            foreignKeyName: "tweets_account_id_fkey"
-            columns: ["account_id"]
+            foreignKeyName: 'tweets_account_id_fkey'
+            columns: ['account_id']
             isOneToOne: false
-            referencedRelation: "account_activity_summary"
-            referencedColumns: ["account_id"]
+            referencedRelation: 'account_activity_summary'
+            referencedColumns: ['account_id']
           },
           {
-            foreignKeyName: "tweets_account_id_fkey"
-            columns: ["account_id"]
+            foreignKeyName: 'tweets_account_id_fkey'
+            columns: ['account_id']
             isOneToOne: false
-            referencedRelation: "all_account"
-            referencedColumns: ["account_id"]
+            referencedRelation: 'all_account'
+            referencedColumns: ['account_id']
           },
           {
-            foreignKeyName: "tweets_archive_upload_id_fkey"
-            columns: ["archive_upload_id"]
+            foreignKeyName: 'tweets_archive_upload_id_fkey'
+            columns: ['archive_upload_id']
             isOneToOne: false
-            referencedRelation: "archive_upload"
-            referencedColumns: ["id"]
+            referencedRelation: 'archive_upload'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -1388,25 +1388,25 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "tweets_account_id_fkey"
-            columns: ["account_id"]
+            foreignKeyName: 'tweets_account_id_fkey'
+            columns: ['account_id']
             isOneToOne: false
-            referencedRelation: "account"
-            referencedColumns: ["account_id"]
+            referencedRelation: 'account'
+            referencedColumns: ['account_id']
           },
           {
-            foreignKeyName: "tweets_account_id_fkey"
-            columns: ["account_id"]
+            foreignKeyName: 'tweets_account_id_fkey'
+            columns: ['account_id']
             isOneToOne: false
-            referencedRelation: "account_activity_summary"
-            referencedColumns: ["account_id"]
+            referencedRelation: 'account_activity_summary'
+            referencedColumns: ['account_id']
           },
           {
-            foreignKeyName: "tweets_account_id_fkey"
-            columns: ["account_id"]
+            foreignKeyName: 'tweets_account_id_fkey'
+            columns: ['account_id']
             isOneToOne: false
-            referencedRelation: "all_account"
-            referencedColumns: ["account_id"]
+            referencedRelation: 'all_account'
+            referencedColumns: ['account_id']
           },
         ]
       }
@@ -1422,32 +1422,32 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "all_profile_account_id_fkey"
-            columns: ["account_id"]
+            foreignKeyName: 'all_profile_account_id_fkey'
+            columns: ['account_id']
             isOneToOne: true
-            referencedRelation: "account"
-            referencedColumns: ["account_id"]
+            referencedRelation: 'account'
+            referencedColumns: ['account_id']
           },
           {
-            foreignKeyName: "all_profile_account_id_fkey"
-            columns: ["account_id"]
+            foreignKeyName: 'all_profile_account_id_fkey'
+            columns: ['account_id']
             isOneToOne: true
-            referencedRelation: "account_activity_summary"
-            referencedColumns: ["account_id"]
+            referencedRelation: 'account_activity_summary'
+            referencedColumns: ['account_id']
           },
           {
-            foreignKeyName: "all_profile_account_id_fkey"
-            columns: ["account_id"]
+            foreignKeyName: 'all_profile_account_id_fkey'
+            columns: ['account_id']
             isOneToOne: true
-            referencedRelation: "all_account"
-            referencedColumns: ["account_id"]
+            referencedRelation: 'all_account'
+            referencedColumns: ['account_id']
           },
           {
-            foreignKeyName: "all_profile_archive_upload_id_fkey"
-            columns: ["archive_upload_id"]
+            foreignKeyName: 'all_profile_archive_upload_id_fkey'
+            columns: ['archive_upload_id']
             isOneToOne: false
-            referencedRelation: "archive_upload"
-            referencedColumns: ["id"]
+            referencedRelation: 'archive_upload'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -1483,32 +1483,32 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "tweets_account_id_fkey"
-            columns: ["account_id"]
+            foreignKeyName: 'tweets_account_id_fkey'
+            columns: ['account_id']
             isOneToOne: false
-            referencedRelation: "account"
-            referencedColumns: ["account_id"]
+            referencedRelation: 'account'
+            referencedColumns: ['account_id']
           },
           {
-            foreignKeyName: "tweets_account_id_fkey"
-            columns: ["account_id"]
+            foreignKeyName: 'tweets_account_id_fkey'
+            columns: ['account_id']
             isOneToOne: false
-            referencedRelation: "account_activity_summary"
-            referencedColumns: ["account_id"]
+            referencedRelation: 'account_activity_summary'
+            referencedColumns: ['account_id']
           },
           {
-            foreignKeyName: "tweets_account_id_fkey"
-            columns: ["account_id"]
+            foreignKeyName: 'tweets_account_id_fkey'
+            columns: ['account_id']
             isOneToOne: false
-            referencedRelation: "all_account"
-            referencedColumns: ["account_id"]
+            referencedRelation: 'all_account'
+            referencedColumns: ['account_id']
           },
           {
-            foreignKeyName: "tweets_archive_upload_id_fkey"
-            columns: ["archive_upload_id"]
+            foreignKeyName: 'tweets_archive_upload_id_fkey'
+            columns: ['archive_upload_id']
             isOneToOne: false
-            referencedRelation: "archive_upload"
-            referencedColumns: ["id"]
+            referencedRelation: 'archive_upload'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -1656,6 +1656,19 @@ export type Database = {
         Returns: undefined
       }
       delete_tweets: {
+        Args: {
+          p_tweet_ids: string[]
+        }
+        Returns: {
+          deleted_tweets: number
+          deleted_conversations: number
+          deleted_tweet_media: number
+          deleted_user_mentions: number
+          deleted_tweet_urls: number
+          deleted_private_tweet_user: number
+        }[]
+      }
+      delete_own_tweets: {
         Args: {
           p_tweet_ids: string[]
         }
@@ -2110,31 +2123,31 @@ export type Database = {
       }
       gtrgm_compress: {
         Args: {
-          "": unknown
+          '': unknown
         }
         Returns: unknown
       }
       gtrgm_decompress: {
         Args: {
-          "": unknown
+          '': unknown
         }
         Returns: unknown
       }
       gtrgm_in: {
         Args: {
-          "": unknown
+          '': unknown
         }
         Returns: unknown
       }
       gtrgm_options: {
         Args: {
-          "": unknown
+          '': unknown
         }
         Returns: undefined
       }
       gtrgm_out: {
         Args: {
-          "": unknown
+          '': unknown
         }
         Returns: unknown
       }
@@ -2302,7 +2315,7 @@ export type Database = {
       }
       set_limit: {
         Args: {
-          "": number
+          '': number
         }
         Returns: number
       }
@@ -2312,7 +2325,7 @@ export type Database = {
       }
       show_trgm: {
         Args: {
-          "": string
+          '': string
         }
         Returns: string[]
       }
@@ -2339,11 +2352,11 @@ export type Database = {
     }
     Enums: {
       upload_phase_enum:
-        | "uploading"
-        | "ready_for_commit"
-        | "committing"
-        | "completed"
-        | "failed"
+        | 'uploading'
+        | 'ready_for_commit'
+        | 'committing'
+        | 'completed'
+        | 'failed'
     }
     CompositeTypes: {
       [_ in never]: never
@@ -2351,27 +2364,27 @@ export type Database = {
   }
 }
 
-type PublicSchema = Database[Extract<keyof Database, "public">]
+type PublicSchema = Database[Extract<keyof Database, 'public'>]
 
 export type Tables<
   PublicTableNameOrOptions extends
-    | keyof (PublicSchema["Tables"] & PublicSchema["Views"])
+    | keyof (PublicSchema['Tables'] & PublicSchema['Views'])
     | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
-        Database[PublicTableNameOrOptions["schema"]]["Views"])
+    ? keyof (Database[PublicTableNameOrOptions['schema']]['Tables'] &
+        Database[PublicTableNameOrOptions['schema']]['Views'])
     : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
-      Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+  ? (Database[PublicTableNameOrOptions['schema']]['Tables'] &
+      Database[PublicTableNameOrOptions['schema']]['Views'])[TableName] extends {
       Row: infer R
     }
     ? R
     : never
-  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
-        PublicSchema["Views"])
-    ? (PublicSchema["Tables"] &
-        PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+  : PublicTableNameOrOptions extends keyof (PublicSchema['Tables'] &
+        PublicSchema['Views'])
+    ? (PublicSchema['Tables'] &
+        PublicSchema['Views'])[PublicTableNameOrOptions] extends {
         Row: infer R
       }
       ? R
@@ -2380,19 +2393,19 @@ export type Tables<
 
 export type TablesInsert<
   PublicTableNameOrOptions extends
-    | keyof PublicSchema["Tables"]
+    | keyof PublicSchema['Tables']
     | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    ? keyof Database[PublicTableNameOrOptions['schema']]['Tables']
     : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+  ? Database[PublicTableNameOrOptions['schema']]['Tables'][TableName] extends {
       Insert: infer I
     }
     ? I
     : never
-  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+  : PublicTableNameOrOptions extends keyof PublicSchema['Tables']
+    ? PublicSchema['Tables'][PublicTableNameOrOptions] extends {
         Insert: infer I
       }
       ? I
@@ -2401,19 +2414,19 @@ export type TablesInsert<
 
 export type TablesUpdate<
   PublicTableNameOrOptions extends
-    | keyof PublicSchema["Tables"]
+    | keyof PublicSchema['Tables']
     | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    ? keyof Database[PublicTableNameOrOptions['schema']]['Tables']
     : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+  ? Database[PublicTableNameOrOptions['schema']]['Tables'][TableName] extends {
       Update: infer U
     }
     ? U
     : never
-  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+  : PublicTableNameOrOptions extends keyof PublicSchema['Tables']
+    ? PublicSchema['Tables'][PublicTableNameOrOptions] extends {
         Update: infer U
       }
       ? U
@@ -2422,29 +2435,28 @@ export type TablesUpdate<
 
 export type Enums<
   PublicEnumNameOrOptions extends
-    | keyof PublicSchema["Enums"]
+    | keyof PublicSchema['Enums']
     | { schema: keyof Database },
   EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
+    ? keyof Database[PublicEnumNameOrOptions['schema']]['Enums']
     : never = never,
 > = PublicEnumNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
-  : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
-    ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+  ? Database[PublicEnumNameOrOptions['schema']]['Enums'][EnumName]
+  : PublicEnumNameOrOptions extends keyof PublicSchema['Enums']
+    ? PublicSchema['Enums'][PublicEnumNameOrOptions]
     : never
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
-    | keyof PublicSchema["CompositeTypes"]
+    | keyof PublicSchema['CompositeTypes']
     | { schema: keyof Database },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
     schema: keyof Database
   }
-    ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    ? keyof Database[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
     : never = never,
 > = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
-    ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+  ? Database[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes'][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof PublicSchema['CompositeTypes']
+    ? PublicSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
     : never
-

--- a/supabase/migrations/20260815085901_delete_own_tweets.sql
+++ b/supabase/migrations/20260815085901_delete_own_tweets.sql
@@ -1,0 +1,79 @@
+-- Allow authenticated members to delete only tweets owned by the Twitter
+-- account in their server-controlled app_metadata. The underlying broad
+-- delete_tweets routine remains service_role-only.
+
+CREATE OR REPLACE FUNCTION public.delete_own_tweets(p_tweet_ids text[])
+RETURNS TABLE(
+  deleted_tweets integer,
+  deleted_conversations integer,
+  deleted_tweet_media integer,
+  deleted_user_mentions integer,
+  deleted_tweet_urls integer,
+  deleted_private_tweet_user integer
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET statement_timeout = '30s'
+SET search_path = ''
+AS $$
+DECLARE
+  v_provider_id text;
+  v_tweet_ids text[];
+BEGIN
+  v_provider_id := nullif(auth.jwt()->'app_metadata'->>'provider_id', '');
+
+  IF auth.uid() IS NULL OR v_provider_id IS NULL THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '42501',
+      MESSAGE = 'A linked Twitter account is required';
+  END IF;
+
+  SELECT array_agg(tweet_id ORDER BY tweet_id)
+  INTO v_tweet_ids
+  FROM (
+    SELECT DISTINCT btrim(candidate) AS tweet_id
+    FROM unnest(p_tweet_ids) AS requested(candidate)
+    WHERE candidate IS NOT NULL AND btrim(candidate) <> ''
+  ) normalized;
+
+  IF coalesce(cardinality(v_tweet_ids), 0) = 0 THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '22023',
+      MESSAGE = 'At least one tweet ID is required';
+  END IF;
+
+  IF cardinality(v_tweet_ids) > 100 THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '22023',
+      MESSAGE = 'At most 100 tweets can be deleted at once';
+  END IF;
+
+  -- Fail the whole request if any ID is missing or belongs to another account.
+  -- The intentionally generic error does not disclose whether another tweet
+  -- exists in the archive.
+  IF EXISTS (
+    SELECT 1
+    FROM unnest(v_tweet_ids) AS requested(tweet_id)
+    LEFT JOIN public.tweets AS owned
+      ON owned.tweet_id = requested.tweet_id
+     AND owned.account_id = v_provider_id
+    WHERE owned.tweet_id IS NULL
+  ) THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '42501',
+      MESSAGE = 'One or more tweets cannot be deleted';
+  END IF;
+
+  RETURN QUERY
+  SELECT * FROM public.delete_tweets(v_tweet_ids);
+END;
+$$;
+
+ALTER FUNCTION public.delete_own_tweets(text[]) OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.delete_own_tweets(text[]) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.delete_own_tweets(text[]) FROM anon;
+GRANT EXECUTE ON FUNCTION public.delete_own_tweets(text[]) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.delete_own_tweets(text[]) TO service_role;
+
+COMMENT ON FUNCTION public.delete_own_tweets(text[]) IS
+  'Deletes up to 100 tweets only when every ID belongs to the authenticated Twitter account in app_metadata.provider_id.';

--- a/supabase/schemas/070_functions.sql
+++ b/supabase/schemas/070_functions.sql
@@ -1262,6 +1262,70 @@ $$;
 ALTER FUNCTION "public"."delete_tweets"("p_tweet_ids" "text"[]) OWNER TO "postgres";
 
 
+CREATE OR REPLACE FUNCTION "public"."delete_own_tweets"("p_tweet_ids" "text"[]) RETURNS TABLE("deleted_tweets" integer, "deleted_conversations" integer, "deleted_tweet_media" integer, "deleted_user_mentions" integer, "deleted_tweet_urls" integer, "deleted_private_tweet_user" integer)
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "statement_timeout" TO '30s'
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+  v_provider_id text;
+  v_tweet_ids text[];
+BEGIN
+  v_provider_id := nullif(auth.jwt()->'app_metadata'->>'provider_id', '');
+
+  IF auth.uid() IS NULL OR v_provider_id IS NULL THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '42501',
+      MESSAGE = 'A linked Twitter account is required';
+  END IF;
+
+  SELECT array_agg(tweet_id ORDER BY tweet_id)
+  INTO v_tweet_ids
+  FROM (
+    SELECT DISTINCT btrim(candidate) AS tweet_id
+    FROM unnest(p_tweet_ids) AS requested(candidate)
+    WHERE candidate IS NOT NULL AND btrim(candidate) <> ''
+  ) normalized;
+
+  IF coalesce(cardinality(v_tweet_ids), 0) = 0 THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '22023',
+      MESSAGE = 'At least one tweet ID is required';
+  END IF;
+
+  IF cardinality(v_tweet_ids) > 100 THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '22023',
+      MESSAGE = 'At most 100 tweets can be deleted at once';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM unnest(v_tweet_ids) AS requested(tweet_id)
+    LEFT JOIN public.tweets AS owned
+      ON owned.tweet_id = requested.tweet_id
+     AND owned.account_id = v_provider_id
+    WHERE owned.tweet_id IS NULL
+  ) THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '42501',
+      MESSAGE = 'One or more tweets cannot be deleted';
+  END IF;
+
+  RETURN QUERY
+  SELECT * FROM public.delete_tweets(v_tweet_ids);
+END;
+$$;
+
+ALTER FUNCTION "public"."delete_own_tweets"("p_tweet_ids" "text"[]) OWNER TO "postgres";
+REVOKE ALL ON FUNCTION "public"."delete_own_tweets"("p_tweet_ids" "text"[]) FROM PUBLIC;
+REVOKE ALL ON FUNCTION "public"."delete_own_tweets"("p_tweet_ids" "text"[]) FROM "anon";
+GRANT EXECUTE ON FUNCTION "public"."delete_own_tweets"("p_tweet_ids" "text"[]) TO "authenticated";
+GRANT EXECUTE ON FUNCTION "public"."delete_own_tweets"("p_tweet_ids" "text"[]) TO "service_role";
+
+COMMENT ON FUNCTION "public"."delete_own_tweets"("p_tweet_ids" "text"[]) IS 'Deletes up to 100 tweets only when every ID belongs to the authenticated Twitter account in app_metadata.provider_id.';
+
+
 CREATE OR REPLACE FUNCTION "public"."delete_user_archive"("p_account_id" "text") RETURNS "void"
     LANGUAGE "plpgsql" SECURITY DEFINER
     SET "statement_timeout" TO '20min'


### PR DESCRIPTION
## Summary
- add a My Tweets settings tab with permanent per-tweet deletion controls
- add an authenticated SECURITY DEFINER wrapper around the existing deletion routine
- derive ownership only from server-controlled app_metadata.provider_id
- reject empty, oversized, mixed-ownership, missing, and non-owned batches atomically
- keep the unrestricted delete_tweets function locked to service_role

## Validation
- pnpm test -- --runInBand src/app/profile/ProfileContent.test.tsx (4 passed)
- pnpm type-check
- pnpm lint
- Supabase migration created with the CLI and mirrored in the declarative schema
- local database migration execution not run: Docker daemon is unavailable

Closes #669