### PR TITLE
Fix archive policy candidate serialization

### DIFF
--- a/services/process_archive/archive_clickhouse.test.ts
+++ b/services/process_archive/archive_clickhouse.test.ts
@@ -353,4 +353,6 @@ test('delivery manifest is content-free and historical uploads are not seeded', 
     completion,
   )
   assert.ok(completion >= 0 && directSink > completion)
+  assert.match(processor, /jsonb_array_elements\(\$\{trx\.json\(candidates as never\)\}::jsonb\)/)
+  assert.doesNotMatch(processor, /JSON\.stringify\(candidates\)/)
 })

--- a/services/process_archive/process_archive_upload.ts
+++ b/services/process_archive/process_archive_upload.ts
@@ -954,7 +954,7 @@ async function resolveArchivePolicyDecisions(
         NULLIF(item->>'accountId', '') AS account_id,
         NULLIF(item->>'username', '') AS username,
         NULLIF(item->>'tweetId', '') AS tweet_id
-      FROM jsonb_array_elements(${JSON.stringify(candidates)}::jsonb) AS item
+      FROM jsonb_array_elements(${trx.json(candidates as never)}::jsonb) AS item
     ), resolved AS (
       SELECT
         candidate.key,


### PR DESCRIPTION
Root cause: the archive worker passed the nested policy-candidate array through JSON.stringify before postgres.js parameter encoding, so PostgreSQL received a JSON scalar and rejected jsonb_array_elements.

This uses postgres.js native JSON parameter encoding and adds a focused source-contract regression.

Validation:
- archive ClickHouse tests: 6/6
- root TypeScript check
- diff hygiene
- production failure reproduced as PostgreSQL 22023 at the nested-policy query