### PR TITLE
Notify owners when archive uploads finish

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,12 @@ NEXT_PUBLIC_LOCAL_SERVICE_ROLE=<your-service-role-key(from pnpm supabase start)>
 SUPABASE_SERVICE_ROLE=<> #same as above, is needed for vercel in the server
 NODE_ENV=development
 
+# Archive upload completion email. CRON_SECRET protects the Vercel Cron route;
+# ARCHIVE_NOTIFICATION_FROM must use a sender/domain verified in Resend.
+CRON_SECRET=<long-random-secret>
+RESEND_API_KEY=<sending-only-resend-key>
+ARCHIVE_NOTIFICATION_FROM=Community Archive <uploads@community-archive.org>
+
 # Staging-only login bypass.
 # Use this with a separate Supabase project loaded with mock data, never with prod data.
 NEXT_PUBLIC_ENABLE_STAGING_DEV_LOGIN=false

--- a/src/app/api/cron/archive-completion-notifications/route.ts
+++ b/src/app/api/cron/archive-completion-notifications/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  isAuthorizedCronRequest,
+  sendArchiveCompletionEmail,
+  type ClaimedArchiveCompletionNotification,
+} from '@/lib/archiveCompletionNotifications'
+import { createServerServiceRoleClient } from '@/utils/supabase'
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 60
+
+const claimLimit = 20
+
+export async function GET(request: NextRequest) {
+  if (
+    !isAuthorizedCronRequest(
+      request.headers.get('authorization'),
+      process.env.CRON_SECRET,
+    )
+  ) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const apiKey = process.env.RESEND_API_KEY
+  const from = process.env.ARCHIVE_NOTIFICATION_FROM
+
+  if (!apiKey || !from) {
+    return NextResponse.json(
+      { error: 'Notification delivery is not configured' },
+      { status: 503 },
+    )
+  }
+
+  const supabase = createServerServiceRoleClient()
+  const { data, error } = await supabase.rpc(
+    'claim_archive_completion_notifications',
+    { p_limit: claimLimit },
+  )
+
+  if (error) {
+    console.error('Failed to claim archive completion notifications', error)
+    return NextResponse.json({ error: 'Unable to claim work' }, { status: 500 })
+  }
+
+  const notifications = (data || []) as ClaimedArchiveCompletionNotification[]
+  const results = await Promise.allSettled(
+    notifications.map(async (notification) => {
+      try {
+        const providerMessageId = await sendArchiveCompletionEmail({
+          notification,
+          apiKey,
+          from,
+        })
+        const { error: finishError } = await supabase.rpc(
+          'finish_archive_completion_notification',
+          {
+            p_id: notification.id,
+            p_provider_message_id: providerMessageId,
+            p_error: undefined,
+          },
+        )
+        if (finishError) throw finishError
+        return { id: notification.id, sent: true }
+      } catch (deliveryError) {
+        const message =
+          deliveryError instanceof Error
+            ? deliveryError.message
+            : 'Unknown delivery error'
+        const { error: finishError } = await supabase.rpc(
+          'finish_archive_completion_notification',
+          {
+            p_id: notification.id,
+            p_provider_message_id: undefined,
+            p_error: message,
+          },
+        )
+        if (finishError) {
+          throw new Error(`Delivery and queue update failed: ${message}`)
+        }
+        throw deliveryError
+      }
+    }),
+  )
+
+  const failed = results.filter((result) => result.status === 'rejected').length
+  return NextResponse.json({
+    claimed: notifications.length,
+    sent: notifications.length - failed,
+    failed,
+  })
+}

--- a/src/app/api/cron/archive-completion-notifications/route.ts
+++ b/src/app/api/cron/archive-completion-notifications/route.ts
@@ -83,9 +83,36 @@ export async function GET(request: NextRequest) {
   )
 
   const failed = results.filter((result) => result.status === 'rejected').length
+  const sent = notifications.length - failed
+  const { error: runStateError } = await supabase.rpc(
+    'finish_archive_completion_notification_run',
+    {
+      p_claimed: notifications.length,
+      p_sent: sent,
+      p_failed: failed,
+      p_error: failed > 0 ? `${failed} deliveries failed` : undefined,
+    },
+  )
+
+  if (runStateError) {
+    console.error(
+      'Failed to record notification worker heartbeat',
+      runStateError,
+    )
+    return NextResponse.json(
+      {
+        claimed: notifications.length,
+        sent,
+        failed,
+        error: 'Heartbeat failed',
+      },
+      { status: 500 },
+    )
+  }
+
   return NextResponse.json({
     claimed: notifications.length,
-    sent: notifications.length - failed,
+    sent,
     failed,
   })
 }

--- a/src/app/profile/ProfileContent.test.tsx
+++ b/src/app/profile/ProfileContent.test.tsx
@@ -5,6 +5,7 @@ import ProfileContent from './ProfileContent'
 const mockFetch = jest.fn()
 const originalFetch = global.fetch
 const mockLogInsert = jest.fn().mockResolvedValue({ error: null })
+const mockRpc = jest.fn().mockResolvedValue({ data: null, error: null })
 const mockUpdateDownloadArchiveVisibility = jest.fn()
 
 jest.mock('next/navigation', () => ({
@@ -20,6 +21,7 @@ jest.mock('@/hooks/useAuthAndArchive', () => ({
 jest.mock('@/utils/supabase', () => ({
   createBrowserClient: () => ({
     from: () => ({ insert: mockLogInsert }),
+    rpc: mockRpc,
     storage: { from: jest.fn() },
   }),
 }))
@@ -40,6 +42,8 @@ jest.mock('@/app/user/[account_id]/actions', () => ({
 
 const user = {
   id: 'auth-user-123',
+  email: 'member@example.com',
+  email_confirmed_at: '2026-08-15T00:00:00.000Z',
   user_metadata: {
     user_name: 'ExampleUser',
     provider_id: 'twitter-123',
@@ -137,5 +141,50 @@ describe('ProfileContent opt-in preference', () => {
     expect(
       screen.getByText('Download Archive is hidden from your public profile'),
     ).toBeVisible()
+  })
+
+  it('explicitly opts into future upload completion emails', async () => {
+    render(
+      <ProfileContent
+        user={user}
+        accountId="123"
+        initialNotificationPreference={null}
+        initialOptInData={null}
+        archives={[]}
+      />,
+    )
+
+    const notificationSwitch = screen.getByRole('switch', {
+      name: /email me when my upload is ready/i,
+    })
+    expect(notificationSwitch).not.toBeChecked()
+
+    fireEvent.click(notificationSwitch)
+
+    await waitFor(() =>
+      expect(mockRpc).toHaveBeenCalledWith(
+        'set_archive_completion_notification',
+        { p_enabled: true },
+      ),
+    )
+    expect(notificationSwitch).toBeChecked()
+    expect(screen.getByText(/we'll email member@example.com/i)).toBeVisible()
+  })
+
+  it('does not enable email notifications without a confirmed email', () => {
+    render(
+      <ProfileContent
+        user={{ ...user, email_confirmed_at: null } as any}
+        accountId="123"
+        initialOptInData={null}
+        archives={[]}
+      />,
+    )
+
+    expect(
+      screen.getByRole('switch', {
+        name: /email me when my upload is ready/i,
+      }),
+    ).toBeDisabled()
   })
 })

--- a/src/app/profile/ProfileContent.tsx
+++ b/src/app/profile/ProfileContent.tsx
@@ -21,7 +21,14 @@ import {
   DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog'
-import { AlertCircle, Archive, Trash2, UserX, CheckCircle } from 'lucide-react'
+import {
+  AlertCircle,
+  Archive,
+  Trash2,
+  UserX,
+  CheckCircle,
+  Mail,
+} from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { createBrowserClient } from '@/utils/supabase'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -38,6 +45,10 @@ interface ProfileContentProps {
   user: User
   accountId?: string | null
   initialDownloadArchiveVisible?: boolean
+  initialNotificationPreference?: {
+    enabled: boolean
+    email: string
+  } | null
   initialOptInData: any
   archives: any[]
 }
@@ -46,6 +57,7 @@ export default function ProfileContent({
   user,
   accountId = null,
   initialDownloadArchiveVisible = true,
+  initialNotificationPreference = null,
   initialOptInData,
   archives,
 }: ProfileContentProps) {
@@ -62,6 +74,8 @@ export default function ProfileContent({
   const [downloadArchiveVisible, setDownloadArchiveVisible] = useState(
     initialDownloadArchiveVisible,
   )
+  const [completionNotificationsEnabled, setCompletionNotificationsEnabled] =
+    useState(initialNotificationPreference?.enabled || false)
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState<string | null>(null)
   const [deletingArchive, setDeletingArchive] = useState<string | null>(null)
@@ -146,6 +160,40 @@ export default function ProfileContent({
       )
     } catch (err: any) {
       setError(err.message || 'Failed to update profile visibility')
+    } finally {
+      endPreferenceMutation()
+    }
+  }
+
+  const handleCompletionNotifications = async (checked: boolean) => {
+    if (!beginPreferenceMutation()) return
+    setError(null)
+    setSuccess(null)
+
+    try {
+      const { error: preferenceError } = await supabase.rpc(
+        'set_archive_completion_notification',
+        { p_enabled: checked },
+      )
+      if (preferenceError) throw preferenceError
+
+      setCompletionNotificationsEnabled(checked)
+      setSuccess(
+        checked
+          ? `We'll email ${user.email} when a future archive upload finishes processing`
+          : 'Archive completion emails are turned off',
+      )
+      capturePostHogEvent('archive_completion_notification_updated', {
+        enabled: checked,
+      })
+      await logUserAction('archive_completion_notification_updated', {
+        enabled: checked,
+      })
+    } catch (err: any) {
+      setError(
+        err.message || 'Failed to update archive completion notifications',
+      )
+      setCompletionNotificationsEnabled(!checked)
     } finally {
       endPreferenceMutation()
     }
@@ -391,6 +439,43 @@ export default function ProfileContent({
         </TabsList>
 
         <TabsContent value="privacy" className="space-y-4">
+          <Card>
+            <CardHeader className="space-y-1.5">
+              <CardTitle className="flex items-center gap-2">
+                <Mail className="h-5 w-5" />
+                Archive Completion Notifications
+              </CardTitle>
+              <CardDescription>
+                Get one email when each future upload finishes processing
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="flex items-center justify-between gap-4">
+                <div className="space-y-0.5">
+                  <Label htmlFor="archive-completion-notifications">
+                    Email me when my upload is ready
+                  </Label>
+                  <div className="text-sm text-muted-foreground">
+                    {user.email && user.email_confirmed_at
+                      ? `Notifications will go to ${user.email}. You can turn them off at any time.`
+                      : 'Add and confirm an email address on your account to enable notifications.'}
+                  </div>
+                </div>
+                <Switch
+                  id="archive-completion-notifications"
+                  checked={completionNotificationsEnabled}
+                  onCheckedChange={handleCompletionNotifications}
+                  disabled={
+                    isPreferenceSaving ||
+                    !accountId ||
+                    !user.email ||
+                    !user.email_confirmed_at
+                  }
+                />
+              </div>
+            </CardContent>
+          </Card>
+
           <Card>
             <CardHeader className="space-y-1.5">
               <CardTitle>Public Profile</CardTitle>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -38,7 +38,12 @@ export default async function SettingsPage() {
         .maybeSingle()
     : admin.from('optin').select('*').eq('user_id', user.id).maybeSingle()
 
-  const [optInResponse, archivesResponse, settings] = await Promise.all([
+  const [
+    optInResponse,
+    archivesResponse,
+    settings,
+    notificationPreferenceResponse,
+  ] = await Promise.all([
     optInQuery,
     twitterAccountId
       ? supabase
@@ -65,6 +70,11 @@ export default async function SettingsPage() {
     twitterAccountId
       ? getPublicProfileSettings(twitterAccountId)
       : Promise.resolve({ downloadArchiveVisible: true }),
+    supabase
+      .from('archive_completion_notification_preferences')
+      .select('enabled,email')
+      .eq('user_id', user.id)
+      .maybeSingle(),
   ])
 
   return (
@@ -74,6 +84,7 @@ export default async function SettingsPage() {
           user={user}
           accountId={twitterAccountId}
           initialDownloadArchiveVisible={settings.downloadArchiveVisible}
+          initialNotificationPreference={notificationPreferenceResponse.data}
           initialOptInData={optInResponse.data}
           archives={archivesResponse.data || []}
         />

--- a/src/database-types.ts
+++ b/src/database-types.ts
@@ -1630,38 +1630,6 @@ export type Database = {
       }
     }
     Functions: {
-      claim_archive_completion_notifications: {
-        Args: { p_limit?: number }
-        Returns: {
-          account_id: string
-          archive_at: string
-          archive_username: string | null
-          id: number
-          recipient_email: string
-        }[]
-      }
-      community_archive_monitoring_completion_notifications: {
-        Args: Record<PropertyKey, never>
-        Returns: {
-          dead_24h_count: number
-          oldest_ready_seconds: number | null
-          processing_count: number
-          ready_count: number
-          seconds_since_last_sent: number | null
-        }[]
-      }
-      finish_archive_completion_notification: {
-        Args: {
-          p_error?: string
-          p_id: number
-          p_provider_message_id?: string
-        }
-        Returns: undefined
-      }
-      set_archive_completion_notification: {
-        Args: { p_enabled: boolean }
-        Returns: { email: string | null; enabled: boolean }[]
-      }
       admin_enqueue_delete_with_export: {
         Args: {
           p_account_id: string
@@ -1734,11 +1702,33 @@ export type Database = {
         }
         Returns: undefined
       }
+      claim_archive_completion_notifications: {
+        Args: {
+          p_limit?: number
+        }
+        Returns: {
+          id: number
+          recipient_email: string
+          account_id: string
+          archive_username: string
+          archive_at: string
+        }[]
+      }
       commit_temp_data: {
         Args: {
           p_suffix: string
         }
         Returns: undefined
+      }
+      community_archive_monitoring_completion_notifications: {
+        Args: Record<PropertyKey, never>
+        Returns: {
+          ready_count: number
+          processing_count: number
+          dead_24h_count: number
+          oldest_ready_seconds: number
+          seconds_since_last_sent: number
+        }[]
       }
       compute_hourly_scraping_stats: {
         Args: {
@@ -1808,6 +1798,14 @@ export type Database = {
       drop_temp_tables: {
         Args: {
           p_suffix: string
+        }
+        Returns: undefined
+      }
+      finish_archive_completion_notification: {
+        Args: {
+          p_id: number
+          p_provider_message_id?: string
+          p_error?: string
         }
         Returns: undefined
       }
@@ -2424,6 +2422,15 @@ export type Database = {
           media: Json
         }[]
       }
+      set_archive_completion_notification: {
+        Args: {
+          p_enabled: boolean
+        }
+        Returns: {
+          enabled: boolean
+          email: string
+        }[]
+      }
       set_limit: {
         Args: {
           "": number
@@ -2571,3 +2578,4 @@ export type CompositeTypes<
   : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
     ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never
+

--- a/src/database-types.ts
+++ b/src/database-types.ts
@@ -355,6 +355,39 @@ export type Database = {
         }
         Relationships: []
       }
+      archive_completion_notification_worker_state: {
+        Row: {
+          last_claimed: number
+          last_error: string | null
+          last_failed: number
+          last_finished_at: string | null
+          last_sent: number
+          last_started_at: string | null
+          singleton: boolean
+          updated_at: string
+        }
+        Insert: {
+          last_claimed?: number
+          last_error?: string | null
+          last_failed?: number
+          last_finished_at?: string | null
+          last_sent?: number
+          last_started_at?: string | null
+          singleton?: boolean
+          updated_at?: string
+        }
+        Update: {
+          last_claimed?: number
+          last_error?: string | null
+          last_failed?: number
+          last_finished_at?: string | null
+          last_sent?: number
+          last_started_at?: string | null
+          singleton?: boolean
+          updated_at?: string
+        }
+        Relationships: []
+      }
       archive_upload: {
         Row: {
           account_id: string
@@ -1728,6 +1761,11 @@ export type Database = {
           dead_24h_count: number
           oldest_ready_seconds: number
           seconds_since_last_sent: number
+          worker_last_started_timestamp_seconds: number
+          worker_last_finished_timestamp_seconds: number
+          worker_last_claimed: number
+          worker_last_sent: number
+          worker_last_failed: number
         }[]
       }
       compute_hourly_scraping_stats: {
@@ -1805,6 +1843,15 @@ export type Database = {
         Args: {
           p_id: number
           p_provider_message_id?: string
+          p_error?: string
+        }
+        Returns: undefined
+      }
+      finish_archive_completion_notification_run: {
+        Args: {
+          p_claimed: number
+          p_sent: number
+          p_failed: number
           p_error?: string
         }
         Returns: undefined
@@ -2578,4 +2625,3 @@ export type CompositeTypes<
   : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
     ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never
-

--- a/src/database-types.ts
+++ b/src/database-types.ts
@@ -2625,3 +2625,4 @@ export type CompositeTypes<
   : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
     ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never
+

--- a/src/database-types.ts
+++ b/src/database-types.ts
@@ -263,6 +263,98 @@ export type Database = {
           },
         ]
       }
+      archive_completion_notification_outbox: {
+        Row: {
+          account_id: string
+          archive_at: string
+          archive_upload_id: number
+          archive_username: string | null
+          attempt_count: number
+          available_at: string
+          created_at: string
+          id: number
+          last_error: string | null
+          locked_at: string | null
+          provider_message_id: string | null
+          recipient_email: string
+          sent_at: string | null
+          status: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          account_id: string
+          archive_at: string
+          archive_upload_id: number
+          archive_username?: string | null
+          attempt_count?: number
+          available_at?: string
+          created_at?: string
+          id?: never
+          last_error?: string | null
+          locked_at?: string | null
+          provider_message_id?: string | null
+          recipient_email: string
+          sent_at?: string | null
+          status?: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          account_id?: string
+          archive_at?: string
+          archive_upload_id?: number
+          archive_username?: string | null
+          attempt_count?: number
+          available_at?: string
+          created_at?: string
+          id?: never
+          last_error?: string | null
+          locked_at?: string | null
+          provider_message_id?: string | null
+          recipient_email?: string
+          sent_at?: string | null
+          status?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "archive_completion_notification_outbox_archive_upload_id_fkey"
+            columns: ["archive_upload_id"]
+            isOneToOne: true
+            referencedRelation: "archive_upload"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      archive_completion_notification_preferences: {
+        Row: {
+          account_id: string
+          created_at: string
+          email: string
+          enabled: boolean
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          account_id: string
+          created_at?: string
+          email: string
+          enabled?: boolean
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          account_id?: string
+          created_at?: string
+          email?: string
+          enabled?: boolean
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       archive_upload: {
         Row: {
           account_id: string
@@ -1538,6 +1630,38 @@ export type Database = {
       }
     }
     Functions: {
+      claim_archive_completion_notifications: {
+        Args: { p_limit?: number }
+        Returns: {
+          account_id: string
+          archive_at: string
+          archive_username: string | null
+          id: number
+          recipient_email: string
+        }[]
+      }
+      community_archive_monitoring_completion_notifications: {
+        Args: Record<PropertyKey, never>
+        Returns: {
+          dead_24h_count: number
+          oldest_ready_seconds: number | null
+          processing_count: number
+          ready_count: number
+          seconds_since_last_sent: number | null
+        }[]
+      }
+      finish_archive_completion_notification: {
+        Args: {
+          p_error?: string
+          p_id: number
+          p_provider_message_id?: string
+        }
+        Returns: undefined
+      }
+      set_archive_completion_notification: {
+        Args: { p_enabled: boolean }
+        Returns: { email: string | null; enabled: boolean }[]
+      }
       admin_enqueue_delete_with_export: {
         Args: {
           p_account_id: string
@@ -2447,4 +2571,3 @@ export type CompositeTypes<
   : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
     ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never
-

--- a/src/lib/archiveCompletionNotifications.test.ts
+++ b/src/lib/archiveCompletionNotifications.test.ts
@@ -1,0 +1,80 @@
+import {
+  buildArchiveCompletionEmail,
+  isAuthorizedCronRequest,
+  sendArchiveCompletionEmail,
+  type ClaimedArchiveCompletionNotification,
+} from './archiveCompletionNotifications'
+
+const notification: ClaimedArchiveCompletionNotification = {
+  id: 17,
+  recipient_email: 'member@example.com',
+  account_id: '123456',
+  archive_username: '<member>',
+  archive_at: '2026-08-15T00:00:00.000Z',
+}
+
+describe('archive completion notifications', () => {
+  it('requires an exact configured cron bearer token', () => {
+    expect(isAuthorizedCronRequest('Bearer correct', 'correct')).toBe(true)
+    expect(isAuthorizedCronRequest('Bearer wrong', 'correct')).toBe(false)
+    expect(isAuthorizedCronRequest('Bearer undefined', undefined)).toBe(false)
+  })
+
+  it('builds a plain-text fallback and escapes user-controlled HTML', () => {
+    const email = buildArchiveCompletionEmail(
+      notification,
+      'Community Archive <archive@example.com>',
+    )
+
+    expect(email.to).toEqual(['member@example.com'])
+    expect(email.text).toContain('@<member>')
+    expect(email.html).toContain('@&lt;member&gt;')
+    expect(email.html).not.toContain('@<member>')
+    expect(email.html).toContain('/user/123456')
+  })
+
+  it('uses a stable outbox idempotency key for provider retries', async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ id: 'email_123' }), { status: 200 }),
+      )
+
+    await expect(
+      sendArchiveCompletionEmail({
+        notification,
+        apiKey: 'secret',
+        from: 'archive@example.com',
+        fetchImpl,
+      }),
+    ).resolves.toBe('email_123')
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://api.resend.com/emails',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Idempotency-Key': 'archive-completion/17',
+        }),
+      }),
+    )
+  })
+
+  it('surfaces provider errors without treating them as delivered', async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ message: 'rate limited' }), {
+          status: 429,
+        }),
+      )
+
+    await expect(
+      sendArchiveCompletionEmail({
+        notification,
+        apiKey: 'secret',
+        from: 'archive@example.com',
+        fetchImpl,
+      }),
+    ).rejects.toThrow('rate limited')
+  })
+})

--- a/src/lib/archiveCompletionNotifications.ts
+++ b/src/lib/archiveCompletionNotifications.ts
@@ -1,0 +1,102 @@
+export interface ClaimedArchiveCompletionNotification {
+  id: number
+  recipient_email: string
+  account_id: string
+  archive_username: string | null
+  archive_at: string
+}
+
+interface ArchiveCompletionEmail {
+  from: string
+  to: string[]
+  subject: string
+  text: string
+  html: string
+}
+
+const escapeHtml = (value: string) =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;')
+
+export const isAuthorizedCronRequest = (
+  authorization: string | null,
+  cronSecret: string | undefined,
+) => Boolean(cronSecret && authorization === `Bearer ${cronSecret}`)
+
+export const buildArchiveCompletionEmail = (
+  notification: ClaimedArchiveCompletionNotification,
+  from: string,
+): ArchiveCompletionEmail => {
+  const displayName = notification.archive_username
+    ? `@${notification.archive_username.replace(/^@/, '')}`
+    : 'your account'
+  const archiveDate = new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'long',
+    timeZone: 'UTC',
+  }).format(new Date(notification.archive_at))
+  const profileUrl = `https://www.community-archive.org/user/${encodeURIComponent(notification.account_id)}`
+
+  return {
+    from,
+    to: [notification.recipient_email],
+    subject: `Your Community Archive upload is ready`,
+    text: [
+      `Your archive upload for ${displayName} has finished processing.`,
+      `Archive date: ${archiveDate}`,
+      `View your profile: ${profileUrl}`,
+      '',
+      'You received this because you enabled archive completion notifications in Settings.',
+      'You can turn them off at https://www.community-archive.org/settings',
+    ].join('\n'),
+    html: `
+      <p>Your archive upload for <strong>${escapeHtml(displayName)}</strong> has finished processing.</p>
+      <p>Archive date: ${escapeHtml(archiveDate)}</p>
+      <p><a href="${profileUrl}">View your Community Archive profile</a></p>
+      <hr>
+      <p style="color:#666;font-size:13px">
+        You received this because you enabled archive completion notifications in Settings.
+        <a href="https://www.community-archive.org/settings">Turn notifications off</a>.
+      </p>
+    `.trim(),
+  }
+}
+
+export const sendArchiveCompletionEmail = async ({
+  notification,
+  apiKey,
+  from,
+  fetchImpl = fetch,
+}: {
+  notification: ClaimedArchiveCompletionNotification
+  apiKey: string
+  from: string
+  fetchImpl?: typeof fetch
+}) => {
+  const response = await fetchImpl('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+      'Idempotency-Key': `archive-completion/${notification.id}`,
+    },
+    body: JSON.stringify(buildArchiveCompletionEmail(notification, from)),
+  })
+
+  const payload = (await response.json().catch(() => null)) as {
+    id?: string
+    message?: string
+    name?: string
+  } | null
+
+  if (!response.ok || !payload?.id) {
+    const detail =
+      payload?.message || payload?.name || `HTTP ${response.status}`
+    throw new Error(`Resend rejected the notification: ${detail}`)
+  }
+
+  return payload.id
+}

--- a/src/lib/archiveCompletionNotificationsMigration.test.ts
+++ b/src/lib/archiveCompletionNotificationsMigration.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const migration = readFileSync(
+  join(
+    process.cwd(),
+    'supabase/migrations/20260815094500_add_archive_completion_notifications.sql',
+  ),
+  'utf8',
+)
+
+describe('archive completion notification migration contract', () => {
+  it('keeps the recipient owner-controlled and the outbox service-only', () => {
+    expect(migration).toContain('u.email_confirmed_at')
+    expect(migration).toContain("u.raw_app_meta_data->>'provider_id'")
+    expect(migration).toContain(
+      'REVOKE ALL PRIVILEGES ON TABLE public.archive_completion_notification_outbox',
+    )
+    expect(migration).toContain(
+      'GRANT SELECT ON TABLE public.archive_completion_notification_preferences TO authenticated',
+    )
+    expect(migration).toContain('USING (user_id = auth.uid())')
+  })
+
+  it('queues only completed opted-in uploads and honors deletion', () => {
+    expect(migration).toContain("NEW.upload_phase = 'completed'")
+    expect(migration).toContain('AND enabled IS TRUE')
+    expect(migration).toContain('ON CONFLICT (archive_upload_id) DO NOTHING')
+    expect(migration).toMatch(
+      /archive_upload_id bigint NOT NULL UNIQUE\s+REFERENCES public\.archive_upload\(id\) ON DELETE CASCADE/,
+    )
+    expect(migration).toContain("status = 'cancelled'")
+  })
+
+  it('claims concurrently, recovers abandoned work, and caps retries', () => {
+    expect(migration).toContain('FOR UPDATE SKIP LOCKED')
+    expect(migration).toContain("locked_at < now() - interval '15 minutes'")
+    expect(migration).toContain(
+      "CASE WHEN attempt_count >= 5 THEN 'dead' ELSE 'retry' END",
+    )
+    expect(migration).toContain('LEFT(p_error, 2000)')
+  })
+})

--- a/src/lib/archiveCompletionNotificationsMigration.test.ts
+++ b/src/lib/archiveCompletionNotificationsMigration.test.ts
@@ -40,4 +40,15 @@ describe('archive completion notification migration contract', () => {
     )
     expect(migration).toContain('LEFT(p_error, 2000)')
   })
+
+  it('records a scheduler heartbeat even when there is no mail to send', () => {
+    expect(migration).toContain(
+      'INSERT INTO public.archive_completion_notification_worker_state',
+    )
+    expect(migration).toContain(
+      'public.finish_archive_completion_notification_run',
+    )
+    expect(migration).toContain('worker_last_finished_timestamp_seconds')
+    expect(migration).toContain('TO archive_metrics_exporter')
+  })
 })

--- a/supabase/migrations/20260815094500_add_archive_completion_notifications.sql
+++ b/supabase/migrations/20260815094500_add_archive_completion_notifications.sql
@@ -1,0 +1,314 @@
+-- Explicit, owner-controlled archive completion email notifications.
+-- Auth remains authoritative for recipient identity; clients cannot supply an email.
+
+CREATE TABLE public.archive_completion_notification_preferences (
+  user_id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  account_id text NOT NULL UNIQUE CHECK (account_id ~ '^[0-9]{1,20}$'),
+  email text NOT NULL CHECK (char_length(email) BETWEEN 3 AND 320),
+  enabled boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE public.archive_completion_notification_outbox (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  archive_upload_id bigint NOT NULL UNIQUE
+    REFERENCES public.archive_upload(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  account_id text NOT NULL CHECK (account_id ~ '^[0-9]{1,20}$'),
+  recipient_email text NOT NULL CHECK (char_length(recipient_email) BETWEEN 3 AND 320),
+  archive_username text,
+  archive_at timestamptz NOT NULL,
+  status text NOT NULL DEFAULT 'queued'
+    CHECK (status IN ('queued', 'processing', 'retry', 'sent', 'dead', 'cancelled')),
+  attempt_count integer NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+  available_at timestamptz NOT NULL DEFAULT now(),
+  locked_at timestamptz,
+  sent_at timestamptz,
+  provider_message_id text,
+  last_error text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX archive_completion_notification_outbox_ready_idx
+  ON public.archive_completion_notification_outbox (available_at, id)
+  WHERE status IN ('queued', 'retry');
+
+CREATE INDEX archive_completion_notification_outbox_status_created_idx
+  ON public.archive_completion_notification_outbox (status, created_at);
+
+ALTER TABLE public.archive_completion_notification_preferences ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.archive_completion_notification_outbox ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Owners can read archive completion notification preference"
+  ON public.archive_completion_notification_preferences
+  FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+REVOKE ALL PRIVILEGES ON TABLE public.archive_completion_notification_preferences
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL PRIVILEGES ON TABLE public.archive_completion_notification_outbox
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL PRIVILEGES ON SEQUENCE public.archive_completion_notification_outbox_id_seq
+  FROM PUBLIC, anon, authenticated;
+
+GRANT SELECT ON TABLE public.archive_completion_notification_preferences TO authenticated;
+GRANT ALL PRIVILEGES ON TABLE public.archive_completion_notification_preferences TO service_role;
+GRANT ALL PRIVILEGES ON TABLE public.archive_completion_notification_outbox TO service_role;
+GRANT USAGE, SELECT ON SEQUENCE public.archive_completion_notification_outbox_id_seq TO service_role;
+
+CREATE OR REPLACE FUNCTION public.set_archive_completion_notification(p_enabled boolean)
+RETURNS TABLE(enabled boolean, email text)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_account_id text;
+  v_email text;
+  v_email_confirmed_at timestamptz;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Authentication required' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT
+    NULLIF(BTRIM(u.raw_app_meta_data->>'provider_id'), ''),
+    NULLIF(BTRIM(LOWER(u.email)), ''),
+    u.email_confirmed_at
+  INTO v_account_id, v_email, v_email_confirmed_at
+  FROM auth.users AS u
+  WHERE u.id = v_user_id;
+
+  -- Disabling must remain possible even if an identity later loses its email or
+  -- provider metadata. Do not create a preference row for a never-opted-in user.
+  IF NOT p_enabled THEN
+    UPDATE public.archive_completion_notification_preferences
+    SET enabled = false, updated_at = now()
+    WHERE user_id = v_user_id;
+
+    UPDATE public.archive_completion_notification_outbox
+    SET status = 'cancelled',
+        locked_at = NULL,
+        updated_at = now(),
+        last_error = 'Cancelled after the owner disabled notifications'
+    WHERE user_id = v_user_id
+      AND status IN ('queued', 'retry');
+
+    RETURN QUERY SELECT false, v_email;
+    RETURN;
+  END IF;
+
+  IF v_account_id IS NULL OR v_account_id !~ '^[0-9]{1,20}$' THEN
+    RAISE EXCEPTION 'A verified X account is required' USING ERRCODE = '22023';
+  END IF;
+
+  IF v_email IS NULL OR v_email_confirmed_at IS NULL THEN
+    RAISE EXCEPTION 'A confirmed email address is required' USING ERRCODE = '22023';
+  END IF;
+
+  INSERT INTO public.archive_completion_notification_preferences (
+    user_id, account_id, email, enabled, updated_at
+  )
+  VALUES (v_user_id, v_account_id, v_email, true, now())
+  ON CONFLICT (user_id) DO UPDATE
+  SET account_id = EXCLUDED.account_id,
+      email = EXCLUDED.email,
+      enabled = true,
+      updated_at = now();
+
+  RETURN QUERY SELECT true, v_email;
+END;
+$$;
+ALTER FUNCTION public.set_archive_completion_notification(boolean) OWNER TO postgres;
+
+CREATE OR REPLACE FUNCTION private.queue_archive_completion_notification()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_preference public.archive_completion_notification_preferences%ROWTYPE;
+BEGIN
+  IF NEW.upload_phase = 'completed'
+     AND (TG_OP = 'INSERT' OR OLD.upload_phase IS DISTINCT FROM 'completed')
+  THEN
+    SELECT * INTO v_preference
+    FROM public.archive_completion_notification_preferences
+    WHERE account_id = NEW.account_id
+      AND enabled IS TRUE;
+
+    IF FOUND THEN
+      INSERT INTO public.archive_completion_notification_outbox (
+        archive_upload_id,
+        user_id,
+        account_id,
+        recipient_email,
+        archive_username,
+        archive_at
+      ) VALUES (
+        NEW.id,
+        v_preference.user_id,
+        NEW.account_id,
+        v_preference.email,
+        NEW.username,
+        NEW.archive_at
+      ) ON CONFLICT (archive_upload_id) DO NOTHING;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+ALTER FUNCTION private.queue_archive_completion_notification() OWNER TO postgres;
+
+CREATE TRIGGER queue_archive_completion_notification
+  AFTER INSERT OR UPDATE OF upload_phase ON public.archive_upload
+  FOR EACH ROW EXECUTE FUNCTION private.queue_archive_completion_notification();
+
+CREATE OR REPLACE FUNCTION public.claim_archive_completion_notifications(p_limit integer DEFAULT 20)
+RETURNS TABLE(
+  id bigint,
+  recipient_email text,
+  account_id text,
+  archive_username text,
+  archive_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF p_limit < 1 OR p_limit > 100 THEN
+    RAISE EXCEPTION 'p_limit must be between 1 and 100' USING ERRCODE = '22023';
+  END IF;
+
+  UPDATE public.archive_completion_notification_outbox AS stale
+  SET status = 'retry',
+      available_at = now(),
+      locked_at = NULL,
+      updated_at = now(),
+      last_error = COALESCE(stale.last_error, 'Recovered an abandoned delivery claim')
+  WHERE stale.status = 'processing'
+    AND stale.locked_at < now() - interval '15 minutes';
+
+  RETURN QUERY
+  WITH ready AS (
+    SELECT candidate.id
+    FROM public.archive_completion_notification_outbox AS candidate
+    WHERE candidate.status IN ('queued', 'retry')
+      AND candidate.available_at <= now()
+    ORDER BY candidate.available_at, candidate.id
+    LIMIT p_limit
+    FOR UPDATE SKIP LOCKED
+  )
+  UPDATE public.archive_completion_notification_outbox AS claimed
+  SET status = 'processing',
+      attempt_count = claimed.attempt_count + 1,
+      locked_at = now(),
+      updated_at = now()
+  FROM ready
+  WHERE claimed.id = ready.id
+  RETURNING
+    claimed.id,
+    claimed.recipient_email,
+    claimed.account_id,
+    claimed.archive_username,
+    claimed.archive_at;
+END;
+$$;
+ALTER FUNCTION public.claim_archive_completion_notifications(integer) OWNER TO postgres;
+
+CREATE OR REPLACE FUNCTION public.finish_archive_completion_notification(
+  p_id bigint,
+  p_provider_message_id text DEFAULT NULL,
+  p_error text DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF p_error IS NULL THEN
+    UPDATE public.archive_completion_notification_outbox
+    SET status = 'sent',
+        sent_at = now(),
+        locked_at = NULL,
+        provider_message_id = NULLIF(BTRIM(p_provider_message_id), ''),
+        last_error = NULL,
+        updated_at = now()
+    WHERE id = p_id AND status = 'processing';
+  ELSE
+    UPDATE public.archive_completion_notification_outbox
+    SET status = CASE WHEN attempt_count >= 5 THEN 'dead' ELSE 'retry' END,
+        available_at = now() + CASE attempt_count
+          WHEN 1 THEN interval '1 minute'
+          WHEN 2 THEN interval '5 minutes'
+          WHEN 3 THEN interval '30 minutes'
+          WHEN 4 THEN interval '2 hours'
+          ELSE interval '6 hours'
+        END,
+        locked_at = NULL,
+        last_error = LEFT(p_error, 2000),
+        updated_at = now()
+    WHERE id = p_id AND status = 'processing';
+  END IF;
+END;
+$$;
+ALTER FUNCTION public.finish_archive_completion_notification(bigint, text, text) OWNER TO postgres;
+
+CREATE OR REPLACE FUNCTION public.community_archive_monitoring_completion_notifications()
+RETURNS TABLE(
+  ready_count bigint,
+  processing_count bigint,
+  dead_24h_count bigint,
+  oldest_ready_seconds double precision,
+  seconds_since_last_sent double precision
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT
+    COUNT(*) FILTER (WHERE status IN ('queued', 'retry') AND available_at <= now()),
+    COUNT(*) FILTER (WHERE status = 'processing'),
+    COUNT(*) FILTER (WHERE status = 'dead' AND updated_at >= now() - interval '24 hours'),
+    EXTRACT(EPOCH FROM now() - MIN(created_at) FILTER (WHERE status IN ('queued', 'retry'))),
+    EXTRACT(EPOCH FROM now() - MAX(sent_at) FILTER (WHERE status = 'sent'))
+  FROM public.archive_completion_notification_outbox;
+$$;
+ALTER FUNCTION public.community_archive_monitoring_completion_notifications() OWNER TO postgres;
+
+REVOKE EXECUTE ON FUNCTION public.set_archive_completion_notification(boolean)
+  FROM PUBLIC, anon, service_role;
+REVOKE EXECUTE ON FUNCTION private.queue_archive_completion_notification()
+  FROM PUBLIC, anon, authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.claim_archive_completion_notifications(integer)
+  FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.finish_archive_completion_notification(bigint, text, text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.community_archive_monitoring_completion_notifications()
+  FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.set_archive_completion_notification(boolean)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION public.claim_archive_completion_notifications(integer)
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.finish_archive_completion_notification(bigint, text, text)
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.community_archive_monitoring_completion_notifications()
+  TO service_role;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'community_archive_metrics') THEN
+    GRANT EXECUTE ON FUNCTION public.community_archive_monitoring_completion_notifications()
+      TO community_archive_metrics;
+  END IF;
+END
+$$;

--- a/supabase/migrations/20260815094500_add_archive_completion_notifications.sql
+++ b/supabase/migrations/20260815094500_add_archive_completion_notifications.sql
@@ -31,6 +31,17 @@ CREATE TABLE public.archive_completion_notification_outbox (
   updated_at timestamptz NOT NULL DEFAULT now()
 );
 
+CREATE TABLE public.archive_completion_notification_worker_state (
+  singleton boolean PRIMARY KEY DEFAULT true CHECK (singleton IS TRUE),
+  last_started_at timestamptz,
+  last_finished_at timestamptz,
+  last_claimed integer NOT NULL DEFAULT 0 CHECK (last_claimed >= 0),
+  last_sent integer NOT NULL DEFAULT 0 CHECK (last_sent >= 0),
+  last_failed integer NOT NULL DEFAULT 0 CHECK (last_failed >= 0),
+  last_error text,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
 CREATE INDEX archive_completion_notification_outbox_ready_idx
   ON public.archive_completion_notification_outbox (available_at, id)
   WHERE status IN ('queued', 'retry');
@@ -40,6 +51,7 @@ CREATE INDEX archive_completion_notification_outbox_status_created_idx
 
 ALTER TABLE public.archive_completion_notification_preferences ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.archive_completion_notification_outbox ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.archive_completion_notification_worker_state ENABLE ROW LEVEL SECURITY;
 
 CREATE POLICY "Owners can read archive completion notification preference"
   ON public.archive_completion_notification_preferences
@@ -50,12 +62,15 @@ REVOKE ALL PRIVILEGES ON TABLE public.archive_completion_notification_preference
   FROM PUBLIC, anon, authenticated;
 REVOKE ALL PRIVILEGES ON TABLE public.archive_completion_notification_outbox
   FROM PUBLIC, anon, authenticated;
+REVOKE ALL PRIVILEGES ON TABLE public.archive_completion_notification_worker_state
+  FROM PUBLIC, anon, authenticated;
 REVOKE ALL PRIVILEGES ON SEQUENCE public.archive_completion_notification_outbox_id_seq
   FROM PUBLIC, anon, authenticated;
 
 GRANT SELECT ON TABLE public.archive_completion_notification_preferences TO authenticated;
 GRANT ALL PRIVILEGES ON TABLE public.archive_completion_notification_preferences TO service_role;
 GRANT ALL PRIVILEGES ON TABLE public.archive_completion_notification_outbox TO service_role;
+GRANT ALL PRIVILEGES ON TABLE public.archive_completion_notification_worker_state TO service_role;
 GRANT USAGE, SELECT ON SEQUENCE public.archive_completion_notification_outbox_id_seq TO service_role;
 
 CREATE OR REPLACE FUNCTION public.set_archive_completion_notification(p_enabled boolean)
@@ -186,6 +201,12 @@ BEGIN
     RAISE EXCEPTION 'p_limit must be between 1 and 100' USING ERRCODE = '22023';
   END IF;
 
+  INSERT INTO public.archive_completion_notification_worker_state (
+    singleton, last_started_at, updated_at
+  ) VALUES (true, now(), now())
+  ON CONFLICT (singleton) DO UPDATE
+  SET last_started_at = now(), updated_at = now();
+
   UPDATE public.archive_completion_notification_outbox AS stale
   SET status = 'retry',
       available_at = now(),
@@ -221,6 +242,34 @@ BEGIN
 END;
 $$;
 ALTER FUNCTION public.claim_archive_completion_notifications(integer) OWNER TO postgres;
+
+CREATE OR REPLACE FUNCTION public.finish_archive_completion_notification_run(
+  p_claimed integer,
+  p_sent integer,
+  p_failed integer,
+  p_error text DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF p_claimed < 0 OR p_sent < 0 OR p_failed < 0 OR p_sent + p_failed > p_claimed THEN
+    RAISE EXCEPTION 'Invalid notification run counts' USING ERRCODE = '22023';
+  END IF;
+
+  UPDATE public.archive_completion_notification_worker_state
+  SET last_finished_at = now(),
+      last_claimed = p_claimed,
+      last_sent = p_sent,
+      last_failed = p_failed,
+      last_error = LEFT(NULLIF(BTRIM(p_error), ''), 2000),
+      updated_at = now()
+  WHERE singleton IS TRUE;
+END;
+$$;
+ALTER FUNCTION public.finish_archive_completion_notification_run(integer, integer, integer, text) OWNER TO postgres;
 
 CREATE OR REPLACE FUNCTION public.finish_archive_completion_notification(
   p_id bigint,
@@ -267,7 +316,12 @@ RETURNS TABLE(
   processing_count bigint,
   dead_24h_count bigint,
   oldest_ready_seconds double precision,
-  seconds_since_last_sent double precision
+  seconds_since_last_sent double precision,
+  worker_last_started_timestamp_seconds double precision,
+  worker_last_finished_timestamp_seconds double precision,
+  worker_last_claimed integer,
+  worker_last_sent integer,
+  worker_last_failed integer
 )
 LANGUAGE sql
 STABLE
@@ -275,12 +329,26 @@ SECURITY DEFINER
 SET search_path = ''
 AS $$
   SELECT
-    COUNT(*) FILTER (WHERE status IN ('queued', 'retry') AND available_at <= now()),
-    COUNT(*) FILTER (WHERE status = 'processing'),
-    COUNT(*) FILTER (WHERE status = 'dead' AND updated_at >= now() - interval '24 hours'),
-    EXTRACT(EPOCH FROM now() - MIN(created_at) FILTER (WHERE status IN ('queued', 'retry'))),
-    EXTRACT(EPOCH FROM now() - MAX(sent_at) FILTER (WHERE status = 'sent'))
-  FROM public.archive_completion_notification_outbox;
+    (SELECT COUNT(*) FROM public.archive_completion_notification_outbox
+      WHERE status IN ('queued', 'retry') AND available_at <= now()),
+    (SELECT COUNT(*) FROM public.archive_completion_notification_outbox
+      WHERE status = 'processing'),
+    (SELECT COUNT(*) FROM public.archive_completion_notification_outbox
+      WHERE status = 'dead' AND updated_at >= now() - interval '24 hours'),
+    (SELECT EXTRACT(EPOCH FROM now() - MIN(created_at))
+      FROM public.archive_completion_notification_outbox
+      WHERE status IN ('queued', 'retry')),
+    (SELECT EXTRACT(EPOCH FROM now() - MAX(sent_at))
+      FROM public.archive_completion_notification_outbox
+      WHERE status = 'sent'),
+    EXTRACT(EPOCH FROM worker.last_started_at),
+    EXTRACT(EPOCH FROM worker.last_finished_at),
+    COALESCE(worker.last_claimed, 0),
+    COALESCE(worker.last_sent, 0),
+    COALESCE(worker.last_failed, 0)
+  FROM (SELECT true AS singleton) AS seed
+  LEFT JOIN public.archive_completion_notification_worker_state AS worker
+    ON worker.singleton = seed.singleton;
 $$;
 ALTER FUNCTION public.community_archive_monitoring_completion_notifications() OWNER TO postgres;
 
@@ -292,6 +360,8 @@ REVOKE EXECUTE ON FUNCTION public.claim_archive_completion_notifications(integer
   FROM PUBLIC, anon, authenticated;
 REVOKE EXECUTE ON FUNCTION public.finish_archive_completion_notification(bigint, text, text)
   FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.finish_archive_completion_notification_run(integer, integer, integer, text)
+  FROM PUBLIC, anon, authenticated;
 REVOKE EXECUTE ON FUNCTION public.community_archive_monitoring_completion_notifications()
   FROM PUBLIC, anon, authenticated;
 
@@ -301,14 +371,16 @@ GRANT EXECUTE ON FUNCTION public.claim_archive_completion_notifications(integer)
   TO service_role;
 GRANT EXECUTE ON FUNCTION public.finish_archive_completion_notification(bigint, text, text)
   TO service_role;
+GRANT EXECUTE ON FUNCTION public.finish_archive_completion_notification_run(integer, integer, integer, text)
+  TO service_role;
 GRANT EXECUTE ON FUNCTION public.community_archive_monitoring_completion_notifications()
   TO service_role;
 
 DO $$
 BEGIN
-  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'community_archive_metrics') THEN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'archive_metrics_exporter') THEN
     GRANT EXECUTE ON FUNCTION public.community_archive_monitoring_completion_notifications()
-      TO community_archive_metrics;
+      TO archive_metrics_exporter;
   END IF;
 END
 $$;

--- a/supabase/schemas/020_tables.sql
+++ b/supabase/schemas/020_tables.sql
@@ -253,6 +253,38 @@ CREATE TABLE IF NOT EXISTS "public"."user_action_log" (
 );
 ALTER TABLE "public"."user_action_log" OWNER TO "postgres";
 
+-- Explicit owner preference and private delivery outbox for archive-completion
+-- email. The outbox snapshots the verified recipient when an upload completes.
+CREATE TABLE IF NOT EXISTS "public"."archive_completion_notification_preferences" (
+    "user_id" uuid PRIMARY KEY REFERENCES "auth"."users"("id") ON DELETE CASCADE,
+    "account_id" text NOT NULL UNIQUE CHECK ("account_id" ~ '^[0-9]{1,20}$'),
+    "email" text NOT NULL CHECK (char_length("email") BETWEEN 3 AND 320),
+    "enabled" boolean NOT NULL DEFAULT false,
+    "created_at" timestamptz NOT NULL DEFAULT now(),
+    "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+ALTER TABLE "public"."archive_completion_notification_preferences" OWNER TO "postgres";
+
+CREATE TABLE IF NOT EXISTS "public"."archive_completion_notification_outbox" (
+    "id" bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    "archive_upload_id" bigint NOT NULL UNIQUE REFERENCES "public"."archive_upload"("id") ON DELETE CASCADE,
+    "user_id" uuid NOT NULL REFERENCES "auth"."users"("id") ON DELETE CASCADE,
+    "account_id" text NOT NULL CHECK ("account_id" ~ '^[0-9]{1,20}$'),
+    "recipient_email" text NOT NULL CHECK (char_length("recipient_email") BETWEEN 3 AND 320),
+    "archive_username" text,
+    "archive_at" timestamptz NOT NULL,
+    "status" text NOT NULL DEFAULT 'queued' CHECK ("status" IN ('queued', 'processing', 'retry', 'sent', 'dead', 'cancelled')),
+    "attempt_count" integer NOT NULL DEFAULT 0 CHECK ("attempt_count" >= 0),
+    "available_at" timestamptz NOT NULL DEFAULT now(),
+    "locked_at" timestamptz,
+    "sent_at" timestamptz,
+    "provider_message_id" text,
+    "last_error" text,
+    "created_at" timestamptz NOT NULL DEFAULT now(),
+    "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+ALTER TABLE "public"."archive_completion_notification_outbox" OWNER TO "postgres";
+
 -- Daily Digest editorial state. Analytical candidates come from ClickHouse,
 -- while PostgreSQL owns prompt/run history and publication status.
 CREATE TABLE IF NOT EXISTS "public"."digest_prompt_versions" (

--- a/supabase/schemas/020_tables.sql
+++ b/supabase/schemas/020_tables.sql
@@ -285,6 +285,18 @@ CREATE TABLE IF NOT EXISTS "public"."archive_completion_notification_outbox" (
 );
 ALTER TABLE "public"."archive_completion_notification_outbox" OWNER TO "postgres";
 
+CREATE TABLE IF NOT EXISTS "public"."archive_completion_notification_worker_state" (
+    "singleton" boolean PRIMARY KEY DEFAULT true CHECK ("singleton" IS TRUE),
+    "last_started_at" timestamptz,
+    "last_finished_at" timestamptz,
+    "last_claimed" integer NOT NULL DEFAULT 0 CHECK ("last_claimed" >= 0),
+    "last_sent" integer NOT NULL DEFAULT 0 CHECK ("last_sent" >= 0),
+    "last_failed" integer NOT NULL DEFAULT 0 CHECK ("last_failed" >= 0),
+    "last_error" text,
+    "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+ALTER TABLE "public"."archive_completion_notification_worker_state" OWNER TO "postgres";
+
 -- Daily Digest editorial state. Analytical candidates come from ClickHouse,
 -- while PostgreSQL owns prompt/run history and publication status.
 CREATE TABLE IF NOT EXISTS "public"."digest_prompt_versions" (

--- a/supabase/schemas/030_indexes.sql
+++ b/supabase/schemas/030_indexes.sql
@@ -85,6 +85,12 @@ CREATE INDEX IF NOT EXISTS user_action_log_user_id_created_at_idx
 CREATE INDEX IF NOT EXISTS user_action_log_action_type_created_at_idx
   ON public.user_action_log (action_type, created_at DESC);
 
+CREATE INDEX IF NOT EXISTS archive_completion_notification_outbox_ready_idx
+  ON public.archive_completion_notification_outbox (available_at, id)
+  WHERE status IN ('queued', 'retry');
+CREATE INDEX IF NOT EXISTS archive_completion_notification_outbox_status_created_idx
+  ON public.archive_completion_notification_outbox (status, created_at);
+
 -- public.all_account: username is a hot lookup key (search_tweets from:/to:,
 -- get_tweet_page_data, client .eq/.in('username')). See #387.
 CREATE INDEX IF NOT EXISTS "idx_all_account_username"

--- a/supabase/schemas/060_grants.sql
+++ b/supabase/schemas/060_grants.sql
@@ -49,10 +49,12 @@ GRANT ALL ON TABLE "public"."tweet_link_previews" TO "service_role";
 -- and recipient snapshots are service-only.
 REVOKE ALL PRIVILEGES ON TABLE "public"."archive_completion_notification_preferences" FROM PUBLIC, "anon", "authenticated";
 REVOKE ALL PRIVILEGES ON TABLE "public"."archive_completion_notification_outbox" FROM PUBLIC, "anon", "authenticated";
+REVOKE ALL PRIVILEGES ON TABLE "public"."archive_completion_notification_worker_state" FROM PUBLIC, "anon", "authenticated";
 REVOKE ALL PRIVILEGES ON SEQUENCE "public"."archive_completion_notification_outbox_id_seq" FROM PUBLIC, "anon", "authenticated";
 GRANT SELECT ON TABLE "public"."archive_completion_notification_preferences" TO "authenticated";
 GRANT ALL PRIVILEGES ON TABLE "public"."archive_completion_notification_preferences" TO "service_role";
 GRANT ALL PRIVILEGES ON TABLE "public"."archive_completion_notification_outbox" TO "service_role";
+GRANT ALL PRIVILEGES ON TABLE "public"."archive_completion_notification_worker_state" TO "service_role";
 GRANT USAGE, SELECT ON SEQUENCE "public"."archive_completion_notification_outbox_id_seq" TO "service_role";
 
 -- quote_tweets / retweets: read-only for anon/authenticated; writes via service_role

--- a/supabase/schemas/060_grants.sql
+++ b/supabase/schemas/060_grants.sql
@@ -45,6 +45,16 @@ GRANT ALL ON TABLE "public"."profile_settings" TO "service_role";
 GRANT ALL ON TABLE "public"."profile_curation" TO "service_role";
 GRANT ALL ON TABLE "public"."tweet_link_previews" TO "service_role";
 
+-- Archive-completion preference is owner-readable and RPC-written. Its outbox
+-- and recipient snapshots are service-only.
+REVOKE ALL PRIVILEGES ON TABLE "public"."archive_completion_notification_preferences" FROM PUBLIC, "anon", "authenticated";
+REVOKE ALL PRIVILEGES ON TABLE "public"."archive_completion_notification_outbox" FROM PUBLIC, "anon", "authenticated";
+REVOKE ALL PRIVILEGES ON SEQUENCE "public"."archive_completion_notification_outbox_id_seq" FROM PUBLIC, "anon", "authenticated";
+GRANT SELECT ON TABLE "public"."archive_completion_notification_preferences" TO "authenticated";
+GRANT ALL PRIVILEGES ON TABLE "public"."archive_completion_notification_preferences" TO "service_role";
+GRANT ALL PRIVILEGES ON TABLE "public"."archive_completion_notification_outbox" TO "service_role";
+GRANT USAGE, SELECT ON SEQUENCE "public"."archive_completion_notification_outbox_id_seq" TO "service_role";
+
 -- quote_tweets / retweets: read-only for anon/authenticated; writes via service_role
 -- only (firehose + worker). See #369. The blanket "GRANT ALL ON TABLE ... TO anon"
 -- previously applied to these tables (via ALTER DEFAULT PRIVILEGES in prod.sql) is

--- a/supabase/schemas/060_policies.sql
+++ b/supabase/schemas/060_policies.sql
@@ -190,6 +190,14 @@ CREATE POLICY "Tweet link previews are publicly visible"
 -- Service role bypasses RLS for the trigger and admin reads.
 ALTER TABLE "public"."user_action_log" ENABLE ROW LEVEL SECURITY;
 
+ALTER TABLE "public"."archive_completion_notification_preferences" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."archive_completion_notification_outbox" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Owners can read archive completion notification preference"
+  ON "public"."archive_completion_notification_preferences"
+  FOR SELECT TO "authenticated"
+  USING ("user_id" = auth.uid());
+
 CREATE POLICY "Users can insert own action log" ON "public"."user_action_log"
   FOR INSERT TO authenticated WITH CHECK (
     user_id = auth.uid()

--- a/supabase/schemas/060_policies.sql
+++ b/supabase/schemas/060_policies.sql
@@ -192,6 +192,7 @@ ALTER TABLE "public"."user_action_log" ENABLE ROW LEVEL SECURITY;
 
 ALTER TABLE "public"."archive_completion_notification_preferences" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."archive_completion_notification_outbox" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."archive_completion_notification_worker_state" ENABLE ROW LEVEL SECURITY;
 
 CREATE POLICY "Owners can read archive completion notification preference"
   ON "public"."archive_completion_notification_preferences"

--- a/supabase/schemas/070_functions.sql
+++ b/supabase/schemas/070_functions.sql
@@ -3051,6 +3051,12 @@ BEGIN
     RAISE EXCEPTION 'p_limit must be between 1 and 100' USING ERRCODE = '22023';
   END IF;
 
+  INSERT INTO public.archive_completion_notification_worker_state (
+    singleton, last_started_at, updated_at
+  ) VALUES (true, now(), now())
+  ON CONFLICT (singleton) DO UPDATE
+  SET last_started_at = now(), updated_at = now();
+
   UPDATE public.archive_completion_notification_outbox AS stale
   SET status = 'retry', available_at = now(), locked_at = NULL,
       updated_at = now(),
@@ -3078,6 +3084,32 @@ BEGIN
 END;
 $$;
 ALTER FUNCTION public.claim_archive_completion_notifications(integer) OWNER TO postgres;
+
+CREATE OR REPLACE FUNCTION public.finish_archive_completion_notification_run(
+  p_claimed integer,
+  p_sent integer,
+  p_failed integer,
+  p_error text DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ''
+AS $$
+BEGIN
+  IF p_claimed < 0 OR p_sent < 0 OR p_failed < 0 OR p_sent + p_failed > p_claimed THEN
+    RAISE EXCEPTION 'Invalid notification run counts' USING ERRCODE = '22023';
+  END IF;
+
+  UPDATE public.archive_completion_notification_worker_state
+  SET last_finished_at = now(),
+      last_claimed = p_claimed,
+      last_sent = p_sent,
+      last_failed = p_failed,
+      last_error = LEFT(NULLIF(BTRIM(p_error), ''), 2000),
+      updated_at = now()
+  WHERE singleton IS TRUE;
+END;
+$$;
+ALTER FUNCTION public.finish_archive_completion_notification_run(integer, integer, integer, text) OWNER TO postgres;
 
 CREATE OR REPLACE FUNCTION public.finish_archive_completion_notification(
   p_id bigint,
@@ -3119,17 +3151,36 @@ RETURNS TABLE(
   processing_count bigint,
   dead_24h_count bigint,
   oldest_ready_seconds double precision,
-  seconds_since_last_sent double precision
+  seconds_since_last_sent double precision,
+  worker_last_started_timestamp_seconds double precision,
+  worker_last_finished_timestamp_seconds double precision,
+  worker_last_claimed integer,
+  worker_last_sent integer,
+  worker_last_failed integer
 )
 LANGUAGE sql STABLE SECURITY DEFINER SET search_path = ''
 AS $$
   SELECT
-    COUNT(*) FILTER (WHERE status IN ('queued', 'retry') AND available_at <= now()),
-    COUNT(*) FILTER (WHERE status = 'processing'),
-    COUNT(*) FILTER (WHERE status = 'dead' AND updated_at >= now() - interval '24 hours'),
-    EXTRACT(EPOCH FROM now() - MIN(created_at) FILTER (WHERE status IN ('queued', 'retry'))),
-    EXTRACT(EPOCH FROM now() - MAX(sent_at) FILTER (WHERE status = 'sent'))
-  FROM public.archive_completion_notification_outbox;
+    (SELECT COUNT(*) FROM public.archive_completion_notification_outbox
+      WHERE status IN ('queued', 'retry') AND available_at <= now()),
+    (SELECT COUNT(*) FROM public.archive_completion_notification_outbox
+      WHERE status = 'processing'),
+    (SELECT COUNT(*) FROM public.archive_completion_notification_outbox
+      WHERE status = 'dead' AND updated_at >= now() - interval '24 hours'),
+    (SELECT EXTRACT(EPOCH FROM now() - MIN(created_at))
+      FROM public.archive_completion_notification_outbox
+      WHERE status IN ('queued', 'retry')),
+    (SELECT EXTRACT(EPOCH FROM now() - MAX(sent_at))
+      FROM public.archive_completion_notification_outbox
+      WHERE status = 'sent'),
+    EXTRACT(EPOCH FROM worker.last_started_at),
+    EXTRACT(EPOCH FROM worker.last_finished_at),
+    COALESCE(worker.last_claimed, 0),
+    COALESCE(worker.last_sent, 0),
+    COALESCE(worker.last_failed, 0)
+  FROM (SELECT true AS singleton) AS seed
+  LEFT JOIN public.archive_completion_notification_worker_state AS worker
+    ON worker.singleton = seed.singleton;
 $$;
 ALTER FUNCTION public.community_archive_monitoring_completion_notifications() OWNER TO postgres;
 
@@ -3137,17 +3188,19 @@ REVOKE EXECUTE ON FUNCTION public.set_archive_completion_notification(boolean) F
 REVOKE EXECUTE ON FUNCTION private.queue_archive_completion_notification() FROM PUBLIC, anon, authenticated, service_role;
 REVOKE EXECUTE ON FUNCTION public.claim_archive_completion_notifications(integer) FROM PUBLIC, anon, authenticated;
 REVOKE EXECUTE ON FUNCTION public.finish_archive_completion_notification(bigint, text, text) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.finish_archive_completion_notification_run(integer, integer, integer, text) FROM PUBLIC, anon, authenticated;
 REVOKE EXECUTE ON FUNCTION public.community_archive_monitoring_completion_notifications() FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.set_archive_completion_notification(boolean) TO authenticated;
 GRANT EXECUTE ON FUNCTION public.claim_archive_completion_notifications(integer) TO service_role;
 GRANT EXECUTE ON FUNCTION public.finish_archive_completion_notification(bigint, text, text) TO service_role;
+GRANT EXECUTE ON FUNCTION public.finish_archive_completion_notification_run(integer, integer, integer, text) TO service_role;
 GRANT EXECUTE ON FUNCTION public.community_archive_monitoring_completion_notifications() TO service_role;
 
 DO $$
 BEGIN
-  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'community_archive_metrics') THEN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'archive_metrics_exporter') THEN
     GRANT EXECUTE ON FUNCTION public.community_archive_monitoring_completion_notifications()
-      TO community_archive_metrics;
+      TO archive_metrics_exporter;
   END IF;
 END
 $$;

--- a/supabase/schemas/070_functions.sql
+++ b/supabase/schemas/070_functions.sql
@@ -2946,6 +2946,212 @@ END;
 $$;
 ALTER FUNCTION public.log_archive_upload_event() OWNER TO postgres;
 
+-- Auth-backed owner preference. The recipient is always read from auth.users,
+-- never accepted from an untrusted browser payload.
+CREATE OR REPLACE FUNCTION public.set_archive_completion_notification(p_enabled boolean)
+RETURNS TABLE(enabled boolean, email text)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ''
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_account_id text;
+  v_email text;
+  v_email_confirmed_at timestamptz;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Authentication required' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT
+    NULLIF(BTRIM(u.raw_app_meta_data->>'provider_id'), ''),
+    NULLIF(BTRIM(LOWER(u.email)), ''),
+    u.email_confirmed_at
+  INTO v_account_id, v_email, v_email_confirmed_at
+  FROM auth.users AS u
+  WHERE u.id = v_user_id;
+
+  -- Disabling must remain possible even if an identity later loses its email or
+  -- provider metadata. Do not create a preference row for a never-opted-in user.
+  IF NOT p_enabled THEN
+    UPDATE public.archive_completion_notification_preferences
+    SET enabled = false, updated_at = now()
+    WHERE user_id = v_user_id;
+
+    UPDATE public.archive_completion_notification_outbox
+    SET status = 'cancelled', locked_at = NULL, updated_at = now(),
+        last_error = 'Cancelled after the owner disabled notifications'
+    WHERE user_id = v_user_id AND status IN ('queued', 'retry');
+
+    RETURN QUERY SELECT false, v_email;
+    RETURN;
+  END IF;
+
+  IF v_account_id IS NULL OR v_account_id !~ '^[0-9]{1,20}$' THEN
+    RAISE EXCEPTION 'A verified X account is required' USING ERRCODE = '22023';
+  END IF;
+  IF v_email IS NULL OR v_email_confirmed_at IS NULL THEN
+    RAISE EXCEPTION 'A confirmed email address is required' USING ERRCODE = '22023';
+  END IF;
+
+  INSERT INTO public.archive_completion_notification_preferences (
+    user_id, account_id, email, enabled, updated_at
+  ) VALUES (v_user_id, v_account_id, v_email, true, now())
+  ON CONFLICT (user_id) DO UPDATE
+  SET account_id = EXCLUDED.account_id,
+      email = EXCLUDED.email,
+      enabled = true,
+      updated_at = now();
+
+  RETURN QUERY SELECT true, v_email;
+END;
+$$;
+ALTER FUNCTION public.set_archive_completion_notification(boolean) OWNER TO postgres;
+
+CREATE OR REPLACE FUNCTION private.queue_archive_completion_notification()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ''
+AS $$
+DECLARE
+  v_preference public.archive_completion_notification_preferences%ROWTYPE;
+BEGIN
+  IF NEW.upload_phase = 'completed'
+     AND (TG_OP = 'INSERT' OR OLD.upload_phase IS DISTINCT FROM 'completed')
+  THEN
+    SELECT * INTO v_preference
+    FROM public.archive_completion_notification_preferences
+    WHERE account_id = NEW.account_id AND enabled IS TRUE;
+
+    IF FOUND THEN
+      INSERT INTO public.archive_completion_notification_outbox (
+        archive_upload_id, user_id, account_id, recipient_email,
+        archive_username, archive_at
+      ) VALUES (
+        NEW.id, v_preference.user_id, NEW.account_id, v_preference.email,
+        NEW.username, NEW.archive_at
+      ) ON CONFLICT (archive_upload_id) DO NOTHING;
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+ALTER FUNCTION private.queue_archive_completion_notification() OWNER TO postgres;
+
+CREATE OR REPLACE FUNCTION public.claim_archive_completion_notifications(p_limit integer DEFAULT 20)
+RETURNS TABLE(
+  id bigint,
+  recipient_email text,
+  account_id text,
+  archive_username text,
+  archive_at timestamptz
+)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ''
+AS $$
+BEGIN
+  IF p_limit < 1 OR p_limit > 100 THEN
+    RAISE EXCEPTION 'p_limit must be between 1 and 100' USING ERRCODE = '22023';
+  END IF;
+
+  UPDATE public.archive_completion_notification_outbox AS stale
+  SET status = 'retry', available_at = now(), locked_at = NULL,
+      updated_at = now(),
+      last_error = COALESCE(stale.last_error, 'Recovered an abandoned delivery claim')
+  WHERE stale.status = 'processing'
+    AND stale.locked_at < now() - interval '15 minutes';
+
+  RETURN QUERY
+  WITH ready AS (
+    SELECT candidate.id
+    FROM public.archive_completion_notification_outbox AS candidate
+    WHERE candidate.status IN ('queued', 'retry')
+      AND candidate.available_at <= now()
+    ORDER BY candidate.available_at, candidate.id
+    LIMIT p_limit
+    FOR UPDATE SKIP LOCKED
+  )
+  UPDATE public.archive_completion_notification_outbox AS claimed
+  SET status = 'processing', attempt_count = claimed.attempt_count + 1,
+      locked_at = now(), updated_at = now()
+  FROM ready
+  WHERE claimed.id = ready.id
+  RETURNING claimed.id, claimed.recipient_email, claimed.account_id,
+            claimed.archive_username, claimed.archive_at;
+END;
+$$;
+ALTER FUNCTION public.claim_archive_completion_notifications(integer) OWNER TO postgres;
+
+CREATE OR REPLACE FUNCTION public.finish_archive_completion_notification(
+  p_id bigint,
+  p_provider_message_id text DEFAULT NULL,
+  p_error text DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ''
+AS $$
+BEGIN
+  IF p_error IS NULL THEN
+    UPDATE public.archive_completion_notification_outbox
+    SET status = 'sent', sent_at = now(), locked_at = NULL,
+        provider_message_id = NULLIF(BTRIM(p_provider_message_id), ''),
+        last_error = NULL, updated_at = now()
+    WHERE id = p_id AND status = 'processing';
+  ELSE
+    UPDATE public.archive_completion_notification_outbox
+    SET status = CASE WHEN attempt_count >= 5 THEN 'dead' ELSE 'retry' END,
+        available_at = now() + CASE attempt_count
+          WHEN 1 THEN interval '1 minute'
+          WHEN 2 THEN interval '5 minutes'
+          WHEN 3 THEN interval '30 minutes'
+          WHEN 4 THEN interval '2 hours'
+          ELSE interval '6 hours'
+        END,
+        locked_at = NULL,
+        last_error = LEFT(p_error, 2000),
+        updated_at = now()
+    WHERE id = p_id AND status = 'processing';
+  END IF;
+END;
+$$;
+ALTER FUNCTION public.finish_archive_completion_notification(bigint, text, text) OWNER TO postgres;
+
+CREATE OR REPLACE FUNCTION public.community_archive_monitoring_completion_notifications()
+RETURNS TABLE(
+  ready_count bigint,
+  processing_count bigint,
+  dead_24h_count bigint,
+  oldest_ready_seconds double precision,
+  seconds_since_last_sent double precision
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = ''
+AS $$
+  SELECT
+    COUNT(*) FILTER (WHERE status IN ('queued', 'retry') AND available_at <= now()),
+    COUNT(*) FILTER (WHERE status = 'processing'),
+    COUNT(*) FILTER (WHERE status = 'dead' AND updated_at >= now() - interval '24 hours'),
+    EXTRACT(EPOCH FROM now() - MIN(created_at) FILTER (WHERE status IN ('queued', 'retry'))),
+    EXTRACT(EPOCH FROM now() - MAX(sent_at) FILTER (WHERE status = 'sent'))
+  FROM public.archive_completion_notification_outbox;
+$$;
+ALTER FUNCTION public.community_archive_monitoring_completion_notifications() OWNER TO postgres;
+
+REVOKE EXECUTE ON FUNCTION public.set_archive_completion_notification(boolean) FROM PUBLIC, anon, service_role;
+REVOKE EXECUTE ON FUNCTION private.queue_archive_completion_notification() FROM PUBLIC, anon, authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.claim_archive_completion_notifications(integer) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.finish_archive_completion_notification(bigint, text, text) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.community_archive_monitoring_completion_notifications() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.set_archive_completion_notification(boolean) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.claim_archive_completion_notifications(integer) TO service_role;
+GRANT EXECUTE ON FUNCTION public.finish_archive_completion_notification(bigint, text, text) TO service_role;
+GRANT EXECUTE ON FUNCTION public.community_archive_monitoring_completion_notifications() TO service_role;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'community_archive_metrics') THEN
+    GRANT EXECUTE ON FUNCTION public.community_archive_monitoring_completion_notifications()
+      TO community_archive_metrics;
+  END IF;
+END
+$$;
+
 
 -- admin_list_blocked_scraping_users / admin_set_scrape_block: wrap
 -- tes.blocked_scraping_users so the admin dashboard can read/write the

--- a/supabase/schemas/080_triggers.sql
+++ b/supabase/schemas/080_triggers.sql
@@ -37,3 +37,7 @@ CREATE OR REPLACE TRIGGER "update_tes_blocked_scraping_timestamp" BEFORE UPDATE 
 CREATE OR REPLACE TRIGGER trg_log_archive_upload_event
   AFTER INSERT OR UPDATE OF upload_phase ON public.archive_upload
   FOR EACH ROW EXECUTE FUNCTION public.log_archive_upload_event();
+
+CREATE OR REPLACE TRIGGER queue_archive_completion_notification
+  AFTER INSERT OR UPDATE OF upload_phase ON public.archive_upload
+  FOR EACH ROW EXECUTE FUNCTION private.queue_archive_completion_notification();

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/archive-completion-notifications",
+      "schedule": "*/5 * * * *"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #623

Companion monitoring/runbook PR: TheExGenesis/community-archive-control-panel#86.

## Summary
- adds an explicit Settings opt-in tied to the signed-in owner and their confirmed auth email
- queues one private outbox item when a future archive reaches completed, with cancellation on opt-out and deletion cascades
- delivers through a CRON_SECRET-protected Vercel Cron route and Resend, with bounded retries, abandoned-claim recovery, and stable provider idempotency keys
- records a worker start/finish heartbeat even on empty runs so monitoring can distinguish an idle queue from a missing scheduler
- exposes aggregate-only monitoring output; recipient addresses remain private
- intentionally does not attempt automatic X DMs, which would require broader account permissions and a separate consent surface

## Rollout dependencies
- apply the Supabase migration before deploying this app revision
- configure CRON_SECRET, RESEND_API_KEY, and ARCHIVE_NOTIFICATION_FROM with a verified Resend sender
- confirm the Vercel plan supports the five-minute cron schedule
- deploy and verify companion control-panel PR #86 before enabling delivery

## Verification
- 8 server/helper and migration-contract tests pass
- 5 Settings UI tests pass
- TypeScript type check passes
- git diff check passes
- live db-schema suite not run: TESTS_SUPABASE_URL and TESTS_SUPABASE_SERVICE_ROLE are unavailable in the isolated worktree; local Supabase lint is also unavailable because Docker is not running

No merge or deployment performed.