### PR TITLE
Add direct policy-safe archive delivery to ClickHouse

### DIFF
--- a/services/process_archive/DEPLOY.md
+++ b/services/process_archive/DEPLOY.md
@@ -121,6 +121,10 @@ NODE_ENV=production
 ARCHIVE_DATA_PATH=./data
 ```
 
+The production ClickHouse HTTP listener remains on host loopback. The checked-in
+Compose service and direct Docker fallback therefore use host networking; do
+not replace this with a public bind or published ClickHouse port.
+
 ### Secure Your Environment File
 
 ```bash

--- a/services/process_archive/DEPLOY.md
+++ b/services/process_archive/DEPLOY.md
@@ -100,6 +100,15 @@ NEXT_PUBLIC_SUPABASE_URL=https://[YOUR_PROJECT_REF].supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 SUPABASE_SERVICE_ROLE=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 
+# Independent new-archive ClickHouse sink. Keep false until the PostgreSQL
+# delivery-state migration and ClickHouse tombstone columns are verified.
+ARCHIVE_CLICKHOUSE_SINK_ENABLED=false
+ARCHIVE_CLICKHOUSE_RETRY_BATCH=5
+CLICKHOUSE_URL=http://clickhouse-host:8123
+CLICKHOUSE_DATABASE=community_archive
+CLICKHOUSE_USER=archive_ingestor
+CLICKHOUSE_PASSWORD=replace-with-runtime-secret
+
 # Performance Configuration (OPTIONAL)
 LOG_LEVEL=info
 PG_BATCH_SIZE=1000
@@ -165,7 +174,23 @@ account's uploads to `ready_for_commit`, run the worker once, and verify:
 - the account row and every authored tweet ID from the archive exist only as
   content-free policy tombstones;
 - no profile, media, URL, mention, like, follower, following, quote, or retweet
-  payload authored by the blocked owner was written.
+payload authored by the blocked owner was written.
+
+The ClickHouse path is an independent sink from the same uploaded archive; it
+must never reconstruct content by reading PostgreSQL tweet/profile rows. Before
+setting `ARCHIVE_CLICKHOUSE_SINK_ENABLED=true`, verify the ClickHouse writer can
+insert into the nine canonical archive tables and that `is_tombstone UInt8`
+exists on `account_observations`, `tweet_content_versions`, and
+`tweet_analytics_versions`. A ClickHouse outage must not roll back a successful
+PostgreSQL archive insertion: the content-free
+`private.archive_clickhouse_delivery` row remains pending and a later cron run
+reloads the original private archive. If that archive has been removed after an
+opt-out, the stored account/tweet IDs are sufficient to deliver tombstones but
+never to reconstruct allowed content.
+
+This rollout applies only to uploads processed after the delivery-state
+migration. Do not seed the delivery table from completed uploads; historical
+tombstoning and replay require separate approval.
 
 Repeat with an account present only in `tes.blocked_scraping_users`. Also verify
 an allowed outer tweet keeps its quote/retweet relationship to a blocked target

--- a/services/process_archive/archive_clickhouse.test.ts
+++ b/services/process_archive/archive_clickhouse.test.ts
@@ -1,0 +1,356 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+import {
+  type ArchiveClickHouseBatch,
+  type ArchivePolicyDecisions,
+  attemptArchiveClickHouseDelivery,
+  buildArchiveClickHouseBatch,
+  buildArchiveTombstoneBatch,
+  collectArchivePolicyCandidates,
+  createArchiveClickHouseManifest,
+} from './archive_clickhouse'
+
+const archive = {
+  account: [
+    {
+      account: {
+        accountId: '111',
+        username: 'allowed_owner',
+        accountDisplayName: 'Allowed Owner',
+        createdAt: '2020-01-01T00:00:00.000Z',
+      },
+    },
+  ],
+  profile: [
+    {
+      profile: {
+        description: {
+          bio: 'owner bio',
+          website: 'https://owner.example',
+          location: 'somewhere',
+        },
+        avatarMediaUrl: 'https://owner.example/avatar.jpg',
+        headerMediaUrl: 'https://owner.example/header.jpg',
+      },
+    },
+  ],
+  tweets: [
+    {
+      tweet: {
+        id_str: '100',
+        created_at: '2024-01-01T00:00:00.000Z',
+        full_text: 'allowed quote commentary https://t.co/q',
+        favorite_count: 2,
+        retweet_count: 1,
+        entities: {
+          urls: [
+            {
+              url: 'https://t.co/q',
+              expanded_url: 'https://x.com/blocked_user/status/900',
+              display_url: 'x.com/blocked/status/900',
+            },
+          ],
+          user_mentions: [],
+          media: [],
+        },
+      },
+    },
+    {
+      tweet: {
+        id_str: '101',
+        created_at: '2024-01-02T00:00:00.000Z',
+        full_text: 'RT @blocked_user: forbidden target text SENTINEL',
+        favorite_count: 4,
+        retweet_count: 3,
+        retweeted_status_id_str: '901',
+        entities: { urls: [], user_mentions: [], media: [] },
+      },
+    },
+    {
+      tweet: {
+        id_str: '102',
+        created_at: '2024-01-03T00:00:00.000Z',
+        full_text: 'ordinary allowed tweet',
+        favorite_count: 6,
+        retweet_count: 5,
+        in_reply_to_status_id_str: '902',
+        in_reply_to_user_id_str: '333',
+        in_reply_to_screen_name: 'blocked_reply',
+        entities: {
+          urls: [],
+          user_mentions: [
+            { id_str: '444', screen_name: 'blocked_mention', name: 'Blocked' },
+          ],
+          media: [],
+        },
+      },
+    },
+  ],
+  like: [],
+  following: [],
+  follower: [],
+}
+
+function blockedDecisions(): ArchivePolicyDecisions {
+  return new Map(
+    collectArchivePolicyCandidates(archive).map((candidate) => [
+      candidate.key,
+      {
+        accountId:
+          candidate.accountId ??
+          (candidate.tweetId === '900' || candidate.tweetId === '901'
+            ? '222'
+            : null),
+        blocked: true,
+      },
+    ]),
+  )
+}
+
+test('allowed outers retain stable quote/retweet/reply edges while blocked targets are tombstones', () => {
+  const manifest = createArchiveClickHouseManifest(archive, '9')
+  const batch = buildArchiveClickHouseBatch(
+    archive,
+    manifest,
+    blockedDecisions(),
+    '2026-08-16T12:00:00.000Z',
+  )
+
+  const quote = batch.tweet_content_versions.find(
+    (row) => row.tweet_id === '100',
+  )
+  const retweet = batch.tweet_content_versions.find(
+    (row) => row.tweet_id === '101',
+  )
+  assert.equal(quote?.full_text, 'allowed quote commentary https://t.co/q')
+  assert.equal(retweet?.full_text, '')
+  assert.equal(retweet?.is_tombstone, 0)
+
+  assert.deepEqual(
+    batch.tweet_relationships.map((row) => [
+      row.tweet_id,
+      row.relationship_type,
+      row.related_tweet_id,
+    ]),
+    [
+      ['100', 'quote', '900'],
+      ['101', 'retweet', '901'],
+      ['102', 'reply', '902'],
+    ],
+  )
+  assert.ok(
+    batch.tweet_content_versions.some(
+      (row) => row.tweet_id === '900' && row.is_tombstone === 1,
+    ),
+  )
+  assert.ok(
+    batch.account_observations.some(
+      (row) => row.account_id === '222' && row.is_tombstone === 1,
+    ),
+  )
+  assert.ok(
+    batch.account_observations.some(
+      (row) => row.account_id === '333' && row.is_tombstone === 1,
+    ),
+  )
+  assert.ok(
+    batch.account_observations.some(
+      (row) => row.account_id === '444' && row.is_tombstone === 1,
+    ),
+  )
+  assert.equal(
+    batch.tweet_url_versions.some((row) =>
+      String(row.expanded_url).includes('blocked_user'),
+    ),
+    false,
+  )
+  assert.equal(
+    JSON.stringify(batch).includes('forbidden target text SENTINEL'),
+    false,
+  )
+})
+
+test('blocked-only archive delivery needs no raw source and writes stable-ID tombstones', async () => {
+  let written: ArchiveClickHouseBatch | undefined
+  let delivered = false
+  let loaderCalled = false
+  const result = await attemptArchiveClickHouseDelivery({
+    delivery: {
+      archive_upload_id: '9',
+      account_id: '111',
+      tweet_ids: ['100', '101', '102'],
+      username: 'allowed_owner',
+    },
+    loadArchive: async () => {
+      loaderCalled = true
+      throw new Error('must not load')
+    },
+    withOwnerPolicyLock: async (_accountId, operation) =>
+      operation({
+        ownerBlocked: true,
+        resolvePolicies: async () => new Map(),
+        markDelivered: async () => {
+          delivered = true
+        },
+      }),
+    sink: {
+      writeBatch: async (batch) => {
+        written = batch
+      },
+    },
+    markPending: async () => assert.fail('must not remain pending'),
+    now: () => new Date('2026-08-16T12:00:00.000Z'),
+  })
+
+  assert.deepEqual(result, { status: 'delivered' })
+  assert.equal(loaderCalled, false)
+  assert.equal(delivered, true)
+  assert.equal(written?.tweet_content_versions.length, 3)
+  assert.equal(written?.tweet_engagement_observations.length, 0)
+  assert.equal(written?.tweet_relationships.length, 0)
+  assert.equal(JSON.stringify(written).includes('SENTINEL'), false)
+})
+
+test('allowed delivery reloads the original archive and never reconstructs content from PostgreSQL', async () => {
+  let loaderCalled = false
+  let delivered = false
+  const manifest = createArchiveClickHouseManifest(archive, '9')
+  const result = await attemptArchiveClickHouseDelivery({
+    delivery: {
+      archive_upload_id: manifest.archiveUploadId,
+      account_id: manifest.accountId,
+      tweet_ids: manifest.tweetIds,
+      username: 'allowed_owner',
+    },
+    loadArchive: async () => {
+      loaderCalled = true
+      return archive
+    },
+    withOwnerPolicyLock: async (_accountId, operation) =>
+      operation({
+        ownerBlocked: false,
+        resolvePolicies: async () => blockedDecisions(),
+        markDelivered: async () => {
+          delivered = true
+        },
+      }),
+    sink: { writeBatch: async () => undefined },
+    markPending: async () => assert.fail('must not remain pending'),
+  })
+  assert.deepEqual(result, { status: 'delivered' })
+  assert.equal(loaderCalled, true)
+  assert.equal(delivered, true)
+})
+
+test('ClickHouse outage cannot roll back PostgreSQL completion and leaves a content-free retry pending', async () => {
+  const manifest = createArchiveClickHouseManifest(archive, '9')
+  let delivered = false
+  let pendingCode = ''
+  const result = await attemptArchiveClickHouseDelivery({
+    delivery: {
+      archive_upload_id: manifest.archiveUploadId,
+      account_id: manifest.accountId,
+      tweet_ids: manifest.tweetIds,
+      username: 'allowed_owner',
+    },
+    archive,
+    withOwnerPolicyLock: async (_accountId, operation) =>
+      operation({
+        ownerBlocked: false,
+        resolvePolicies: async () => new Map(),
+        markDelivered: async () => {
+          delivered = true
+        },
+      }),
+    sink: {
+      writeBatch: async () => {
+        throw new Error('raw response with SENTINEL')
+      },
+    },
+    markPending: async (code) => {
+      pendingCode = code
+    },
+  })
+  assert.deepEqual(result, {
+    status: 'pending',
+    errorCode: 'archive_clickhouse_delivery_failed',
+  })
+  assert.equal(delivered, false)
+  assert.equal(pendingCode, 'archive_clickhouse_delivery_failed')
+  assert.equal(pendingCode.includes('SENTINEL'), false)
+})
+
+test('allowed retry fails closed when the original archive is unavailable', async () => {
+  let pendingCode = ''
+  const result = await attemptArchiveClickHouseDelivery({
+    delivery: {
+      archive_upload_id: '9',
+      account_id: '111',
+      tweet_ids: ['100'],
+      username: null,
+    },
+    withOwnerPolicyLock: async (_accountId, operation) =>
+      operation({
+        ownerBlocked: false,
+        resolvePolicies: async () => new Map(),
+        markDelivered: async () => assert.fail('must not deliver'),
+      }),
+    sink: { writeBatch: async () => assert.fail('must not write') },
+    markPending: async (code) => {
+      pendingCode = code
+    },
+  })
+  assert.deepEqual(result, {
+    status: 'pending',
+    errorCode: 'archive_source_unavailable',
+  })
+  assert.equal(pendingCode, 'archive_source_unavailable')
+})
+
+test('delivery manifest is content-free and historical uploads are not seeded', () => {
+  const manifest = createArchiveClickHouseManifest(archive, '9')
+  assert.deepEqual(Object.keys(manifest).sort(), [
+    'accountId',
+    'archiveUploadId',
+    'tweetIds',
+  ])
+  assert.equal(JSON.stringify(manifest).includes('SENTINEL'), false)
+  assert.equal(
+    JSON.stringify(buildArchiveTombstoneBatch(manifest)).includes('SENTINEL'),
+    false,
+  )
+
+  const migration = fs.readFileSync(
+    path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      '../../supabase/migrations/20260816200315_add_archive_clickhouse_delivery_state.sql',
+    ),
+    'utf8',
+  )
+  assert.equal(
+    /INSERT\s+INTO\s+private\.archive_clickhouse_delivery/i.test(migration),
+    false,
+  )
+  assert.equal(/FROM\s+public\.archive_upload/i.test(migration), false)
+  assert.equal(
+    /\b(full_text|username|profile|media|url)\b/i.test(migration),
+    false,
+  )
+
+  const processor = fs.readFileSync(
+    path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      'process_archive_upload.ts',
+    ),
+    'utf8',
+  )
+  const completion = processor.indexOf("SET upload_phase = 'completed'")
+  const directSink = processor.indexOf(
+    'await attemptClickHouseDelivery(',
+    completion,
+  )
+  assert.ok(completion >= 0 && directSink > completion)
+})

--- a/services/process_archive/archive_clickhouse.ts
+++ b/services/process_archive/archive_clickhouse.ts
@@ -1,0 +1,752 @@
+const UINT64_PATTERN = /^(0|[1-9][0-9]*)$/
+const MAX_UINT64 = (1n << 64n) - 1n
+const TWITTER_USERNAME_PATTERN = /^[A-Za-z0-9_]{1,15}$/
+const EPOCH = '1970-01-01T00:00:00.000Z'
+
+export const ARCHIVE_CLICKHOUSE_SOURCE = 'archive_upload'
+export const ARCHIVE_CLICKHOUSE_TOMBSTONE_SOURCE =
+  'archive_upload_policy_tombstone'
+
+export interface ArchiveClickHouseManifest {
+  archiveUploadId: string
+  accountId: string
+  tweetIds: string[]
+}
+
+export interface ArchiveClickHouseDelivery {
+  archive_upload_id: string | number
+  account_id: string
+  tweet_ids: string[]
+  username?: string | null
+}
+
+export interface ArchivePolicyCandidate {
+  key: string
+  accountId: string | null
+  username: string | null
+  tweetId: string | null
+}
+
+export interface ArchivePolicyDecision {
+  accountId: string | null
+  blocked: boolean
+}
+
+export type ArchivePolicyDecisions = Map<string, ArchivePolicyDecision>
+
+export interface ArchiveClickHouseBatch {
+  account_observations: Record<string, unknown>[]
+  tweet_content_versions: Record<string, unknown>[]
+  tweet_engagement_observations: Record<string, unknown>[]
+  tweet_analytics_versions: Record<string, unknown>[]
+  tweet_archive_provenance: Record<string, unknown>[]
+  tweet_mentions: Record<string, unknown>[]
+  tweet_relationships: Record<string, unknown>[]
+  tweet_media_versions: Record<string, unknown>[]
+  tweet_url_versions: Record<string, unknown>[]
+}
+
+export interface LockedArchiveDeliveryContext {
+  ownerBlocked: boolean
+  resolvePolicies(
+    candidates: ArchivePolicyCandidate[],
+  ): Promise<ArchivePolicyDecisions>
+  markDelivered(): Promise<void>
+}
+
+export interface ArchiveDeliveryAttemptOptions {
+  delivery: ArchiveClickHouseDelivery
+  archive?: any
+  loadArchive?: (username: string) => Promise<any>
+  withOwnerPolicyLock(
+    accountId: string,
+    operation: (context: LockedArchiveDeliveryContext) => Promise<void>,
+  ): Promise<void>
+  sink: Pick<ArchiveClickHouseSink, 'writeBatch'>
+  markPending(errorCode: string): Promise<void>
+  now?: () => Date
+}
+
+export type ArchiveDeliveryAttemptResult =
+  | { status: 'delivered' }
+  | { status: 'pending'; errorCode: string }
+
+export class ArchiveClickHouseError extends Error {
+  constructor(readonly code: string) {
+    super(code)
+    this.name = 'ArchiveClickHouseError'
+  }
+}
+
+function asUInt64(value: unknown): string | null {
+  if (
+    typeof value !== 'string' &&
+    typeof value !== 'number' &&
+    typeof value !== 'bigint'
+  ) {
+    return null
+  }
+  const normalized = String(value).trim()
+  if (!UINT64_PATTERN.test(normalized)) return null
+  try {
+    if (BigInt(normalized) > MAX_UINT64) return null
+  } catch {
+    return null
+  }
+  return normalized
+}
+
+function asUsername(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const normalized = value.trim()
+  return TWITTER_USERNAME_PATTERN.test(normalized) ? normalized : null
+}
+
+function cleanText(value: unknown): string {
+  if (typeof value !== 'string') return ''
+  return value.replace(/[\u0000-\u001F\u007F-\u009F]/g, '')
+}
+
+function nonnegativeInteger(value: unknown): number {
+  const number = Number(value)
+  if (!Number.isFinite(number) || number < 0) return 0
+  return Math.trunc(number)
+}
+
+function nullableDate(value: unknown): string | null {
+  if (typeof value !== 'string' && typeof value !== 'number') return null
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date.toISOString()
+}
+
+function eventPrefix(manifest: ArchiveClickHouseManifest): string {
+  return `archive:${manifest.archiveUploadId}`
+}
+
+function candidateKey(
+  accountId: string | null,
+  username: string | null,
+  tweetId: string | null,
+): string {
+  return `${accountId ?? ''}|${username?.toLowerCase() ?? ''}|${tweetId ?? ''}`
+}
+
+function quoteTarget(
+  url: unknown,
+): { tweetId: string; username: string | null } | null {
+  if (typeof url !== 'string') return null
+  const match = url.match(
+    /(?:twitter\.com|x\.com)\/([A-Za-z0-9_]{1,15})\/status\/(\d+)/i,
+  )
+  const tweetId = asUInt64(match?.[2])
+  if (!tweetId) return null
+  return { tweetId, username: asUsername(match?.[1]) }
+}
+
+function retweetTarget(
+  tweet: any,
+): { tweetId: string; username: string | null } | null {
+  const tweetId = asUInt64(
+    tweet?.retweeted_status_id_str ??
+      tweet?.retweeted_status_id ??
+      tweet?.retweeted_status?.id_str,
+  )
+  if (!tweetId) return null
+  const username = asUsername(
+    typeof tweet?.full_text === 'string'
+      ? tweet.full_text.match(/^RT @([A-Za-z0-9_]{1,15}):/)?.[1]
+      : null,
+  )
+  return { tweetId, username }
+}
+
+export function createArchiveClickHouseManifest(
+  archive: any,
+  archiveUploadId: string | number,
+): ArchiveClickHouseManifest {
+  const accountId = asUInt64(archive?.account?.[0]?.account?.accountId)
+  const normalizedUploadId = asUInt64(archiveUploadId)
+  if (!accountId || !normalizedUploadId) {
+    throw new ArchiveClickHouseError('invalid_archive_identity')
+  }
+
+  const tweetIds = new Set<string>()
+  for (const record of archive?.tweets ?? []) {
+    const tweetId = asUInt64(record?.tweet?.id_str ?? record?.tweet?.id)
+    if (tweetId) tweetIds.add(tweetId)
+  }
+
+  return {
+    archiveUploadId: normalizedUploadId,
+    accountId,
+    tweetIds: [...tweetIds].sort((left, right) =>
+      BigInt(left) < BigInt(right) ? -1 : BigInt(left) > BigInt(right) ? 1 : 0,
+    ),
+  }
+}
+
+export function collectArchivePolicyCandidates(
+  archive: any,
+): ArchivePolicyCandidate[] {
+  const candidates = new Map<string, ArchivePolicyCandidate>()
+  const add = (
+    accountIdValue: unknown,
+    usernameValue: unknown,
+    tweetIdValue: unknown,
+  ) => {
+    const accountId = asUInt64(accountIdValue)
+    const username = asUsername(usernameValue)
+    const tweetId = asUInt64(tweetIdValue)
+    if (!accountId && !username && !tweetId) return
+    const key = candidateKey(accountId, username, tweetId)
+    candidates.set(key, { key, accountId, username, tweetId })
+  }
+
+  for (const record of archive?.tweets ?? []) {
+    const tweet = record?.tweet
+    if (!tweet) continue
+
+    for (const mention of tweet.entities?.user_mentions ?? []) {
+      add(mention?.id_str ?? mention?.id, mention?.screen_name, null)
+    }
+
+    add(
+      tweet.in_reply_to_user_id_str ?? tweet.in_reply_to_user_id,
+      tweet.in_reply_to_screen_name,
+      tweet.in_reply_to_status_id_str ?? tweet.in_reply_to_status_id,
+    )
+
+    for (const url of tweet.entities?.urls ?? []) {
+      const target = quoteTarget(url?.expanded_url)
+      if (target) add(null, target.username, target.tweetId)
+    }
+
+    const target = retweetTarget(tweet)
+    if (target) add(null, target.username, target.tweetId)
+  }
+
+  return [...candidates.values()]
+}
+
+function emptyBatch(): ArchiveClickHouseBatch {
+  return {
+    account_observations: [],
+    tweet_content_versions: [],
+    tweet_engagement_observations: [],
+    tweet_analytics_versions: [],
+    tweet_archive_provenance: [],
+    tweet_mentions: [],
+    tweet_relationships: [],
+    tweet_media_versions: [],
+    tweet_url_versions: [],
+  }
+}
+
+function addAccountTombstone(
+  batch: ArchiveClickHouseBatch,
+  manifest: ArchiveClickHouseManifest,
+  accountId: string,
+  observedAt: string,
+  suffix: string,
+): void {
+  batch.account_observations.push({
+    account_id: accountId,
+    is_tombstone: 1,
+    username: '',
+    account_display_name: '',
+    account_created_at: null,
+    num_tweets: null,
+    num_following: null,
+    num_followers: null,
+    num_likes: null,
+    bio: null,
+    website: null,
+    location: null,
+    avatar_media_url: null,
+    header_media_url: null,
+    source: ARCHIVE_CLICKHOUSE_TOMBSTONE_SOURCE,
+    event_id: `${eventPrefix(manifest)}:tombstone:account:${suffix}:${accountId}`,
+    observed_at: observedAt,
+  })
+}
+
+function addTweetTombstone(
+  batch: ArchiveClickHouseBatch,
+  manifest: ArchiveClickHouseManifest,
+  tweetId: string,
+  accountId: string | null,
+  observedAt: string,
+  suffix: string,
+): void {
+  const content = {
+    tweet_id: tweetId,
+    account_id: accountId ?? '0',
+    is_tombstone: 1,
+    created_at: EPOCH,
+    full_text: '',
+    reply_to_tweet_id: null,
+    reply_to_user_id: null,
+    reply_to_username: null,
+    source: ARCHIVE_CLICKHOUSE_TOMBSTONE_SOURCE,
+    event_id: `${eventPrefix(manifest)}:tombstone:tweet:${suffix}:${tweetId}`,
+    observed_at: observedAt,
+  }
+  batch.tweet_content_versions.push(content)
+  batch.tweet_analytics_versions.push({
+    ...content,
+    favorite_count: 0,
+    retweet_count: 0,
+  })
+}
+
+export function buildArchiveTombstoneBatch(
+  manifest: ArchiveClickHouseManifest,
+  observedAt = new Date().toISOString(),
+): ArchiveClickHouseBatch {
+  const batch = emptyBatch()
+  addAccountTombstone(batch, manifest, manifest.accountId, observedAt, 'owner')
+  for (const tweetId of manifest.tweetIds) {
+    addTweetTombstone(
+      batch,
+      manifest,
+      tweetId,
+      manifest.accountId,
+      observedAt,
+      'owner',
+    )
+    batch.tweet_archive_provenance.push({
+      tweet_id: tweetId,
+      archive_upload_id: manifest.archiveUploadId,
+      source: ARCHIVE_CLICKHOUSE_TOMBSTONE_SOURCE,
+      event_id: `${eventPrefix(manifest)}:provenance:${tweetId}`,
+      observed_at: observedAt,
+    })
+  }
+  return deduplicateBatch(batch)
+}
+
+function decisionFor(
+  decisions: ArchivePolicyDecisions,
+  accountIdValue: unknown,
+  usernameValue: unknown,
+  tweetIdValue: unknown,
+): ArchivePolicyDecision {
+  const accountId = asUInt64(accountIdValue)
+  const username = asUsername(usernameValue)
+  const tweetId = asUInt64(tweetIdValue)
+  return (
+    decisions.get(candidateKey(accountId, username, tweetId)) ?? {
+      accountId,
+      blocked: false,
+    }
+  )
+}
+
+function addBlockedTarget(
+  batch: ArchiveClickHouseBatch,
+  manifest: ArchiveClickHouseManifest,
+  decision: ArchivePolicyDecision,
+  tweetId: string | null,
+  observedAt: string,
+): void {
+  if (!decision.blocked) return
+  if (decision.accountId) {
+    addAccountTombstone(
+      batch,
+      manifest,
+      decision.accountId,
+      observedAt,
+      'target',
+    )
+  }
+  if (tweetId) {
+    addTweetTombstone(
+      batch,
+      manifest,
+      tweetId,
+      decision.accountId,
+      observedAt,
+      'target',
+    )
+  }
+}
+
+export function buildArchiveClickHouseBatch(
+  archive: any,
+  manifest: ArchiveClickHouseManifest,
+  decisions: ArchivePolicyDecisions,
+  observedAt = new Date().toISOString(),
+): ArchiveClickHouseBatch {
+  const account = archive?.account?.[0]?.account
+  if (asUInt64(account?.accountId) !== manifest.accountId) {
+    throw new ArchiveClickHouseError('archive_owner_mismatch')
+  }
+
+  const batch = emptyBatch()
+  const manifestTweetIds = new Set(manifest.tweetIds)
+  const profile = archive?.profile?.[0]?.profile
+  batch.account_observations.push({
+    account_id: manifest.accountId,
+    is_tombstone: 0,
+    username: asUsername(account?.username) ?? '',
+    account_display_name: cleanText(account?.accountDisplayName),
+    account_created_at: nullableDate(account?.createdAt),
+    num_tweets: (archive?.tweets ?? []).length,
+    num_following: (archive?.following ?? []).length,
+    num_followers: (archive?.follower ?? []).length,
+    num_likes: (archive?.like ?? []).length,
+    bio: cleanText(profile?.description?.bio) || null,
+    website: cleanText(profile?.description?.website) || null,
+    location: cleanText(profile?.description?.location) || null,
+    avatar_media_url: cleanText(profile?.avatarMediaUrl) || null,
+    header_media_url: cleanText(profile?.headerMediaUrl) || null,
+    source: ARCHIVE_CLICKHOUSE_SOURCE,
+    event_id: `${eventPrefix(manifest)}:account:${manifest.accountId}`,
+    observed_at: observedAt,
+  })
+
+  for (const record of archive?.tweets ?? []) {
+    const tweet = record?.tweet
+    const tweetId = asUInt64(tweet?.id_str ?? tweet?.id)
+    if (!tweetId || !manifestTweetIds.has(tweetId)) continue
+
+    const replyTweetId = asUInt64(
+      tweet?.in_reply_to_status_id_str ?? tweet?.in_reply_to_status_id,
+    )
+    const replyAccountId = asUInt64(
+      tweet?.in_reply_to_user_id_str ?? tweet?.in_reply_to_user_id,
+    )
+    const replyUsername = asUsername(tweet?.in_reply_to_screen_name)
+    const replyDecision = decisionFor(
+      decisions,
+      replyAccountId,
+      replyUsername,
+      replyTweetId,
+    )
+    addBlockedTarget(batch, manifest, replyDecision, replyTweetId, observedAt)
+
+    const retweet = retweetTarget(tweet)
+    const retweetDecision = retweet
+      ? decisionFor(decisions, null, retweet.username, retweet.tweetId)
+      : { accountId: null, blocked: false }
+    if (retweet) {
+      addBlockedTarget(
+        batch,
+        manifest,
+        retweetDecision,
+        retweet.tweetId,
+        observedAt,
+      )
+    }
+
+    // A Twitter archive's RT text is a copy of the target author's content.
+    // Keep the allowed retweet record and edge, but never duplicate a blocked
+    // target's text into the allowed author's row.
+    const fullText = retweetDecision.blocked ? '' : cleanText(tweet?.full_text)
+    const createdAt = nullableDate(tweet?.created_at) ?? EPOCH
+    const tweetEventId = `${eventPrefix(manifest)}:tweet:${tweetId}`
+    const content = {
+      tweet_id: tweetId,
+      account_id: manifest.accountId,
+      is_tombstone: 0,
+      created_at: createdAt,
+      full_text: fullText,
+      reply_to_tweet_id: replyTweetId,
+      reply_to_user_id: replyAccountId,
+      // The stable target IDs preserve the reply; usernames are deliberately
+      // not duplicated into ClickHouse.
+      reply_to_username: null,
+      source: ARCHIVE_CLICKHOUSE_SOURCE,
+      event_id: tweetEventId,
+      observed_at: observedAt,
+    }
+    batch.tweet_content_versions.push(content)
+    batch.tweet_engagement_observations.push({
+      tweet_id: tweetId,
+      favorite_count: nonnegativeInteger(tweet?.favorite_count),
+      retweet_count: nonnegativeInteger(tweet?.retweet_count),
+      source: ARCHIVE_CLICKHOUSE_SOURCE,
+      event_id: tweetEventId,
+      observed_at: observedAt,
+    })
+    batch.tweet_analytics_versions.push({
+      ...content,
+      favorite_count: nonnegativeInteger(tweet?.favorite_count),
+      retweet_count: nonnegativeInteger(tweet?.retweet_count),
+    })
+    batch.tweet_archive_provenance.push({
+      tweet_id: tweetId,
+      archive_upload_id: manifest.archiveUploadId,
+      source: ARCHIVE_CLICKHOUSE_SOURCE,
+      event_id: `${eventPrefix(manifest)}:provenance:${tweetId}`,
+      observed_at: observedAt,
+    })
+
+    if (replyTweetId) {
+      batch.tweet_relationships.push({
+        tweet_id: tweetId,
+        relationship_type: 'reply',
+        related_tweet_id: replyTweetId,
+        source: ARCHIVE_CLICKHOUSE_SOURCE,
+        event_id: `${eventPrefix(manifest)}:reply:${tweetId}:${replyTweetId}`,
+        observed_at: observedAt,
+      })
+    }
+
+    for (const mention of tweet?.entities?.user_mentions ?? []) {
+      const mentionedAccountId = asUInt64(mention?.id_str ?? mention?.id)
+      if (!mentionedAccountId) continue
+      const mentionDecision = decisionFor(
+        decisions,
+        mentionedAccountId,
+        mention?.screen_name,
+        null,
+      )
+      addBlockedTarget(batch, manifest, mentionDecision, null, observedAt)
+      batch.tweet_mentions.push({
+        tweet_id: tweetId,
+        mentioned_account_id: mentionedAccountId,
+        source: ARCHIVE_CLICKHOUSE_SOURCE,
+        event_id: `${eventPrefix(manifest)}:mention:${tweetId}:${mentionedAccountId}`,
+        observed_at: observedAt,
+      })
+    }
+
+    for (const url of tweet?.entities?.urls ?? []) {
+      const quoted = quoteTarget(url?.expanded_url)
+      if (quoted) {
+        const quoteDecision = decisionFor(
+          decisions,
+          null,
+          quoted.username,
+          quoted.tweetId,
+        )
+        addBlockedTarget(
+          batch,
+          manifest,
+          quoteDecision,
+          quoted.tweetId,
+          observedAt,
+        )
+        batch.tweet_relationships.push({
+          tweet_id: tweetId,
+          relationship_type: 'quote',
+          related_tweet_id: quoted.tweetId,
+          source: ARCHIVE_CLICKHOUSE_SOURCE,
+          event_id: `${eventPrefix(manifest)}:quote:${tweetId}:${quoted.tweetId}`,
+          observed_at: observedAt,
+        })
+        // The stable relationship replaces the content-bearing URL metadata
+        // when its target author is blocked.
+        if (quoteDecision.blocked) continue
+      }
+
+      const urlValue = cleanText(url?.url)
+      if (!urlValue) continue
+      batch.tweet_url_versions.push({
+        tweet_id: tweetId,
+        url: urlValue,
+        expanded_url: cleanText(url?.expanded_url) || null,
+        display_url: cleanText(url?.display_url),
+        source: ARCHIVE_CLICKHOUSE_SOURCE,
+        event_id: `${eventPrefix(manifest)}:url:${tweetId}:${urlValue}`,
+        observed_at: observedAt,
+      })
+    }
+
+    for (const media of tweet?.entities?.media ?? []) {
+      const mediaId = asUInt64(media?.id_str ?? media?.id)
+      const mediaUrl = cleanText(media?.media_url_https ?? media?.media_url)
+      if (!mediaId || !mediaUrl) continue
+      batch.tweet_media_versions.push({
+        media_id: mediaId,
+        tweet_id: tweetId,
+        media_type: cleanText(media?.type),
+        media_url: mediaUrl,
+        width: nonnegativeInteger(media?.sizes?.large?.w) || null,
+        height: nonnegativeInteger(media?.sizes?.large?.h) || null,
+        source: ARCHIVE_CLICKHOUSE_SOURCE,
+        event_id: `${eventPrefix(manifest)}:media:${mediaId}`,
+        observed_at: observedAt,
+      })
+    }
+
+    if (retweet) {
+      batch.tweet_relationships.push({
+        tweet_id: tweetId,
+        relationship_type: 'retweet',
+        related_tweet_id: retweet.tweetId,
+        source: ARCHIVE_CLICKHOUSE_SOURCE,
+        event_id: `${eventPrefix(manifest)}:retweet:${tweetId}:${retweet.tweetId}`,
+        observed_at: observedAt,
+      })
+    }
+  }
+
+  return deduplicateBatch(batch)
+}
+
+function deduplicateBatch(
+  batch: ArchiveClickHouseBatch,
+): ArchiveClickHouseBatch {
+  return Object.fromEntries(
+    Object.entries(batch).map(([table, rows]) => {
+      const byEvent = new Map<string, Record<string, unknown>>()
+      for (const row of rows) byEvent.set(String(row.event_id), row)
+      return [table, [...byEvent.values()]]
+    }),
+  ) as unknown as ArchiveClickHouseBatch
+}
+
+export function safeArchiveClickHouseErrorCode(error: unknown): string {
+  if (error instanceof ArchiveClickHouseError) return error.code
+  return 'archive_clickhouse_delivery_failed'
+}
+
+export async function attemptArchiveClickHouseDelivery(
+  options: ArchiveDeliveryAttemptOptions,
+): Promise<ArchiveDeliveryAttemptResult> {
+  const manifest: ArchiveClickHouseManifest = {
+    archiveUploadId: asUInt64(options.delivery.archive_upload_id) ?? '',
+    accountId: asUInt64(options.delivery.account_id) ?? '',
+    tweetIds: (options.delivery.tweet_ids ?? [])
+      .map(asUInt64)
+      .filter((value): value is string => Boolean(value)),
+  }
+  if (!manifest.archiveUploadId || !manifest.accountId) {
+    const errorCode = 'invalid_delivery_manifest'
+    await options.markPending(errorCode)
+    return { status: 'pending', errorCode }
+  }
+
+  try {
+    await options.withOwnerPolicyLock(manifest.accountId, async (context) => {
+      const observedAt = (options.now ?? (() => new Date()))().toISOString()
+      let batch: ArchiveClickHouseBatch
+      if (context.ownerBlocked) {
+        batch = buildArchiveTombstoneBatch(manifest, observedAt)
+      } else {
+        const archive =
+          options.archive ??
+          (options.delivery.username && options.loadArchive
+            ? await options.loadArchive(options.delivery.username)
+            : null)
+        if (!archive) {
+          throw new ArchiveClickHouseError('archive_source_unavailable')
+        }
+        const archiveManifest = createArchiveClickHouseManifest(
+          archive,
+          manifest.archiveUploadId,
+        )
+        if (
+          archiveManifest.accountId !== manifest.accountId ||
+          archiveManifest.tweetIds.join(',') !== manifest.tweetIds.join(',')
+        ) {
+          throw new ArchiveClickHouseError('archive_manifest_mismatch')
+        }
+        const candidates = collectArchivePolicyCandidates(archive)
+        const decisions = await context.resolvePolicies(candidates)
+        batch = buildArchiveClickHouseBatch(
+          archive,
+          manifest,
+          decisions,
+          observedAt,
+        )
+      }
+
+      await options.sink.writeBatch(batch)
+      await context.markDelivered()
+    })
+    return { status: 'delivered' }
+  } catch (error) {
+    const errorCode = safeArchiveClickHouseErrorCode(error)
+    await options.markPending(errorCode)
+    return { status: 'pending', errorCode }
+  }
+}
+
+export class ArchiveClickHouseSink {
+  constructor(
+    private readonly url: string,
+    private readonly database: string,
+    private readonly user: string,
+    private readonly password: string,
+  ) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(database)) {
+      throw new ArchiveClickHouseError('invalid_clickhouse_database')
+    }
+  }
+
+  async healthCheck(): Promise<void> {
+    const health = await this.request('SELECT 1')
+    if (health.trim() !== '1') {
+      throw new ArchiveClickHouseError('clickhouse_health_failed')
+    }
+    const tableReadiness = await this.request(`
+      SELECT count()
+      FROM system.tables
+      WHERE database = '${this.database}'
+        AND name IN (
+          'account_observations',
+          'tweet_content_versions',
+          'tweet_engagement_observations',
+          'tweet_analytics_versions',
+          'tweet_archive_provenance',
+          'tweet_mentions',
+          'tweet_relationships',
+          'tweet_media_versions',
+          'tweet_url_versions'
+        )
+    `)
+    if (tableReadiness.trim() !== '9') {
+      throw new ArchiveClickHouseError('clickhouse_archive_schema_missing')
+    }
+    const tombstoneReadiness = await this.request(`
+      SELECT count()
+      FROM system.columns
+      WHERE database = '${this.database}'
+        AND (table, name) IN (
+          ('account_observations', 'is_tombstone'),
+          ('tweet_content_versions', 'is_tombstone'),
+          ('tweet_analytics_versions', 'is_tombstone')
+        )
+    `)
+    if (tombstoneReadiness.trim() !== '3') {
+      throw new ArchiveClickHouseError('clickhouse_tombstone_schema_missing')
+    }
+  }
+
+  async writeBatch(batch: ArchiveClickHouseBatch): Promise<void> {
+    for (const [table, rows] of Object.entries(batch)) {
+      if (rows.length === 0) continue
+      const body = rows.map((row) => JSON.stringify(row)).join('\n')
+      await this.request(
+        `INSERT INTO ${this.database}.${table} FORMAT JSONEachRow`,
+        body,
+      )
+    }
+  }
+
+  private async request(query: string, body?: string): Promise<string> {
+    const endpoint = new URL(this.url)
+    endpoint.searchParams.set('query', query)
+    endpoint.searchParams.set('date_time_input_format', 'best_effort')
+    const response = await fetch(endpoint, {
+      method: body === undefined ? 'GET' : 'POST',
+      headers: {
+        Authorization: `Basic ${Buffer.from(`${this.user}:${this.password}`).toString('base64')}`,
+        ...(body === undefined
+          ? {}
+          : { 'Content-Type': 'application/x-ndjson' }),
+      },
+      body,
+      signal: AbortSignal.timeout(30_000),
+    })
+    if (!response.ok) {
+      // Never include the response body: ClickHouse parse errors can echo
+      // archive content from the rejected row.
+      throw new ArchiveClickHouseError(`clickhouse_http_${response.status}`)
+    }
+    return response.text()
+  }
+}

--- a/services/process_archive/docker-compose.yml
+++ b/services/process_archive/docker-compose.yml
@@ -9,6 +9,11 @@ services:
     # Explicitly load environment file
     env_file:
       - ../../.env
+
+    # Production ClickHouse is intentionally bound to host loopback only.
+    # The one-shot archive container therefore shares the host network rather
+    # than exposing ClickHouse or relying on an unstable bridge address.
+    network_mode: host
     
     # Environment variables - customize these
     

--- a/services/process_archive/docker-run.sh
+++ b/services/process_archive/docker-run.sh
@@ -45,6 +45,7 @@ else
     echo "Using direct docker run..."
     docker run --rm \
         --name process-archive-service \
+        --network host \
         --env-file=.env \
         -v "$(pwd)/logs:/app/logs" \
         -v "$(pwd)/data:/app/data" \

--- a/services/process_archive/env.example
+++ b/services/process_archive/env.example
@@ -22,6 +22,16 @@ PG_BATCH_SIZE=1000
 MEMORY_BATCH_SIZE=3000
 MAX_MEMORY_MB=2000
 
+# Independent new-archive ClickHouse sink (OPTIONAL until rollout approval)
+# PostgreSQL remains authoritative for consent. When enabled, the worker writes
+# the same uploaded archive independently to PostgreSQL and ClickHouse.
+ARCHIVE_CLICKHOUSE_SINK_ENABLED=false
+ARCHIVE_CLICKHOUSE_RETRY_BATCH=5
+CLICKHOUSE_URL=http://clickhouse-host:8123
+CLICKHOUSE_DATABASE=community_archive
+CLICKHOUSE_USER=archive_ingestor
+CLICKHOUSE_PASSWORD=replace-with-runtime-secret
+
 NODE_ENV=production
 
 # Docker-specific Configuration (OPTIONAL)

--- a/services/process_archive/package.json
+++ b/services/process_archive/package.json
@@ -12,6 +12,7 @@
     "start:stream": "set NODE_OPTIONS=--expose-gc && tsx --env-file=.env process_stream.ts",
     "start:copy": "npm run start",
     "smoke:runtime": "node --expose-gc runtime_smoke_test.cjs",
+    "test:archive-clickhouse": "node --import tsx --test archive_clickhouse.test.ts",
     "run": "set NODE_OPTIONS=--expose-gc && tsx --env-file=.env process.ts",
     "docker:build": "cd ../../ && docker build -f services/process_archive/Dockerfile -t process-archive .",
     "docker:run": "docker compose run --rm process-archive",
@@ -30,4 +31,3 @@
     "typescript": "^5.1.3"
   }
 }
-

--- a/services/process_archive/process_archive_upload.ts
+++ b/services/process_archive/process_archive_upload.ts
@@ -10,6 +10,15 @@ import postgres from 'postgres'
 type Sql = postgres.Sql
 
 import { createClient } from '@supabase/supabase-js'
+import {
+  ArchiveClickHouseError,
+  ArchiveClickHouseSink,
+  type ArchiveClickHouseDelivery,
+  type ArchivePolicyCandidate,
+  type ArchivePolicyDecisions,
+  attemptArchiveClickHouseDelivery,
+  createArchiveClickHouseManifest,
+} from './archive_clickhouse'
 
 // Configuration
 const CONFIG = {
@@ -20,7 +29,21 @@ const CONFIG = {
   POSTGRES_CONNECTION_STRING: process.env.POSTGRES_CONNECTION_STRING,
   MAX_MEMORY_MB: parseInt(process.env.MAX_MEMORY_MB || '1000', 10), // Memory limit
   PROCESS_RETWEETS: process.env.PROCESS_RETWEETS !== 'false', // Enable retweet processing by default
-  DEBUG_PG_QUERIES: process.env.DEBUG_PG_QUERIES === 'true' // only log if it has been explicitly enabled
+  DEBUG_PG_QUERIES: process.env.DEBUG_PG_QUERIES === 'true', // only log if it has been explicitly enabled
+  ARCHIVE_CLICKHOUSE_SINK_ENABLED:
+    process.env.ARCHIVE_CLICKHOUSE_SINK_ENABLED === 'true',
+  ARCHIVE_CLICKHOUSE_RETRY_BATCH: Math.max(
+    1,
+    Math.min(
+      50,
+      parseInt(process.env.ARCHIVE_CLICKHOUSE_RETRY_BATCH || '5', 10),
+    ),
+  ),
+  CLICKHOUSE_URL: process.env.CLICKHOUSE_URL,
+  CLICKHOUSE_DATABASE:
+    process.env.CLICKHOUSE_DATABASE || 'community_archive',
+  CLICKHOUSE_USER: process.env.CLICKHOUSE_USER,
+  CLICKHOUSE_PASSWORD: process.env.CLICKHOUSE_PASSWORD,
 } as const
 
 export async function createServerScriptClient() {
@@ -302,6 +325,10 @@ export class ArchiveUploadProcessor {
   async processArchive(archive: any): Promise<void> {
 
     archive = patchArchive(archive);
+    const clickHouseManifest = createArchiveClickHouseManifest(
+      archive,
+      this.archiveUploadId,
+    )
 
 
     logger.info(`Processing large archive with optimized batch inserts (${getMemoryUsageMB()}MB memory used)`)
@@ -314,6 +341,7 @@ export class ArchiveUploadProcessor {
       const ownerBlocked = await this.archiveOwnerIsBlocked(trx, archive)
       if (ownerBlocked) {
         await this.processBlockedArchive(trx, archive)
+        await this.enqueueClickHouseDelivery(trx, clickHouseManifest)
         return
       }
 
@@ -343,7 +371,45 @@ export class ArchiveUploadProcessor {
 
       // Process remaining data that depends on all tweets being processed
       await this.processRemainingData(trx, archive)
+      await this.enqueueClickHouseDelivery(trx, clickHouseManifest)
     })
+  }
+
+  private async enqueueClickHouseDelivery(
+    trx: Sql,
+    manifest: ReturnType<typeof createArchiveClickHouseManifest>,
+  ): Promise<void> {
+    await trx`
+      INSERT INTO private.archive_clickhouse_delivery (
+        archive_upload_id,
+        account_id,
+        tweet_ids,
+        delivery_state,
+        next_attempt_at,
+        updated_at
+      ) VALUES (
+        ${manifest.archiveUploadId},
+        ${manifest.accountId},
+        ${manifest.tweetIds}::text[],
+        'pending',
+        now(),
+        now()
+      )
+      ON CONFLICT (archive_upload_id) DO UPDATE SET
+        account_id = EXCLUDED.account_id,
+        tweet_ids = EXCLUDED.tweet_ids,
+        delivery_state = CASE
+          WHEN private.archive_clickhouse_delivery.delivery_state = 'delivered'
+            THEN 'delivered'
+          ELSE 'pending'
+        END,
+        next_attempt_at = CASE
+          WHEN private.archive_clickhouse_delivery.delivery_state = 'delivered'
+            THEN private.archive_clickhouse_delivery.next_attempt_at
+          ELSE now()
+        END,
+        updated_at = now()
+    `
   }
 
   private async archiveOwnerIsBlocked(
@@ -841,7 +907,7 @@ function patchArchive(archive: any): any {
 }
 
 // Main processing function
-async function processSingleArchive(sql: Sql, username: string, archiveUploadId: number): Promise<void> {
+async function processSingleArchive(sql: Sql, username: string, archiveUploadId: number): Promise<any> {
   logger.debug(`Loading archive for optimized processing (current memory: ${getMemoryUsageMB()}MB)`)
   
   const archive = await loadArchiveData(username)
@@ -857,6 +923,170 @@ async function processSingleArchive(sql: Sql, username: string, archiveUploadId:
   await processor.processArchive(archive)
   
   logger.info(`Optimized processing completed (memory usage: ${getMemoryUsageMB()}MB)`)
+  return archive
+}
+
+function createArchiveClickHouseSink(): ArchiveClickHouseSink {
+  if (
+    !CONFIG.CLICKHOUSE_URL ||
+    !CONFIG.CLICKHOUSE_USER ||
+    !CONFIG.CLICKHOUSE_PASSWORD
+  ) {
+    throw new ArchiveClickHouseError('clickhouse_configuration_missing')
+  }
+  return new ArchiveClickHouseSink(
+    CONFIG.CLICKHOUSE_URL,
+    CONFIG.CLICKHOUSE_DATABASE,
+    CONFIG.CLICKHOUSE_USER,
+    CONFIG.CLICKHOUSE_PASSWORD,
+  )
+}
+
+async function resolveArchivePolicyDecisions(
+  trx: Sql,
+  candidates: ArchivePolicyCandidate[],
+): Promise<ArchivePolicyDecisions> {
+  if (candidates.length === 0) return new Map()
+  const rows = await trx`
+    WITH candidate AS (
+      SELECT
+        item->>'key' AS key,
+        NULLIF(item->>'accountId', '') AS account_id,
+        NULLIF(item->>'username', '') AS username,
+        NULLIF(item->>'tweetId', '') AS tweet_id
+      FROM jsonb_array_elements(${JSON.stringify(candidates)}::jsonb) AS item
+    ), resolved AS (
+      SELECT
+        candidate.key,
+        candidate.username,
+        COALESCE(
+          candidate.account_id,
+          CASE
+            WHEN target.account_id ~ '^(0|[1-9][0-9]*)$'
+              THEN target.account_id
+            ELSE NULL
+          END,
+          public.policy_blocked_account_id(candidate.username)
+        ) AS account_id
+      FROM candidate
+      LEFT JOIN public.tweets AS target
+        ON target.tweet_id = candidate.tweet_id
+    )
+    SELECT
+      key,
+      CASE
+        WHEN account_id ~ '^(0|[1-9][0-9]*)$' THEN account_id
+        ELSE NULL
+      END AS account_id,
+      public.policy_account_is_blocked(account_id, username) AS blocked
+    FROM resolved
+  `
+  return new Map(
+    rows.map((row) => [
+      row.key,
+      {
+        accountId: row.account_id ?? null,
+        blocked: row.blocked === true,
+      },
+    ]),
+  )
+}
+
+async function attemptClickHouseDelivery(
+  sql: Sql,
+  sink: ArchiveClickHouseSink,
+  delivery: ArchiveClickHouseDelivery,
+  archive?: any,
+): Promise<void> {
+  const result = await attemptArchiveClickHouseDelivery({
+    delivery,
+    archive,
+    loadArchive: async (username) => patchArchive(await loadArchiveData(username)),
+    sink,
+    withOwnerPolicyLock: async (accountId, operation) => {
+      await sql.begin(async (trx: Sql) => {
+        await trx`SELECT public.lock_policy_account(${accountId})`
+        const [policy] = await trx`
+          SELECT public.policy_account_is_blocked(
+            ${accountId},
+            ${delivery.username ?? null}
+          ) AS blocked
+        `
+        await operation({
+          ownerBlocked: policy?.blocked === true,
+          resolvePolicies: (candidates) =>
+            resolveArchivePolicyDecisions(trx, candidates),
+          markDelivered: async () => {
+            const updated = await trx`
+              UPDATE private.archive_clickhouse_delivery
+              SET
+                delivery_state = 'delivered',
+                attempt_count = attempt_count + 1,
+                last_error_code = NULL,
+                delivered_at = now(),
+                updated_at = now()
+              WHERE archive_upload_id = ${delivery.archive_upload_id}
+                AND account_id = ${delivery.account_id}
+              RETURNING archive_upload_id
+            `
+            if (updated.length !== 1) {
+              throw new ArchiveClickHouseError('delivery_state_missing')
+            }
+          },
+        })
+      })
+    },
+    markPending: async (errorCode) => {
+      await sql`
+        UPDATE private.archive_clickhouse_delivery
+        SET
+          delivery_state = 'pending',
+          attempt_count = attempt_count + 1,
+          last_error_code = ${errorCode},
+          next_attempt_at = now() + interval '5 minutes',
+          updated_at = now()
+        WHERE archive_upload_id = ${delivery.archive_upload_id}
+          AND account_id = ${delivery.account_id}
+      `
+    },
+  })
+
+  if (result.status === 'delivered') {
+    logger.info(
+      `ClickHouse delivery completed (archive_upload_id=${delivery.archive_upload_id})`,
+    )
+  } else {
+    logger.warn(
+      `ClickHouse delivery remains pending (archive_upload_id=${delivery.archive_upload_id}, code=${result.errorCode})`,
+    )
+  }
+}
+
+async function retryPendingClickHouseDeliveries(
+  sql: Sql,
+  sink: ArchiveClickHouseSink,
+): Promise<void> {
+  const pending = await sql`
+    SELECT
+      delivery.archive_upload_id,
+      delivery.account_id,
+      delivery.tweet_ids,
+      upload.username
+    FROM private.archive_clickhouse_delivery AS delivery
+    LEFT JOIN public.archive_upload AS upload
+      ON upload.id = delivery.archive_upload_id
+    WHERE delivery.delivery_state = 'pending'
+      AND delivery.next_attempt_at <= now()
+    ORDER BY delivery.next_attempt_at, delivery.archive_upload_id
+    LIMIT ${CONFIG.ARCHIVE_CLICKHOUSE_RETRY_BATCH}
+  `
+  for (const delivery of pending) {
+    await attemptClickHouseDelivery(
+      sql,
+      sink,
+      delivery as ArchiveClickHouseDelivery,
+    )
+  }
 }
 
 // Main function
@@ -890,6 +1120,24 @@ async function main() {
 
   try {
     logger.debug(`Starting optimized batch processing with ${getMemoryUsageMB()}MB memory usage`)
+
+    let clickHouseSink: ArchiveClickHouseSink | null = null
+    if (CONFIG.ARCHIVE_CLICKHOUSE_SINK_ENABLED) {
+      try {
+        clickHouseSink = createArchiveClickHouseSink()
+        await clickHouseSink.healthCheck()
+        await retryPendingClickHouseDeliveries(sql, clickHouseSink)
+      } catch (error) {
+        const code =
+          error instanceof ArchiveClickHouseError
+            ? error.code
+            : 'clickhouse_readiness_failed'
+        logger.warn(
+          `ClickHouse unavailable; PostgreSQL ingestion will continue and deliveries will remain pending (code=${code})`,
+        )
+        clickHouseSink = null
+      }
+    }
 
     logger.info('Fetching archive_upload records ready for processing...')
 
@@ -929,7 +1177,7 @@ async function main() {
         }
 
         // Process archive with optimized batch inserts
-        await processSingleArchive(sql, username, archiveUploadId)
+        const archive = await processSingleArchive(sql, username, archiveUploadId)
 
         // Mark as completed
         const completeResult = await sql`
@@ -945,6 +1193,23 @@ async function main() {
         }
 
         logger.info(`✅ Successfully completed account ${account_id} with optimized batches (archive_upload_id=${archiveUploadId})`)
+
+        if (clickHouseSink) {
+          await attemptClickHouseDelivery(
+            sql,
+            clickHouseSink,
+            {
+              archive_upload_id: archiveUploadId,
+              account_id,
+              tweet_ids: createArchiveClickHouseManifest(
+                archive,
+                archiveUploadId,
+              ).tweetIds,
+              username,
+            },
+            archive,
+          )
+        }
 
         // Force GC between accounts
         if (global.gc) {

--- a/supabase/migrations/20260816200315_add_archive_clickhouse_delivery_state.sql
+++ b/supabase/migrations/20260816200315_add_archive_clickhouse_delivery_state.sql
@@ -1,0 +1,50 @@
+-- Durable, content-free delivery control for the independent archive ->
+-- ClickHouse sink. This migration deliberately does not enqueue completed
+-- historical uploads: only the policy-aware archive processor creates rows.
+CREATE TABLE private.archive_clickhouse_delivery (
+  archive_upload_id bigint PRIMARY KEY,
+  account_id text NOT NULL,
+  tweet_ids text[] DEFAULT '{}'::text[] NOT NULL,
+  delivery_state text DEFAULT 'pending'::text NOT NULL,
+  attempt_count integer DEFAULT 0 NOT NULL,
+  last_error_code text,
+  next_attempt_at timestamptz DEFAULT now() NOT NULL,
+  delivered_at timestamptz,
+  created_at timestamptz DEFAULT now() NOT NULL,
+  updated_at timestamptz DEFAULT now() NOT NULL,
+  CONSTRAINT archive_clickhouse_delivery_account_id_check
+    CHECK (account_id ~ '^(0|[1-9][0-9]*)$'),
+  CONSTRAINT archive_clickhouse_delivery_tweet_ids_nonnull_check
+    CHECK (array_position(tweet_ids, NULL::text) IS NULL),
+  CONSTRAINT archive_clickhouse_delivery_tweet_ids_format_check
+    CHECK (
+      cardinality(tweet_ids) = 0
+      OR array_to_string(tweet_ids, ',') ~ '^((0|[1-9][0-9]*),)*(0|[1-9][0-9]*)$'
+    ),
+  CONSTRAINT archive_clickhouse_delivery_state_check
+    CHECK (delivery_state IN ('pending', 'delivered')),
+  CONSTRAINT archive_clickhouse_delivery_attempt_count_check
+    CHECK (attempt_count >= 0),
+  CONSTRAINT archive_clickhouse_delivery_error_code_check
+    CHECK (
+      last_error_code IS NULL
+      OR last_error_code ~ '^[a-z0-9_]{1,80}$'
+    )
+);
+
+ALTER TABLE private.archive_clickhouse_delivery OWNER TO postgres;
+ALTER TABLE private.archive_clickhouse_delivery ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE private.archive_clickhouse_delivery
+  FROM PUBLIC, anon, authenticated, readclient, service_role;
+
+CREATE INDEX archive_clickhouse_delivery_pending_idx
+  ON private.archive_clickhouse_delivery (next_attempt_at, archive_upload_id)
+  WHERE delivery_state = 'pending';
+
+CREATE TRIGGER update_archive_clickhouse_delivery_updated_at
+  BEFORE UPDATE ON private.archive_clickhouse_delivery
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+COMMENT ON TABLE private.archive_clickhouse_delivery IS
+  'Content-free stable-ID retry control for independent new archive ClickHouse delivery; never a source for content reconstruction or historical backfill.';

--- a/supabase/schemas/020_tables.sql
+++ b/supabase/schemas/020_tables.sql
@@ -80,6 +80,32 @@ CREATE TABLE IF NOT EXISTS "private"."policy_historical_reconcile_progress" (
 ALTER TABLE "private"."policy_historical_reconcile_progress" OWNER TO "postgres";
 REVOKE ALL ON TABLE "private"."policy_historical_reconcile_progress" FROM PUBLIC, "anon", "authenticated", "readclient", "service_role";
 
+-- Content-free stable-ID retry control for the direct archive-to-ClickHouse
+-- sink. It intentionally has no foreign key to archive_upload because an
+-- opt-out deletes upload metadata while its tombstone delivery must survive.
+CREATE TABLE IF NOT EXISTS "private"."archive_clickhouse_delivery" (
+    "archive_upload_id" bigint PRIMARY KEY,
+    "account_id" "text" NOT NULL,
+    "tweet_ids" "text"[] DEFAULT '{}'::"text"[] NOT NULL,
+    "delivery_state" "text" DEFAULT 'pending'::"text" NOT NULL,
+    "attempt_count" integer DEFAULT 0 NOT NULL,
+    "last_error_code" "text",
+    "next_attempt_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "delivered_at" timestamp with time zone,
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    CONSTRAINT "archive_clickhouse_delivery_account_id_check" CHECK (("account_id" ~ '^(0|[1-9][0-9]*)$'::"text")),
+    CONSTRAINT "archive_clickhouse_delivery_tweet_ids_nonnull_check" CHECK ((array_position("tweet_ids", NULL::"text") IS NULL)),
+    CONSTRAINT "archive_clickhouse_delivery_tweet_ids_format_check" CHECK (((cardinality("tweet_ids") = 0) OR (array_to_string("tweet_ids", ','::"text") ~ '^((0|[1-9][0-9]*),)*(0|[1-9][0-9]*)$'::"text"))),
+    CONSTRAINT "archive_clickhouse_delivery_state_check" CHECK (("delivery_state" = ANY (ARRAY['pending'::"text", 'delivered'::"text"]))),
+    CONSTRAINT "archive_clickhouse_delivery_attempt_count_check" CHECK (("attempt_count" >= 0)),
+    CONSTRAINT "archive_clickhouse_delivery_error_code_check" CHECK ((("last_error_code" IS NULL) OR ("last_error_code" ~ '^[a-z0-9_]{1,80}$'::"text")))
+);
+ALTER TABLE "private"."archive_clickhouse_delivery" OWNER TO "postgres";
+ALTER TABLE "private"."archive_clickhouse_delivery" ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE "private"."archive_clickhouse_delivery" FROM PUBLIC, "anon", "authenticated", "readclient", "service_role";
+COMMENT ON TABLE "private"."archive_clickhouse_delivery" IS 'Content-free stable-ID retry control for independent new archive ClickHouse delivery; never a source for content reconstruction or historical backfill.';
+
 -- public.all_account
 CREATE TABLE IF NOT EXISTS "public"."all_account" (
     "account_id" "text" NOT NULL,

--- a/supabase/schemas/030_indexes.sql
+++ b/supabase/schemas/030_indexes.sql
@@ -127,3 +127,7 @@ ON "private"."policy_storage_objects" USING "gin" ("account_ids");
 
 CREATE INDEX IF NOT EXISTS "policy_storage_objects_username_hashes_idx"
 ON "private"."policy_storage_objects" USING "gin" ("username_hashes");
+
+CREATE INDEX IF NOT EXISTS "archive_clickhouse_delivery_pending_idx"
+ON "private"."archive_clickhouse_delivery" ("next_attempt_at", "archive_upload_id")
+WHERE ("delivery_state" = 'pending'::"text");

--- a/supabase/schemas/080_triggers.sql
+++ b/supabase/schemas/080_triggers.sql
@@ -29,6 +29,8 @@ CREATE OR REPLACE TRIGGER "update_tweets_updated_at" BEFORE UPDATE ON "public"."
 
 CREATE OR REPLACE TRIGGER "update_user_mentions_updated_at" BEFORE UPDATE ON "public"."user_mentions" FOR EACH ROW EXECUTE FUNCTION "public"."update_updated_at_column"();
 
+CREATE OR REPLACE TRIGGER "update_archive_clickhouse_delivery_updated_at" BEFORE UPDATE ON "private"."archive_clickhouse_delivery" FOR EACH ROW EXECUTE FUNCTION "public"."update_updated_at_column"();
+
 CREATE OR REPLACE TRIGGER "update_tes_blocked_scraping_timestamp" BEFORE UPDATE ON "tes"."blocked_scraping_users" FOR EACH ROW EXECUTE FUNCTION "public"."update_updated_at_column"();
 
 CREATE OR REPLACE TRIGGER "capture_policy_block_username" BEFORE INSERT OR UPDATE OF "account_id", "username" ON "tes"."blocked_scraping_users" FOR EACH ROW EXECUTE FUNCTION "public"."capture_policy_block_username"();

--- a/supabase/schemas/090_policy_grants.sql
+++ b/supabase/schemas/090_policy_grants.sql
@@ -4,6 +4,8 @@ REVOKE ALL ON TABLE public.account_activity_summary
   FROM PUBLIC, anon, authenticated, readclient;
 REVOKE ALL ON TABLE public.global_activity_summary
   FROM PUBLIC, anon, authenticated, readclient;
+REVOKE ALL ON TABLE private.archive_clickhouse_delivery
+  FROM PUBLIC, anon, authenticated, readclient, service_role;
 
 REVOKE ALL ON FUNCTION public.policy_account_is_blocked(text, text)
   FROM PUBLIC, anon, authenticated, readclient;


### PR DESCRIPTION
## What changed

- sends each newly processed archive independently to PostgreSQL and ClickHouse from the same uploaded archive
- checks PostgreSQL's authoritative consent policy at the ClickHouse sink boundary
- writes stable-ID tombstones for blocked owners and blocked quote/retweet/reply targets while retaining allowed outer relationships
- adds a private, content-free delivery record containing only the upload ID, owner account ID, and tweet IDs for bounded retries
- lets PostgreSQL archive processing complete during a ClickHouse outage; later retries reload the original private archive, while blocked retries need only the stable IDs

## Scope boundary

This is **new-upload filtering only**. It does not seed completed uploads, scan history, run historical reconciliation, activate the separate PostgreSQL-to-ClickHouse shadow sync, merge, or deploy anything.

PostgreSQL remains authoritative for consent and transactional policy. It is not used as the source of tweet/profile content for ClickHouse.

## Validation

- `npm run test:archive-clickhouse` — 6/6 passed
- focused TypeScript compile for the archive processor and ClickHouse module
- PostgreSQL parse validation for the migration and four declarative schema files
- Prettier check for the new module/tests
- `git diff --check`

## Rollout prerequisites

Before enabling the sink, apply the delivery-state migration and verify all nine ClickHouse archive tables plus `is_tombstone` on account/content/analytics tables. The worker flag remains off by default.
