### PR TITLE
feat: add community feedback to digest editions

### DIFF
--- a/src/components/digest/DigestEditionView.tsx
+++ b/src/components/digest/DigestEditionView.tsx
@@ -5,6 +5,7 @@ import { DigestMarkdown } from '@/components/digest/DigestMarkdown'
 import type { DigestCalendarDay, DigestEdition } from '@/lib/digest/types'
 import { buildSearchHref } from '@/lib/searchParams'
 import { MUTED, SERIF } from '@/components/portal/styles'
+import { DigestFeedback } from '@/components/digest/DigestFeedback'
 
 const longDate = (date: string) =>
   new Intl.DateTimeFormat('en-GB', {
@@ -245,6 +246,13 @@ export function DigestEditionView({
             ) : null}
           </aside>
         </div>
+
+        {!edition.isPreview ? (
+          <DigestFeedback
+            digestDate={edition.digestDate}
+            editionId={edition.id}
+          />
+        ) : null}
 
         <footer className={`mt-4 border-t pt-5 text-xs leading-5 ${MUTED}`}>
           {edition.isPreview

--- a/src/components/digest/DigestFeedback.test.tsx
+++ b/src/components/digest/DigestFeedback.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { DigestFeedback } from './DigestFeedback'
+
+const mockGetUser = jest.fn()
+const mockMaybeSingle = jest.fn()
+const mockUpsert = jest.fn()
+
+jest.mock('@/utils/supabase', () => ({
+  createBrowserClient: () => ({
+    auth: { getUser: mockGetUser },
+    from: () => ({
+      select: () => ({
+        eq: () => ({ maybeSingle: mockMaybeSingle }),
+      }),
+      upsert: mockUpsert,
+    }),
+  }),
+}))
+
+describe('DigestFeedback', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('saves one signed-in member response for the edition', async () => {
+    const interaction = userEvent.setup()
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockMaybeSingle.mockResolvedValue({ data: null, error: null })
+    mockUpsert.mockResolvedValue({ error: null })
+
+    render(
+      <DigestFeedback
+        digestDate="2026-08-14"
+        editionId="11111111-1111-4111-8111-111111111111"
+      />,
+    )
+
+    await interaction.click(
+      await screen.findByRole('button', { name: 'Helpful' }),
+    )
+    await interaction.type(
+      screen.getByLabelText(/What should we improve/i),
+      'More context around the second story.',
+    )
+    await interaction.click(
+      screen.getByRole('button', { name: 'Save feedback' }),
+    )
+
+    await waitFor(() =>
+      expect(mockUpsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          edition_id: '11111111-1111-4111-8111-111111111111',
+          user_id: 'user-1',
+          sentiment: 'helpful',
+          comment: 'More context around the second story.',
+        }),
+        { onConflict: 'edition_id,user_id' },
+      ),
+    )
+    expect(screen.getByText('Thanks — your feedback was saved.')).toBeVisible()
+  })
+
+  it('invites signed-out readers to authenticate', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+
+    render(
+      <DigestFeedback
+        digestDate="2026-08-14"
+        editionId="11111111-1111-4111-8111-111111111111"
+      />,
+    )
+
+    expect(
+      await screen.findByRole('link', { name: 'Sign in' }),
+    ).toHaveAttribute('href', '/login?redirect=%2Fdigest%2F2026-08-14')
+  })
+})

--- a/src/components/digest/DigestFeedback.tsx
+++ b/src/components/digest/DigestFeedback.tsx
@@ -1,0 +1,172 @@
+'use client'
+
+import Link from 'next/link'
+import { FormEvent, useEffect, useMemo, useState } from 'react'
+import { ThumbsDown, ThumbsUp } from 'lucide-react'
+import { createBrowserClient } from '@/utils/supabase'
+
+type Sentiment = 'helpful' | 'not_helpful'
+type LoadState = 'loading' | 'signed_out' | 'ready'
+
+export function DigestFeedback({
+  digestDate,
+  editionId,
+}: {
+  digestDate: string
+  editionId: string
+}) {
+  const supabase = useMemo(() => createBrowserClient(), [])
+  const [loadState, setLoadState] = useState<LoadState>('loading')
+  const [userId, setUserId] = useState<string | null>(null)
+  const [sentiment, setSentiment] = useState<Sentiment | null>(null)
+  const [comment, setComment] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [message, setMessage] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    const load = async () => {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+      if (cancelled) return
+      if (!user) {
+        setLoadState('signed_out')
+        return
+      }
+
+      setUserId(user.id)
+      const { data, error: readError } = await supabase
+        .from('digest_feedback')
+        .select('sentiment, comment')
+        .eq('edition_id', editionId)
+        .maybeSingle()
+      if (cancelled) return
+
+      if (readError) {
+        setError('Feedback is temporarily unavailable.')
+      } else if (data) {
+        setSentiment(data.sentiment as Sentiment)
+        setComment(data.comment ?? '')
+      }
+      setLoadState('ready')
+    }
+
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [editionId, supabase])
+
+  const save = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!userId || !sentiment || saving) return
+
+    setSaving(true)
+    setError(null)
+    setMessage(null)
+    const { error: writeError } = await supabase.from('digest_feedback').upsert(
+      {
+        edition_id: editionId,
+        user_id: userId,
+        sentiment,
+        comment: comment.trim() || null,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'edition_id,user_id' },
+    )
+
+    if (writeError) {
+      setError('Could not save feedback. Please try again.')
+    } else {
+      setMessage('Thanks — your feedback was saved.')
+    }
+    setSaving(false)
+  }
+
+  if (loadState === 'loading') {
+    return (
+      <section className="mt-12 border-t border-zinc-200 pt-7 text-sm text-muted-foreground dark:border-zinc-800">
+        Loading feedback…
+      </section>
+    )
+  }
+
+  if (loadState === 'signed_out') {
+    return (
+      <section className="mt-12 border-t border-zinc-200 pt-7 dark:border-zinc-800">
+        <h2 className="text-lg font-semibold">Help improve the Digest</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          <Link
+            href={`/login?redirect=${encodeURIComponent(`/digest/${digestDate}`)}`}
+            className="font-semibold text-brand hover:underline"
+          >
+            Sign in
+          </Link>{' '}
+          to share private feedback with the editors.
+        </p>
+      </section>
+    )
+  }
+
+  return (
+    <section className="mt-12 border-t border-zinc-200 pt-7 dark:border-zinc-800">
+      <form onSubmit={save} className="max-w-2xl space-y-4">
+        <div>
+          <h2 className="text-lg font-semibold">Help improve the Digest</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Was this edition useful? Your response is shared privately with
+            digest editors.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            aria-pressed={sentiment === 'helpful'}
+            onClick={() => setSentiment('helpful')}
+            className="inline-flex items-center gap-2 rounded-full border border-border px-4 py-2 text-sm font-semibold aria-pressed:border-brand aria-pressed:bg-blue-50 aria-pressed:text-brand dark:aria-pressed:bg-blue-950"
+          >
+            <ThumbsUp className="h-4 w-4" aria-hidden="true" />
+            Helpful
+          </button>
+          <button
+            type="button"
+            aria-pressed={sentiment === 'not_helpful'}
+            onClick={() => setSentiment('not_helpful')}
+            className="inline-flex items-center gap-2 rounded-full border border-border px-4 py-2 text-sm font-semibold aria-pressed:border-brand aria-pressed:bg-blue-50 aria-pressed:text-brand dark:aria-pressed:bg-blue-950"
+          >
+            <ThumbsDown className="h-4 w-4" aria-hidden="true" />
+            Not helpful
+          </button>
+        </div>
+
+        <label className="block text-sm font-medium">
+          What should we improve?{' '}
+          <span className="font-normal">(optional)</span>
+          <textarea
+            value={comment}
+            onChange={(event) => setComment(event.target.value)}
+            maxLength={2000}
+            rows={3}
+            className="mt-2 block w-full rounded-lg border border-border bg-background px-3 py-2 text-sm font-normal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+          />
+        </label>
+
+        <div className="flex items-center gap-3">
+          <button
+            type="submit"
+            disabled={!sentiment || saving}
+            className="rounded-full bg-brand px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {saving ? 'Saving…' : 'Save feedback'}
+          </button>
+          {message ? <p className="text-sm text-green-700">{message}</p> : null}
+          {error ? <p className="text-sm text-destructive">{error}</p> : null}
+        </div>
+      </form>
+    </section>
+  )
+}

--- a/src/database-types.ts
+++ b/src/database-types.ts
@@ -411,6 +411,44 @@ export type Database = {
           },
         ]
       }
+      digest_feedback: {
+        Row: {
+          comment: string | null
+          created_at: string
+          edition_id: string
+          id: string
+          sentiment: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          comment?: string | null
+          created_at?: string
+          edition_id: string
+          id?: string
+          sentiment: string
+          updated_at?: string
+          user_id?: string
+        }
+        Update: {
+          comment?: string | null
+          created_at?: string
+          edition_id?: string
+          id?: string
+          sentiment?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "digest_feedback_edition_id_fkey"
+            columns: ["edition_id"]
+            isOneToOne: false
+            referencedRelation: "digest_editions"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       digest_prompt_versions: {
         Row: {
           created_at: string
@@ -2447,4 +2485,3 @@ export type CompositeTypes<
   : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
     ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never
-

--- a/src/database-types.ts
+++ b/src/database-types.ts
@@ -2485,3 +2485,4 @@ export type CompositeTypes<
   : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
     ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never
+

--- a/supabase/migrations/20260815090739_digest_community_feedback.sql
+++ b/supabase/migrations/20260815090739_digest_community_feedback.sql
@@ -1,0 +1,57 @@
+-- Authenticated community members can leave one private feedback response per
+-- published digest edition. Editors read aggregate/free-form feedback through the
+-- service role; members can only read and edit their own row.
+
+CREATE TABLE public.digest_feedback (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  edition_id uuid NOT NULL REFERENCES public.digest_editions(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL DEFAULT auth.uid() REFERENCES auth.users(id) ON DELETE CASCADE,
+  sentiment text NOT NULL,
+  comment text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT digest_feedback_edition_user_key UNIQUE (edition_id, user_id),
+  CONSTRAINT digest_feedback_sentiment_check CHECK (sentiment IN ('helpful', 'not_helpful')),
+  CONSTRAINT digest_feedback_comment_length CHECK (comment IS NULL OR char_length(comment) <= 2000)
+);
+
+ALTER TABLE public.digest_feedback OWNER TO postgres;
+CREATE INDEX digest_feedback_edition_sentiment_idx
+  ON public.digest_feedback (edition_id, sentiment);
+
+ALTER TABLE public.digest_feedback ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Members can read own digest feedback"
+  ON public.digest_feedback FOR SELECT TO authenticated
+  USING (user_id = (SELECT auth.uid()));
+
+CREATE POLICY "Members can insert own published digest feedback"
+  ON public.digest_feedback FOR INSERT TO authenticated
+  WITH CHECK (
+    user_id = (SELECT auth.uid())
+    AND EXISTS (
+      SELECT 1 FROM public.digest_editions edition
+      WHERE edition.id = digest_feedback.edition_id
+        AND edition.status = 'published'
+    )
+  );
+
+CREATE POLICY "Members can update own published digest feedback"
+  ON public.digest_feedback FOR UPDATE TO authenticated
+  USING (user_id = (SELECT auth.uid()))
+  WITH CHECK (
+    user_id = (SELECT auth.uid())
+    AND EXISTS (
+      SELECT 1 FROM public.digest_editions edition
+      WHERE edition.id = digest_feedback.edition_id
+        AND edition.status = 'published'
+    )
+  );
+
+CREATE POLICY "Members can delete own digest feedback"
+  ON public.digest_feedback FOR DELETE TO authenticated
+  USING (user_id = (SELECT auth.uid()));
+
+REVOKE ALL PRIVILEGES ON TABLE public.digest_feedback FROM anon, authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.digest_feedback TO authenticated;
+GRANT ALL PRIVILEGES ON TABLE public.digest_feedback TO service_role;

--- a/supabase/schemas/020_tables.sql
+++ b/supabase/schemas/020_tables.sql
@@ -329,6 +329,22 @@ CREATE TABLE IF NOT EXISTS "public"."digest_editions" (
 );
 ALTER TABLE "public"."digest_editions" OWNER TO "postgres";
 
+-- Private member feedback on published digest editions. Editorial tooling
+-- reads it with the service role; public clients never see other responses.
+CREATE TABLE IF NOT EXISTS "public"."digest_feedback" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "edition_id" uuid NOT NULL REFERENCES "public"."digest_editions"("id") ON DELETE CASCADE,
+    "user_id" uuid NOT NULL DEFAULT auth.uid() REFERENCES auth.users(id) ON DELETE CASCADE,
+    "sentiment" text NOT NULL,
+    "comment" text,
+    "created_at" timestamptz NOT NULL DEFAULT now(),
+    "updated_at" timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT "digest_feedback_edition_user_key" UNIQUE ("edition_id", "user_id"),
+    CONSTRAINT "digest_feedback_sentiment_check" CHECK ("sentiment" IN ('helpful', 'not_helpful')),
+    CONSTRAINT "digest_feedback_comment_length" CHECK ("comment" IS NULL OR char_length("comment") <= 2000)
+);
+ALTER TABLE "public"."digest_feedback" OWNER TO "postgres";
+
 -- Public profile preferences. PostgreSQL remains authoritative for this
 -- owner-controlled policy state; analytical stores only consume the result.
 CREATE TABLE IF NOT EXISTS "public"."profile_settings" (

--- a/supabase/schemas/030_indexes.sql
+++ b/supabase/schemas/030_indexes.sql
@@ -113,3 +113,6 @@ CREATE UNIQUE INDEX IF NOT EXISTS "digest_editions_one_published_per_date_idx"
 CREATE INDEX IF NOT EXISTS "digest_editions_public_archive_idx"
   ON "public"."digest_editions" ("digest_date" DESC, "published_at" DESC)
   WHERE "status" = 'published';
+
+CREATE INDEX IF NOT EXISTS "digest_feedback_edition_sentiment_idx"
+  ON "public"."digest_feedback" ("edition_id", "sentiment");

--- a/supabase/schemas/060_grants.sql
+++ b/supabase/schemas/060_grants.sql
@@ -86,3 +86,9 @@ GRANT ALL PRIVILEGES ON TABLE "public"."digest_editions" TO "service_role";
 GRANT USAGE, SELECT ON SEQUENCE "public"."digest_prompt_versions_version_seq" TO "service_role";
 GRANT USAGE, SELECT ON SEQUENCE "public"."digest_editions_issue_number_seq" TO "service_role";
 GRANT SELECT ON TABLE "public"."digest_editions" TO "anon", "authenticated";
+
+-- Feedback comments are never public. Members manage only their own rows via
+-- RLS; editors and aggregation jobs use service_role.
+REVOKE ALL PRIVILEGES ON TABLE "public"."digest_feedback" FROM "anon", "authenticated";
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "public"."digest_feedback" TO "authenticated";
+GRANT ALL PRIVILEGES ON TABLE "public"."digest_feedback" TO "service_role";

--- a/supabase/schemas/060_policies.sql
+++ b/supabase/schemas/060_policies.sql
@@ -202,5 +202,40 @@ CREATE POLICY "Users can read own action log" ON "public"."user_action_log"
     OR account_id = ((auth.jwt()->'app_metadata'->>'provider_id')::text)
   );
 
+-- Digest feedback is private to the author. Service-role editorial reads bypass
+-- RLS; client writes are accepted only for published editions.
+ALTER TABLE "public"."digest_feedback" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Members can read own digest feedback"
+  ON "public"."digest_feedback" FOR SELECT TO "authenticated"
+  USING ("user_id" = (SELECT "auth"."uid"()));
+
+CREATE POLICY "Members can insert own published digest feedback"
+  ON "public"."digest_feedback" FOR INSERT TO "authenticated"
+  WITH CHECK (
+    "user_id" = (SELECT "auth"."uid"())
+    AND EXISTS (
+      SELECT 1 FROM "public"."digest_editions" AS "edition"
+      WHERE "edition"."id" = "digest_feedback"."edition_id"
+        AND "edition"."status" = 'published'
+    )
+  );
+
+CREATE POLICY "Members can update own published digest feedback"
+  ON "public"."digest_feedback" FOR UPDATE TO "authenticated"
+  USING ("user_id" = (SELECT "auth"."uid"()))
+  WITH CHECK (
+    "user_id" = (SELECT "auth"."uid"())
+    AND EXISTS (
+      SELECT 1 FROM "public"."digest_editions" AS "edition"
+      WHERE "edition"."id" = "digest_feedback"."edition_id"
+        AND "edition"."status" = 'published'
+    )
+  );
+
+CREATE POLICY "Members can delete own digest feedback"
+  ON "public"."digest_feedback" FOR DELETE TO "authenticated"
+  USING ("user_id" = (SELECT "auth"."uid"()));
+
 GRANT SELECT, INSERT ON public.user_action_log TO authenticated, service_role;
 GRANT USAGE, SELECT ON SEQUENCE public.user_action_log_id_seq TO authenticated, service_role;

--- a/tests/db-schema/schema-validation.test.ts
+++ b/tests/db-schema/schema-validation.test.ts
@@ -34,6 +34,7 @@ describe('Database Schema Validation', () => {
       'profile_settings',
       'profile_curation',
       'tweet_link_previews',
+      'digest_feedback',
     ]
 
     test.each(requiredTables)(


### PR DESCRIPTION
## Summary
- add Helpful / Not helpful feedback with an optional private comment on published digest editions
- load and revise the signed-in member's existing response
- store one response per member and edition with a 2,000-character database constraint
- enforce owner-only reads/writes with RLS and allow feedback only on published editions
- keep free-form feedback unavailable to anonymous/public readers while service-role editorial tooling can aggregate it

## Validation
- pnpm test -- --runInBand src/components/digest/DigestFeedback.test.tsx src/components/digest/DigestEditionView.test.tsx (4 passed)
- pnpm type-check
- pnpm lint
- schema validation manifest updated
- local migration execution not run: Docker daemon is unavailable

Closes #687