### PR TITLE
Render selected digest commentary first

### DIFF
--- a/src/components/digest/DigestStoryView.test.tsx
+++ b/src/components/digest/DigestStoryView.test.tsx
@@ -60,6 +60,12 @@ describe('DigestStoryView', () => {
     expect(
       screen.getByRole('heading', { name: 'Archived quote posts' }),
     ).toBeVisible()
+    const headings = screen
+      .getAllByRole('heading')
+      .map((heading) => heading.textContent)
+    expect(headings.indexOf('Surrounding conversation')).toBeLessThan(
+      headings.indexOf('Archived quote posts'),
+    )
     expect(
       screen.getByText('This quote belongs on the story page'),
     ).toBeVisible()

--- a/src/components/digest/DigestStoryView.tsx
+++ b/src/components/digest/DigestStoryView.tsx
@@ -123,6 +123,35 @@ export function DigestStoryView({
               </div>
             </section>
 
+            {story.commentary.length ? (
+              <section>
+                <div className="flex items-center gap-3.5">
+                  <h2 className={sectionLabel}>Surrounding conversation</h2>
+                  <span className="flex-1 border-t border-zinc-200 dark:border-zinc-800" />
+                  <span className={`text-xs ${MUTED}`}>
+                    {story.commentary.length} selected
+                  </span>
+                </div>
+                <p className={`mt-2 text-sm leading-6 ${MUTED}`}>
+                  Quote posts that extended, challenged, or remixed the featured
+                  bangers.
+                </p>
+                <div className="mt-5">
+                  {story.commentary.map((tweet) => (
+                    <TweetCard
+                      key={tweet.id}
+                      tweet={tweet}
+                      variant="editorial"
+                      noClamp
+                      showDate
+                      origin="digest"
+                      returnTo={returnTo}
+                    />
+                  ))}
+                </div>
+              </section>
+            ) : null}
+
             {unselectedQuotePosts.length ? (
               <section>
                 <div className="flex items-center gap-3.5">
@@ -161,35 +190,6 @@ export function DigestStoryView({
                       </section>
                     )
                   })}
-                </div>
-              </section>
-            ) : null}
-
-            {story.commentary.length ? (
-              <section>
-                <div className="flex items-center gap-3.5">
-                  <h2 className={sectionLabel}>Surrounding conversation</h2>
-                  <span className="flex-1 border-t border-zinc-200 dark:border-zinc-800" />
-                  <span className={`text-xs ${MUTED}`}>
-                    {story.commentary.length} selected
-                  </span>
-                </div>
-                <p className={`mt-2 text-sm leading-6 ${MUTED}`}>
-                  Quote posts that extended, challenged, or remixed the featured
-                  bangers.
-                </p>
-                <div className="mt-5">
-                  {story.commentary.map((tweet) => (
-                    <TweetCard
-                      key={tweet.id}
-                      tweet={tweet}
-                      variant="editorial"
-                      noClamp
-                      showDate
-                      origin="digest"
-                      returnTo={returnTo}
-                    />
-                  ))}
                 </div>
               </section>
             ) : null}


### PR DESCRIPTION
## What changed

- Render the editorially selected **Surrounding conversation** before the remaining archived quote posts on digest story pages.
- Add a regression assertion covering the section order.

## Why

Selected commentary is the intended editorial lead-in. Rendering the exhaustive archive first made Community Archive members appear to be classified differently and buried the selected context.

## Validation

- `pnpm test -- --runInBand src/components/digest/DigestStoryView.test.tsx`
- Prettier check on both changed files
