### PR TITLE
Detect installed extension without messaging

### DIFF
--- a/src/lib/browserExtension.test.ts
+++ b/src/lib/browserExtension.test.ts
@@ -1,39 +1,49 @@
 import {
-  CHROME_EXTENSION_ID,
-  EXTENSION_STATUS_REQUEST,
-  type BrowserExtensionRuntime,
+  CHROME_EXTENSION_PROBE_URL,
+  type BrowserExtensionProbeImage,
   detectBrowserExtension,
 } from '@/lib/browserExtension'
 
-describe('browser extension detection', () => {
-  test('recognizes the extension status response', async () => {
-    const runtime: BrowserExtensionRuntime = {
-      sendMessage: (extensionId, message, callback) => {
-        expect(extensionId).toBe(CHROME_EXTENSION_ID)
-        expect(message).toEqual({ type: EXTENSION_STATUS_REQUEST })
-        callback({ installed: true, version: '0.0.4' })
-      },
-    }
+function createProbe(): BrowserExtensionProbeImage {
+  return { onload: null, onerror: null, src: '' }
+}
 
-    await expect(detectBrowserExtension(runtime)).resolves.toBe('installed')
+describe('browser extension detection', () => {
+  afterEach(() => {
+    jest.useRealTimers()
   })
 
-  test('treats a missing browser messaging API as not installed', async () => {
+  test('recognizes the published web-accessible resource', async () => {
+    const image = createProbe()
+    const status = detectBrowserExtension(image)
+
+    expect(image.src).toBe(CHROME_EXTENSION_PROBE_URL)
+    image.onload?.(new Event('load'))
+
+    await expect(status).resolves.toBe('installed')
+  })
+
+  test('treats a failed resource load as not installed', async () => {
+    const image = createProbe()
+    const status = detectBrowserExtension(image)
+    image.onerror?.(new Event('error'))
+
+    await expect(status).resolves.toBe('not-installed')
+  })
+
+  test('treats a missing browser image API as not installed', async () => {
     await expect(detectBrowserExtension(undefined)).resolves.toBe(
       'not-installed',
     )
   })
 
-  test('times out when an older extension cannot answer', async () => {
+  test('times out when the resource probe does not settle', async () => {
     jest.useFakeTimers()
-    const runtime: BrowserExtensionRuntime = {
-      sendMessage: () => undefined,
-    }
+    const image = createProbe()
 
-    const status = detectBrowserExtension(runtime, 50)
+    const status = detectBrowserExtension(image, 50)
     jest.advanceTimersByTime(50)
 
     await expect(status).resolves.toBe('not-installed')
-    jest.useRealTimers()
   })
 })

--- a/src/lib/browserExtension.ts
+++ b/src/lib/browserExtension.ts
@@ -2,37 +2,30 @@ export const CHROME_EXTENSION_ID = 'igclpobjpjlphgllncjcgaookmncegbk'
 
 export const CHROME_EXTENSION_URL = `https://chromewebstore.google.com/detail/community-archive-stream/${CHROME_EXTENSION_ID}`
 
-export const EXTENSION_STATUS_REQUEST =
-  'community-archive:extension-status' as const
+export const CHROME_EXTENSION_PROBE_URL = `chrome-extension://${CHROME_EXTENSION_ID}/assets/custom/nopfp2_4832.jpg`
 
 export type BrowserExtensionStatus = 'checking' | 'installed' | 'not-installed'
 
-export interface BrowserExtensionRuntime {
-  lastError?: { message?: string }
-  sendMessage: (
-    extensionId: string,
-    message: { type: typeof EXTENSION_STATUS_REQUEST },
-    callback: (response?: unknown) => void,
-  ) => void
+export interface BrowserExtensionProbeImage {
+  onload: ((event: Event) => void) | null
+  onerror: ((event: Event) => void) | null
+  src: string
 }
 
 let sharedStatusRequest:
   | Promise<Exclude<BrowserExtensionStatus, 'checking'>>
   | undefined
 
-function browserRuntime(): BrowserExtensionRuntime | undefined {
-  return (
-    globalThis as typeof globalThis & {
-      chrome?: { runtime?: BrowserExtensionRuntime }
-    }
-  ).chrome?.runtime
+function createProbeImage(): BrowserExtensionProbeImage | undefined {
+  if (typeof Image === 'undefined') return undefined
+  return new Image()
 }
 
 export function detectBrowserExtension(
-  runtime = browserRuntime(),
+  image = createProbeImage(),
   timeoutMs = 800,
 ): Promise<Exclude<BrowserExtensionStatus, 'checking'>> {
-  if (!runtime?.sendMessage) return Promise.resolve('not-installed')
+  if (!image) return Promise.resolve('not-installed')
 
   return new Promise((resolve) => {
     let settled = false
@@ -40,26 +33,19 @@ export function detectBrowserExtension(
       if (settled) return
       settled = true
       clearTimeout(timeout)
+      image.onload = null
+      image.onerror = null
       resolve(status)
     }
     const timeout = setTimeout(() => finish('not-installed'), timeoutMs)
 
+    image.onload = () => finish('installed')
+    image.onerror = () => finish('not-installed')
+
     try {
-      runtime.sendMessage(
-        CHROME_EXTENSION_ID,
-        { type: EXTENSION_STATUS_REQUEST },
-        (response) => {
-          // Reading lastError prevents Chrome from logging an expected error
-          // when the extension is absent or predates the status handshake.
-          void runtime.lastError
-          const installed =
-            typeof response === 'object' &&
-            response !== null &&
-            'installed' in response &&
-            response.installed === true
-          finish(installed ? 'installed' : 'not-installed')
-        },
-      )
+      // Version 0.0.3 already exposes this image as a web-accessible resource.
+      // A successful load is a positive signal without messaging the extension.
+      image.src = CHROME_EXTENSION_PROBE_URL
     } catch {
       finish('not-installed')
     }


### PR DESCRIPTION
## Summary

- replace the new runtime-message handshake with a website-only image probe
- load the extension's existing `assets/custom/nopfp2_4832.jpg` web-accessible resource as a positive installation signal
- keep all CTA placement, dismissal, and installed-user hiding behavior unchanged
- remove the extension-release dependency from the website rollout

## Why

The published Chrome Web Store package for version 0.0.3 already exposes this image to all web pages. Community Archive can therefore detect a successful resource load without requiring new extension code or a Store update.

## Detection behavior

- successful image load: extension is installed in the current browser context
- load error, unavailable image API, or 800 ms timeout: show the install suggestion

This is intentionally best-effort: only a positive resource load hides the CTA.

## Validation

- `pnpm type-check`
- 4 detector tests
- 5 existing CTA integration tests
- `pnpm build`
- `git diff --check`

The production build passed with the repository's existing dynamic-route diagnostics and existing test `<img>` lint warning.

## Context

Follow-up to merged PR #730. No extension release is required for this change.
