### PR TITLE
Remove per-row policy enforcement triggers

### DIFF
--- a/docs/policy-tombstone-rollout.md
+++ b/docs/policy-tombstone-rollout.md
@@ -1,8 +1,19 @@
 # Policy tombstone rollout
 
-Do not deploy the web or worker changes independently of the matching database
-migration. PostgreSQL consent must become the policy boundary before any writer
-or private download endpoint depends on it.
+PostgreSQL remains the consent authority. Active ingestion services must load
+that authority once per batch immediately before persistence and send the same
+policy-safe input independently to PostgreSQL and ClickHouse.
+
+The database no longer re-evaluates consent through row triggers on every
+account, tweet, child, archive metadata, Storage, or digest write. The archive
+worker, Firehose persistence worker, and autorefresh writer each fail closed at
+their ingestion boundary. Rare triggers on `optin` and
+`tes.blocked_scraping_users` remain so a newly recorded opt-out synchronously
+tombstones existing data.
+
+Do not deploy the trigger-removal migration until every active writer version
+with those boundary checks is confirmed live. Deployment and writer cutover are
+separate from this repository change.
 
 ## Migration ledger preflight
 
@@ -109,8 +120,10 @@ even when older checkpoints exist. Each checkpoint stores both
 `policy_version = 'universal_policy_tombstones_v1'` and the authoritative
 PostgreSQL consent fingerprint computed immediately before it is written. If an
 opt-out lands between phases, the final migration rejects mixed fingerprints;
-rerun the operator to converge the new policy snapshot. New blocks are also
-handled synchronously by the fast migration's write triggers.
+rerun the operator to converge the new policy snapshot. New blocks are handled
+synchronously by the policy-state event triggers. Every subsequent writer must
+independently reload the authoritative policy snapshot before persisting its
+batch.
 
 The reconciliation keeps `public.tweets.tweet_id` and
 `public.all_account.account_id`. It deletes content-bearing children only when
@@ -148,11 +161,11 @@ current-fingerprint `liked_tweets` and `verification` phases.
 
 The universal migration deliberately does not rewrite or index the multi-million
 row `public.liked_tweets` table. It immediately hides legacy content whose author
-is unknown, enforces content-free tombstones for every new write, installs a
-bounded reconciliation function, and adds the liked-tweet and mentioned-user
-minimal tombstone constraints as `NOT VALID`. PostgreSQL still enforces a
-`NOT VALID` check on new and changed rows; only the historical validation scans
-are deferred.
+is unknown, installs a bounded reconciliation function, and adds the liked-tweet
+and mentioned-user minimal tombstone constraints as `NOT VALID`. Active writers
+must provide content-free tombstones for blocked or unattributed authors before
+inserting. PostgreSQL still enforces a `NOT VALID` check on new and changed rows;
+only the historical validation scans are deferred.
 
 The operator accepts author provenance only from a matching canonical
 `public.tweets` row. It retains an allowed payload after recording that author's

--- a/supabase/migrations/20260817164043_remove_hot_path_policy_triggers.sql
+++ b/supabase/migrations/20260817164043_remove_hot_path_policy_triggers.sql
@@ -1,0 +1,48 @@
+-- Consent remains authoritative in PostgreSQL, but active ingestion services
+-- now resolve it once per batch immediately before writing the same policy-safe
+-- input to PostgreSQL and ClickHouse. Remove the redundant row-level backstop:
+-- it performed multiple consent/index lookups for every corpus row and child.
+
+SET lock_timeout = '5s';
+
+DROP TRIGGER IF EXISTS enforce_policy_account_tombstone ON public.all_account;
+DROP TRIGGER IF EXISTS enforce_policy_tweet_tombstone ON public.tweets;
+DROP TRIGGER IF EXISTS protect_policy_tombstone_delete ON public.all_account;
+DROP TRIGGER IF EXISTS protect_policy_tombstone_delete ON public.tweets;
+DROP TRIGGER IF EXISTS enforce_policy_mentioned_user_tombstone ON public.mentioned_users;
+DROP TRIGGER IF EXISTS enforce_policy_liked_tweet_tombstone ON public.liked_tweets;
+DROP TRIGGER IF EXISTS enforce_policy_archive_object ON storage.objects;
+
+DROP TRIGGER IF EXISTS reject_policy_blocked_account_detail ON public.all_profile;
+DROP TRIGGER IF EXISTS reject_policy_blocked_account_detail ON public.archive_upload;
+DROP TRIGGER IF EXISTS reject_policy_blocked_account_detail ON public.likes;
+DROP TRIGGER IF EXISTS reject_policy_blocked_account_detail ON public.followers;
+DROP TRIGGER IF EXISTS reject_policy_blocked_account_detail ON public.following;
+DROP TRIGGER IF EXISTS reject_policy_blocked_account_detail ON public.profile_settings;
+DROP TRIGGER IF EXISTS reject_policy_blocked_account_detail ON public.profile_curation;
+
+DROP TRIGGER IF EXISTS reject_policy_tombstone_tweet_detail ON public.conversations;
+DROP TRIGGER IF EXISTS reject_policy_tombstone_tweet_detail ON public.tweet_media;
+DROP TRIGGER IF EXISTS reject_policy_tombstone_tweet_detail ON public.user_mentions;
+DROP TRIGGER IF EXISTS reject_policy_tombstone_tweet_detail ON public.tweet_urls;
+DROP TRIGGER IF EXISTS reject_policy_tombstone_tweet_detail ON public.quote_tweets;
+DROP TRIGGER IF EXISTS reject_policy_tombstone_tweet_detail ON public.retweets;
+DROP TRIGGER IF EXISTS reject_policy_tombstone_tweet_detail ON private.tweet_user;
+
+DROP TRIGGER IF EXISTS reject_policy_blocked_json_payload ON public.digest_runs;
+DROP TRIGGER IF EXISTS reject_policy_blocked_json_payload ON public.digest_editions;
+
+DO $drop_retired_policy_trigger$
+BEGIN
+  IF to_regclass('private.archived_temporary_data') IS NOT NULL THEN
+    EXECUTE 'DROP TRIGGER IF EXISTS reject_policy_blocked_json_payload '
+      'ON private.archived_temporary_data';
+  END IF;
+END
+$drop_retired_policy_trigger$;
+
+-- These rare event triggers intentionally remain:
+-- - optin.propagate_explicit_optout_scrape_block
+-- - blocked_scraping_users.capture_policy_block_username
+-- - blocked_scraping_users.apply_policy_block_tombstone
+-- They run only when policy state changes and synchronously scrub existing data.

--- a/supabase/schemas/075_policy_enforcement.sql
+++ b/supabase/schemas/075_policy_enforcement.sql
@@ -707,9 +707,8 @@ SECURITY DEFINER
 SET search_path = ''
 AS $$
 BEGIN
-  -- A nested block write from enforce_policy_account_tombstone only records
-  -- the stable-id association. The outer account trigger already scrubs that
-  -- row, so avoid recursively upserting the same account.
+  -- Avoid recursively applying the same block while tombstone_policy_account
+  -- updates policy-owned rows.
   IF pg_trigger_depth() > 1 THEN
     RETURN NEW;
   END IF;

--- a/supabase/schemas/080_triggers.sql
+++ b/supabase/schemas/080_triggers.sql
@@ -37,34 +37,9 @@ CREATE OR REPLACE TRIGGER "capture_policy_block_username" BEFORE INSERT OR UPDAT
 
 CREATE OR REPLACE TRIGGER "apply_policy_block_tombstone" AFTER INSERT OR UPDATE OF "account_id", "username" ON "tes"."blocked_scraping_users" FOR EACH ROW EXECUTE FUNCTION "public"."apply_policy_block_tombstone"();
 
-CREATE OR REPLACE TRIGGER "enforce_policy_account_tombstone" BEFORE INSERT OR UPDATE ON "public"."all_account" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_policy_account_tombstone"();
-
-CREATE OR REPLACE TRIGGER "enforce_policy_tweet_tombstone" BEFORE INSERT OR UPDATE ON "public"."tweets" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_policy_tweet_tombstone"();
-
-CREATE OR REPLACE TRIGGER "protect_policy_tombstone_delete" BEFORE DELETE ON "public"."all_account" FOR EACH ROW EXECUTE FUNCTION "public"."protect_policy_tombstone_delete"();
-CREATE OR REPLACE TRIGGER "protect_policy_tombstone_delete" BEFORE DELETE ON "public"."tweets" FOR EACH ROW EXECUTE FUNCTION "public"."protect_policy_tombstone_delete"();
-
-CREATE OR REPLACE TRIGGER "enforce_policy_mentioned_user_tombstone" BEFORE INSERT OR UPDATE ON "public"."mentioned_users" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_policy_mentioned_user_tombstone"();
-
-CREATE OR REPLACE TRIGGER "enforce_policy_liked_tweet_tombstone" BEFORE INSERT OR UPDATE ON "public"."liked_tweets" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_policy_liked_tweet_tombstone"();
-
-CREATE OR REPLACE TRIGGER "enforce_policy_archive_object" BEFORE INSERT OR UPDATE OF "bucket_id", "name" ON "storage"."objects" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_policy_archive_object"();
-
-CREATE OR REPLACE TRIGGER "reject_policy_blocked_account_detail" BEFORE INSERT OR UPDATE ON "public"."all_profile" FOR EACH ROW EXECUTE FUNCTION "public"."reject_policy_blocked_account_detail"('account_id');
-CREATE OR REPLACE TRIGGER "reject_policy_blocked_account_detail" BEFORE INSERT OR UPDATE ON "public"."archive_upload" FOR EACH ROW EXECUTE FUNCTION "public"."reject_policy_blocked_account_detail"('account_id');
-CREATE OR REPLACE TRIGGER "reject_policy_blocked_account_detail" BEFORE INSERT OR UPDATE ON "public"."likes" FOR EACH ROW EXECUTE FUNCTION "public"."reject_policy_blocked_account_detail"('account_id');
-CREATE OR REPLACE TRIGGER "reject_policy_blocked_account_detail" BEFORE INSERT OR UPDATE ON "public"."followers" FOR EACH ROW EXECUTE FUNCTION "public"."reject_policy_blocked_account_detail"('account_id');
-CREATE OR REPLACE TRIGGER "reject_policy_blocked_account_detail" BEFORE INSERT OR UPDATE ON "public"."following" FOR EACH ROW EXECUTE FUNCTION "public"."reject_policy_blocked_account_detail"('account_id');
-CREATE OR REPLACE TRIGGER "reject_policy_blocked_account_detail" BEFORE INSERT OR UPDATE ON "public"."profile_settings" FOR EACH ROW EXECUTE FUNCTION "public"."reject_policy_blocked_account_detail"('account_id');
-CREATE OR REPLACE TRIGGER "reject_policy_blocked_account_detail" BEFORE INSERT OR UPDATE ON "public"."profile_curation" FOR EACH ROW EXECUTE FUNCTION "public"."reject_policy_blocked_account_detail"('account_id');
-
-CREATE OR REPLACE TRIGGER "reject_policy_tombstone_tweet_detail" BEFORE INSERT OR UPDATE ON "public"."conversations" FOR EACH ROW EXECUTE FUNCTION "public"."reject_policy_tombstone_tweet_detail"('tweet_id');
-CREATE OR REPLACE TRIGGER "reject_policy_tombstone_tweet_detail" BEFORE INSERT OR UPDATE ON "public"."tweet_media" FOR EACH ROW EXECUTE FUNCTION "public"."reject_policy_tombstone_tweet_detail"('tweet_id');
-CREATE OR REPLACE TRIGGER "reject_policy_tombstone_tweet_detail" BEFORE INSERT OR UPDATE ON "public"."user_mentions" FOR EACH ROW EXECUTE FUNCTION "public"."reject_policy_tombstone_tweet_detail"('tweet_id');
-CREATE OR REPLACE TRIGGER "reject_policy_tombstone_tweet_detail" BEFORE INSERT OR UPDATE ON "public"."tweet_urls" FOR EACH ROW EXECUTE FUNCTION "public"."reject_policy_tombstone_tweet_detail"('tweet_id');
-CREATE OR REPLACE TRIGGER "reject_policy_tombstone_tweet_detail" BEFORE INSERT OR UPDATE ON "public"."quote_tweets" FOR EACH ROW EXECUTE FUNCTION "public"."reject_policy_tombstone_tweet_detail"('tweet_id');
-CREATE OR REPLACE TRIGGER "reject_policy_tombstone_tweet_detail" BEFORE INSERT OR UPDATE ON "public"."retweets" FOR EACH ROW EXECUTE FUNCTION "public"."reject_policy_tombstone_tweet_detail"('tweet_id');
-CREATE OR REPLACE TRIGGER "reject_policy_tombstone_tweet_detail" BEFORE INSERT OR UPDATE ON "private"."tweet_user" FOR EACH ROW EXECUTE FUNCTION "public"."reject_policy_tombstone_tweet_detail"('tweet_id');
+-- Policy is evaluated once at each trusted ingestion boundary. Keep only the
+-- rare block-event triggers above so a newly recorded opt-out synchronously
+-- tombstones existing rows; do not re-read consent on every corpus write.
 
 
 

--- a/supabase/schemas/095_policy_legacy_triggers.sql
+++ b/supabase/schemas/095_policy_legacy_triggers.sql
@@ -1,15 +1,3 @@
--- prod.sql still owns legacy private staging tables, so attach their policy
--- triggers only after that compatibility schema has been loaded.
-CREATE OR REPLACE TRIGGER "reject_policy_blocked_json_payload"
-BEFORE INSERT OR UPDATE ON "private"."archived_temporary_data"
-FOR EACH ROW EXECUTE FUNCTION "public"."reject_policy_blocked_json_payload"('data');
-
-CREATE OR REPLACE TRIGGER "reject_policy_blocked_json_payload"
-BEFORE INSERT OR UPDATE ON "public"."digest_runs"
-FOR EACH ROW EXECUTE FUNCTION "public"."reject_policy_blocked_json_payload"(
-  'candidates', 'model_request', 'raw_response', 'parsed_output'
-);
-
-CREATE OR REPLACE TRIGGER "reject_policy_blocked_json_payload"
-BEFORE INSERT OR UPDATE ON "public"."digest_editions"
-FOR EACH ROW EXECUTE FUNCTION "public"."reject_policy_blocked_json_payload"('content');
+-- Durable JSON producers must consume the same policy-safe input used by the
+-- PostgreSQL and ClickHouse sinks. Database-wide JSON scans are intentionally
+-- not attached to insert/update operations.

--- a/supabase/tests/database/policy_tombstones.test.sql
+++ b/supabase/tests/database/policy_tombstones.test.sql
@@ -3,873 +3,190 @@ BEGIN;
 CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
 SET LOCAL search_path = public, extensions;
 
-SELECT plan(75);
-
--- Production builds these four indexes concurrently between the fast and
--- final migrations. A clean reset creates them in the guarded final migration;
--- keep the fixture explicit so the opt-out tests always exercise indexed paths.
-CREATE INDEX IF NOT EXISTS liked_tweets_author_account_id_idx
-  ON public.liked_tweets (author_account_id)
-  WHERE author_account_id IS NOT NULL;
-CREATE INDEX IF NOT EXISTS mentioned_users_screen_name_lower_idx
-  ON public.mentioned_users (lower(screen_name))
-  WHERE screen_name <> '';
-CREATE INDEX IF NOT EXISTS tweets_reply_to_username_lower_idx
-  ON public.tweets (lower(reply_to_username))
-  WHERE reply_to_username IS NOT NULL;
-CREATE INDEX IF NOT EXISTS tweets_retweeted_username_lower_idx
-  ON public.tweets (
-    lower(substring(full_text FROM '^RT @([A-Za-z0-9_]{1,15}):'))
-  )
-  WHERE full_text ~ '^RT @[A-Za-z0-9_]{1,15}:';
+SELECT plan(16);
 
 INSERT INTO public.all_account (
-  account_id,
-  created_via,
-  username,
-  created_at,
-  account_display_name
+  account_id, created_via, username, created_at, account_display_name
 ) VALUES (
-  '990000000000000001',
-  'twitter_import',
-  '__pgtap_tombstone',
-  '2026-01-01 00:00:00+00',
-  'Policy Test'
+  '990000000000000001', 'test', '__pgtap_policy_boundary', now(), 'Policy test'
 );
 
 INSERT INTO public.tweets (
-  tweet_id,
-  account_id,
-  created_at,
-  full_text,
-  favorite_count,
-  retweet_count
+  tweet_id, account_id, created_at, full_text, favorite_count, retweet_count
 ) VALUES (
-  '990000000000000002',
-  '990000000000000001',
-  '2026-01-02 00:00:00+00',
-  'authorized content',
-  4,
-  2
+  '990000000000000002', '990000000000000001', now(),
+  'authorized content', 1, 1
 );
 
 SELECT public.tombstone_policy_account('990000000000000001');
 
 SELECT is(
-  (SELECT is_tombstone FROM public.all_account WHERE account_id = '990000000000000001'),
+  (SELECT is_tombstone FROM public.all_account
+   WHERE account_id = '990000000000000001'),
   true,
-  'an account can be reduced to a policy tombstone'
+  'the explicit policy operation tombstones an account'
 );
 
 SELECT is(
-  (SELECT is_tombstone FROM public.tweets WHERE tweet_id = '990000000000000002'),
+  (SELECT is_tombstone FROM public.tweets
+   WHERE tweet_id = '990000000000000002'),
   true,
-  'a tweet can be reduced to a policy tombstone'
+  'the explicit policy operation tombstones authored tweets'
 );
 
 SELECT throws_ok(
   $$
     UPDATE public.tweets
-    SET full_text = 'must not survive'
+    SET full_text = 'content must not enter a tombstone'
     WHERE tweet_id = '990000000000000002'
   $$,
   '23514',
   NULL,
-  'database constraints reject content-bearing tombstones'
+  'content-free tombstone constraints remain enforced'
 );
 
 UPDATE public.all_account
-SET
-  created_via = 'twitter_archive',
-  username = '__pgtap_tombstone',
-  created_at = '2026-01-01 00:00:00+00',
-  account_display_name = 'Policy Test',
-  is_tombstone = false
+SET created_via = 'test', username = '__pgtap_policy_boundary',
+    created_at = now(), account_display_name = 'Policy test',
+    is_tombstone = false
 WHERE account_id = '990000000000000001';
 
 UPDATE public.tweets
-SET
-  created_at = '2026-01-02 00:00:00+00',
-  full_text = 'authorized content restored',
-  favorite_count = 5,
-  retweet_count = 3,
-  is_tombstone = false
+SET created_at = now(), full_text = 'authorized content restored',
+    favorite_count = 1, retweet_count = 1, is_tombstone = false
 WHERE tweet_id = '990000000000000002';
 
 SELECT is(
-  (SELECT full_text FROM public.tweets WHERE tweet_id = '990000000000000002'),
+  (SELECT full_text FROM public.tweets
+   WHERE tweet_id = '990000000000000002'),
   'authorized content restored',
-  'an authorized import can hydrate the same tweet primary key'
-);
-
-SELECT is(
-  (SELECT is_tombstone FROM public.all_account WHERE account_id = '990000000000000001'),
-  false,
-  'an authorized import can hydrate the same account primary key'
+  'a trusted writer can hydrate a stable tombstone key'
 );
 
 INSERT INTO tes.blocked_scraping_users (account_id, block_source)
 VALUES ('990000000000000001', 'admin');
 
-INSERT INTO public.optin (
-  username,
-  twitter_user_id,
-  opted_in,
-  explicit_optout
-) VALUES (
-  '__pgtap_tombstone',
-  '990000000000000001',
-  false,
-  true
-);
-
 SELECT is(
-  (
-    SELECT count(*)::integer
-    FROM tes.blocked_scraping_users
-    WHERE account_id = '990000000000000001'
-  ),
-  2,
-  'administrator and explicit-optout blocks coexist independently'
-);
-
-UPDATE public.optin
-SET opted_in = true, explicit_optout = false
-WHERE username = '__pgtap_tombstone';
-
-SELECT is(
-  (
-    SELECT count(*)::integer
-    FROM tes.blocked_scraping_users
-    WHERE account_id = '990000000000000001'
-      AND block_source = 'explicit_optout'
-  ),
-  0,
-  'opting in removes the consent-derived scrape block'
-);
-
-SELECT is(
-  (
-    SELECT count(*)::integer
-    FROM tes.blocked_scraping_users
-    WHERE account_id = '990000000000000001'
-      AND block_source = 'admin'
-  ),
-  1,
-  'opting in preserves an independent administrator block'
-);
-
-UPDATE public.all_account
-SET username = 'must_not_return',
-    account_display_name = 'must not return',
-    is_tombstone = false
-WHERE account_id = '990000000000000001';
-
-SELECT is(
-  (SELECT is_tombstone FROM public.all_account WHERE account_id = '990000000000000001'),
+  (SELECT is_tombstone FROM public.all_account
+   WHERE account_id = '990000000000000001'),
   true,
-  'a privileged direct account update cannot hydrate an active policy block'
-);
-
-INSERT INTO public.tweets (
-  tweet_id, account_id, created_at, full_text, favorite_count, retweet_count
-) VALUES (
-  '990000000000000003', '990000000000000001', now(),
-  'direct privileged write', 1, 1
+  'recording a block synchronously tombstones existing account content'
 );
 
 SELECT is(
-  (SELECT is_tombstone FROM public.tweets WHERE tweet_id = '990000000000000003'),
+  (SELECT is_tombstone FROM public.tweets
+   WHERE tweet_id = '990000000000000002'),
   true,
-  'a privileged direct tweet insert becomes a stable tombstone'
-);
-
-SELECT is(
-  (SELECT full_text FROM public.tweets WHERE tweet_id = '990000000000000003'),
-  '',
-  'a privileged direct tweet insert cannot retain blocked content'
-);
-
--- A consent row may predate discovery of the stable Twitter account ID. The
--- first later account write must bind that username policy to the ID so every
--- subsequent writer remains fail closed after the username is blanked.
-INSERT INTO public.optin (username, opted_in, explicit_optout)
-VALUES ('__pgtap_username_only', false, true);
-INSERT INTO public.all_account (
-  account_id, created_via, username, created_at, account_display_name
-) VALUES (
-  '990000000000000004', 'manual_import', '__pgtap_username_only', now(),
-  'must be scrubbed'
-);
-INSERT INTO public.tweets (
-  tweet_id, account_id, created_at, full_text, favorite_count, retweet_count
-) VALUES (
-  '990000000000000005', '990000000000000004', now(),
-  'must also be scrubbed', 0, 0
-);
-
-SELECT is(
-  (SELECT is_tombstone FROM public.all_account WHERE account_id = '990000000000000004'),
-  true,
-  'a username-only opt-out tombstones the first later account write'
-);
-
-SELECT is(
-  (SELECT is_tombstone FROM public.tweets WHERE tweet_id = '990000000000000005'),
-  true,
-  'the derived stable-ID block protects subsequent direct tweet writes'
-);
-
-SELECT is(
-  (
-    SELECT count(*)::integer
-    FROM tes.blocked_scraping_users
-    WHERE account_id = '990000000000000004'
-      AND block_source = 'explicit_optout'
-  ),
-  1,
-  'a username-only consent block is associated with the discovered stable ID'
-);
-
--- Simulate consent arriving after account intake while the normal derived-ID
--- propagation is briefly delayed. The write boundary must still resolve the
--- authoritative username policy and fail closed at every sink.
-INSERT INTO public.all_account (
-  account_id, created_via, username, created_at, account_display_name
-) VALUES (
-  '990000000000000006', 'manual_import', '__pgtap_policy_lag', now(),
-  'Policy lag'
-);
-ALTER TABLE public.optin
-  DISABLE TRIGGER propagate_explicit_optout_scrape_block;
-INSERT INTO public.optin (username, opted_in, explicit_optout)
-VALUES ('__pgtap_policy_lag', false, true);
-
-INSERT INTO public.tweets (
-  tweet_id, account_id, created_at, full_text, favorite_count, retweet_count
-) VALUES (
-  '990000000000000007', '990000000000000006', now(),
-  'must be tombstoned despite delayed stable-id propagation', 1, 1
-);
-
-SELECT is(
-  (SELECT is_tombstone FROM public.tweets WHERE tweet_id = '990000000000000007'),
-  true,
-  'a direct tweet write resolves username-only consent while ID propagation lags'
-);
-
-INSERT INTO public.archive_upload (
-  account_id, archive_at, username, upload_phase
-) VALUES (
-  '990000000000000006', now(), '__pgtap_policy_lag', 'ready_for_commit'
-);
-SELECT is(
-  (SELECT count(*)::integer FROM public.archive_upload WHERE account_id = '990000000000000006'),
-  0,
-  'an archive metadata write is discarded while stable-ID propagation lags'
-);
-ALTER TABLE public.optin
-  ENABLE TRIGGER propagate_explicit_optout_scrape_block;
-
-INSERT INTO public.all_profile (account_id, bio)
-VALUES ('990000000000000001', 'blocked profile content');
-SELECT is(
-  (SELECT count(*)::integer FROM public.all_profile WHERE account_id = '990000000000000001'),
-  0,
-  'dependent content writes for blocked accounts are discarded'
-);
-
-SELECT throws_ok(
-  $$ DELETE FROM public.tweets WHERE tweet_id = '990000000000000003' $$,
-  '42501',
-  NULL,
-  'stable tweet tombstones cannot be deleted'
-);
-
--- Allowed outer tweet quoting and retweeting a blocked author. The allowed
--- interaction and inbound relationships survive; the blocked target is blank.
-INSERT INTO public.all_account (
-  account_id, created_via, username, created_at, account_display_name
-) VALUES
-  ('990000000000000010', 'twitter_import', '__pgtap_allowed_outer', now(), 'Allowed'),
-  ('990000000000000011', 'twitter_import', '__pgtap_blocked_target', now(), 'Blocked');
-
-INSERT INTO public.tweets (
-  tweet_id, account_id, created_at, full_text, favorite_count, retweet_count,
-  reply_to_user_id, reply_to_username
-) VALUES
-  ('990000000000000012', '990000000000000010', now(), 'allowed outer commentary', 0, 0, '990000000000000011', '__pgtap_blocked_target'),
-  ('990000000000000014', '990000000000000010', now(), 'RT @__pgtap_blocked_target: blocked target payload', 0, 0, NULL, NULL),
-  ('990000000000000013', '990000000000000011', now(), 'blocked target payload', 0, 0, NULL, NULL);
-
-INSERT INTO public.quote_tweets (tweet_id, quoted_tweet_id)
-VALUES ('990000000000000012', '990000000000000013');
-INSERT INTO public.retweets (tweet_id, retweeted_tweet_id)
-VALUES ('990000000000000014', '990000000000000013');
-
-INSERT INTO tes.blocked_scraping_users (account_id, block_source)
-VALUES ('990000000000000011', 'admin');
-
-SELECT is(
-  public.policy_json_contains_blocked_author(
-    '{"nested":{"username":"__pgtap_blocked_target"}}'::jsonb
-  ),
-  true,
-  'durable JSON sinks detect a nested blocked author'
-);
-
-SELECT is(
-  (SELECT full_text FROM public.tweets WHERE tweet_id = '990000000000000012'),
-  'allowed outer commentary',
-  'allowed outer content survives a nested-author block'
-);
-
-SELECT is(
-  (SELECT is_tombstone FROM public.tweets WHERE tweet_id = '990000000000000013'),
-  true,
-  'blocked quoted/retweeted target becomes a tombstone'
-);
-
-SELECT is(
-  (SELECT full_text FROM public.tweets WHERE tweet_id = '990000000000000014'),
-  '',
-  'historical copied retweet payload is scrubbed while the allowed row survives'
-);
-
-SELECT is(
-  (SELECT reply_to_user_id FROM public.tweets WHERE tweet_id = '990000000000000012'),
-  '990000000000000011',
-  'an allowed reply retains the blocked target stable account ID'
-);
-
-SELECT is(
-  (SELECT reply_to_username FROM public.tweets WHERE tweet_id = '990000000000000012'),
-  NULL::text,
-  'an allowed reply drops blocked target username metadata'
-);
-
-SELECT is(
-  (SELECT count(*)::integer FROM public.quote_tweets WHERE tweet_id = '990000000000000012'),
-  1,
-  'allowed quote relationship to a blocked tombstone is retained'
-);
-
-SELECT is(
-  (SELECT count(*)::integer FROM public.retweets WHERE tweet_id = '990000000000000014'),
-  1,
-  'allowed retweet relationship to a blocked tombstone is retained'
-);
-
--- Blocking the outer author removes only its outgoing relationship rows. An
--- independently allowed embedded tweet remains hydrated.
-INSERT INTO public.all_account (
-  account_id, created_via, username, created_at, account_display_name
-) VALUES
-  ('990000000000000020', 'twitter_import', '__pgtap_blocked_outer', now(), 'Blocked outer'),
-  ('990000000000000021', 'twitter_import', '__pgtap_allowed_child', now(), 'Allowed child');
-
-INSERT INTO public.tweets (
-  tweet_id, account_id, created_at, full_text, favorite_count, retweet_count
-) VALUES
-  ('990000000000000022', '990000000000000020', now(), 'blocked outer payload', 0, 0),
-  ('990000000000000023', '990000000000000021', now(), 'allowed embedded payload', 0, 0);
-
-INSERT INTO public.quote_tweets (tweet_id, quoted_tweet_id)
-VALUES ('990000000000000022', '990000000000000023');
-INSERT INTO public.retweets (tweet_id, retweeted_tweet_id)
-VALUES ('990000000000000022', '990000000000000023');
-
-INSERT INTO tes.blocked_scraping_users (account_id, block_source)
-VALUES ('990000000000000020', 'admin');
-
-SELECT is(
-  (SELECT is_tombstone FROM public.tweets WHERE tweet_id = '990000000000000022'),
-  true,
-  'a blocked outer tweet becomes a tombstone'
-);
-
-SELECT is(
-  (SELECT full_text FROM public.tweets WHERE tweet_id = '990000000000000023'),
-  'allowed embedded payload',
-  'an allowed embedded tweet is retained when the outer author is blocked'
-);
-
-SELECT is(
-  (SELECT count(*)::integer FROM public.quote_tweets WHERE tweet_id = '990000000000000022'),
-  0,
-  'a blocked outer quote relationship is detached'
-);
-
-SELECT is(
-  (SELECT count(*)::integer FROM public.retweets WHERE tweet_id = '990000000000000022'),
-  0,
-  'a blocked outer retweet relationship is detached'
+  'recording a block synchronously tombstones existing tweet content'
 );
 
 INSERT INTO public.all_account (
   account_id, created_via, username, created_at, account_display_name
-) VALUES ('990000000000000030', 'twitter_import', '__pgtap_late_optout', now(), 'Late optout');
-INSERT INTO public.tweets (
-  tweet_id, account_id, created_at, full_text, favorite_count, retweet_count
-) VALUES ('990000000000000031', '990000000000000030', now(), 'intake before optout', 0, 0);
+) VALUES (
+  '990000000000000003', 'test', '__pgtap_explicit_optout', now(), 'Opt out test'
+);
+
 INSERT INTO public.optin (
   username, twitter_user_id, opted_in, explicit_optout
-) VALUES ('__pgtap_late_optout', '990000000000000030', false, true);
-
-SELECT is(
-  (SELECT is_tombstone FROM public.tweets WHERE tweet_id = '990000000000000031'),
-  true,
-  'an opt-out after intake synchronously tombstones PostgreSQL content'
-);
-
-INSERT INTO public.archive_upload (
-  account_id, archive_at, username, upload_phase
 ) VALUES (
-  '990000000000000030', now(), '__pgtap_late_optout', 'ready_for_commit'
+  '__pgtap_explicit_optout', '990000000000000003', false, true
 );
+
 SELECT is(
-  (SELECT count(*)::integer FROM public.archive_upload WHERE account_id = '990000000000000030'),
-  0,
-  'archive metadata writes are discarded while the owner is blocked'
+  (SELECT count(*)::integer FROM tes.blocked_scraping_users
+   WHERE account_id = '990000000000000003'
+     AND block_source = 'explicit_optout'),
+  1,
+  'an explicit opt-out propagates to the block authority'
+);
+
+SELECT is(
+  (SELECT is_tombstone FROM public.all_account
+   WHERE account_id = '990000000000000003'),
+  true,
+  'an explicit opt-out synchronously tombstones existing account content'
+);
+
+SELECT is(
+  public.policy_account_is_blocked(
+    '990000000000000003', '__pgtap_explicit_optout'
+  ),
+  true,
+  'trusted ingestion boundaries can resolve authoritative policy'
 );
 
 SELECT throws_ok(
   $$
     SELECT public.assert_archive_upload_allowed(
-      '990000000000000030',
-      '__pgtap_late_optout'
+      '990000000000000003', '__pgtap_explicit_optout'
     )
   $$,
   '42501',
   NULL,
-  'the canonical upload assertion rejects a blocked archive owner'
+  'the archive intake boundary rejects an opted-out owner'
 );
 
-SELECT throws_ok(
-  $$
-    INSERT INTO storage.objects (bucket_id, name)
-    VALUES ('archives', '__pgtap_late_optout/archive.json')
-  $$,
-  '42501',
-  NULL,
-  'a privileged raw Storage object write is rejected while blocked'
+SELECT is(
+  public.archive_upload_is_allowed(
+    '990000000000000099', '__pgtap_allowed_owner'
+  ),
+  true,
+  'the archive intake boundary permits an unblocked owner'
+);
+
+SELECT is(
+  (
+    SELECT count(*)::integer
+    FROM pg_trigger
+    WHERE NOT tgisinternal
+      AND tgname IN (
+        'enforce_policy_account_tombstone',
+        'enforce_policy_tweet_tombstone',
+        'protect_policy_tombstone_delete',
+        'enforce_policy_mentioned_user_tombstone',
+        'enforce_policy_liked_tweet_tombstone',
+        'enforce_policy_archive_object',
+        'reject_policy_blocked_account_detail',
+        'reject_policy_tombstone_tweet_detail',
+        'reject_policy_blocked_json_payload'
+      )
+  ),
+  0,
+  'corpus writes have no per-row policy triggers'
+);
+
+SELECT is(
+  (
+    SELECT count(*)::integer
+    FROM pg_trigger
+    WHERE NOT tgisinternal
+      AND tgname IN (
+        'propagate_explicit_optout_scrape_block',
+        'capture_policy_block_username',
+        'apply_policy_block_tombstone'
+      )
+  ),
+  3,
+  'only the three policy-state event triggers remain'
 );
 
 SELECT is(
   (SELECT public FROM storage.buckets WHERE id = 'archives'),
   false,
-  'raw archives are not publicly addressable'
-);
-
-SELECT is(
-  (SELECT public FROM storage.buckets WHERE id = 'enriched_tweets'),
-  false,
-  'the historical non-policy-aware Parquet bucket is private'
-);
-
-SELECT ok(
-  NOT EXISTS (
-    SELECT 1
-    FROM storage.buckets
-    WHERE id IN ('firehose', 'firehose_private')
-      AND public IS TRUE
-  ),
-  'every configured Firehose Parquet bucket is private'
-);
-
-SELECT is(
-  (
-    SELECT count(*)::integer
-    FROM public.account_activity_summary
-    WHERE COALESCE(top_engaged_tweets::text, '') LIKE '%blocked target payload%'
-       OR COALESCE(top_engaged_tweets::text, '') LIKE '%intake before optout%'
-  ),
-  0,
-  'the refreshed historical materialized view contains no blocked tweet text'
+  'raw archives remain private'
 );
 
 SELECT is(
   has_table_privilege('anon', 'public.account_activity_summary', 'SELECT'),
   false,
-  'the legacy content-bearing activity snapshot is not publicly readable'
-);
-
-SELECT is(
-  has_table_privilege('anon', 'public.global_activity_summary', 'SELECT'),
-  false,
-  'the historical global account snapshot is not publicly readable'
-);
-
-INSERT INTO public.liked_tweets (tweet_id, full_text)
-VALUES ('990000000000000040', 'unattributed liked payload');
-
-SELECT ok(
-  (
-    SELECT is_tombstone IS TRUE AND full_text = ''
-    FROM public.liked_tweets
-    WHERE tweet_id = '990000000000000040'
-  ),
-  'unattributed liked tweets retain only a stable ID'
-);
-
--- Simulate three pre-migration liked-tweet payloads. The bounded operator uses
--- canonical tweets for author provenance, tombstones a blocked canonical
--- author, and fails closed when no canonical author exists.
-DELETE FROM private.policy_backfill_progress
-WHERE job_name = 'legacy_liked_tweets_v1';
-
-ALTER TABLE public.liked_tweets
-  DISABLE TRIGGER enforce_policy_liked_tweet_tombstone;
-INSERT INTO public.liked_tweets (
-  tweet_id, full_text, author_account_id, is_tombstone
-) VALUES
-  ('990000000000000013', 'legacy blocked liked payload', NULL, false),
-  ('990000000000000023', 'legacy allowed liked payload', NULL, false),
-  ('990000000000000049', 'legacy unknown liked payload', NULL, false);
-ALTER TABLE public.liked_tweets
-  ENABLE TRIGGER enforce_policy_liked_tweet_tombstone;
-
-CREATE TEMP TABLE policy_first_liked_batch AS
-SELECT * FROM private.reconcile_legacy_liked_tweets_batch(2);
-
-SELECT is(
-  (SELECT batch_rows FROM policy_first_liked_batch),
-  2,
-  'the legacy liked-tweet operator respects its batch bound'
-);
-
-SELECT is(
-  (SELECT batch_authors_backfilled FROM policy_first_liked_batch),
-  2,
-  'the first batch backfills canonical author IDs'
-);
-
-SELECT is(
-  (SELECT batch_tombstones_written FROM policy_first_liked_batch),
-  1,
-  'the first batch tombstones the blocked canonical author'
-);
-
-SELECT ok(
-  (
-    SELECT author_account_id = '990000000000000021'
-       AND is_tombstone IS FALSE
-       AND full_text = 'legacy allowed liked payload'
-    FROM public.liked_tweets
-    WHERE tweet_id = '990000000000000023'
-  ),
-  'known allowed liked-tweet content survives with canonical provenance'
-);
-
-SELECT ok(
-  (
-    SELECT author_account_id = '990000000000000011'
-       AND is_tombstone IS TRUE
-       AND full_text = ''
-    FROM public.liked_tweets
-    WHERE tweet_id = '990000000000000013'
-  ),
-  'known blocked liked-tweet content becomes a stable-ID tombstone'
-);
-
-SELECT is(
-  (SELECT checkpoint_tweet_id FROM policy_first_liked_batch),
-  '990000000000000023',
-  'the first batch persists a deterministic keyset checkpoint'
-);
-
-CREATE TEMP TABLE policy_second_liked_batch AS
-SELECT * FROM private.reconcile_legacy_liked_tweets_batch(2);
-
-SELECT is(
-  (SELECT batch_rows FROM policy_second_liked_batch),
-  1,
-  'a resumed batch starts after the durable checkpoint'
-);
-
-SELECT ok(
-  (
-    SELECT author_account_id IS NULL
-       AND is_tombstone IS TRUE
-       AND full_text = ''
-    FROM public.liked_tweets
-    WHERE tweet_id = '990000000000000049'
-  ),
-  'a liked tweet without canonical provenance becomes a stable-ID tombstone'
-);
-
-SELECT is(
-  (SELECT completed FROM policy_second_liked_batch),
-  true,
-  'a short final batch marks the resumable job complete'
-);
-
-SELECT ok(
-  (
-    SELECT rows_processed = 3
-       AND authors_backfilled = 2
-       AND tombstones_written = 2
-       AND completed_at IS NOT NULL
-    FROM private.policy_backfill_progress
-    WHERE job_name = 'legacy_liked_tweets_v1'
-  ),
-  'the durable checkpoint records cumulative reconciliation progress'
-);
-
-CREATE TEMP TABLE policy_idempotent_liked_batch AS
-SELECT * FROM private.reconcile_legacy_liked_tweets_batch(2);
-
-SELECT ok(
-  (
-    SELECT batch_rows = 0
-       AND completed IS TRUE
-       AND total_rows_processed = 3
-    FROM policy_idempotent_liked_batch
-  ),
-  'rerunning a completed liked-tweet reconciliation is idempotent'
-);
-
-SELECT throws_ok(
-  $$ SELECT * FROM private.reconcile_legacy_liked_tweets_batch(0) $$,
-  'P0001',
-  'p_batch_size must be between 1 and 10000',
-  'the operator rejects an unbounded or empty batch size'
-);
-
-INSERT INTO public.mentioned_users (user_id, name, screen_name)
-VALUES ('990000000000000011', 'Blocked name', '__pgtap_blocked_target')
-ON CONFLICT (user_id) DO UPDATE
-SET name = EXCLUDED.name, screen_name = EXCLUDED.screen_name;
-
-SELECT ok(
-  (
-    SELECT is_tombstone IS TRUE AND name = '' AND screen_name = ''
-    FROM public.mentioned_users
-    WHERE user_id = '990000000000000011'
-  ),
-  'nested metadata for a blocked mentioned author is content-free'
+  'the legacy content-bearing activity snapshot remains private'
 );
 
 SELECT has_table(
   'private',
   'policy_storage_objects',
-  'durable Firehose objects have a content-free late-opt-out manifest'
-);
-
-SELECT hasnt_column(
-  'private',
-  'policy_storage_objects',
-  'payload',
-  'Storage reconciliation manifest cannot retain a payload'
-);
-
-SELECT hasnt_column(
-  'private',
-  'policy_storage_objects',
-  'username',
-  'Storage reconciliation manifest retains stable IDs rather than profile data'
-);
-
-SELECT is(
-  has_function_privilege(
-    'anon',
-    'tes.search_liked_tweets(text,text,text,date,date,integer,integer,integer,integer,integer)',
-    'EXECUTE'
-  ),
-  false,
-  'anonymous callers cannot bypass liked-tweet RLS through the legacy definer search'
-);
-
-SELECT is(
-  has_function_privilege(
-    'authenticated',
-    'tes.search_liked_tweets(text,text,text,date,date,integer,integer,integer,integer,integer)',
-    'EXECUTE'
-  ),
-  false,
-  'authenticated callers cannot bypass liked-tweet RLS through the legacy definer search'
-);
-
-SELECT is(
-  has_function_privilege(
-    'service_role',
-    'tes.search_liked_tweets(text,text,text,date,date,integer,integer,integer,integer,integer)',
-    'EXECUTE'
-  ),
-  true,
-  'the trusted service role retains the legacy liked-tweet search grant'
-);
-
-SELECT has_column(
-  'private',
-  'policy_historical_reconcile_progress',
-  'policy_version',
-  'historical checkpoints pin the rollout contract version'
-);
-
-SELECT has_column(
-  'private',
-  'policy_historical_reconcile_progress',
-  'policy_fingerprint',
-  'historical checkpoints pin the authoritative consent set'
-);
-
-CREATE TEMP TABLE policy_fingerprint_before AS
-SELECT private.policy_authority_fingerprint() AS value;
-
-SELECT matches(
-  (SELECT value FROM policy_fingerprint_before),
-  '^[0-9a-f]{64}$',
-  'the policy authority fingerprint is a deterministic SHA-256 value'
-);
-
-INSERT INTO tes.blocked_scraping_users (account_id, block_source)
-VALUES ('990000000000000090', 'admin');
-
-SELECT isnt(
-  private.policy_authority_fingerprint(),
-  (SELECT value FROM policy_fingerprint_before),
-  'a policy change invalidates stale reconciliation checkpoints'
-);
-
-INSERT INTO public.all_account (
-  account_id, created_via, username, created_at, account_display_name
-) VALUES (
-  '990000000000000091', 'manual_import', 'CaseSensitiveArchivePath', now(),
-  'Archive path case'
-);
-INSERT INTO public.archive_upload (
-  account_id, archive_at, username, upload_phase
-) VALUES
-  (
-    '990000000000000091', now() - interval '1 day',
-    'CaseSensitiveArchivePath', 'ready_for_commit'
-  ),
-  (
-    '990000000000000091', now(),
-    'casesensitivearchivepath', 'ready_for_commit'
-  );
-INSERT INTO tes.blocked_scraping_users (account_id, block_source)
-VALUES ('990000000000000091', 'admin');
-
-SELECT is(
-  (
-    SELECT array_agg(args->>'username' ORDER BY args->>'username')
-    FROM private.admin_jobs
-    WHERE job_name = 'admin_delete_with_export'
-      AND args->>'account_id' = '990000000000000091'
-  ),
-  ARRAY['CaseSensitiveArchivePath', 'casesensitivearchivepath']::text[],
-  'archive cleanup preserves every exact case-sensitive Storage path identity'
-);
-
-SELECT is(
-  (SELECT prosecdef FROM pg_proc
-   WHERE oid = 'public.search_tweets(text,text,text,date,date,integer,integer)'::regprocedure),
-  false,
-  'rich search runs with invoker policy instead of bypassing RLS'
-);
-
-SELECT is(
-  (SELECT prosecdef FROM pg_proc
-   WHERE oid = 'public.search_tweets(text,integer,text,timestamp without time zone,timestamp without time zone)'::regprocedure),
-  false,
-  'the compact search overload runs with invoker policy'
-);
-
-SELECT is(
-  (SELECT prosecdef FROM pg_proc
-   WHERE oid = 'public.search_tweets_exact_phrase(text,text,text,date,date,integer,integer)'::regprocedure),
-  false,
-  'exact-phrase search runs with invoker policy instead of bypassing RLS'
-);
-
-SELECT ok(
-  has_function_privilege(
-    'anon',
-    'public.search_tweets(text,text,text,date,date,integer,integer)',
-    'EXECUTE'
-  )
-  AND has_function_privilege(
-    'anon',
-    'public.search_tweets(text,integer,text,timestamp without time zone,timestamp without time zone)',
-    'EXECUTE'
-  )
-  AND has_function_privilege(
-    'anon',
-    'public.search_tweets_exact_phrase(text,text,text,date,date,integer,integer)',
-    'EXECUTE'
-  ),
-  'only policy-invoker search RPCs are restored for anonymous callers'
-);
-
-SELECT ok(
-  NOT has_function_privilege(
-    'readclient',
-    'public.search_tweets(text,text,text,date,date,integer,integer)',
-    'EXECUTE'
-  )
-  AND NOT has_function_privilege(
-    'readclient',
-    'public.search_tweets(text,integer,text,timestamp without time zone,timestamp without time zone)',
-    'EXECUTE'
-  )
-  AND NOT has_function_privilege(
-    'readclient',
-    'public.search_tweets_exact_phrase(text,text,text,date,date,integer,integer)',
-    'EXECUTE'
-  ),
-  'readclient cannot call RPCs outside its table/view contract'
-);
-
-SELECT ok(
-  NOT has_function_privilege('authenticated', 'tes.get_followers()', 'EXECUTE')
-  AND NOT has_function_privilege('authenticated', 'tes.get_followings()', 'EXECUTE')
-  AND NOT has_function_privilege('authenticated', 'tes.get_moots()', 'EXECUTE'),
-  'legacy social-graph definers remain closed after finalization'
-);
-
-SELECT ok(
-  (
-    SELECT count(*) = 6
-       AND bool_and('security_invoker=true' = ANY(COALESCE(reloptions, ARRAY[]::text[])))
-    FROM pg_class
-    WHERE oid = ANY (ARRAY[
-      'public.account'::regclass,
-      'public.profile'::regclass,
-      'public.enriched_tweets'::regclass,
-      'public.tweet_replies_view'::regclass,
-      'public.tweets_w_conversation_id'::regclass,
-      'public.user_directory'::regclass
-    ])
-  ),
-  'content-bearing views permanently inherit caller RLS'
-);
-
-SELECT hasnt_function(
-  'public',
-  'policy_historical_tweet_is_visible',
-  ARRAY['text', 'text', 'text', 'text', 'boolean'],
-  'the expensive historical tweet overlay helper is removed after proof'
-);
-
-SELECT hasnt_function(
-  'public',
-  'policy_historical_tweet_id_is_visible',
-  ARRAY['text'],
-  'the dependent-row historical overlay helper is removed after proof'
-);
-
-SELECT is(
-  (
-    SELECT count(*)::integer
-    FROM pg_policies
-    WHERE policyname = 'policy reconciliation overlay'
-  ),
-  0,
-  'all temporary reconciliation policies are removed after proof'
+  'late opt-outs retain a content-free durable-object manifest'
 );
 
 SELECT * FROM finish();
-
 ROLLBACK;


### PR DESCRIPTION
## Summary

- remove 23 policy triggers from high-volume PostgreSQL corpus, child, Storage, and digest writes
- retain only the three rare policy-state event triggers that propagate an opt-out and scrub existing data
- keep PostgreSQL consent authoritative at the archive, Firehose, and autorefresh batch boundaries
- update the focused pgTAP contract and rollout documentation

Closes #763.

## Validation

- `git diff --check`
- static schema check confirms no `enforce_policy_*`, `reject_policy_*`, or `protect_policy_*` trigger remains attached
- focused pgTAP plan count checked statically
- database-backed tests were not run locally because Docker is unavailable and no live staging write was authorized

## Rollout

Do not deploy this migration until the policy-safe archive worker, Firehose persistence worker, and autorefresh writer are confirmed live. The migration uses a five-second lock timeout and should be deployed separately from application changes.