### PR TITLE
Rename the public digest to “What Happened Yesterday”

### DIFF
--- a/src/app/digest/[date]/[slug]/page.tsx
+++ b/src/app/digest/[date]/[slug]/page.tsx
@@ -13,7 +13,7 @@ export async function generateMetadata({
   params: { date: string; slug: string }
 }): Promise<Metadata> {
   if (!DATE_PATTERN.test(params.date))
-    return { title: 'Daily Digest · Community Archive' }
+    return { title: 'What Happened Yesterday · Community Archive' }
   const edition = await getPublishedDigest(params.date)
   const story = edition?.content.stories.find(
     (item) => item.slug === params.slug,
@@ -23,7 +23,7 @@ export async function generateMetadata({
         title: `${markdownToPlainText(story.title)} · Community Archive`,
         description: markdownToPlainText(story.subtitle),
       }
-    : { title: 'Daily Digest · Community Archive' }
+    : { title: 'What Happened Yesterday · Community Archive' }
 }
 
 export default async function DigestStoryPage({

--- a/src/app/digest/[date]/page.tsx
+++ b/src/app/digest/[date]/page.tsx
@@ -14,8 +14,8 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   return {
     title: DATE_PATTERN.test(params.date)
-      ? `${params.date} Daily Digest · Community Archive`
-      : 'Daily Digest · Community Archive',
+      ? `What Happened Yesterday · ${params.date} · Community Archive`
+      : 'What Happened Yesterday · Community Archive',
   }
 }
 

--- a/src/app/digest/page.tsx
+++ b/src/app/digest/page.tsx
@@ -3,7 +3,7 @@ import { checkIsAdmin } from '@/app/admin/data'
 import { DigestEditionView } from '@/components/digest/DigestEditionView'
 import { getPublishedDigest, listPublishedDigestDays } from '@/lib/digest/data'
 
-export const metadata = { title: 'Daily Digest · Community Archive' }
+export const metadata = { title: 'What Happened Yesterday · Community Archive' }
 export const revalidate = 300
 
 export default async function DigestPage() {
@@ -26,7 +26,7 @@ export default async function DigestPage() {
     <main className="min-h-[70vh] bg-zinc-100/70 px-4 py-16 dark:bg-background">
       <div className="mx-auto max-w-3xl rounded-lg border border-dashed bg-card p-10 text-center">
         <div className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-          Daily Digest
+          What Happened Yesterday
         </div>
         <h1 className="mt-3 font-serif text-4xl font-semibold">
           The first edition is being assembled

--- a/src/components/digest/DigestEditionView.test.tsx
+++ b/src/components/digest/DigestEditionView.test.tsx
@@ -34,6 +34,18 @@ jest.mock('@/components/digest/DigestMarkdown', () => ({
 }))
 
 describe('DigestEditionView', () => {
+  test('uses the What Happened Yesterday public title', () => {
+    render(
+      <DigestEditionView
+        edition={AUGUST_11_MOCK_DIGEST}
+        archive={[AUGUST_11_MOCK_DIGEST]}
+      />,
+    )
+
+    expect(screen.getByText('What Happened Yesterday')).toBeVisible()
+    expect(screen.queryByText('The Daily Digest')).not.toBeInTheDocument()
+  })
+
   test('keeps the future weekly newsletter call to action hidden', () => {
     render(
       <DigestEditionView

--- a/src/components/digest/DigestEditionView.tsx
+++ b/src/components/digest/DigestEditionView.tsx
@@ -47,7 +47,7 @@ export function DigestEditionView({
 
         <header>
           <div className="flex flex-wrap items-baseline justify-between gap-3 border-t border-zinc-800 pt-2.5 dark:border-zinc-200">
-            <div className={sectionLabel}>The Daily Digest</div>
+            <div className={sectionLabel}>What Happened Yesterday</div>
             <div className="flex flex-wrap items-center justify-end gap-3">
               {isAdmin ? (
                 <Link
@@ -249,7 +249,7 @@ export function DigestEditionView({
         <footer className={`mt-4 border-t pt-5 text-xs leading-5 ${MUTED}`}>
           {edition.isPreview
             ? 'Prototype assembled from a frozen research snapshot. Tweet text and engagement were hydrated for this preview; editorial summaries come from the cluster memo.'
-            : 'Curated automatically from the previous 24 hours of archive bangers and reviewed through the Daily Digest lab before publication.'}
+            : 'Curated automatically from the previous 24 hours of archive bangers and reviewed in the editorial lab before publication.'}
         </footer>
       </article>
     </main>

--- a/src/components/digest/DigestStoryView.tsx
+++ b/src/components/digest/DigestStoryView.tsx
@@ -38,7 +38,7 @@ export function DigestStoryView({
             href={`/digest/${edition.digestDate}`}
             className="rounded-sm text-sm font-semibold text-muted-foreground hover:text-brand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
           >
-            ← The Daily Digest
+            ← What Happened Yesterday
           </Link>
           <span className={`text-xs ${MUTED}`}>{edition.digestDate}</span>
         </div>

--- a/src/components/portal/Portal.tsx
+++ b/src/components/portal/Portal.tsx
@@ -634,8 +634,8 @@ export default function Portal({
                   <div className="flex items-center justify-between gap-3">
                     <span className="text-[15px] font-bold">
                       {digestPreview.isPreview
-                        ? 'Mock Daily Digest'
-                        : 'Latest Daily Digest'}
+                        ? 'What Happened Yesterday · Preview'
+                        : 'What Happened Yesterday'}
                     </span>
                     <span className="text-[12px] font-semibold text-white/75 group-hover:text-white dark:text-zinc-700 dark:group-hover:text-zinc-950">
                       Read →

--- a/src/lib/navigation.test.ts
+++ b/src/lib/navigation.test.ts
@@ -132,7 +132,7 @@ describe('tweet detail navigation', () => {
         from: 'digest',
         returnTo: '/digest/2026-08-12/taste',
       }).label,
-    ).toBe('Back to Daily Digest')
+    ).toBe('Back to What Happened Yesterday')
     expect(
       getTweetBackLink({
         from: 'profile',

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -58,7 +58,7 @@ const TWEET_ORIGINS: Record<
   },
   digest: {
     href: '/digest',
-    label: 'Back to Daily Digest',
+    label: 'Back to What Happened Yesterday',
     matches: (href) => href === '/digest' || href.startsWith('/digest/'),
   },
   trends: {


### PR DESCRIPTION
## What changed

- Renamed the public-facing digest title to **What Happened Yesterday**.
- Updated the homepage digest card, digest pages, story and tweet return links, and page metadata.
- Kept internal generation and editorial tooling terminology unchanged.
- Added focused coverage for the public title and updated navigation expectations.

## Why

The digest should describe its reader-facing purpose directly instead of using the generic “Daily Digest” label.

## Validation

- Focused digest component test
- Focused navigation test
- Full TypeScript check
- Prettier check on every changed file
- `git diff --check`