### PR TITLE
Scope homepage interactions to the current year

### DIFF
--- a/memos/20260814-1629-homepage-featured-archives.md
+++ b/memos/20260814-1629-homepage-featured-archives.md
@@ -6,11 +6,11 @@ _2026-08-14 16:29 PDT_
 
 The homepage now uses two archive-selection paths:
 
-- Signed-in members see up to eight accounts from the existing cached `topInteractedAccounts` analytics result. The cache counts mentions, replies, quotes, and reposts and is refreshed every five minutes.
+- Signed-in members see up to eight accounts from the existing persisted, current-calendar-year interaction result. The cache counts mentions, replies, quotes, and reposts; its year-scoped serving rows are refreshed in the background and the homepage revalidates every five minutes.
 - Guests see eight archives sampled on each render from a 29-person editorial pool. The sampler chooses one person from each of eight subject/community buckets and then shuffles the result, so follower count does not dominate the homepage.
 - The selected accounts are resolved in one batched `user_directory` read. This filters interaction targets to Community Archive users and supplies current usernames, avatars, and archived tweet counts for the captions. The verified editorial pool also stores a production tweet-count snapshot so guest captions remain present when a sparse preview directory triggers the intended local fallback.
 
-The current interaction projection is all-time. A one- or two-year preference should be added at the gateway/cache layer later; the homepage deliberately does not introduce an uncached ClickHouse query or pretend the present cache is time-weighted.
+The personalized path calls the existing `/analytics/user/:identifier/interactions?year=…` resource with the current UTC year. That route already resolves usernames, reads the persisted year-scoped interaction cache, and returns a scope marker that the homepage validates before rendering.
 
 ## Guest candidate pool
 

--- a/src/components/home/HomepagePeople.test.tsx
+++ b/src/components/home/HomepagePeople.test.tsx
@@ -89,7 +89,9 @@ it('shows the eight cached interaction leaders to a signed-in member', async () 
 
   render(await HomepagePeople({ isMember: true }))
 
-  expect(screen.getByText('People you interact with most')).toBeInTheDocument()
+  expect(
+    screen.getByText('People you interact with most this year'),
+  ).toBeInTheDocument()
   expect(screen.getByTestId('homepage-avatars')).toHaveTextContent(
     Array.from(
       { length: 8 },

--- a/src/components/home/HomepagePeople.tsx
+++ b/src/components/home/HomepagePeople.tsx
@@ -70,7 +70,7 @@ export default async function HomepagePeople({
     <div className="pt-2">
       <p className={labelClassName}>
         {personalized.length
-          ? 'People you interact with most'
+          ? 'People you interact with most this year'
           : 'Featured archives'}
       </p>
       <div className="mx-auto w-full max-w-3xl">

--- a/src/lib/clickhouseGateway.ts
+++ b/src/lib/clickhouseGateway.ts
@@ -100,7 +100,7 @@ export function analyticsGatewayRequestUrl(
   } else if (
     cleanPath.length === 3 &&
     cleanPath[0] === 'user' &&
-    /^\d{1,20}$/.test(cleanPath[1]) &&
+    /^(?:\d{1,20}|[A-Za-z0-9_@]{1,80})$/.test(cleanPath[1]) &&
     cleanPath[2] === 'interactions'
   ) {
     allowedParams = new Set(['year', 'limit'])

--- a/src/lib/clickhouseLab.test.ts
+++ b/src/lib/clickhouseLab.test.ts
@@ -235,6 +235,15 @@ describe('ClickHouse staging lab guard', () => {
     expect(interactions.toString()).toBe(
       'https://stream.example/analytics/user/42/interactions?year=2025&limit=8',
     )
+
+    const usernameInteractions = analyticsGatewayRequestUrl(
+      ['user', 'alice', 'interactions'],
+      new URLSearchParams('year=2025&limit=8'),
+      'https://stream.example/analytics',
+    )
+    expect(usernameInteractions.toString()).toBe(
+      'https://stream.example/analytics/user/alice/interactions?year=2025&limit=8',
+    )
   })
 
   test('allows bounded reverse-quote parameters for numeric tweet IDs', () => {

--- a/src/lib/favoritePeople.test.ts
+++ b/src/lib/favoritePeople.test.ts
@@ -1,10 +1,11 @@
 import { fetchFavoritePeople, loadFavoritePeople } from './favoritePeople'
 
 describe('fetchFavoritePeople', () => {
-  test('maps the user analytics interaction breakdown', async () => {
+  test('maps the current-year interaction breakdown', async () => {
+    const currentYear = new Date().getUTCFullYear()
     const fetcher = jest.fn().mockResolvedValue({
       data: {
-        topInteractedAccounts: [
+        people: [
           {
             accountId: '20',
             username: 'bob',
@@ -18,6 +19,7 @@ describe('fetchFavoritePeople', () => {
           },
         ],
       },
+      query: { year: currentYear, peopleLimit: 8 },
     })
 
     await expect(fetchFavoritePeople('@alice', 8, fetcher)).resolves.toEqual([
@@ -34,8 +36,8 @@ describe('fetchFavoritePeople', () => {
       },
     ])
     expect(fetcher).toHaveBeenCalledWith(
-      ['user', 'alice'],
-      new URLSearchParams({ limit: '8' }),
+      ['user', 'alice', 'interactions'],
+      new URLSearchParams({ year: String(currentYear), limit: '8' }),
       { revalidate: 300, timeoutMs: 8_000 },
     )
   })
@@ -50,12 +52,26 @@ describe('fetchFavoritePeople', () => {
   })
 
   test('rejects malformed account rows', async () => {
+    const currentYear = new Date().getUTCFullYear()
     const fetcher = jest.fn().mockResolvedValue({
-      data: { topInteractedAccounts: [{ accountId: 'not-a-number' }] },
+      data: { people: [{ accountId: 'not-a-number' }] },
+      query: { year: currentYear, peopleLimit: 8 },
     })
 
     await expect(fetchFavoritePeople('alice', 8, fetcher)).rejects.toThrow(
       'invalid account',
+    )
+  })
+
+  test('rejects a response for a different year', async () => {
+    const currentYear = new Date().getUTCFullYear()
+    const fetcher = jest.fn().mockResolvedValue({
+      data: { people: [] },
+      query: { year: currentYear - 1, peopleLimit: 8 },
+    })
+
+    await expect(fetchFavoritePeople('alice', 8, fetcher)).rejects.toThrow(
+      'mismatched scope',
     )
   })
 })

--- a/src/lib/favoritePeople.ts
+++ b/src/lib/favoritePeople.ts
@@ -17,9 +17,13 @@ interface ClickHouseInteractedAccount {
   repostCount: unknown
 }
 
-interface ClickHouseUserResponse {
+interface ClickHouseInteractionsResponse {
   data?: {
-    topInteractedAccounts?: unknown
+    people?: unknown
+  }
+  query?: {
+    year?: unknown
+    peopleLimit?: unknown
   }
 }
 
@@ -86,14 +90,22 @@ export async function fetchFavoritePeople(
     1,
     Math.min(MAX_LIMIT, Math.trunc(finiteLimit || DEFAULT_LIMIT)),
   )
-  const response = await fetcher<ClickHouseUserResponse>(
-    ['user', cleanIdentifier],
-    new URLSearchParams({ limit: String(limit) }),
+  const currentYear = new Date().getUTCFullYear()
+  const response = await fetcher<ClickHouseInteractionsResponse>(
+    ['user', cleanIdentifier, 'interactions'],
+    new URLSearchParams({ year: String(currentYear), limit: String(limit) }),
     { revalidate: 300, timeoutMs: 8_000 },
   )
-  const accounts = response.data?.topInteractedAccounts
+  if (
+    Number(response.query?.year) !== currentYear ||
+    Number(response.query?.peopleLimit) !== limit
+  ) {
+    throw new Error('ClickHouse interactions returned a mismatched scope')
+  }
+
+  const accounts = response.data?.people
   if (!Array.isArray(accounts)) {
-    throw new Error('ClickHouse user analytics returned an invalid response')
+    throw new Error('ClickHouse interactions returned an invalid response')
   }
 
   return accounts


### PR DESCRIPTION
## What changed

- use the existing year-scoped interaction resource for the signed-in homepage list
- request the current UTC calendar year and verify the returned scope before rendering
- make the year scope explicit in the homepage heading
- keep the logged-out editorial rotation unchanged

## Why

The personalized homepage previously used an all-time interaction summary. This follows the requested behavior of showing the people the signed-in member has interacted with most during the current calendar year, using the gateway’s existing persisted interaction cache.

## Validation

- 39 focused server/client tests passed
- TypeScript check passed
- Prettier check passed
- ESLint passed with one pre-existing unrelated `no-img-element` warning