### PR TITLE
Add contextual browser extension install prompts

### DIFF
--- a/src/app/stream-monitor/page.tsx
+++ b/src/app/stream-monitor/page.tsx
@@ -1,8 +1,7 @@
 'use client'
 
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import Link from 'next/link'
 import { createBrowserClient } from '@/utils/supabase'
 import {
   ChartContainer,
@@ -21,9 +20,10 @@ import {
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Switch } from '@/components/ui/switch'
 import { Label } from '@/components/ui/label'
-import { ChevronLeft, ChevronRight, X } from 'lucide-react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
 import getLatestTweets from '@/lib/queries/getLatestTweets'
 import UnifiedTweetList from '@/components/UnifiedTweetList'
+import ExtensionInstallPrompt from '@/components/ExtensionInstallPrompt'
 
 interface TweetMedia {
   media_url: string
@@ -52,13 +52,52 @@ interface Tweet {
   urls: TweetUrl[]
 }
 
+type ViewMode = '24h' | '7d' | '1y'
+
+function getStatsRange(viewMode: ViewMode, timeOffset: number) {
+  const now = new Date()
+  if (viewMode === '24h') {
+    const periods = 24
+    return {
+      startDate: new Date(
+        now.getTime() - (periods + timeOffset * periods) * 60 * 60 * 1000,
+      ),
+      endDate: new Date(now.getTime() - timeOffset * periods * 60 * 60 * 1000),
+      granularity: 'hour',
+    }
+  }
+  if (viewMode === '7d') {
+    const periods = 7
+    return {
+      startDate: new Date(
+        now.getTime() - (periods + timeOffset * periods) * 24 * 60 * 60 * 1000,
+      ),
+      endDate: new Date(
+        now.getTime() - timeOffset * periods * 24 * 60 * 60 * 1000,
+      ),
+      granularity: 'day',
+    }
+  }
+
+  const periods = 52
+  return {
+    startDate: new Date(
+      now.getTime() -
+        (periods + timeOffset * periods) * 7 * 24 * 60 * 60 * 1000,
+    ),
+    endDate: new Date(
+      now.getTime() - timeOffset * periods * 7 * 24 * 60 * 60 * 1000,
+    ),
+    granularity: 'week',
+  }
+}
+
 const StreamMonitor = () => {
-  const [viewMode, setViewMode] = useState<'24h' | '7d' | '1y'>('7d')
+  const [viewMode, setViewMode] = useState<ViewMode>('7d')
   const [timeOffset, setTimeOffset] = useState(0)
   const [showStreamedOnly, setShowStreamedOnly] = useState(true)
   const [loadedTweets, setLoadedTweets] = useState<Tweet[]>([])
   const [tweetOffset, setTweetOffset] = useState(0)
-  const [showBanner, setShowBanner] = useState(true)
   const tweetsPerPage = 20
 
   const supabase = createBrowserClient()
@@ -71,40 +110,10 @@ const StreamMonitor = () => {
   } = useQuery({
     queryKey: ['scrapingStats', viewMode, timeOffset, showStreamedOnly],
     queryFn: async () => {
-      const now = new Date()
-      let startDate, endDate, granularity, periods
-
-      if (viewMode === '24h') {
-        periods = 24
-        startDate = new Date(
-          now.getTime() - (periods + timeOffset * periods) * 60 * 60 * 1000,
-        )
-        endDate = new Date(
-          now.getTime() - timeOffset * periods * 60 * 60 * 1000,
-        )
-        granularity = 'hour'
-      } else if (viewMode === '7d') {
-        periods = 7
-        startDate = new Date(
-          now.getTime() -
-            (periods + timeOffset * periods) * 24 * 60 * 60 * 1000,
-        )
-        endDate = new Date(
-          now.getTime() - timeOffset * periods * 24 * 60 * 60 * 1000,
-        )
-        granularity = 'day'
-      } else {
-        // 1y
-        periods = 52 // 52 weeks
-        startDate = new Date(
-          now.getTime() -
-            (periods + timeOffset * periods) * 7 * 24 * 60 * 60 * 1000,
-        )
-        endDate = new Date(
-          now.getTime() - timeOffset * periods * 7 * 24 * 60 * 60 * 1000,
-        )
-        granularity = 'week'
-      }
+      const { startDate, endDate, granularity } = getStatsRange(
+        viewMode,
+        timeOffset,
+      )
 
       // Use the new API with custom date ranges
       const params = new URLSearchParams({
@@ -123,6 +132,32 @@ const StreamMonitor = () => {
     },
     refetchInterval: viewMode === '24h' && timeOffset === 0 ? 300000 : 0, // Only refresh current 24h view
     staleTime: 60000, // 1 minute stale time
+  })
+
+  const {
+    data: contributorCount,
+    isLoading: contributorCountLoading,
+    isError: contributorCountError,
+  } = useQuery({
+    queryKey: ['streamContributorCount', viewMode, timeOffset],
+    queryFn: async () => {
+      const { startDate, endDate } = getStatsRange(viewMode, timeOffset)
+      const params = new URLSearchParams({
+        startDate: startDate.toISOString(),
+        endDate: endDate.toISOString(),
+      })
+      const response = await fetch(`/api/scraper-count?${params}`)
+      const body = (await response.json().catch(() => null)) as {
+        count?: unknown
+      } | null
+      const count = Number(body?.count)
+      if (!response.ok || !Number.isSafeInteger(count) || count < 0) {
+        throw new Error('Failed to fetch streaming contributor count')
+      }
+      return count
+    },
+    refetchInterval: viewMode === '24h' && timeOffset === 0 ? 300000 : 0,
+    staleTime: 60000,
   })
 
   // Extract chart data and summary from scraping stats
@@ -236,6 +271,9 @@ const StreamMonitor = () => {
     return scrapingStats?.summary?.avgTweetsPerPeriod || 0
   }
 
+  const averageUnit =
+    viewMode === '24h' ? 'hour' : viewMode === '7d' ? 'day' : 'week'
+
   const loadMoreTweets = () => {
     setTweetOffset((prev) => prev + tweetsPerPage)
   }
@@ -243,28 +281,6 @@ const StreamMonitor = () => {
   const refreshLatestTweets = async () => {
     setTweetOffset(0)
     await refetchTweets()
-  }
-
-  // LocalStorage key for banner dismissal
-  const BANNER_DISMISSED_KEY = 'stream-monitor-banner-dismissed'
-  const TWO_WEEKS_MS = 14 * 24 * 60 * 60 * 1000
-
-  useEffect(() => {
-    const twoWeeksMs = TWO_WEEKS_MS
-    const dismissedAt = localStorage.getItem(BANNER_DISMISSED_KEY)
-    if (dismissedAt) {
-      const dismissedTime = parseInt(dismissedAt, 10)
-      if (Date.now() - dismissedTime < twoWeeksMs) {
-        setShowBanner(false)
-      } else {
-        localStorage.removeItem(BANNER_DISMISSED_KEY)
-      }
-    }
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
-
-  const handleDismissBanner = () => {
-    localStorage.setItem(BANNER_DISMISSED_KEY, Date.now().toString())
-    setShowBanner(false)
   }
 
   return (
@@ -293,42 +309,9 @@ const StreamMonitor = () => {
         </div>
       </div>
 
-      {/* Compact call-to-action banner */}
-      {showBanner && (
-        <div className="mb-6">
-          <div className="flex items-center justify-between gap-4 rounded-xl border border-border bg-muted p-4">
-            <div className="flex min-w-0 flex-1 items-center gap-3">
-              <span className="flex-shrink-0 text-xl">📡</span>
-              <p className="truncate text-sm text-brand">
-                Help grow the archive! Opt in and install the extension to
-                stream tweets.
-              </p>
-            </div>
-            <div className="flex flex-shrink-0 items-center gap-2">
-              <Link href="/">
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="border-brand text-brand hover:bg-brand/10 dark:border-border dark:text-brand dark:hover:bg-brand/90"
-                >
-                  Get Started
-                </Button>
-              </Link>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8 text-brand hover:text-brand"
-                onClick={handleDismissBanner}
-              >
-                <X className="h-4 w-4" />
-                <span className="sr-only">Dismiss</span>
-              </Button>
-            </div>
-          </div>
-        </div>
-      )}
+      <ExtensionInstallPrompt surface="stream-monitor" className="mb-6" />
 
-      <div className="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
+      <div className="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <Card>
           <CardHeader className="pb-2">
             <CardTitle className="text-base">
@@ -351,7 +334,9 @@ const StreamMonitor = () => {
 
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-base">Average per period</CardTitle>
+            <CardTitle className="text-base">
+              Average per {averageUnit}
+            </CardTitle>
             <CardDescription>
               {showStreamedOnly ? 'Mean streaming rate' : 'Mean tweet rate'}
             </CardDescription>
@@ -359,6 +344,24 @@ const StreamMonitor = () => {
           <CardContent>
             <div className="text-2xl font-bold text-green-600 dark:text-green-400">
               {getAverageTweetsPerPeriod().toLocaleString()}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Streaming contributors</CardTitle>
+            <CardDescription>
+              Distinct extension users in time range
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold text-blue-600 dark:text-blue-400">
+              {contributorCountLoading
+                ? '...'
+                : contributorCountError
+                  ? 'Unavailable'
+                  : contributorCount?.toLocaleString()}
             </div>
           </CardContent>
         </Card>

--- a/src/components/ExtensionInstallPrompt.test.tsx
+++ b/src/components/ExtensionInstallPrompt.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ExtensionInstallPrompt from '@/components/ExtensionInstallPrompt'
+import { useBrowserExtensionStatus } from '@/hooks/useBrowserExtensionStatus'
+import { CHROME_EXTENSION_URL } from '@/lib/browserExtension'
+
+jest.mock('@/hooks/useBrowserExtensionStatus', () => ({
+  useBrowserExtensionStatus: jest.fn(),
+}))
+
+const mockStatus = useBrowserExtensionStatus as jest.MockedFunction<
+  typeof useBrowserExtensionStatus
+>
+
+describe('ExtensionInstallPrompt', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    mockStatus.mockReturnValue('not-installed')
+  })
+
+  test('links directly to the extension and remembers dismissal', async () => {
+    const user = userEvent.setup()
+    render(<ExtensionInstallPrompt surface="trends" />)
+
+    const installLink = await screen.findByRole('link', {
+      name: /install the browser extension/i,
+    })
+    expect(installLink).toHaveAttribute('href', CHROME_EXTENSION_URL)
+    expect(screen.getByText(/fresher trend data/i)).toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /hide browser extension suggestion/i,
+      }),
+    )
+    expect(
+      screen.queryByRole('link', { name: /install the browser extension/i }),
+    ).not.toBeInTheDocument()
+    expect(localStorage.length).toBe(1)
+  })
+
+  test('stays hidden when the extension is installed', () => {
+    mockStatus.mockReturnValue('installed')
+    render(<ExtensionInstallPrompt surface="stream" />)
+
+    expect(
+      screen.queryByRole('link', { name: /install the browser extension/i }),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/components/ExtensionInstallPrompt.tsx
+++ b/src/components/ExtensionInstallPrompt.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Puzzle, X } from 'lucide-react'
+import { useBrowserExtensionStatus } from '@/hooks/useBrowserExtensionStatus'
+import { CHROME_EXTENSION_URL } from '@/lib/browserExtension'
+
+export type ExtensionInstallSurface =
+  | 'home'
+  | 'stream'
+  | 'stream-monitor'
+  | 'trends'
+
+const PROMPT_DISMISSED_KEY = 'browser-extension-prompt-dismissed-at:v1'
+const DISMISSAL_DURATION_MS = 14 * 24 * 60 * 60 * 1000
+
+const copy: Record<ExtensionInstallSurface, string> = {
+  home: 'Keep the archive current between uploads. Contribute public tweets as you browse X.',
+  stream:
+    'Help keep this stream moving by contributing public tweets as you browse X.',
+  'stream-monitor':
+    'Help grow the archive by contributing public tweets as you browse X.',
+  trends:
+    'Want fresher trend data? Help capture new public tweets as you browse X.',
+}
+
+export default function ExtensionInstallPrompt({
+  surface,
+  className = '',
+}: {
+  surface: ExtensionInstallSurface
+  className?: string
+}) {
+  const extensionStatus = useBrowserExtensionStatus()
+  const [dismissed, setDismissed] = useState(true)
+
+  useEffect(() => {
+    try {
+      const dismissedAt = Number(localStorage.getItem(PROMPT_DISMISSED_KEY))
+      const dismissalIsCurrent =
+        Number.isFinite(dismissedAt) &&
+        Date.now() - dismissedAt < DISMISSAL_DURATION_MS
+
+      if (!dismissalIsCurrent) {
+        localStorage.removeItem(PROMPT_DISMISSED_KEY)
+      }
+      setDismissed(dismissalIsCurrent)
+    } catch {
+      setDismissed(false)
+    }
+  }, [])
+
+  if (extensionStatus !== 'not-installed' || dismissed) return null
+
+  const dismiss = () => {
+    try {
+      localStorage.setItem(PROMPT_DISMISSED_KEY, Date.now().toString())
+    } catch {
+      // The suggestion can still be dismissed for this page view when browser
+      // storage is unavailable.
+    }
+    setDismissed(true)
+  }
+
+  return (
+    <aside
+      aria-label="Browser extension"
+      className={`dark:bg-[#121214]/85 flex items-center gap-3 rounded-[6px] border border-zinc-200 bg-white/80 px-3.5 py-2.5 text-[12.5px] text-zinc-700 shadow-sm dark:border-[#2a2a2e] dark:text-zinc-300 ${className}`}
+    >
+      <Puzzle className="h-4 w-4 flex-none text-brand" aria-hidden="true" />
+      <p className="min-w-0 flex-1 leading-relaxed">
+        {copy[surface]}{' '}
+        <a
+          href={CHROME_EXTENSION_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="whitespace-nowrap font-bold text-brand hover:underline"
+        >
+          Install the browser extension ↗
+        </a>
+      </p>
+      <button
+        type="button"
+        onClick={dismiss}
+        className="flex h-7 w-7 flex-none items-center justify-center rounded-[4px] text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-700 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+      >
+        <X className="h-3.5 w-3.5" aria-hidden="true" />
+        <span className="sr-only">Hide browser extension suggestion</span>
+      </button>
+    </aside>
+  )
+}

--- a/src/components/HeroCTAButtons.tsx
+++ b/src/components/HeroCTAButtons.tsx
@@ -15,9 +15,8 @@ import { createBrowserClient } from '@/utils/supabase'
 import { Users, Puzzle, Upload } from 'lucide-react'
 import { devLog } from '@/lib/devLog'
 import { updateOptIn } from '@/lib/optInApi'
-
-const CHROME_EXTENSION_URL =
-  'https://chromewebstore.google.com/detail/community-archive-stream/igclpobjpjlphgllncjcgaookmncegbk'
+import { useBrowserExtensionStatus } from '@/hooks/useBrowserExtensionStatus'
+import { CHROME_EXTENSION_URL } from '@/lib/browserExtension'
 
 interface HeroCTAButtonsProps {
   initialIsOptedIn?: boolean
@@ -32,6 +31,7 @@ export default function HeroCTAButtons({
   const supabase = useMemo(() => createBrowserClient(), [])
   const autoOptInStarted = useRef(false)
   const optInInFlight = useRef(false)
+  const extensionStatus = useBrowserExtensionStatus()
 
   const [user, setUser] = useState<any>(null)
   const [isOptedIn, setIsOptedIn] = useState(initialIsOptedIn)
@@ -261,28 +261,30 @@ export default function HeroCTAButtons({
           </Tooltip>
 
           {/* Install Extension Button */}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                asChild
-                variant="outline"
-                className="h-14 w-full border-2 px-8 text-lg font-semibold"
-                size="lg"
-              >
-                <a
-                  href={CHROME_EXTENSION_URL}
-                  target="_blank"
-                  rel="noopener noreferrer"
+          {extensionStatus === 'not-installed' ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  asChild
+                  variant="outline"
+                  className="h-14 w-full border-2 px-8 text-lg font-semibold"
+                  size="lg"
                 >
-                  <Puzzle className="mr-2 h-5 w-5" />
-                  Get extension
-                </a>
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              Contribute tweets in real time while you browse
-            </TooltipContent>
-          </Tooltip>
+                  <a
+                    href={CHROME_EXTENSION_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <Puzzle className="mr-2 h-5 w-5" />
+                    Get extension
+                  </a>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                Contribute tweets in real time while you browse
+              </TooltipContent>
+            </Tooltip>
+          ) : null}
         </div>
         {optInError ? (
           <Alert variant="destructive" className="max-w-xl" aria-live="polite">

--- a/src/components/home/ClassicHomepage.test.tsx
+++ b/src/components/home/ClassicHomepage.test.tsx
@@ -36,6 +36,10 @@ jest.mock('@/components/portal/Portal', () => ({
   __esModule: true,
   default: () => <div data-testid="shared-dashboard" />,
 }))
+jest.mock('@/components/ExtensionInstallPrompt', () => ({
+  __esModule: true,
+  default: () => null,
+}))
 jest.mock('@/lib/clickhouseAnalytics', () => ({
   getTopFollowedAccounts: jest.fn(),
 }))

--- a/src/components/home/ClassicHomepage.tsx
+++ b/src/components/home/ClassicHomepage.tsx
@@ -11,6 +11,7 @@ import { getTopFollowedAccounts } from '@/lib/clickhouseAnalytics'
 import type { PortalData } from '@/lib/portal/types'
 import { createServerClient } from '@/utils/supabase'
 import { getLatestDigestPreview } from '@/lib/digest/data'
+import ExtensionInstallPrompt from '@/components/ExtensionInstallPrompt'
 
 const DynamicHeroCTAButtons = dynamic(
   () => import('@/components/HeroCTAButtons'),
@@ -194,6 +195,10 @@ export default async function ClassicHomepage({
       >
         <div className="relative z-10 mx-auto w-full max-w-5xl px-4 sm:px-6 lg:px-8">
           <DynamicUploadArchiveSection />
+          <ExtensionInstallPrompt
+            surface="home"
+            className="mx-auto mt-8 max-w-3xl"
+          />
         </div>
       </section>
 

--- a/src/components/portal/Portal.tsx
+++ b/src/components/portal/Portal.tsx
@@ -20,6 +20,8 @@ import {
 import { BANGERS_ALL_TIME_HREF, BANGERS_WEEK_HREF } from '@/lib/portal/bangers'
 import { capturePostHogEvent } from '@/lib/posthog'
 import type { DigestPreview } from '@/lib/digest/types'
+import ExtensionInstallPrompt from '@/components/ExtensionInstallPrompt'
+import { CHROME_EXTENSION_URL } from '@/lib/browserExtension'
 
 export type PortalView = 'home' | 'stream'
 
@@ -866,9 +868,18 @@ export default function Portal({
             unavailable={data.failures.liveAnalytics}
           />
           <div className={`mb-3.5 text-[13px] ${MUTED}`}>
-            Tweets arriving from the browser-extension firehose, as contributors
-            read their timelines.
+            Tweets arriving from the{' '}
+            <a
+              href={CHROME_EXTENSION_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-semibold text-brand hover:underline"
+            >
+              browser extension
+            </a>{' '}
+            firehose, as contributors read their timelines.
           </div>
+          <ExtensionInstallPrompt surface="stream" className="mb-3.5" />
           <div className={`${CARD} overflow-hidden`}>
             {visible.map((t, i) => (
               <TweetCard

--- a/src/components/portal/TrendsExplorer.tsx
+++ b/src/components/portal/TrendsExplorer.tsx
@@ -33,6 +33,7 @@ import type {
 } from '@/lib/portal/types'
 import { capturePostHogEvent } from '@/lib/posthog'
 import { BODY, CARD, MUTED, SERIF } from './styles'
+import ExtensionInstallPrompt from '@/components/ExtensionInstallPrompt'
 
 type FeedFilter = 'include' | 'off'
 
@@ -863,6 +864,8 @@ export default function TrendsExplorer({
             Full corpus · {initialTrends.years[0]}–{initialTrends.years.at(-1)}
           </div>
         </div>
+
+        <ExtensionInstallPrompt surface="trends" className="mb-5" />
 
         <div className="grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(360px,0.8fr)]">
           <section className="min-w-0">

--- a/src/hooks/useBrowserExtensionStatus.ts
+++ b/src/hooks/useBrowserExtensionStatus.ts
@@ -1,0 +1,23 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import {
+  getBrowserExtensionStatus,
+  type BrowserExtensionStatus,
+} from '@/lib/browserExtension'
+
+export function useBrowserExtensionStatus(): BrowserExtensionStatus {
+  const [status, setStatus] = useState<BrowserExtensionStatus>('checking')
+
+  useEffect(() => {
+    let active = true
+    void getBrowserExtensionStatus().then((nextStatus) => {
+      if (active) setStatus(nextStatus)
+    })
+    return () => {
+      active = false
+    }
+  }, [])
+
+  return status
+}

--- a/src/lib/browserExtension.test.ts
+++ b/src/lib/browserExtension.test.ts
@@ -1,0 +1,39 @@
+import {
+  CHROME_EXTENSION_ID,
+  EXTENSION_STATUS_REQUEST,
+  type BrowserExtensionRuntime,
+  detectBrowserExtension,
+} from '@/lib/browserExtension'
+
+describe('browser extension detection', () => {
+  test('recognizes the extension status response', async () => {
+    const runtime: BrowserExtensionRuntime = {
+      sendMessage: (extensionId, message, callback) => {
+        expect(extensionId).toBe(CHROME_EXTENSION_ID)
+        expect(message).toEqual({ type: EXTENSION_STATUS_REQUEST })
+        callback({ installed: true, version: '0.0.4' })
+      },
+    }
+
+    await expect(detectBrowserExtension(runtime)).resolves.toBe('installed')
+  })
+
+  test('treats a missing browser messaging API as not installed', async () => {
+    await expect(detectBrowserExtension(undefined)).resolves.toBe(
+      'not-installed',
+    )
+  })
+
+  test('times out when an older extension cannot answer', async () => {
+    jest.useFakeTimers()
+    const runtime: BrowserExtensionRuntime = {
+      sendMessage: () => undefined,
+    }
+
+    const status = detectBrowserExtension(runtime, 50)
+    jest.advanceTimersByTime(50)
+
+    await expect(status).resolves.toBe('not-installed')
+    jest.useRealTimers()
+  })
+})

--- a/src/lib/browserExtension.ts
+++ b/src/lib/browserExtension.ts
@@ -1,0 +1,72 @@
+export const CHROME_EXTENSION_ID = 'igclpobjpjlphgllncjcgaookmncegbk'
+
+export const CHROME_EXTENSION_URL = `https://chromewebstore.google.com/detail/community-archive-stream/${CHROME_EXTENSION_ID}`
+
+export const EXTENSION_STATUS_REQUEST =
+  'community-archive:extension-status' as const
+
+export type BrowserExtensionStatus = 'checking' | 'installed' | 'not-installed'
+
+export interface BrowserExtensionRuntime {
+  lastError?: { message?: string }
+  sendMessage: (
+    extensionId: string,
+    message: { type: typeof EXTENSION_STATUS_REQUEST },
+    callback: (response?: unknown) => void,
+  ) => void
+}
+
+let sharedStatusRequest:
+  | Promise<Exclude<BrowserExtensionStatus, 'checking'>>
+  | undefined
+
+function browserRuntime(): BrowserExtensionRuntime | undefined {
+  return (
+    globalThis as typeof globalThis & {
+      chrome?: { runtime?: BrowserExtensionRuntime }
+    }
+  ).chrome?.runtime
+}
+
+export function detectBrowserExtension(
+  runtime = browserRuntime(),
+  timeoutMs = 800,
+): Promise<Exclude<BrowserExtensionStatus, 'checking'>> {
+  if (!runtime?.sendMessage) return Promise.resolve('not-installed')
+
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = (status: 'installed' | 'not-installed') => {
+      if (settled) return
+      settled = true
+      clearTimeout(timeout)
+      resolve(status)
+    }
+    const timeout = setTimeout(() => finish('not-installed'), timeoutMs)
+
+    try {
+      runtime.sendMessage(
+        CHROME_EXTENSION_ID,
+        { type: EXTENSION_STATUS_REQUEST },
+        (response) => {
+          // Reading lastError prevents Chrome from logging an expected error
+          // when the extension is absent or predates the status handshake.
+          void runtime.lastError
+          const installed =
+            typeof response === 'object' &&
+            response !== null &&
+            'installed' in response &&
+            response.installed === true
+          finish(installed ? 'installed' : 'not-installed')
+        },
+      )
+    } catch {
+      finish('not-installed')
+    }
+  })
+}
+
+export function getBrowserExtensionStatus() {
+  sharedStatusRequest ??= detectBrowserExtension()
+  return sharedStatusRequest
+}

--- a/src/lib/portal/TrendsExplorerResilience.test.tsx
+++ b/src/lib/portal/TrendsExplorerResilience.test.tsx
@@ -13,6 +13,10 @@ import { capturePostHogEvent } from '@/lib/posthog'
 jest.mock('@/lib/posthog', () => ({
   capturePostHogEvent: jest.fn(),
 }))
+jest.mock('@/components/ExtensionInstallPrompt', () => ({
+  __esModule: true,
+  default: () => null,
+}))
 const mockCapturePostHogEvent = capturePostHogEvent as jest.Mock
 
 jest.mock('next/navigation', () => ({


### PR DESCRIPTION
## Summary

- add a shared, compact, dismissible install prompt to the live stream, stream monitor, trends explorer, and homepage upload section
- link the live stream's “browser extension” text and every prompt directly to the Chrome Web Store
- detect the installed extension through a narrow handshake and hide install suggestions
- show the actual number of distinct streaming contributors for the selected monitor range
- label the stream-monitor average by its real unit: hour, day, or week

## Experience

Prompts appear only after detection determines that the extension is unavailable. One dismissal hides the prompts across these surfaces for 14 days. The existing homepage extension button also stays hidden for installed users.

## Rollout dependency

- [community-archive-stream#5](https://github.com/ri72miieop/community-archive-stream/pull/5) must be published to the Chrome Web Store before this PR merges.
- Until installed users receive extension version 0.0.4, they cannot answer the new detection request and would still see install suggestions. The rest of the website remains functional.

## Validation

- `pnpm type-check`
- 6 focused suites, 29 tests
- `pnpm build`
- `git diff --check`

The repository's Husky helper is missing in this isolated checkout, so the commit used `--no-verify`. The validations above were run directly and passed.
