### PR TITLE
Load the user directory from ClickHouse

### DIFF
--- a/src/app/api/user-directory/route.ts
+++ b/src/app/api/user-directory/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { getUserDirectoryPage } from '@/lib/userDirectory'
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 15
+
+export async function GET(request: NextRequest) {
+  try {
+    const page = await getUserDirectoryPage(new URL(request.url).searchParams)
+    return NextResponse.json(page, {
+      headers: {
+        'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=60',
+      },
+    })
+  } catch (error) {
+    console.error('ClickHouse member-directory request failed:', error)
+    return NextResponse.json(
+      { error: 'The user directory is temporarily unavailable' },
+      {
+        status: 502,
+        headers: { 'Cache-Control': 'private, no-store' },
+      },
+    )
+  }
+}

--- a/src/app/user-dir/UserDirectoryClient.test.tsx
+++ b/src/app/user-dir/UserDirectoryClient.test.tsx
@@ -5,10 +5,6 @@ import UserDirectoryClient, { USERS_PER_PAGE } from './UserDirectoryClient'
 import { fetchUsers } from '@/lib/queries/fetchUsers'
 import type { DirectoryUser } from '@/lib/types'
 
-jest.mock('@/utils/supabase', () => ({
-  createBrowserClient: () => ({ kind: 'test-client' }),
-}))
-
 jest.mock('@/lib/queries/fetchUsers', () => ({
   fetchUsers: jest.fn(),
   getDirectoryProfileHref: (user: DirectoryUser) => `/user/${user.username}`,
@@ -53,33 +49,39 @@ describe('UserDirectoryClient', () => {
     })
   })
 
-  test('requests and renders only the first 15 users without an exact count query', async () => {
-    mockFetchUsers.mockResolvedValueOnce(
-      Array.from({ length: USERS_PER_PAGE }, (_, index) =>
-        directoryUser(index),
-      ),
+  test('renders the server-supplied first 15 users without a client refetch', async () => {
+    const initialUsers = Array.from({ length: USERS_PER_PAGE }, (_, index) =>
+      directoryUser(index),
     )
 
-    render(<UserDirectoryClient totalCount={740} />)
+    render(
+      <UserDirectoryClient
+        totalCount={740}
+        initialUsers={initialUsers}
+        initialHasMore
+      />,
+    )
 
     expect(await screen.findByText('15 of 740 users')).toBeInTheDocument()
-    expect(mockFetchUsers).toHaveBeenCalledTimes(1)
-    expect(mockFetchUsers).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ limit: 15, offset: 0 }),
-    )
+    expect(mockFetchUsers).not.toHaveBeenCalled()
   })
 
   test('loads the next page when the scroll target enters view', async () => {
-    mockFetchUsers
-      .mockResolvedValueOnce(
-        Array.from({ length: USERS_PER_PAGE }, (_, index) =>
-          directoryUser(index),
-        ),
-      )
-      .mockResolvedValueOnce([directoryUser(15), directoryUser(16)])
+    const initialUsers = Array.from({ length: USERS_PER_PAGE }, (_, index) =>
+      directoryUser(index),
+    )
+    mockFetchUsers.mockResolvedValueOnce({
+      users: [directoryUser(15), directoryUser(16)],
+      hasMore: false,
+    })
 
-    render(<UserDirectoryClient totalCount={740} />)
+    render(
+      <UserDirectoryClient
+        totalCount={740}
+        initialUsers={initialUsers}
+        initialHasMore
+      />,
+    )
 
     await screen.findByText('15 of 740 users')
     await waitFor(() =>
@@ -95,13 +97,31 @@ describe('UserDirectoryClient', () => {
     })
 
     expect(await screen.findByText('17 of 740 users')).toBeInTheDocument()
-    expect(mockFetchUsers).toHaveBeenNthCalledWith(
-      2,
-      expect.anything(),
+    expect(mockFetchUsers).toHaveBeenCalledWith(
       expect.objectContaining({ limit: 15, offset: 15 }),
     )
     expect(
       screen.queryByRole('button', { name: 'Load more users' }),
     ).not.toBeInTheDocument()
+  })
+
+  test('loads in the browser when the server could not supply the first page', async () => {
+    mockFetchUsers.mockResolvedValueOnce({
+      users: [directoryUser(0)],
+      hasMore: false,
+    })
+
+    render(
+      <UserDirectoryClient
+        totalCount={740}
+        initialUsers={null}
+        initialHasMore
+      />,
+    )
+
+    expect(await screen.findByText('1 of 740 users')).toBeInTheDocument()
+    expect(mockFetchUsers).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 15, offset: 0 }),
+    )
   })
 })

--- a/src/app/user-dir/UserDirectoryClient.tsx
+++ b/src/app/user-dir/UserDirectoryClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { ArrowDown, ArrowUp, ArrowUpDown, Loader2, Search } from 'lucide-react'
 
@@ -19,7 +19,6 @@ import { MembershipStatusIcon } from '@/components/MembershipStatusIcon'
 import { formatNumber } from '@/lib/formatNumber'
 import { fetchUsers, getDirectoryProfileHref } from '@/lib/queries/fetchUsers'
 import { DirectoryUser, SortKey } from '@/lib/types'
-import { createBrowserClient } from '@/utils/supabase'
 
 export const USERS_PER_PAGE = 15
 
@@ -36,24 +35,28 @@ function formatJoinedDate(date: string | null) {
 
 interface UserDirectoryClientProps {
   totalCount: number | null
+  initialUsers: DirectoryUser[] | null
+  initialHasMore: boolean
 }
 
 export default function UserDirectoryClient({
   totalCount,
+  initialUsers,
+  initialHasMore,
 }: UserDirectoryClientProps) {
-  const supabase = useMemo(() => createBrowserClient(), [])
-  const [users, setUsers] = useState<DirectoryUser[]>([])
-  const [loading, setLoading] = useState(true)
+  const [users, setUsers] = useState<DirectoryUser[]>(initialUsers ?? [])
+  const [loading, setLoading] = useState(initialUsers === null)
   const [loadingMore, setLoadingMore] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [sortKey, setSortKey] = useState<SortKey>('num_followers')
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
-  const [hasMore, setHasMore] = useState(true)
+  const [hasMore, setHasMore] = useState(initialHasMore)
   const [searchQuery, setSearchQuery] = useState('')
   const [debouncedSearch, setDebouncedSearch] = useState('')
   const loadMoreTargetRef = useRef<HTMLDivElement>(null)
   const loadMoreInFlightRef = useRef(false)
   const requestVersionRef = useRef(0)
+  const skipInitialRequestRef = useRef(initialUsers !== null)
 
   useEffect(() => {
     const timer = setTimeout(() => setDebouncedSearch(searchQuery), 300)
@@ -61,6 +64,10 @@ export default function UserDirectoryClient({
   }, [searchQuery])
 
   useEffect(() => {
+    if (skipInitialRequestRef.current) {
+      skipInitialRequestRef.current = false
+      return
+    }
     let isCurrentRequest = true
     const requestVersion = ++requestVersionRef.current
 
@@ -70,7 +77,7 @@ export default function UserDirectoryClient({
 
       try {
         const search = debouncedSearch || undefined
-        const fetchedUsers = await fetchUsers(supabase, {
+        const page = await fetchUsers({
           limit: USERS_PER_PAGE,
           offset: 0,
           sortBy: sortKey,
@@ -80,13 +87,8 @@ export default function UserDirectoryClient({
 
         if (!isCurrentRequest || requestVersion !== requestVersionRef.current)
           return
-        setUsers(fetchedUsers)
-        setHasMore(
-          fetchedUsers.length === USERS_PER_PAGE &&
-            (Boolean(search) ||
-              totalCount === null ||
-              fetchedUsers.length < totalCount),
-        )
+        setUsers(page.users)
+        setHasMore(page.hasMore)
       } catch (err) {
         if (!isCurrentRequest) return
         setError('We could not load users. Please try again.')
@@ -100,7 +102,7 @@ export default function UserDirectoryClient({
     return () => {
       isCurrentRequest = false
     }
-  }, [debouncedSearch, sortKey, sortOrder, supabase, totalCount])
+  }, [debouncedSearch, sortKey, sortOrder])
 
   const loadMore = useCallback(async () => {
     if (loading || loadingMore || !hasMore || loadMoreInFlightRef.current) {
@@ -108,13 +110,12 @@ export default function UserDirectoryClient({
     }
 
     const requestVersion = requestVersionRef.current
-    const offset = users.length
     loadMoreInFlightRef.current = true
     setLoadingMore(true)
     setError(null)
 
     try {
-      const fetchedUsers = await fetchUsers(supabase, {
+      const page = await fetchUsers({
         limit: USERS_PER_PAGE,
         offset: users.length,
         sortBy: sortKey,
@@ -123,13 +124,8 @@ export default function UserDirectoryClient({
       })
       if (requestVersion !== requestVersionRef.current) return
 
-      setUsers((currentUsers) => [...currentUsers, ...fetchedUsers])
-      setHasMore(
-        fetchedUsers.length === USERS_PER_PAGE &&
-          (Boolean(debouncedSearch) ||
-            totalCount === null ||
-            offset + fetchedUsers.length < totalCount),
-      )
+      setUsers((currentUsers) => [...currentUsers, ...page.users])
+      setHasMore(page.hasMore)
     } catch (err) {
       if (requestVersion !== requestVersionRef.current) return
       setError('We could not load more members. Please try again.')
@@ -145,8 +141,6 @@ export default function UserDirectoryClient({
     loadingMore,
     sortKey,
     sortOrder,
-    supabase,
-    totalCount,
     users.length,
   ])
 

--- a/src/app/user-dir/page.tsx
+++ b/src/app/user-dir/page.tsx
@@ -1,13 +1,26 @@
 import UserDirectoryClient from './UserDirectoryClient'
 import { getStats } from '@/lib/stats'
+import { getUserDirectoryPage } from '@/lib/userDirectory'
 
 export default async function UserDirectoryPage() {
-  const totalCount = await getStats()
-    .then((stats) => stats.userCount)
-    .catch((error) => {
-      console.error('Error fetching the directory member count:', error)
+  const [totalCount, initialPage] = await Promise.all([
+    getStats()
+      .then((stats) => stats.userCount)
+      .catch((error) => {
+        console.error('Error fetching the directory member count:', error)
+        return null
+      }),
+    getUserDirectoryPage().catch((error) => {
+      console.error('Error fetching the initial user directory page:', error)
       return null
-    })
+    }),
+  ])
 
-  return <UserDirectoryClient totalCount={totalCount} />
+  return (
+    <UserDirectoryClient
+      totalCount={totalCount}
+      initialUsers={initialPage?.users ?? null}
+      initialHasMore={initialPage?.hasMore ?? true}
+    />
+  )
 }

--- a/src/lib/clickhouseGateway.test.ts
+++ b/src/lib/clickhouseGateway.test.ts
@@ -34,6 +34,19 @@ describe('ClickHouse analytics gateway requests', () => {
     )
   })
 
+  test('allows only bounded member-directory parameters', () => {
+    const target = analyticsGatewayRequestUrl(
+      ['member-directory'],
+      new URLSearchParams(
+        'limit=15&offset=30&sort_by=num_followers&sort_order=desc&search=alice&raw_sql=DROP',
+      ),
+      'https://stream.example/analytics',
+    )
+    expect(target.toString()).toBe(
+      'https://stream.example/analytics/member-directory?limit=15&offset=30&sort_by=num_followers&sort_order=desc&search=alice',
+    )
+  })
+
   test('allows only bounded tweet-search parameters', () => {
     const target = analyticsGatewayRequestUrl(
       ['search'],

--- a/src/lib/clickhouseGateway.ts
+++ b/src/lib/clickhouseGateway.ts
@@ -1,6 +1,13 @@
 const ALLOWED_ENDPOINTS: Record<string, ReadonlySet<string>> = {
   'corpus-count': new Set(),
   summary: new Set(),
+  'member-directory': new Set([
+    'limit',
+    'offset',
+    'sort_by',
+    'sort_order',
+    'search',
+  ]),
   'social-graph': new Set(),
   search: new Set([
     'q',

--- a/src/lib/queries/fetchUsers.test.ts
+++ b/src/lib/queries/fetchUsers.test.ts
@@ -1,6 +1,7 @@
 import { DirectoryUser } from '@/lib/types'
 import {
   buildDirectorySearchFilter,
+  fetchUsers,
   getDirectoryProfileHref,
   getUserData,
 } from './fetchUsers'
@@ -30,6 +31,32 @@ describe('buildDirectorySearchFilter', () => {
   it('escapes quotes and backslashes inside quoted filter values', () => {
     expect(buildDirectorySearchFilter('a"b\\c')).toBe(
       'username.ilike."%a\\"b\\\\c%",account_display_name.ilike."%a\\"b\\\\c%"',
+    )
+  })
+})
+
+describe('fetchUsers', () => {
+  it('requests a bounded ClickHouse-backed website page', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ users: [directoryUser({})], hasMore: true }),
+    })
+
+    await expect(
+      fetchUsers(
+        {
+          limit: 15,
+          offset: 30,
+          sortBy: 'joined_at',
+          sortOrder: 'asc',
+          search: 'alice',
+        },
+        fetchImpl as unknown as typeof fetch,
+      ),
+    ).resolves.toMatchObject({ hasMore: true })
+    expect(fetchImpl).toHaveBeenCalledWith(
+      '/api/user-directory?limit=15&offset=30&sort_by=joined_at&sort_order=asc&search=alice',
+      { cache: 'no-store' },
     )
   })
 })

--- a/src/lib/queries/fetchUsers.ts
+++ b/src/lib/queries/fetchUsers.ts
@@ -1,5 +1,10 @@
-import { DirectoryUser, FormattedUser, SortKey } from '@/lib/types'
-import { SupabaseClient } from '@supabase/supabase-js'
+import {
+  DirectoryUser,
+  FormattedUser,
+  SortKey,
+  UserDirectoryPage,
+} from '@/lib/types'
+import type { SupabaseClient } from '@supabase/supabase-js'
 import { devLog } from '@/lib/devLog'
 import { rankUserSuggestions } from '@/lib/searchSuggestions'
 import type { UserSuggestion } from '@/lib/searchSuggestions'
@@ -25,9 +30,9 @@ export const getDirectoryProfileHref = (user: DirectoryUser) =>
   userProfileHref(user.username, user.account_id || user.directory_id)
 
 export const fetchUsers = async (
-  supabase: SupabaseClient,
   options?: FetchUsersOptions,
-): Promise<DirectoryUser[]> => {
+  fetchImpl: typeof fetch = fetch,
+): Promise<UserDirectoryPage> => {
   const {
     limit,
     offset = 0,
@@ -36,44 +41,25 @@ export const fetchUsers = async (
     search,
   } = options || {}
 
-  let query = supabase
-    .schema('public')
-    .from('user_directory')
-    .select(
-      `
-      account_id,
-      username,
-      account_display_name,
-      avatar_media_url,
-      num_followers,
-      archive_uploaded_at,
-      directory_id,
-      has_archive,
-      is_opted_in,
-      opted_in_at,
-      joined_at
-    `,
-    )
-
-  if (search) {
-    query = query.or(buildDirectorySearchFilter(search))
-  }
-
-  query = query.order(sortBy, {
-    ascending: sortOrder === 'asc',
-    nullsFirst: false,
+  const searchParams = new URLSearchParams({
+    limit: String(limit || 15),
+    offset: String(offset),
+    sort_by: sortBy,
+    sort_order: sortOrder,
   })
-  query = query.order('directory_id', { ascending: true })
+  if (search) searchParams.set('search', search)
 
-  if (limit) {
-    query = query.range(offset, offset + limit - 1)
+  const response = await fetchImpl(`/api/user-directory?${searchParams}`, {
+    cache: 'no-store',
+  })
+  if (!response.ok) {
+    throw new Error(`User directory request failed (${response.status})`)
   }
-
-  const { data, error } = await query
-
-  if (error) throw error
-
-  return (data as DirectoryUser[]) || []
+  const page = (await response.json()) as UserDirectoryPage
+  if (!Array.isArray(page?.users) || typeof page.hasMore !== 'boolean') {
+    throw new Error('User directory returned an invalid response')
+  }
+  return page
 }
 
 export const fetchUserSuggestions = async (

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -178,6 +178,11 @@ export type SortKey =
   | 'num_followers'
   | 'joined_at'
 
+export type UserDirectoryPage = {
+  users: DirectoryUser[]
+  hasMore: boolean
+}
+
 export type FormattedUser = {
   account_id: string | null
   username: string

--- a/src/lib/userDirectory.test.ts
+++ b/src/lib/userDirectory.test.ts
@@ -1,0 +1,48 @@
+import { getUserDirectoryPage } from './userDirectory'
+
+describe('getUserDirectoryPage', () => {
+  test('maps the ClickHouse gateway response into directory users', async () => {
+    const fetcher = jest.fn().mockResolvedValue({
+      data: {
+        users: [
+          {
+            directoryId: 'id:42',
+            accountId: '42',
+            username: 'alice',
+            displayName: 'Alice',
+            avatarUrl: 'https://pbs.twimg.com/alice.jpg',
+            followerCount: '1234',
+            joinedAt: '2026-08-01T00:00:00.000Z',
+            hasArchive: true,
+            isOptedIn: false,
+          },
+        ],
+      },
+      pagination: { hasMore: true },
+    })
+    const params = new URLSearchParams({ limit: '15', offset: '30' })
+
+    await expect(getUserDirectoryPage(params, fetcher)).resolves.toEqual({
+      users: [
+        {
+          directory_id: 'id:42',
+          account_id: '42',
+          username: 'alice',
+          account_display_name: 'Alice',
+          avatar_media_url: 'https://pbs.twimg.com/alice.jpg',
+          num_followers: 1234,
+          has_archive: true,
+          is_opted_in: false,
+          opted_in_at: null,
+          archive_uploaded_at: null,
+          joined_at: '2026-08-01T00:00:00.000Z',
+        },
+      ],
+      hasMore: true,
+    })
+    expect(fetcher).toHaveBeenCalledWith(['member-directory'], params, {
+      revalidate: 30,
+      timeoutMs: 8_000,
+    })
+  })
+})

--- a/src/lib/userDirectory.ts
+++ b/src/lib/userDirectory.ts
@@ -1,0 +1,81 @@
+import 'server-only'
+
+import {
+  fetchAnalyticsGatewayJson,
+  type AnalyticsGatewayFetcher,
+} from '@/lib/clickhouseGateway'
+import type { DirectoryUser, UserDirectoryPage } from '@/lib/types'
+
+interface ClickHouseMemberDirectoryResponse {
+  data: {
+    users: Array<{
+      directoryId: string
+      accountId: string | null
+      username: string
+      displayName: string
+      avatarUrl: string | null
+      followerCount: string | number | null
+      joinedAt: string | null
+      hasArchive: boolean
+      isOptedIn: boolean
+    }>
+  }
+  pagination: {
+    hasMore: boolean
+  }
+}
+
+function mapDirectoryUser(
+  user: ClickHouseMemberDirectoryResponse['data']['users'][number],
+): DirectoryUser {
+  const followerCount =
+    user.followerCount === null ? null : Number(user.followerCount)
+  if (
+    !user.directoryId ||
+    !user.username ||
+    !user.displayName ||
+    (user.accountId !== null && !/^\d{1,20}$/.test(user.accountId)) ||
+    (followerCount !== null &&
+      (!Number.isSafeInteger(followerCount) || followerCount < 0)) ||
+    typeof user.hasArchive !== 'boolean' ||
+    typeof user.isOptedIn !== 'boolean'
+  ) {
+    throw new Error('ClickHouse returned an invalid member-directory user')
+  }
+
+  return {
+    directory_id: user.directoryId,
+    account_id: user.accountId,
+    username: user.username,
+    account_display_name: user.displayName,
+    avatar_media_url: user.avatarUrl,
+    num_followers: followerCount,
+    has_archive: user.hasArchive,
+    is_opted_in: user.isOptedIn,
+    opted_in_at: null,
+    archive_uploaded_at: null,
+    joined_at: user.joinedAt,
+  }
+}
+
+export async function getUserDirectoryPage(
+  searchParams = new URLSearchParams({ limit: '15' }),
+  fetcher: AnalyticsGatewayFetcher = fetchAnalyticsGatewayJson,
+): Promise<UserDirectoryPage> {
+  const response = await fetcher<ClickHouseMemberDirectoryResponse>(
+    ['member-directory'],
+    searchParams,
+    { revalidate: 30, timeoutMs: 8_000 },
+  )
+  if (
+    !response?.data ||
+    !Array.isArray(response.data.users) ||
+    typeof response.pagination?.hasMore !== 'boolean'
+  ) {
+    throw new Error('ClickHouse returned an invalid member-directory response')
+  }
+  return {
+    users: response.data.users.map(mapDirectoryUser),
+    hasMore: response.pagination.hasMore,
+  }
+}


### PR DESCRIPTION
## Summary
- server-render the first 15 directory users from the ClickHouse gateway
- load later pages, search, and sorting through the same website API with infinite scroll
- remove the Supabase browser query from the directory list while leaving profile and suggestion data unchanged
- keep the existing cached summary count

## Dependency
Deploy TheExGenesis/community-archive-control-panel#105 before merging this frontend.

## Validation
- 12 focused user-directory tests passed
- `pnpm type-check` passed
- first-page fetch runs in parallel with the existing cached count