### PR TITLE
Classify profile interactions by type

### DIFF
--- a/src/components/metaTwitter/Workspace.tsx
+++ b/src/components/metaTwitter/Workspace.tsx
@@ -15,6 +15,7 @@ import type {
   ArchivePerson,
   BangerTweet,
 } from '@/lib/metaTwitter/types'
+import { interactionBreakdown } from '@/lib/metaTwitter/interactionBreakdown'
 
 export const BANGER_SCORE_EXPLANATION =
   'Banger score is the number of archived quote posts from Community Archive members, excluding self-quotes.'
@@ -408,8 +409,7 @@ export function Workspace({
                       </span>
                       <br />
                       <span className="text-muted-foreground">
-                        {person.interactions} interaction
-                        {person.interactions === 1 ? '' : 's'}
+                        {interactionBreakdown(person)}
                       </span>
                     </div>
                     {person.curation?.is_featured && !editing && (

--- a/src/lib/metaTwitter/clickhouseSidebar.test.ts
+++ b/src/lib/metaTwitter/clickhouseSidebar.test.ts
@@ -68,6 +68,12 @@ test('maps year-scoped ClickHouse media and interactions for the sidebar', async
         screen_name: 'bob',
         name: 'Bob',
         interactions: 9,
+        interaction_counts: {
+          mentions: 2,
+          replies: 3,
+          quotes: 1,
+          reposts: 3,
+        },
         avatar_media_url:
           'https://pbs.twimg.com/profile_images/7/avatar_normal.jpg',
         in_archive: true,

--- a/src/lib/metaTwitter/clickhouseSidebar.ts
+++ b/src/lib/metaTwitter/clickhouseSidebar.ts
@@ -66,6 +66,10 @@ interface SidebarPersonRow {
   displayName?: unknown
   avatarUrl?: unknown
   interactionCount?: unknown
+  mentionCount?: unknown
+  replyCount?: unknown
+  quoteCount?: unknown
+  repostCount?: unknown
 }
 
 export interface ClickHouseProfileSidebar {
@@ -160,6 +164,12 @@ const personItem = (value: unknown): ArchivePerson | null => {
         ? row.displayName
         : null,
     interactions,
+    interaction_counts: {
+      mentions: safeCount(row.mentionCount) ?? 0,
+      replies: safeCount(row.replyCount) ?? 0,
+      quotes: safeCount(row.quoteCount) ?? 0,
+      reposts: safeCount(row.repostCount) ?? 0,
+    },
     avatar_media_url:
       typeof row.avatarUrl === 'string' && row.avatarUrl.trim()
         ? row.avatarUrl

--- a/src/lib/metaTwitter/interactionBreakdown.test.ts
+++ b/src/lib/metaTwitter/interactionBreakdown.test.ts
@@ -1,0 +1,32 @@
+import { interactionBreakdown } from './interactionBreakdown'
+import type { ArchivePerson } from './types'
+
+test('classifies a profile interaction total by type', () => {
+  const person: ArchivePerson = {
+    user_id: '7',
+    screen_name: 'bob',
+    name: 'Bob',
+    interactions: 9,
+    interaction_counts: {
+      mentions: 2,
+      replies: 3,
+      quotes: 1,
+      reposts: 3,
+    },
+  }
+
+  expect(interactionBreakdown(person)).toBe(
+    '9 total · 3 replies · 2 mentions · 1 quote · 3 reposts',
+  )
+})
+
+test('keeps the legacy total when classified counts are unavailable', () => {
+  expect(
+    interactionBreakdown({
+      user_id: '7',
+      screen_name: 'bob',
+      name: 'Bob',
+      interactions: 1,
+    }),
+  ).toBe('1 interaction')
+})

--- a/src/lib/metaTwitter/interactionBreakdown.ts
+++ b/src/lib/metaTwitter/interactionBreakdown.ts
@@ -1,0 +1,22 @@
+import type { ArchivePerson } from './types'
+
+const label = (count: number, singular: string, plural = `${singular}s`) =>
+  `${count} ${count === 1 ? singular : plural}`
+
+export function interactionBreakdown(person: ArchivePerson): string {
+  const counts = person.interaction_counts
+  if (!counts) {
+    return label(person.interactions, 'interaction')
+  }
+
+  const parts = [
+    counts.replies > 0 ? label(counts.replies, 'reply', 'replies') : null,
+    counts.mentions > 0 ? label(counts.mentions, 'mention') : null,
+    counts.quotes > 0 ? label(counts.quotes, 'quote') : null,
+    counts.reposts > 0 ? label(counts.reposts, 'repost') : null,
+  ].filter((part): part is string => part !== null)
+
+  return parts.length > 0
+    ? `${person.interactions} total · ${parts.join(' · ')}`
+    : label(person.interactions, 'interaction')
+}

--- a/src/lib/metaTwitter/types.ts
+++ b/src/lib/metaTwitter/types.ts
@@ -45,6 +45,12 @@ export interface ArchivePerson {
   screen_name: string
   name: string | null
   interactions: number
+  interaction_counts?: {
+    mentions: number
+    replies: number
+    quotes: number
+    reposts: number
+  }
   avatar_media_url?: string | null
   in_archive?: boolean
   curation?: {


### PR DESCRIPTION
Closes #605

## What changed
- retain the gateway existing mention, reply, quote, and repost counts in profile data
- show a compact typed breakdown beneath each top-interacted account
- preserve the legacy total when classified fields are absent
- cover response mapping, pluralization, and profile rendering

## Validation
- 17 focused tests passed
- pnpm type-check
- pnpm lint (one pre-existing no-img warning in UnifiedTweetList.test.tsx)