### PR TITLE
fix: show archived quote posts in digest stories

### DIFF
--- a/src/app/digest/[date]/[slug]/page.tsx
+++ b/src/app/digest/[date]/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation'
 import { DigestStoryView } from '@/components/digest/DigestStoryView'
 import { getPublishedDigest } from '@/lib/digest/data'
 import { markdownToPlainText } from '@/lib/digest/markdown'
+import { loadDigestQuotePosts } from '@/lib/digest/quotePosts'
 
 export const revalidate = 300
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
@@ -37,5 +38,8 @@ export default async function DigestStoryPage({
     (item) => item.slug === params.slug,
   )
   if (!edition || !story) notFound()
-  return <DigestStoryView edition={edition} story={story} />
+  const quotePosts = await loadDigestQuotePosts(story.bangers)
+  return (
+    <DigestStoryView edition={edition} story={story} quotePosts={quotePosts} />
+  )
 }

--- a/src/components/digest/DigestStoryView.test.tsx
+++ b/src/components/digest/DigestStoryView.test.tsx
@@ -1,0 +1,70 @@
+/** @jest-environment jsdom */
+
+import React from 'react'
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { DigestStoryView } from './DigestStoryView'
+import { AUGUST_11_MOCK_DIGEST } from '@/lib/digest/mock'
+import type { PortalTweet } from '@/lib/portal/types'
+;(globalThis as typeof globalThis & { React: typeof React }).React = React
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({
+    href,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={String(href)} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+jest.mock('@/components/TweetCard', () => ({
+  __esModule: true,
+  default: ({ tweet }: { tweet: PortalTweet }) => (
+    <div data-testid="tweet-card">{tweet.text}</div>
+  ),
+}))
+
+jest.mock('@/components/digest/DigestMarkdown', () => ({
+  DigestMarkdown: ({ children }: { children: string }) => <>{children}</>,
+}))
+
+describe('DigestStoryView', () => {
+  test('shows archived quote posts that were not selected as commentary', () => {
+    const story = AUGUST_11_MOCK_DIGEST.content.stories[0]
+    const quotePost: PortalTweet = {
+      ...story.bangers[0],
+      id: 'quote-post-1',
+      username: 'quote_author',
+      name: 'Quote Author',
+      text: 'This quote belongs on the story page',
+    }
+
+    render(
+      <DigestStoryView
+        edition={AUGUST_11_MOCK_DIGEST}
+        story={story}
+        quotePosts={[
+          {
+            bangerId: story.bangers[0].id,
+            tweets: [quotePost],
+            totalCount: 1,
+          },
+        ]}
+      />,
+    )
+
+    expect(
+      screen.getByRole('heading', { name: 'Archived quote posts' }),
+    ).toBeVisible()
+    expect(
+      screen.getByText('This quote belongs on the story page'),
+    ).toBeVisible()
+    expect(
+      screen.getByText(`Quotes of @${story.bangers[0].username}`),
+    ).toBeVisible()
+  })
+})

--- a/src/components/digest/DigestStoryView.tsx
+++ b/src/components/digest/DigestStoryView.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import TweetCard from '@/components/TweetCard'
 import { DigestMarkdown } from '@/components/digest/DigestMarkdown'
 import { MUTED, SERIF } from '@/components/portal/styles'
+import type { DigestQuotePosts } from '@/lib/digest/quotePosts'
 import type { DigestEdition, DigestStory } from '@/lib/digest/types'
 
 const timeLabel = (value: string | null) =>
@@ -20,15 +21,26 @@ const sectionLabel =
 export function DigestStoryView({
   edition,
   story,
+  quotePosts = [],
 }: {
   edition: DigestEdition
   story: DigestStory
+  quotePosts?: DigestQuotePosts[]
 }) {
   const returnTo = `/digest/${edition.digestDate}/${story.slug}`
   const archivedQuotes = story.bangers.reduce(
     (total, tweet) => total + (tweet.quoteCount ?? 0),
     0,
   )
+  const selectedCommentaryIds = new Set(story.commentary.map(({ id }) => id))
+  const unselectedQuotePosts = quotePosts
+    .map((group) => ({
+      ...group,
+      tweets: group.tweets.filter(
+        (tweet) => !selectedCommentaryIds.has(tweet.id),
+      ),
+    }))
+    .filter(({ tweets }) => tweets.length > 0)
 
   return (
     <main className="min-h-screen bg-white dark:bg-[#111114]">
@@ -110,6 +122,48 @@ export function DigestStoryView({
                 ))}
               </div>
             </section>
+
+            {unselectedQuotePosts.length ? (
+              <section>
+                <div className="flex items-center gap-3.5">
+                  <h2 className={sectionLabel}>Archived quote posts</h2>
+                  <span className="flex-1 border-t border-zinc-200 dark:border-zinc-800" />
+                </div>
+                <p className={`mt-2 text-sm leading-6 ${MUTED}`}>
+                  Community Archive members who quoted the featured bangers.
+                </p>
+                <div className="mt-5 space-y-8">
+                  {unselectedQuotePosts.map((group) => {
+                    const banger = story.bangers.find(
+                      ({ id }) => id === group.bangerId,
+                    )
+                    if (!banger) return null
+                    return (
+                      <section key={group.bangerId}>
+                        <div className="mb-1 flex items-baseline gap-2 text-xs text-muted-foreground">
+                          <span className="font-semibold text-zinc-800 dark:text-zinc-200">
+                            Quotes of @{banger.username}
+                          </span>
+                          <span>· {group.totalCount} archived</span>
+                        </div>
+                        {group.tweets.map((tweet) => (
+                          <TweetCard
+                            key={tweet.id}
+                            tweet={tweet}
+                            variant="editorial"
+                            noClamp
+                            showDate
+                            quotedTweetDisplay="summary"
+                            origin="digest"
+                            returnTo={returnTo}
+                          />
+                        ))}
+                      </section>
+                    )
+                  })}
+                </div>
+              </section>
+            ) : null}
 
             {story.commentary.length ? (
               <section>

--- a/src/lib/digest/quotePosts.test.ts
+++ b/src/lib/digest/quotePosts.test.ts
@@ -1,0 +1,96 @@
+import type { TweetData } from '@/components/TweetComponent'
+import { getQuotingTweetsPage } from '@/lib/quotingTweets'
+import type { PortalTweet } from '@/lib/portal/types'
+import { loadDigestQuotePosts } from './quotePosts'
+
+jest.mock('@/lib/quotingTweets', () => ({
+  getQuotingTweetsPage: jest.fn(),
+}))
+
+const getQuotingTweetsPageMock = getQuotingTweetsPage as jest.MockedFunction<
+  typeof getQuotingTweetsPage
+>
+
+const banger: PortalTweet = {
+  id: '101',
+  accountId: 'account-1',
+  username: 'author',
+  name: 'Author',
+  avatar: null,
+  text: 'The original post',
+  observedAt: '2026-08-14T10:00:00Z',
+  createdAt: '2026-08-14T10:00:00Z',
+  likes: 278,
+  rts: 26,
+  media: [],
+  quoteCount: 1,
+}
+
+const quotePost: TweetData = {
+  tweet_id: '202',
+  account_id: 'account-2',
+  created_at: '2026-08-14T11:00:00Z',
+  full_text: 'A useful quote post',
+  retweet_count: 3,
+  favorite_count: 12,
+  reply_to_tweet_id: null,
+  quote_tweet_id: '101',
+  retweeted_tweet_id: null,
+  avatar_media_url: null,
+  username: 'commenter',
+  account_display_name: 'Commenter',
+  media: [],
+  urls: [],
+}
+
+describe('loadDigestQuotePosts', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  test('loads and adapts archived quote posts for numeric bangers', async () => {
+    getQuotingTweetsPageMock.mockResolvedValue({
+      tweets: [quotePost],
+      totalCount: 1,
+      nextOffset: null,
+    })
+
+    await expect(
+      loadDigestQuotePosts([banger, { ...banger, id: 'preview-id' }]),
+    ).resolves.toEqual([
+      {
+        bangerId: '101',
+        totalCount: 1,
+        tweets: [
+          expect.objectContaining({
+            id: '202',
+            text: 'A useful quote post',
+            quotedTweet: expect.objectContaining({
+              id: '101',
+              text: 'The original post',
+            }),
+          }),
+        ],
+      },
+    ])
+    expect(getQuotingTweetsPageMock).toHaveBeenCalledWith('101', 0, 50)
+  })
+
+  test('keeps the article available when a quote-post read fails', async () => {
+    getQuotingTweetsPageMock.mockRejectedValue(new Error('gateway down'))
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+
+    await expect(loadDigestQuotePosts([banger])).resolves.toEqual([
+      { bangerId: '101', tweets: [], totalCount: 0 },
+    ])
+
+    expect(consoleError).toHaveBeenCalledWith(
+      'Digest quote-post read failed:',
+      {
+        tweetId: '101',
+        error: 'gateway down',
+      },
+    )
+    consoleError.mockRestore()
+  })
+})

--- a/src/lib/digest/quotePosts.ts
+++ b/src/lib/digest/quotePosts.ts
@@ -1,0 +1,52 @@
+import 'server-only'
+
+import { getQuotingTweetsPage } from '@/lib/quotingTweets'
+import { quoteTweetToPortalTweet } from '@/lib/portal/quoteTweet'
+import type { PortalTweet } from '@/lib/portal/types'
+
+const TWEET_ID_PATTERN = /^\d{1,20}$/
+const INITIAL_QUOTE_POST_LIMIT = 50
+
+export interface DigestQuotePosts {
+  bangerId: string
+  tweets: PortalTweet[]
+  totalCount: number
+}
+
+/**
+ * Load the archived quote posts for each featured banger. The digest stores
+ * only the model-selected commentary, so this fills in the quote posts that
+ * were available to the editor but were not selected for the story.
+ */
+export async function loadDigestQuotePosts(
+  bangers: PortalTweet[],
+): Promise<DigestQuotePosts[]> {
+  const results = await Promise.all(
+    bangers
+      .filter(({ id }) => TWEET_ID_PATTERN.test(id))
+      .map(async (banger): Promise<DigestQuotePosts> => {
+        try {
+          const page = await getQuotingTweetsPage(
+            banger.id,
+            0,
+            INITIAL_QUOTE_POST_LIMIT,
+          )
+          return {
+            bangerId: banger.id,
+            tweets: page.tweets.map((tweet) =>
+              quoteTweetToPortalTweet(tweet, banger),
+            ),
+            totalCount: page.totalCount,
+          }
+        } catch (error) {
+          console.error('Digest quote-post read failed:', {
+            tweetId: banger.id,
+            error: error instanceof Error ? error.message : String(error),
+          })
+          return { bangerId: banger.id, tweets: [], totalCount: 0 }
+        }
+      }),
+  )
+
+  return results
+}

--- a/src/lib/portal/quoteTweet.ts
+++ b/src/lib/portal/quoteTweet.ts
@@ -1,0 +1,51 @@
+import type { TweetData } from '@/components/TweetComponent'
+import type { PortalMedia, PortalQuotedTweet, PortalTweet } from './types'
+
+function portalMedia(media: TweetData['media']): PortalMedia[] {
+  return (media ?? []).map((item) => ({
+    url: item.media_url,
+    type: item.media_type,
+    width: item.width,
+    height: item.height,
+  }))
+}
+
+/** Adapt a reverse quote-post result to the canonical portal tweet renderer. */
+export function quoteTweetToPortalTweet(
+  tweet: TweetData,
+  target: PortalTweet,
+): PortalTweet {
+  return {
+    id: tweet.tweet_id,
+    accountId: tweet.account_id,
+    username: tweet.username,
+    name: tweet.account_display_name,
+    avatar: tweet.avatar_media_url,
+    text: tweet.full_text,
+    observedAt: tweet.created_at,
+    createdAt: tweet.created_at,
+    likes: tweet.favorite_count,
+    rts: tweet.retweet_count ?? 0,
+    media: portalMedia(tweet.media),
+    quotedTweet: {
+      ...portalQuotedTweetFromPortalTweet(target),
+    },
+  }
+}
+
+function portalQuotedTweetFromPortalTweet(
+  tweet: PortalTweet,
+): PortalQuotedTweet {
+  return {
+    id: tweet.id,
+    accountId: tweet.accountId,
+    username: tweet.username,
+    name: tweet.name,
+    avatar: tweet.avatar,
+    text: tweet.text,
+    createdAt: tweet.createdAt,
+    likes: tweet.likes,
+    rts: tweet.rts,
+    media: tweet.media ?? [],
+  }
+}


### PR DESCRIPTION
## What changed

- Load archived quote posts for each digest banger through the existing quote-post data path.
- Render quote posts that were not already selected as editorial commentary on the article page.
- Preserve the canonical tweet renderer and quoted-tweet payload, including media.
- Keep the article available if a quote-post read fails.

## Root cause

Digest editions persisted only model-selected commentary. The article displayed the banger's archived-quote count and linked to the tweet permalink, but did not load the remaining archived quote posts itself.

## Validation

- Focused quote-loader and digest-story tests: 3 passed.
- Server tests: 83 suites / 400 tests passed.
- TypeScript type-check passed.
- Prettier and diff checks passed.
- Lint passed with one pre-existing unrelated `<img>` warning in `src/components/UnifiedTweetList.test.tsx`.

The repository's local commit hook could not run because Docker/Supabase was unavailable in the isolated worktree; the hook was skipped explicitly after the checks above passed.
