### PR TITLE
Add daily digest link preview metadata

### DIFF
--- a/src/app/digest/[date]/page.tsx
+++ b/src/app/digest/[date]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation'
 import { checkIsAdmin } from '@/app/admin/data'
 import { DigestEditionView } from '@/components/digest/DigestEditionView'
 import { getPublishedDigest, listPublishedDigestDays } from '@/lib/digest/data'
+import { getDigestMetadata } from '@/lib/digest/metadata'
 
 export const revalidate = 300
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
@@ -12,11 +13,14 @@ export async function generateMetadata({
 }: {
   params: { date: string }
 }): Promise<Metadata> {
-  return {
-    title: DATE_PATTERN.test(params.date)
-      ? `What Happened Yesterday · ${params.date} · Community Archive`
-      : 'What Happened Yesterday · Community Archive',
-  }
+  if (!DATE_PATTERN.test(params.date))
+    return getDigestMetadata(null, `/digest/${params.date}`, 'article')
+
+  return getDigestMetadata(
+    await getPublishedDigest(params.date),
+    `/digest/${params.date}`,
+    'article',
+  )
 }
 
 export default async function DatedDigestPage({

--- a/src/app/digest/page.tsx
+++ b/src/app/digest/page.tsx
@@ -1,10 +1,15 @@
+import type { Metadata } from 'next'
 import Link from 'next/link'
 import { checkIsAdmin } from '@/app/admin/data'
 import { DigestEditionView } from '@/components/digest/DigestEditionView'
 import { getPublishedDigest, listPublishedDigestDays } from '@/lib/digest/data'
+import { getDigestMetadata } from '@/lib/digest/metadata'
 
-export const metadata = { title: 'What Happened Yesterday · Community Archive' }
 export const revalidate = 300
+
+export async function generateMetadata(): Promise<Metadata> {
+  return getDigestMetadata(await getPublishedDigest(), '/digest', 'website')
+}
 
 export default async function DigestPage() {
   const [edition, archive, isAdmin] = await Promise.all([

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -38,9 +38,12 @@ const manrope = Manrope({
   display: 'swap',
 })
 
-const defaultUrl = process.env.VERCEL_URL
-  ? `https://${process.env.VERCEL_URL}`
-  : 'http://localhost:3000'
+const defaultUrl =
+  process.env.VERCEL_ENV === 'production'
+    ? 'https://www.community-archive.org'
+    : process.env.VERCEL_URL
+      ? `https://${process.env.VERCEL_URL}`
+      : 'http://localhost:3000'
 
 export const metadata = {
   metadataBase: new URL(defaultUrl),

--- a/src/lib/digest/metadata.test.ts
+++ b/src/lib/digest/metadata.test.ts
@@ -1,0 +1,45 @@
+import { getDigestMetadata } from './metadata'
+import type { DigestEdition } from './types'
+
+const edition = {
+  digestDate: '2026-08-13',
+  publishedAt: '2026-08-14T06:00:00.000Z',
+  createdAt: '2026-08-14T05:00:00.000Z',
+  content: {
+    executiveSummary: [
+      '**AI builders** compare notes on a new release.',
+      "A joke becomes the day's most shared post.",
+    ],
+  },
+} as DigestEdition
+
+describe('daily digest metadata', () => {
+  test('builds a dated Open Graph and Twitter preview from the edition', () => {
+    const metadata = getDigestMetadata(edition, '/digest/2026-08-13', 'article')
+
+    expect(metadata).toMatchObject({
+      title: 'What Happened Yesterday · 13 August 2026 · Community Archive',
+      description:
+        "AI builders compare notes on a new release. A joke becomes the day's most shared post.",
+      alternates: { canonical: '/digest/2026-08-13' },
+      openGraph: {
+        url: '/digest/2026-08-13',
+        type: 'article',
+        publishedTime: '2026-08-14T06:00:00.000Z',
+      },
+      twitter: { card: 'summary' },
+    })
+  })
+
+  test('keeps a useful fallback preview when no edition is published', () => {
+    const metadata = getDigestMetadata(null, '/digest', 'website')
+
+    expect(metadata).toMatchObject({
+      title: 'What Happened Yesterday · Community Archive',
+      alternates: { canonical: '/digest' },
+      openGraph: { url: '/digest', type: 'website' },
+      twitter: { card: 'summary' },
+    })
+    expect(metadata.description).toContain('strongest conversations')
+  })
+})

--- a/src/lib/digest/metadata.ts
+++ b/src/lib/digest/metadata.ts
@@ -1,0 +1,68 @@
+import type { Metadata } from 'next'
+import { markdownToPlainText } from './markdown'
+import type { DigestEdition } from './types'
+
+const FALLBACK_TITLE = 'What Happened Yesterday · Community Archive'
+const FALLBACK_DESCRIPTION =
+  'A daily briefing of the strongest conversations from the Community Archive.'
+const SOCIAL_IMAGE = '/images/logo.png'
+
+const formatDigestDate = (digestDate: string) =>
+  new Intl.DateTimeFormat('en-GB', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(`${digestDate}T12:00:00Z`))
+
+const compactDescription = (edition: DigestEdition) => {
+  const description = edition.content.executiveSummary
+    .map(markdownToPlainText)
+    .join(' ')
+    .trim()
+
+  if (description.length <= 200) return description
+  return `${description.slice(0, 197).trimEnd()}…`
+}
+
+export function getDigestMetadata(
+  edition: DigestEdition | null,
+  pathname: string,
+  type: 'article' | 'website',
+): Metadata {
+  const title = edition
+    ? `What Happened Yesterday · ${formatDigestDate(edition.digestDate)} · Community Archive`
+    : FALLBACK_TITLE
+  const description = edition
+    ? compactDescription(edition)
+    : FALLBACK_DESCRIPTION
+  const publishedTime = edition?.publishedAt ?? edition?.createdAt
+
+  return {
+    title,
+    description,
+    alternates: { canonical: pathname },
+    openGraph: {
+      title,
+      description,
+      url: pathname,
+      siteName: 'Community Archive',
+      type,
+      ...(publishedTime && type === 'article' ? { publishedTime } : {}),
+      images: [
+        {
+          url: SOCIAL_IMAGE,
+          width: 160,
+          height: 160,
+          alt: 'Community Archive logo',
+        },
+      ],
+    },
+    twitter: {
+      card: 'summary',
+      title,
+      description,
+      images: [SOCIAL_IMAGE],
+    },
+  }
+}


### PR DESCRIPTION
## What changed

- Add issue-specific Open Graph and Twitter metadata to `/digest` and `/digest/[date]`.
- Use the published edition summary for social descriptions and set canonical URLs.
- Resolve production metadata URLs against `https://www.community-archive.org`.
- Add focused metadata tests.

## Why

Daily digest links should render useful previews when shared in social and messaging clients instead of inheriting only the site-wide description.

## Validation

- `pnpm exec jest --selectProjects server src/lib/digest/metadata.test.ts --runInBand`
- `pnpm type-check`
- `pnpm exec prettier --check ...`
- `VERCEL_ENV=production pnpm build`

The branch intentionally excludes separate uncommitted quote-post/story changes in the local checkout.
