### PR TITLE
Forward Bangers period bounds

### DIFF
--- a/src/lib/clickhouseGateway.ts
+++ b/src/lib/clickhouseGateway.ts
@@ -32,6 +32,8 @@ const ALLOWED_ENDPOINTS: Record<string, ReadonlySet<string>> = {
     'offset',
     'sort',
     'year',
+    'created_after',
+    'created_before',
     'q',
     'target_account_id',
     'min_quote_count',

--- a/src/lib/clickhouseLab.test.ts
+++ b/src/lib/clickhouseLab.test.ts
@@ -108,16 +108,16 @@ describe('ClickHouse staging lab guard', () => {
     ).toBe('https://stream.example/analytics')
   })
 
-  test('allows quote filters without forwarding unknown parameters', () => {
+  test('allows quote and authored-time filters without forwarding unknown parameters', () => {
     const target = analyticsGatewayRequestUrl(
       ['top-quotes'],
       new URLSearchParams(
-        'limit=25&offset=50&sort=recent&year=2024&q=archive&target_account_id=42&min_quote_count=2&exclude_self=true&target_ca_users_only=false&quote_ca_users_only=true&include_usernames=alice%2C+bob&exclude_usernames=bot&raw_sql=DROP',
+        'limit=25&offset=50&sort=recent&year=2024&created_after=2024-01-01T00%3A00%3A00.000Z&created_before=2024-04-01T00%3A00%3A00.000Z&q=archive&target_account_id=42&min_quote_count=2&exclude_self=true&target_ca_users_only=false&quote_ca_users_only=true&include_usernames=alice%2C+bob&exclude_usernames=bot&raw_sql=DROP',
       ),
       'https://stream.example/analytics',
     )
     expect(target.toString()).toBe(
-      'https://stream.example/analytics/top-quotes?limit=25&offset=50&sort=recent&year=2024&q=archive&target_account_id=42&min_quote_count=2&exclude_self=true&target_ca_users_only=false&quote_ca_users_only=true&include_usernames=alice%2C+bob&exclude_usernames=bot',
+      'https://stream.example/analytics/top-quotes?limit=25&offset=50&sort=recent&year=2024&created_after=2024-01-01T00%3A00%3A00.000Z&created_before=2024-04-01T00%3A00%3A00.000Z&q=archive&target_account_id=42&min_quote_count=2&exclude_self=true&target_ca_users_only=false&quote_ca_users_only=true&include_usernames=alice%2C+bob&exclude_usernames=bot',
     )
   })
 


### PR DESCRIPTION
## What changed
- allow created_after and created_before on the top-quotes gateway request
- cover both authored-time parameters in the gateway allowlist regression test

## Why
The Bangers period loader calculated the correct rolling bounds, but the web gateway allowlist stripped them before calling ClickHouse. As a result, Today, week, and three-month requests returned all-time rankings.

## Validation
- focused gateway allowlist suite: 17 tests passed
- diff whitespace check passed