### PR TITLE
Distinguish the contributor badge from the archive status icon

### DIFF
--- a/src/components/MembershipStatusIcon.test.tsx
+++ b/src/components/MembershipStatusIcon.test.tsx
@@ -11,7 +11,7 @@ test.each([
 
   const icon = screen.getByRole('img', { name: status.label })
   expect(icon).toHaveClass(
-    status.hasArchive ? 'text-[#25AADF]/70' : 'text-brand/60',
+    status.hasArchive ? 'text-muted-foreground/60' : 'text-brand/60',
   )
 
   await user.hover(icon)

--- a/src/components/MembershipStatusIcon.tsx
+++ b/src/components/MembershipStatusIcon.tsx
@@ -19,7 +19,7 @@ export function MembershipStatusIcon({
   const Icon = hasArchive ? Archive : Radio
   if (!label) return null
   const colorClassName = hasArchive
-    ? 'text-[#25AADF]/70 hover:bg-[#25AADF]/5 hover:text-[#25AADF] focus-visible:ring-[#25AADF]'
+    ? 'text-muted-foreground/60 hover:bg-muted-foreground/5 hover:text-muted-foreground focus-visible:ring-muted-foreground'
     : 'text-brand/60 hover:bg-brand/5 hover:text-brand focus-visible:ring-brand'
 
   return (

--- a/src/components/ProjectContributorBadge.tsx
+++ b/src/components/ProjectContributorBadge.tsx
@@ -8,7 +8,7 @@ export function ProjectContributorBadge({ username }: { username: string }) {
   return (
     <Badge
       variant="outline"
-      className="gap-1.5 border-brand/40 bg-brand/10 text-brand"
+      className="gap-1.5 border-yellow-500/40 bg-yellow-500/10 text-yellow-600 dark:border-amber-300/25 dark:bg-amber-300/[0.07] dark:text-amber-200/80"
     >
       <Award aria-hidden="true" className="h-3.5 w-3.5" />
       Archive contributor

--- a/src/components/metaTwitter/ProfileHeader.test.tsx
+++ b/src/components/metaTwitter/ProfileHeader.test.tsx
@@ -102,7 +102,7 @@ test('shows the archive icon without exposing another owner raw download', () =>
   ).not.toBeInTheDocument()
 })
 
-test('gives rostered contributors a distinct blue award badge', () => {
+test('gives rostered contributors a distinct gold award badge', () => {
   render(
     <ProfileHeader
       profile={{
@@ -114,9 +114,9 @@ test('gives rostered contributors a distinct blue award badge', () => {
   )
 
   expect(screen.getByText('Archive contributor')).toHaveClass(
-    'border-brand/40',
-    'bg-brand/10',
-    'text-brand',
+    'border-yellow-500/40',
+    'bg-yellow-500/10',
+    'text-yellow-600',
   )
   expect(screen.getByRole('img', { name: 'Archive uploaded' })).toBeVisible()
   expect(screen.getByText('Archive contributor').parentElement).toHaveClass(


### PR DESCRIPTION
In the profile header the "Archive contributor" badge and the "Archive uploaded" icon both sat in brand blue, right next to each other and next to blue links. The badge read as one more UI accent rather than a distinction, and the icon competed with the links around it.

- **Contributor badge → gold.** Same outline pill and `Award` icon, now `yellow-500/600` in light mode and a paler, less saturated amber in dark mode so it doesn't glare.
- **"Archive uploaded" icon → light grey.** `text-[#25AADF]/70` becomes `text-muted-foreground/60`, with hover and focus-visible following. Theme tokens instead of a hardcoded hex, so it behaves in both themes.

The status icon is shared with the user directory, so it's grey there too.

`MembershipStatusIcon.test.tsx` asserted on the old hex class and was updated; both component tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)