### PR TITLE
Let owners add archived tweets to their profiles

### DIFF
--- a/src/app/user/[account_id]/actions.ts
+++ b/src/app/user/[account_id]/actions.ts
@@ -6,6 +6,7 @@ import {
   createServerClient,
   createServerServiceRoleClient,
 } from '@/utils/supabase'
+import { fetchClickHouseTweetPageData } from '@/lib/clickhouseTweetPage'
 import type { ProfileCurationSection } from '@/lib/profileCurationState'
 
 const idPattern = /^\d{1,20}$/
@@ -17,6 +18,7 @@ interface CurationTarget {
 }
 
 type ProfileCurationMutation =
+  | (CurationTarget & { action: 'add'; itemId: string })
   | (CurationTarget & { action: 'dismiss'; itemId: string })
   | (CurationTarget & { action: 'toggle-feature'; itemId: string })
   | (CurationTarget & { action: 'reorder'; itemIds: string[] })
@@ -29,7 +31,7 @@ function validateTarget(input: CurationTarget) {
   }
 }
 
-async function authenticatedOwner(accountId: string) {
+async function authenticatedAccount() {
   const cookieStore = await cookies()
   const supabase = createServerClient(cookieStore)
   const {
@@ -38,18 +40,28 @@ async function authenticatedOwner(accountId: string) {
   } = await supabase.auth.getUser()
   const ownedAccountId = user?.app_metadata?.provider_id
 
-  if (
-    error ||
-    !user ||
-    typeof ownedAccountId !== 'string' ||
-    ownedAccountId !== accountId
-  ) {
+  if (error || !user || typeof ownedAccountId !== 'string') {
+    throw new Error('Sign in with X to edit your profile')
+  }
+  if (!idPattern.test(ownedAccountId)) {
+    throw new Error('Your X account could not be verified')
+  }
+
+  return {
+    accountId: ownedAccountId,
+    // The identity above comes from the authoritative Auth user. Perform the
+    // write with the server credential so a just-updated OAuth JWT cannot make
+    // an otherwise valid first-session edit fail RLS.
+    supabase: createServerServiceRoleClient(),
+  }
+}
+
+async function authenticatedOwner(accountId: string) {
+  const authenticated = await authenticatedAccount()
+  if (authenticated.accountId !== accountId) {
     throw new Error('You can only edit your own profile')
   }
-  // The explicit ownership check above uses the authoritative Auth user.
-  // Perform the write with the server credential so a just-updated OAuth JWT
-  // cannot make an otherwise valid first-session edit fail RLS.
-  return createServerServiceRoleClient()
+  return authenticated.supabase
 }
 
 function revalidateProfile(accountId: string) {
@@ -58,12 +70,57 @@ function revalidateProfile(accountId: string) {
   revalidatePath(`/api/profile/${accountId}/interactions`)
 }
 
+async function addOwnedProfileTweet(
+  accountId: string,
+  itemId: string,
+  supabase: ReturnType<typeof createServerServiceRoleClient>,
+) {
+  if (!idPattern.test(itemId)) throw new Error('Invalid tweet')
+
+  const tweet = await fetchClickHouseTweetPageData(itemId)
+  if (!tweet) throw new Error('That tweet is not in Community Archive yet')
+  if (tweet.account_id !== accountId) {
+    throw new Error('You can only add your own tweets to your profile')
+  }
+
+  const { error } = await supabase.from('profile_curation').upsert(
+    {
+      account_id: accountId,
+      section: 'bangers',
+      item_id: itemId,
+      is_hidden: false,
+      is_featured: true,
+      position: 0,
+    },
+    { onConflict: 'account_id,section,item_id' },
+  )
+  if (error) throw error
+  revalidateProfile(accountId)
+  return { ok: true as const, accountId }
+}
+
+export async function addTweetToOwnProfile(itemId: string) {
+  const authenticated = await authenticatedAccount()
+  return addOwnedProfileTweet(
+    authenticated.accountId,
+    itemId,
+    authenticated.supabase,
+  )
+}
+
 export async function mutateProfileCuration(input: ProfileCurationMutation) {
   validateTarget(input)
   const supabase = await authenticatedOwner(input.accountId)
   const target = {
     account_id: input.accountId,
     section: input.section,
+  }
+
+  if (input.action === 'add') {
+    if (input.section !== 'bangers') {
+      throw new Error('Only tweets can be added to a profile')
+    }
+    return addOwnedProfileTweet(input.accountId, input.itemId, supabase)
   }
 
   if (input.action === 'restore') {

--- a/src/components/metaTwitter/ProfileArchive.test.tsx
+++ b/src/components/metaTwitter/ProfileArchive.test.tsx
@@ -178,6 +178,20 @@ test('shows owner-only curation controls and persists section edits', async () =
   expect(screen.getByRole('button', { name: 'Restore Bangers' })).toBeVisible()
   expect(screen.getByRole('button', { name: 'Restore' })).toBeVisible()
 
+  await user.type(
+    screen.getByRole('textbox', { name: 'Add one of your archived tweets' }),
+    'https://x.com/alice/status/999',
+  )
+  await user.click(screen.getByRole('button', { name: 'Add to profile' }))
+  await waitFor(() =>
+    expect(mockMutateProfileCuration).toHaveBeenCalledWith({
+      action: 'add',
+      accountId: '42',
+      section: 'bangers',
+      itemId: '999',
+    }),
+  )
+
   await user.click(screen.getByRole('button', { name: 'Dismiss banger 1' }))
   await waitFor(() =>
     expect(mockMutateProfileCuration).toHaveBeenCalledWith({

--- a/src/components/metaTwitter/ProfileArchive.tsx
+++ b/src/components/metaTwitter/ProfileArchive.tsx
@@ -711,6 +711,30 @@ export function ProfileArchive({
     ],
   )
 
+  const addTweet = useCallback(
+    async (itemId: string) => {
+      const result = await runEditMutation({
+        action: 'add',
+        accountId,
+        section: 'bangers',
+        itemId,
+      })
+      if (!result) return false
+
+      const nextFeeds = Object.fromEntries(
+        Object.entries(feedsRef.current).filter(
+          ([key]) => !key.startsWith('overall:'),
+        ),
+      )
+      feedsRef.current = nextFeeds
+      setFeeds(nextFeeds)
+      automaticallyFilledFeeds.current.delete(activeKey)
+      await loadFeedPage(null, sort, 0, PROFILE_BANGERS_PRELOAD_LIMIT)
+      return true
+    },
+    [accountId, activeKey, loadFeedPage, runEditMutation, sort],
+  )
+
   const contextTitle = activeYear
     ? `Best of ${activeYear}`
     : `Best of ${displayName}`
@@ -767,6 +791,7 @@ export function ProfileArchive({
           void moveItem(section, itemId, direction)
         }
         onRestore={(section) => void restoreSection(section)}
+        onAddTweet={addTweet}
       />
     </div>
   )

--- a/src/components/metaTwitter/Workspace.tsx
+++ b/src/components/metaTwitter/Workspace.tsx
@@ -1,14 +1,23 @@
 'use client'
 
-import type { RefObject } from 'react'
+import { useState, type FormEvent, type RefObject } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
-import { ArrowDown, ArrowUp, Info, RotateCcw, Star, X } from 'lucide-react'
+import {
+  ArrowDown,
+  ArrowUp,
+  Info,
+  Plus,
+  RotateCcw,
+  Star,
+  X,
+} from 'lucide-react'
 import TweetCard from '@/components/TweetCard'
 import { getSmallAvatarUrl } from '@/lib/avatar'
 import { formatNumber } from '@/lib/formatNumber'
 import { bangerPortalTweet } from '@/lib/metaTwitter/bangerPortalTweet'
 import { tweetPermalinkHref } from '@/lib/navigation'
+import { parseProfileTweetId } from '@/lib/profileTweetLink'
 import type { ProfileBangerSort } from '@/lib/metaTwitter/profilePagination'
 import type {
   ArchiveMediaItem,
@@ -63,6 +72,7 @@ export function Workspace({
   onToggleFeature,
   onMove,
   onRestore,
+  onAddTweet,
 }: {
   avatarUrl: string | null
   contextTitle: string
@@ -97,9 +107,23 @@ export function Workspace({
     direction: -1 | 1,
   ) => void
   onRestore?: (section: 'bangers' | 'people') => void
+  onAddTweet?: (tweetId: string) => Promise<boolean>
 }) {
   const mediaTiles = media.slice(0, 6)
   const mediaOverflow = Math.max(mediaCount - 6, 0)
+  const [tweetReference, setTweetReference] = useState('')
+  const [addError, setAddError] = useState<string | null>(null)
+
+  const submitTweet = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const tweetId = parseProfileTweetId(tweetReference)
+    if (!tweetId) {
+      setAddError('Paste an X or Community Archive tweet link.')
+      return
+    }
+    setAddError(null)
+    if (await onAddTweet?.(tweetId)) setTweetReference('')
+  }
 
   return (
     <main className="flex min-w-0 flex-col gap-4 px-4 py-4 sm:px-6">
@@ -154,6 +178,45 @@ export function Workspace({
           </label>
         </div>
       </div>
+
+      {editing && (
+        <form
+          onSubmit={submitTweet}
+          className="flex flex-col gap-2 rounded-xl border border-dashed border-border bg-muted/20 p-3 sm:flex-row sm:flex-wrap sm:items-end"
+        >
+          <label className="min-w-0 flex-1 text-xs font-semibold text-muted-foreground">
+            Add one of your archived tweets
+            <input
+              type="text"
+              value={tweetReference}
+              onChange={(event) => setTweetReference(event.target.value)}
+              placeholder="Paste an X or Community Archive tweet link"
+              disabled={editSaving}
+              aria-describedby={
+                addError ? 'profile-add-tweet-error' : undefined
+              }
+              className="mt-1.5 w-full rounded-lg border border-border bg-background px-3 py-2 text-sm font-normal text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
+            />
+          </label>
+          <button
+            type="submit"
+            disabled={editSaving || tweetReference.trim().length === 0}
+            className="inline-flex items-center justify-center gap-1.5 rounded-lg bg-foreground px-3 py-2 text-sm font-semibold text-background hover:opacity-90 disabled:opacity-50"
+          >
+            <Plus className="h-4 w-4" aria-hidden="true" />
+            Add to profile
+          </button>
+          {addError && (
+            <span
+              id="profile-add-tweet-error"
+              role="alert"
+              className="text-xs text-destructive sm:basis-full"
+            >
+              {addError}
+            </span>
+          )}
+        </form>
+      )}
 
       {editError && (
         <div

--- a/src/components/portal/AddToProfileButton.test.tsx
+++ b/src/components/portal/AddToProfileButton.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {
+  AddToProfileButton,
+  resetViewerAccountForTests,
+} from './AddToProfileButton'
+import { addTweetToOwnProfile } from '@/app/user/[account_id]/actions'
+
+const mockGetUser = jest.fn()
+
+jest.mock('@/utils/supabase', () => ({
+  createBrowserClient: () => ({ auth: { getUser: mockGetUser } }),
+}))
+jest.mock('@/app/user/[account_id]/actions', () => ({
+  addTweetToOwnProfile: jest.fn(),
+}))
+
+const mockAddTweet = addTweetToOwnProfile as jest.MockedFunction<
+  typeof addTweetToOwnProfile
+>
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  resetViewerAccountForTests()
+  mockAddTweet.mockResolvedValue({ ok: true, accountId: '42' })
+})
+
+test('lets the signed-in author add a tweet to their profile', async () => {
+  const user = userEvent.setup()
+  mockGetUser.mockResolvedValue({
+    data: { user: { app_metadata: { provider_id: '42' } } },
+  })
+
+  render(<AddToProfileButton tweetId="100" accountId="42" />)
+
+  const button = await screen.findByRole('button', { name: 'Add to profile' })
+  await user.click(button)
+
+  expect(mockAddTweet).toHaveBeenCalledWith('100')
+  await waitFor(() =>
+    expect(
+      screen.getByRole('button', { name: 'Added to profile' }),
+    ).toBeDisabled(),
+  )
+})
+
+test('does not expose the action on someone elses tweet', async () => {
+  mockGetUser.mockResolvedValue({
+    data: { user: { app_metadata: { provider_id: '41' } } },
+  })
+
+  render(<AddToProfileButton tweetId="100" accountId="42" />)
+
+  await waitFor(() => expect(mockGetUser).toHaveBeenCalled())
+  expect(
+    screen.queryByRole('button', { name: 'Add to profile' }),
+  ).not.toBeInTheDocument()
+})

--- a/src/components/portal/AddToProfileButton.tsx
+++ b/src/components/portal/AddToProfileButton.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Star } from 'lucide-react'
+import { addTweetToOwnProfile } from '@/app/user/[account_id]/actions'
+import { createBrowserClient } from '@/utils/supabase'
+
+let viewerAccountIdPromise: Promise<string | null> | null = null
+
+function getViewerAccountId() {
+  if (!viewerAccountIdPromise) {
+    const supabase = createBrowserClient()
+    viewerAccountIdPromise = supabase.auth
+      .getUser()
+      .then(({ data }) => {
+        const providerId = data.user?.app_metadata?.provider_id
+        return typeof providerId === 'string' ? providerId : null
+      })
+      .catch(() => null)
+  }
+  return viewerAccountIdPromise
+}
+
+export function AddToProfileButton({
+  tweetId,
+  accountId,
+}: {
+  tweetId: string
+  accountId?: string
+}) {
+  const [isOwner, setIsOwner] = useState(false)
+  const [state, setState] = useState<'idle' | 'saving' | 'added' | 'error'>(
+    'idle',
+  )
+
+  useEffect(() => {
+    let active = true
+    if (!accountId) return () => undefined
+
+    void getViewerAccountId().then((viewerAccountId) => {
+      if (active) setIsOwner(viewerAccountId === accountId)
+    })
+    return () => {
+      active = false
+    }
+  }, [accountId])
+
+  if (!isOwner) return null
+
+  return (
+    <button
+      type="button"
+      disabled={state === 'saving' || state === 'added'}
+      onClick={async () => {
+        setState('saving')
+        try {
+          await addTweetToOwnProfile(tweetId)
+          setState('added')
+        } catch {
+          setState('error')
+        }
+      }}
+      aria-label={
+        state === 'added'
+          ? 'Added to profile'
+          : state === 'error'
+            ? 'Try adding to profile again'
+            : 'Add to profile'
+      }
+      className="inline-flex items-center gap-1 rounded-sm transition-colors hover:text-zinc-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 disabled:opacity-70 dark:hover:text-zinc-200"
+    >
+      <Star
+        className={`h-3.5 w-3.5 ${state === 'added' ? 'fill-current' : ''}`}
+        aria-hidden="true"
+      />
+      <span>
+        {state === 'saving'
+          ? 'Adding…'
+          : state === 'added'
+            ? 'Added'
+            : state === 'error'
+              ? 'Try again'
+              : 'Add to profile'}
+      </span>
+    </button>
+  )
+}
+
+export function resetViewerAccountForTests() {
+  viewerAccountIdPromise = null
+}

--- a/src/components/portal/TweetRow.tsx
+++ b/src/components/portal/TweetRow.tsx
@@ -23,6 +23,7 @@ import {
 import { PortalMedia, PortalQuotedTweet, PortalTweet } from '@/lib/portal/types'
 import { capturePostHogEvent } from '@/lib/posthog'
 import { TweetLinkPreviews } from '@/components/TweetLinkPreviews'
+import { AddToProfileButton } from './AddToProfileButton'
 
 const HUES = [262, 32, 145, 4, 155, 200, 217, 88, 240, 190, 340, 45, 280, 20]
 const FEATURED_CARD_HOVER =
@@ -519,6 +520,12 @@ export function TweetRow({
             </CountMetric>
           ) : null}
           {showArchivedBadge && <span className="text-brand">archived</span>}
+          {origin !== 'profile' && (
+            <AddToProfileButton
+              tweetId={tweet.id}
+              accountId={tweet.accountId}
+            />
+          )}
           {showExternalLink && (
             <a
               href={`https://x.com/${encodeURIComponent(tweet.username)}/status/${encodeURIComponent(tweet.id)}`}

--- a/src/lib/profileCuration.test.ts
+++ b/src/lib/profileCuration.test.ts
@@ -1,5 +1,6 @@
 import { getCuratedProfileBangersPage } from './profileCuration'
 import { getProfileBangers, getProfileBangersPage } from './metaTwitter/bangers'
+import { fetchClickHouseTweetPageData } from './clickhouseTweetPage'
 import type { BangerTweet } from './metaTwitter/types'
 
 const mockFinalEq = jest.fn()
@@ -20,12 +21,18 @@ jest.mock('./metaTwitter/bangers', () => ({
   getProfileBangers: jest.fn(),
   getProfileBangersPage: jest.fn(),
 }))
+jest.mock('./clickhouseTweetPage', () => ({
+  fetchClickHouseTweetPageData: jest.fn(),
+}))
 
 const mockGetProfileBangers = getProfileBangers as jest.MockedFunction<
   typeof getProfileBangers
 >
 const mockGetProfileBangersPage = getProfileBangersPage as jest.MockedFunction<
   typeof getProfileBangersPage
+>
+const mockFetchTweet = fetchClickHouseTweetPageData as jest.MockedFunction<
+  typeof fetchClickHouseTweetPageData
 >
 
 const banger = (id: string, quoteCount: number): BangerTweet => ({
@@ -45,6 +52,7 @@ const banger = (id: string, quoteCount: number): BangerTweet => ({
 })
 
 test('keeps persisted featured bangers ahead of the ClickHouse page boundary', async () => {
+  mockFetchTweet.mockResolvedValue(null)
   const generated = [banger('1', 10), banger('2', 9), banger('3', 8)]
   mockGetProfileBangersPage.mockResolvedValue({
     tweets: generated.slice(0, 1),
@@ -79,4 +87,62 @@ test('keeps persisted featured bangers ahead of the ClickHouse page boundary', a
   expect(page.tweets.map((tweet) => tweet.tweet_id)).toEqual(['3'])
   expect(page.tweets[0].curation?.is_featured).toBe(true)
   expect(page.nextOffset).toBe(1)
+})
+
+test('hydrates an owned manually added tweet outside the generated bangers set', async () => {
+  const generated = [banger('1', 10)]
+  mockGetProfileBangersPage.mockResolvedValue({
+    tweets: generated,
+    yearCounts: [{ year: 2025, count: 1 }],
+    total: 1,
+    nextOffset: null,
+    available: true,
+  })
+  mockGetProfileBangers.mockResolvedValue({
+    tweets: generated,
+    yearCounts: [{ year: 2025, count: 1 }],
+    total: 1,
+    available: true,
+  })
+  mockFinalEq.mockResolvedValue({
+    data: [
+      {
+        item_id: '2',
+        is_hidden: false,
+        is_featured: true,
+        position: 0,
+      },
+    ],
+    error: null,
+  })
+  mockFetchTweet.mockResolvedValue({
+    tweet_id: '2',
+    account_id: '42',
+    created_at: '2025-02-01T00:00:00.000Z',
+    full_text: 'Manually added',
+    retweet_count: 2,
+    favorite_count: 20,
+    reply_to_tweet_id: null,
+    quote_tweet_id: null,
+    retweeted_tweet_id: null,
+    avatar_media_url: null,
+    username: 'alice',
+    account_display_name: 'Alice',
+    media: [],
+    urls: [],
+  })
+
+  const page = await getCuratedProfileBangersPage('42', {
+    limit: 10,
+    sort: 'quotes',
+  })
+
+  expect(mockFetchTweet).toHaveBeenCalledWith('2')
+  expect(page.tweets.map((tweet) => tweet.tweet_id)).toEqual(['2', '1'])
+  expect(page.tweets[0]).toMatchObject({
+    full_text: 'Manually added',
+    quote_count: 0,
+    curation: { is_featured: true, position: 0 },
+  })
+  expect(page.total).toBe(2)
 })

--- a/src/lib/profileCuration.ts
+++ b/src/lib/profileCuration.ts
@@ -2,6 +2,8 @@ import 'server-only'
 
 import { createServerServiceRoleClient } from '@/utils/supabase'
 import { devLog } from '@/lib/devLog'
+import { fetchClickHouseTweetPageData } from '@/lib/clickhouseTweetPage'
+import type { TweetData } from '@/components/TweetComponent'
 import {
   applyProfileCuration,
   type ProfileCurationRow,
@@ -9,9 +11,96 @@ import {
 } from './profileCurationState'
 import { getProfileBangers, getProfileBangersPage } from './metaTwitter/bangers'
 import type { ProfileBangersPageOptions } from './metaTwitter/bangers'
-import type { ArchivePerson } from './metaTwitter/types'
+import type {
+  ArchivePerson,
+  ArchiveTweet,
+  BangerTweet,
+} from './metaTwitter/types'
 
 const accountPattern = /^\d{1,20}$/
+
+function archiveTweet(tweet: NonNullable<TweetData['quoted_tweet']>) {
+  const converted: ArchiveTweet = {
+    tweet_id: tweet.tweet_id,
+    account_id: tweet.account_id,
+    created_at: tweet.created_at,
+    full_text: tweet.full_text,
+    favorite_count: tweet.favorite_count,
+    retweet_count: tweet.retweet_count,
+    reply_to_username: null,
+    username: tweet.username,
+    account_display_name: tweet.account_display_name,
+    avatar_media_url: tweet.avatar_media_url ?? null,
+    media: (tweet.media ?? []).map((item) => ({
+      media_url: item.media_url,
+      media_type: item.media_type,
+      width: item.width ?? 0,
+      height: item.height ?? 0,
+    })),
+  }
+  return converted
+}
+
+export function manuallyCuratedBanger(tweet: TweetData): BangerTweet {
+  return {
+    tweet_id: tweet.tweet_id,
+    account_id: tweet.account_id,
+    created_at: tweet.created_at,
+    full_text: tweet.full_text,
+    favorite_count: tweet.favorite_count,
+    retweet_count: tweet.retweet_count,
+    reply_to_username: tweet.reply_to_username ?? null,
+    username: tweet.username,
+    account_display_name: tweet.account_display_name,
+    avatar_media_url: tweet.avatar_media_url,
+    media: tweet.media.map((item) => ({
+      media_url: item.media_url,
+      media_type: item.media_type,
+      width: item.width ?? 0,
+      height: item.height ?? 0,
+    })),
+    quote_count: 0,
+    quoting_accounts: 0,
+    quote_tweet_id: tweet.quote_tweet_id,
+    quoted_tweet:
+      tweet.quoted_tweet && !tweet.quoted_tweet.is_deleted
+        ? archiveTweet(tweet.quoted_tweet)
+        : null,
+  }
+}
+
+async function getManuallyCuratedBangers(
+  accountId: string,
+  rows: ProfileCurationRow[],
+  generated: BangerTweet[],
+) {
+  const generatedIds = new Set(generated.map((tweet) => tweet.tweet_id))
+  const itemIds = rows
+    .filter((row) => !row.is_hidden && !generatedIds.has(row.item_id))
+    .map((row) => row.item_id)
+
+  const tweets = await Promise.all(
+    itemIds.map(async (itemId) => {
+      try {
+        return await fetchClickHouseTweetPageData(itemId)
+      } catch (error) {
+        devLog('manually curated profile tweet unavailable', {
+          accountId,
+          itemId,
+          error,
+        })
+        return null
+      }
+    }),
+  )
+
+  return tweets
+    .filter(
+      (tweet): tweet is TweetData =>
+        tweet !== null && tweet.account_id === accountId,
+    )
+    .map(manuallyCuratedBanger)
+}
 
 export async function getPublicProfileSettings(accountId: string) {
   if (!accountPattern.test(accountId)) {
@@ -86,8 +175,13 @@ export async function getCuratedProfileBangersPage(
     }
   }
 
+  const manual = await getManuallyCuratedBangers(
+    accountId,
+    rows,
+    collection.tweets,
+  )
   const sort = options.sort ?? 'quotes'
-  const generated = collection.tweets.slice().sort((left, right) => {
+  const generated = [...collection.tweets, ...manual].sort((left, right) => {
     if (sort === 'likes') {
       return (
         right.favorite_count - left.favorite_count ||

--- a/src/lib/profileCurationActions.test.ts
+++ b/src/lib/profileCurationActions.test.ts
@@ -1,7 +1,9 @@
 import {
+  addTweetToOwnProfile,
   mutateProfileCuration,
   updateDownloadArchiveVisibility,
 } from '@/app/user/[account_id]/actions'
+import { fetchClickHouseTweetPageData } from '@/lib/clickhouseTweetPage'
 
 const mockGetUser = jest.fn()
 const mockUpsert = jest.fn()
@@ -18,11 +20,19 @@ jest.mock('@/utils/supabase', () => ({
   }),
   createServerServiceRoleClient: () => ({ from: mockFrom }),
 }))
+jest.mock('@/lib/clickhouseTweetPage', () => ({
+  fetchClickHouseTweetPageData: jest.fn(),
+}))
+
+const mockFetchTweet = fetchClickHouseTweetPageData as jest.MockedFunction<
+  typeof fetchClickHouseTweetPageData
+>
 
 describe('owner profile server actions', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockUpsert.mockResolvedValue({ error: null })
+    mockFetchTweet.mockResolvedValue(null)
   })
 
   test('rejects a signed-in user editing another account before any write', async () => {
@@ -81,5 +91,48 @@ describe('owner profile server actions', () => {
       { account_id: '42', download_archive_visible: false },
       { onConflict: 'account_id' },
     )
+  })
+
+  test('adds an authenticated owners archived tweet as a featured profile item', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { app_metadata: { provider_id: '42' } } },
+      error: null,
+    })
+    mockFetchTweet.mockResolvedValue({
+      tweet_id: '100',
+      account_id: '42',
+    } as Awaited<ReturnType<typeof fetchClickHouseTweetPageData>>)
+
+    await expect(addTweetToOwnProfile('100')).resolves.toEqual({
+      ok: true,
+      accountId: '42',
+    })
+    expect(mockUpsert).toHaveBeenCalledWith(
+      {
+        account_id: '42',
+        section: 'bangers',
+        item_id: '100',
+        is_hidden: false,
+        is_featured: true,
+        position: 0,
+      },
+      { onConflict: 'account_id,section,item_id' },
+    )
+  })
+
+  test('rejects a tweet that belongs to another archived account', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { app_metadata: { provider_id: '42' } } },
+      error: null,
+    })
+    mockFetchTweet.mockResolvedValue({
+      tweet_id: '100',
+      account_id: '41',
+    } as Awaited<ReturnType<typeof fetchClickHouseTweetPageData>>)
+
+    await expect(addTweetToOwnProfile('100')).rejects.toThrow(
+      'only add your own tweets',
+    )
+    expect(mockUpsert).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/profileTweetLink.test.ts
+++ b/src/lib/profileTweetLink.test.ts
@@ -1,0 +1,31 @@
+import { parseProfileTweetId } from './profileTweetLink'
+
+test.each([
+  ['1234567890123456789', '1234567890123456789'],
+  [
+    'https://x.com/alice/status/1234567890123456789?s=20',
+    '1234567890123456789',
+  ],
+  [
+    'https://twitter.com/alice/status/1234567890123456789',
+    '1234567890123456789',
+  ],
+  [
+    'https://community-archive.org/tweets/1234567890123456789?from=profile',
+    '1234567890123456789',
+  ],
+  ['/tweets/1234567890123456789', '1234567890123456789'],
+])('extracts an archived tweet ID from %s', (input, expected) => {
+  expect(parseProfileTweetId(input)).toBe(expected)
+})
+
+test.each([
+  '',
+  'not a tweet',
+  'https://example.com/tweets/123',
+  'https://x.com/alice/likes/123',
+  'https://x.com/alice/status/not-a-number',
+  '123456789012345678901',
+])('rejects invalid or unsupported tweet references: %s', (input) => {
+  expect(parseProfileTweetId(input)).toBeNull()
+})

--- a/src/lib/profileTweetLink.ts
+++ b/src/lib/profileTweetLink.ts
@@ -1,0 +1,27 @@
+const tweetIdPattern = /^\d{1,20}$/
+
+/** Extract an archived tweet ID from an X, Twitter, or Community Archive URL. */
+export function parseProfileTweetId(value: string): string | null {
+  const input = value.trim()
+  if (tweetIdPattern.test(input)) return input
+
+  let url: URL
+  try {
+    url = new URL(input, 'https://community-archive.org')
+  } catch {
+    return null
+  }
+
+  const hostname = url.hostname.toLowerCase().replace(/^www\./, '')
+  const segments = url.pathname.split('/').filter(Boolean)
+  let candidate: string | undefined
+
+  if (hostname === 'x.com' || hostname === 'twitter.com') {
+    const statusIndex = segments.indexOf('status')
+    candidate = statusIndex > 0 ? segments[statusIndex + 1] : undefined
+  } else if (hostname === 'community-archive.org' || hostname === 'localhost') {
+    candidate = segments[0] === 'tweets' ? segments[1] : undefined
+  }
+
+  return candidate && tweetIdPattern.test(candidate) ? candidate : null
+}


### PR DESCRIPTION
Closes #662

## What changed
- accept X, Twitter, Community Archive links, or tweet IDs in owner profile edit mode
- expose an owner-only Add to profile action on canonical tweet cards
- verify the authenticated X account owns the archived tweet before writing
- hydrate manually added posts even when they are below the generated Bangers quote threshold
- add focused parser, action, curation, profile, and tweet-card tests

## Validation
- 46 focused tests passed
- pnpm type-check
- pnpm lint (one pre-existing no-img warning in UnifiedTweetList.test.tsx)