### PR TITLE
Add Community Archive Substack subscribe button

### DIFF
--- a/src/components/digest/DigestEditionView.test.tsx
+++ b/src/components/digest/DigestEditionView.test.tsx
@@ -46,7 +46,7 @@ describe('DigestEditionView', () => {
     expect(screen.queryByText('The Daily Digest')).not.toBeInTheDocument()
   })
 
-  test('keeps the future weekly newsletter call to action hidden', () => {
+  test('links to the Community Archive Substack subscription page', () => {
     render(
       <DigestEditionView
         edition={AUGUST_11_MOCK_DIGEST}
@@ -54,9 +54,19 @@ describe('DigestEditionView', () => {
       />,
     )
 
-    expect(
-      screen.queryByRole('link', { name: 'Get the weekly email' }),
-    ).not.toBeInTheDocument()
+    const subscribeLink = screen.getByRole('link', {
+      name: 'Subscribe to Community Archive on Substack',
+    })
+
+    expect(subscribeLink).toHaveAttribute(
+      'href',
+      'https://communityarchive.substack.com/subscribe',
+    )
+    expect(subscribeLink).toHaveAttribute('target', '_blank')
+    expect(subscribeLink).not.toHaveAttribute(
+      'href',
+      expect.stringContaining('xiqo.substack.com'),
+    )
   })
 
   test('shows the editorial lab shortcut only to admins', () => {

--- a/src/components/digest/DigestEditionView.tsx
+++ b/src/components/digest/DigestEditionView.tsx
@@ -49,6 +49,15 @@ export function DigestEditionView({
           <div className="flex flex-wrap items-baseline justify-between gap-3 border-t border-zinc-800 pt-2.5 dark:border-zinc-200">
             <div className={sectionLabel}>What Happened Yesterday</div>
             <div className="flex flex-wrap items-center justify-end gap-3">
+              <a
+                href="https://communityarchive.substack.com/subscribe"
+                target="_blank"
+                rel="noreferrer"
+                aria-label="Subscribe to Community Archive on Substack"
+                className="rounded-full bg-brand px-3.5 py-1.5 text-[11px] font-bold uppercase tracking-[0.12em] text-white transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 dark:text-brand-foreground dark:focus-visible:ring-offset-[#111114]"
+              >
+                Subscribe
+              </a>
               {isAdmin ? (
                 <Link
                   href="/admin/digest"


### PR DESCRIPTION
## What changed

- Added a Subscribe button to the public digest masthead.
- Linked it directly to the Community Archive Substack subscription page.
- Added a regression test that verifies the destination and guards against using the Epistemic Garden Substack URL.

## Why

The digest previously kept its newsletter call to action hidden while publication plans were still future work. With Community Archive digests moving to Substack, readers now have a direct subscription path from each digest page.

## User impact

Readers can subscribe to Community Archive on Substack without leaving the digest discovery flow.

## Validation

- Client test suite: 41 suites, 126 tests passed.
- Prettier check passed for both changed files.
- The Community Archive subscription URL returned HTTP 200, and the hyphenated alias resolved to the same canonical publication.