### PR TITLE
Show owners personalized Community Archive invitations

### DIFF
--- a/src/app/api/profile/[account_id]/outreach/route.ts
+++ b/src/app/api/profile/[account_id]/outreach/route.ts
@@ -1,0 +1,53 @@
+import { cookies } from 'next/headers'
+import { NextRequest, NextResponse } from 'next/server'
+import { fetchClickHouseProfileOutreach } from '@/lib/metaTwitter/clickhouseSidebar'
+import { createServerClient } from '@/utils/supabase'
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 60
+
+const ACCOUNT_ID_PATTERN = /^\d{1,20}$/
+const privateHeaders = { 'Cache-Control': 'private, no-store' }
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { account_id: string } },
+) {
+  if (!ACCOUNT_ID_PATTERN.test(params.account_id)) {
+    return NextResponse.json(
+      { error: 'Invalid profile account' },
+      { status: 400, headers: privateHeaders },
+    )
+  }
+
+  const supabase = createServerClient(await cookies())
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  const ownedAccountId = user?.app_metadata?.provider_id
+  if (typeof ownedAccountId !== 'string') {
+    return NextResponse.json(
+      { error: 'Sign in with X to view outreach suggestions' },
+      { status: 401, headers: privateHeaders },
+    )
+  }
+  if (ownedAccountId !== params.account_id) {
+    return NextResponse.json(
+      { error: 'You can only view your own outreach suggestions' },
+      { status: 403, headers: privateHeaders },
+    )
+  }
+
+  try {
+    return NextResponse.json(
+      await fetchClickHouseProfileOutreach(params.account_id),
+      { headers: privateHeaders },
+    )
+  } catch (error) {
+    console.error('Profile outreach request failed:', error)
+    return NextResponse.json(
+      { error: 'Outreach suggestions are temporarily unavailable' },
+      { status: 502, headers: privateHeaders },
+    )
+  }
+}

--- a/src/components/metaTwitter/ProfileArchive.tsx
+++ b/src/components/metaTwitter/ProfileArchive.tsx
@@ -726,6 +726,7 @@ export function ProfileArchive({
         onSelect={selectChapter}
       />
       <Workspace
+        accountId={accountId}
         key={`${activeKey}:${activeFeed ? 'ready' : 'loading'}`}
         avatarUrl={avatarUrl}
         contextTitle={contextTitle}

--- a/src/components/metaTwitter/ProfileOutreach.test.tsx
+++ b/src/components/metaTwitter/ProfileOutreach.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ProfileOutreach, outreachIntentHref } from './ProfileOutreach'
+import type { ArchivePerson } from '@/lib/metaTwitter/types'
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: ({ alt = '', ...props }: { alt?: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={alt} {...props} />
+  ),
+}))
+
+const candidate: ArchivePerson = {
+  user_id: '8',
+  screen_name: 'carol',
+  name: 'Carol',
+  interactions: 12,
+  avatar_media_url: null,
+  in_archive: false,
+}
+
+afterEach(() => jest.restoreAllMocks())
+
+test('shows personalized non-member suggestions with an editable X intent', async () => {
+  jest.spyOn(global, 'fetch').mockResolvedValue(
+    new Response(JSON.stringify({ people: [candidate] }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  )
+
+  render(<ProfileOutreach accountId="42" />)
+
+  expect(await screen.findByText('Carol')).toBeVisible()
+  expect(screen.getByText('@carol · 12 interactions')).toBeVisible()
+  const link = screen.getByRole('link', { name: 'Invite' })
+  expect(link).toHaveAttribute('href', outreachIntentHref(candidate))
+  expect(
+    new URL(link.getAttribute('href')!).searchParams.get('text'),
+  ).toContain('@carol')
+})
+
+test('offers a retry after a temporary request failure', async () => {
+  const user = userEvent.setup()
+  const fetchMock = jest
+    .spyOn(global, 'fetch')
+    .mockRejectedValueOnce(new Error('offline'))
+    .mockResolvedValueOnce(
+      new Response(JSON.stringify({ people: [] }), { status: 200 }),
+    )
+
+  render(<ProfileOutreach accountId="42" />)
+  await user.click(
+    await screen.findByRole('button', {
+      name: 'Suggestions are unavailable. Retry',
+    }),
+  )
+
+  expect(
+    await screen.findByText('No non-member suggestions right now.'),
+  ).toBeVisible()
+  expect(fetchMock).toHaveBeenCalledTimes(2)
+})

--- a/src/components/metaTwitter/ProfileOutreach.tsx
+++ b/src/components/metaTwitter/ProfileOutreach.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Image from 'next/image'
+import { ExternalLink, UserPlus } from 'lucide-react'
+import { getSmallAvatarUrl } from '@/lib/avatar'
+import type { ArchivePerson } from '@/lib/metaTwitter/types'
+
+export function outreachIntentHref(person: ArchivePerson) {
+  const text = `@${person.screen_name} You’re one of the people I interact with most on X. I’d love to see your archive in Community Archive: https://community-archive.org/upload`
+  return `https://x.com/intent/post?${new URLSearchParams({ text })}`
+}
+
+export function ProfileOutreach({ accountId }: { accountId: string }) {
+  const [people, setPeople] = useState<ArchivePerson[] | null>(null)
+  const [failed, setFailed] = useState(false)
+  const [attempt, setAttempt] = useState(0)
+
+  useEffect(() => {
+    const controller = new AbortController()
+    setFailed(false)
+    void fetch(`/api/profile/${encodeURIComponent(accountId)}/outreach`, {
+      cache: 'no-store',
+      signal: controller.signal,
+    })
+      .then(async (response) => {
+        if (!response.ok) throw new Error('Profile outreach request failed')
+        const payload = (await response.json()) as { people?: unknown }
+        if (!Array.isArray(payload.people)) {
+          throw new Error('Profile outreach response was invalid')
+        }
+        setPeople(payload.people as ArchivePerson[])
+      })
+      .catch((error) => {
+        if (error instanceof Error && error.name === 'AbortError') return
+        setFailed(true)
+      })
+    return () => controller.abort()
+  }, [accountId, attempt])
+
+  return (
+    <section
+      aria-labelledby="profile-outreach-heading"
+      className="rounded-xl border border-brand/20 bg-brand/5 p-3"
+    >
+      <h3
+        id="profile-outreach-heading"
+        className="flex items-center gap-1.5 text-[14px] font-extrabold"
+      >
+        <UserPlus className="h-4 w-4" aria-hidden="true" />
+        People you could invite
+      </h3>
+      <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+        You interact with these accounts often, but they aren’t in Community
+        Archive. A personal invitation can help.
+      </p>
+
+      {people === null && !failed && (
+        <p className="mt-3 text-xs text-muted-foreground">Finding people…</p>
+      )}
+      {failed && (
+        <button
+          type="button"
+          onClick={() => setAttempt((current) => current + 1)}
+          className="mt-3 text-xs font-semibold text-muted-foreground hover:text-foreground"
+        >
+          Suggestions are unavailable. Retry
+        </button>
+      )}
+      {people?.length === 0 && (
+        <p className="mt-3 text-xs text-muted-foreground">
+          No non-member suggestions right now.
+        </p>
+      )}
+      {people && people.length > 0 && (
+        <div className="mt-3 flex flex-col gap-2.5">
+          {people.map((person) => {
+            const avatarUrl = getSmallAvatarUrl(person.avatar_media_url)
+            return (
+              <div key={person.user_id} className="flex items-center gap-2">
+                {avatarUrl ? (
+                  <Image
+                    src={avatarUrl}
+                    alt=""
+                    width={32}
+                    height={32}
+                    sizes="32px"
+                    className="h-8 w-8 flex-none rounded-full object-cover"
+                  />
+                ) : (
+                  <span className="grid h-8 w-8 flex-none place-items-center rounded-full bg-muted text-xs font-bold">
+                    {person.screen_name.charAt(0).toUpperCase()}
+                  </span>
+                )}
+                <div className="min-w-0 flex-1 text-xs leading-tight">
+                  <b className="block truncate">
+                    {person.name ?? person.screen_name}
+                  </b>
+                  <span className="text-muted-foreground">
+                    @{person.screen_name} · {person.interactions} interactions
+                  </span>
+                </div>
+                <a
+                  href={outreachIntentHref(person)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex flex-none items-center gap-1 rounded-full border border-border bg-background px-2 py-1 text-[11px] font-semibold hover:bg-muted"
+                >
+                  Invite
+                  <ExternalLink className="h-3 w-3" aria-hidden="true" />
+                </a>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/metaTwitter/Workspace.test.tsx
+++ b/src/components/metaTwitter/Workspace.test.tsx
@@ -73,6 +73,7 @@ test('shows the initial canonical banger cards with media and profile return lin
   const onLoadMore = jest.fn()
   render(
     <Workspace
+      accountId="42"
       avatarUrl={null}
       contextTitle="Best of Alice"
       tweets={tweets.slice(0, 2)}

--- a/src/components/metaTwitter/Workspace.tsx
+++ b/src/components/metaTwitter/Workspace.tsx
@@ -15,6 +15,7 @@ import type {
   ArchivePerson,
   BangerTweet,
 } from '@/lib/metaTwitter/types'
+import { ProfileOutreach } from './ProfileOutreach'
 
 export const BANGER_SCORE_EXPLANATION =
   'Banger score is the number of archived quote posts from Community Archive members, excluding self-quotes.'
@@ -34,6 +35,7 @@ const sharesFeaturedGroup = (
   Boolean(left?.curation?.is_featured) === Boolean(right?.curation?.is_featured)
 
 export function Workspace({
+  accountId,
   avatarUrl,
   contextTitle,
   tweets,
@@ -64,6 +66,7 @@ export function Workspace({
   onMove,
   onRestore,
 }: {
+  accountId: string
   avatarUrl: string | null
   contextTitle: string
   tweets: BangerTweet[]
@@ -285,6 +288,7 @@ export function Workspace({
         </section>
 
         <aside className="flex flex-col gap-5">
+          {editing && <ProfileOutreach accountId={accountId} />}
           <section aria-labelledby="profile-media-heading">
             <h3
               id="profile-media-heading"

--- a/src/lib/clickhouseGateway.test.ts
+++ b/src/lib/clickhouseGateway.test.ts
@@ -1,0 +1,19 @@
+import { analyticsGatewayRequestUrl } from './clickhouseGateway'
+
+test('forwards only allowlisted personalized interaction parameters', () => {
+  const params = new URLSearchParams({
+    limit: '5',
+    missing_only: 'true',
+    unexpected: 'secret',
+  })
+
+  const url = analyticsGatewayRequestUrl(
+    ['user', '42', 'interactions'],
+    params,
+    'https://analytics.example/analytics',
+  )
+
+  expect(url.toString()).toBe(
+    'https://analytics.example/analytics/user/42/interactions?limit=5&missing_only=true',
+  )
+})

--- a/src/lib/clickhouseGateway.ts
+++ b/src/lib/clickhouseGateway.ts
@@ -103,7 +103,7 @@ export function analyticsGatewayRequestUrl(
     /^\d{1,20}$/.test(cleanPath[1]) &&
     cleanPath[2] === 'interactions'
   ) {
-    allowedParams = new Set(['year', 'limit'])
+    allowedParams = new Set(['year', 'limit', 'missing_only'])
   } else if (
     cleanPath.length === 2 &&
     cleanPath[0] === 'tweet' &&

--- a/src/lib/metaTwitter/clickhouseSidebar.test.ts
+++ b/src/lib/metaTwitter/clickhouseSidebar.test.ts
@@ -2,6 +2,7 @@ import type { AnalyticsGatewayFetcher } from '@/lib/clickhouseGateway'
 import {
   fetchClickHouseProfileInteractions,
   fetchClickHouseProfileMedia,
+  fetchClickHouseProfileOutreach,
   fetchClickHouseProfileSidebar,
 } from './clickhouseSidebar'
 
@@ -129,4 +130,45 @@ test('omits the year for the all-time sidebar and rejects scope drift', async ()
   await expect(
     fetchClickHouseProfileSidebar('42', 2025, wrongYearFetcher),
   ).rejects.toThrow('mismatched profile sidebar scope')
+})
+
+test('loads a scoped non-member outreach list', async () => {
+  const fetcher = jest.fn(async () => ({
+    data: {
+      people: [
+        {
+          accountId: '8',
+          username: 'carol',
+          displayName: 'Carol',
+          avatarUrl: null,
+          interactionCount: '12',
+          inCommunityArchive: false,
+        },
+      ],
+    },
+    query: {
+      accountId: '42',
+      year: null,
+      peopleLimit: 5,
+      missingOnly: true,
+    },
+  })) as unknown as AnalyticsGatewayFetcher
+
+  await expect(fetchClickHouseProfileOutreach('42', fetcher)).resolves.toEqual({
+    people: [
+      {
+        user_id: '8',
+        screen_name: 'carol',
+        name: 'Carol',
+        interactions: 12,
+        avatar_media_url: null,
+        in_archive: false,
+      },
+    ],
+  })
+  expect(fetcher).toHaveBeenCalledWith(
+    ['user', '42', 'interactions'],
+    new URLSearchParams({ limit: '5', missing_only: 'true' }),
+    { timeoutMs: 30_000 },
+  )
 })

--- a/src/lib/metaTwitter/clickhouseSidebar.ts
+++ b/src/lib/metaTwitter/clickhouseSidebar.ts
@@ -11,6 +11,7 @@ import type { ArchiveMediaItem, ArchivePerson } from './types'
 const DAY = 86_400
 const MEDIA_LIMIT = 6
 const PEOPLE_LIMIT = 8
+const OUTREACH_LIMIT = 5
 const ID_PATTERN = /^\d{1,20}$/
 
 interface SidebarResponse {
@@ -47,6 +48,7 @@ interface InteractionsResponse {
     accountId?: unknown
     year?: unknown
     peopleLimit?: unknown
+    missingOnly?: unknown
   }
 }
 
@@ -66,6 +68,7 @@ interface SidebarPersonRow {
   displayName?: unknown
   avatarUrl?: unknown
   interactionCount?: unknown
+  inCommunityArchive?: unknown
 }
 
 export interface ClickHouseProfileSidebar {
@@ -164,7 +167,7 @@ const personItem = (value: unknown): ArchivePerson | null => {
       typeof row.avatarUrl === 'string' && row.avatarUrl.trim()
         ? row.avatarUrl
         : null,
-    in_archive: true,
+    in_archive: row.inCommunityArchive !== false,
   }
 }
 
@@ -236,6 +239,40 @@ export async function fetchClickHouseProfileInteractions(
     people: people.flatMap((value) => {
       const item = personItem(value)
       return item ? [item] : []
+    }),
+  }
+}
+
+export async function fetchClickHouseProfileOutreach(
+  accountId: string,
+  fetcher: AnalyticsGatewayFetcher = fetchAnalyticsGatewayJson,
+): Promise<ClickHouseProfileInteractions> {
+  if (!ID_PATTERN.test(accountId)) {
+    throw new Error('Profile outreach requires a numeric account ID')
+  }
+  const params = profileParams(undefined, OUTREACH_LIMIT)
+  params.set('missing_only', 'true')
+  const response = await fetcher<InteractionsResponse>(
+    ['user', accountId, 'interactions'],
+    params,
+    { timeoutMs: 30_000 },
+  )
+  if (
+    response.query?.accountId !== accountId ||
+    response.query?.year !== null ||
+    Number(response.query?.peopleLimit) !== OUTREACH_LIMIT ||
+    response.query?.missingOnly !== true
+  ) {
+    throw new Error('ClickHouse returned mismatched profile outreach scope')
+  }
+  const people = response.data?.people
+  if (!Array.isArray(people)) {
+    throw new Error('ClickHouse returned invalid profile outreach')
+  }
+  return {
+    people: people.flatMap((value) => {
+      const item = personItem(value)
+      return item && item.in_archive === false ? [item] : []
     }),
   }
 }

--- a/src/lib/profileOutreachRoute.test.ts
+++ b/src/lib/profileOutreachRoute.test.ts
@@ -1,0 +1,42 @@
+import { GET } from '@/app/api/profile/[account_id]/outreach/route'
+import { fetchClickHouseProfileOutreach } from '@/lib/metaTwitter/clickhouseSidebar'
+
+const mockGetUser = jest.fn()
+
+jest.mock('next/headers', () => ({ cookies: jest.fn(async () => ({})) }))
+jest.mock('@/utils/supabase', () => ({
+  createServerClient: () => ({ auth: { getUser: mockGetUser } }),
+}))
+jest.mock('@/lib/metaTwitter/clickhouseSidebar', () => ({
+  fetchClickHouseProfileOutreach: jest.fn(),
+}))
+
+const mockFetchOutreach = fetchClickHouseProfileOutreach as jest.MockedFunction<
+  typeof fetchClickHouseProfileOutreach
+>
+
+beforeEach(() => jest.clearAllMocks())
+
+test('does not expose another accounts personalized suggestions', async () => {
+  mockGetUser.mockResolvedValue({
+    data: { user: { app_metadata: { provider_id: '41' } } },
+  })
+
+  const response = await GET({} as never, { params: { account_id: '42' } })
+
+  expect(response.status).toBe(403)
+  expect(mockFetchOutreach).not.toHaveBeenCalled()
+})
+
+test('serves suggestions only to the authenticated profile owner', async () => {
+  mockGetUser.mockResolvedValue({
+    data: { user: { app_metadata: { provider_id: '42' } } },
+  })
+  mockFetchOutreach.mockResolvedValue({ people: [] })
+
+  const response = await GET({} as never, { params: { account_id: '42' } })
+
+  expect(response.status).toBe(200)
+  expect(await response.json()).toEqual({ people: [] })
+  expect(mockFetchOutreach).toHaveBeenCalledWith('42')
+})


### PR DESCRIPTION
Closes #626

## What changed
- add an owner-authenticated outreach endpoint for each profile
- show non-member accounts the owner interacts with most in profile edit mode
- open an editable X composer invitation rather than sending anything automatically
- add retry and empty states
- validate gateway allowlisting, ownership, response scope, and UI behavior

## Dependency
Depends on community-archive-control-panel#84. Deploy and verify that gateway change before merging this frontend PR; it supplies current membership labels and removes explicit opt-outs before persistence and serving.

## Validation
- 21 focused tests passed
- pnpm type-check
- pnpm lint (one pre-existing no-img warning in UnifiedTweetList.test.tsx)