### PR TITLE
Polish the homepage dashboard

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,15 +24,16 @@
     --border: 240 5.9% 90%;
     --input: 240 5.9% 90%;
     --ring: 240 5.9% 10%;
-    --brand: 197 74% 46%;
+    /* One hue for the whole family; each value lands exactly on its hex. */
+    --brand: 197 74.4% 46%; /* #1E9BCD */
     --brand-foreground: 0 0% 100%;
     /* Deep brand: emphasis surfaces only (banners, callouts) - never body text. */
-    --brand-deep: 199 74% 24%;
+    --brand-deep: 197 74% 24.1%; /* #10516B */
     --brand-deep-foreground: 0 0% 100%;
     /* Tracked off the brand so data viz never drifts from the accent. */
-    --chart-accent: 197 74% 46%;
+    --chart-accent: 197 74.4% 46%;
     /* Icon glyphs only: a lift off the accent so small marks stay legible. */
-    --brand-icon: 196 76% 51%;
+    --brand-icon: 197 74.1% 51%; /* #25AADF */
     --radius: 0.3rem;
   }
 
@@ -57,12 +58,16 @@
     --border: 240 4% 16%;
     --input: 240 4% 16%;
     --ring: 0 0% 80%;
-    --brand: 197 74% 46%;
-    --brand-foreground: 0 0% 100%;
-    --brand-deep: 199 74% 24%;
-    --brand-deep-foreground: 0 0% 100%;
-    --chart-accent: 197 74% 46%;
-    --brand-icon: 196 76% 51%;
+    /* Dark keeps the hue and flips the lightness: the accent lifts to #75C9EB
+       and the deep tone inverts into a light surface (#8BD2EE), so both
+       foregrounds flip to the page ink to stay readable. */
+    --brand: 197 74.1% 69%; /* #75C9EB */
+    --brand-foreground: 240 5% 7%;
+    --brand-deep: 197 75% 74%; /* #8BD2EE */
+    --brand-deep-foreground: 240 5% 7%;
+    --chart-accent: 197 74.1% 69%;
+    /* Same +5% lift off the accent that the light theme uses. */
+    --brand-icon: 197 74.1% 74%;
   }
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,8 +24,13 @@
     --border: 240 5.9% 90%;
     --input: 240 5.9% 90%;
     --ring: 240 5.9% 10%;
-    --brand: 217 91% 60%;
+    --brand: 197 74% 46%;
     --brand-foreground: 0 0% 100%;
+    /* Deep brand: emphasis surfaces only (banners, callouts) - never body text. */
+    --brand-deep: 199 74% 24%;
+    --brand-deep-foreground: 0 0% 100%;
+    /* Tracked off the brand so data viz never drifts from the accent. */
+    --chart-accent: 197 74% 46%;
     --radius: 0.3rem;
   }
 
@@ -50,8 +55,11 @@
     --border: 240 4% 16%;
     --input: 240 4% 16%;
     --ring: 0 0% 80%;
-    --brand: 217 91% 60%;
+    --brand: 197 74% 46%;
     --brand-foreground: 0 0% 100%;
+    --brand-deep: 199 74% 24%;
+    --brand-deep-foreground: 0 0% 100%;
+    --chart-accent: 197 74% 46%;
   }
 }
 
@@ -64,6 +72,15 @@
   }
   html {
     scroll-behavior: smooth;
+  }
+  /* Links inherit their surrounding color and lean on weight, not hue, to read
+     as links. Utility classes still win over this base rule. */
+  a {
+    color: inherit;
+    font-weight: 600;
+  }
+  a:hover {
+    text-decoration: underline;
   }
   /* Petrona is reserved for the hero (h1) and section headers (h2).
      Smaller headings (card titles, etc.) stay on the Manrope body font. */
@@ -86,4 +103,14 @@
 }
 .portal-slide-in {
   animation: portal-slide-in 0.35s ease-out;
+}
+
+/* Homepage hero: corpus ribbon marquee (the track is rendered twice) */
+@keyframes corpus-marquee {
+  from {
+    transform: translate3d(0, 0, 0);
+  }
+  to {
+    transform: translate3d(-50%, 0, 0);
+  }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -31,6 +31,8 @@
     --brand-deep-foreground: 0 0% 100%;
     /* Tracked off the brand so data viz never drifts from the accent. */
     --chart-accent: 197 74% 46%;
+    /* Icon glyphs only: a lift off the accent so small marks stay legible. */
+    --brand-icon: 196 76% 51%;
     --radius: 0.3rem;
   }
 
@@ -60,6 +62,7 @@
     --brand-deep: 199 74% 24%;
     --brand-deep-foreground: 0 0% 100%;
     --chart-accent: 197 74% 46%;
+    --brand-icon: 196 76% 51%;
   }
 }
 
@@ -103,6 +106,27 @@
 }
 .portal-slide-in {
   animation: portal-slide-in 0.35s ease-out;
+}
+
+/* Homepage hero: streamed-in blocks (avatars, social proof) settle rather than
+   snapping in when their Suspense boundary resolves. */
+@keyframes home-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+.home-fade-in {
+  animation: home-fade-in 0.45s ease-out both;
+}
+@media (prefers-reduced-motion: reduce) {
+  .home-fade-in {
+    animation: none;
+  }
 }
 
 /* Homepage hero: corpus ribbon marquee (the track is rendered twice) */

--- a/src/app/stream-monitor/page.tsx
+++ b/src/app/stream-monitor/page.tsx
@@ -209,7 +209,7 @@ const StreamMonitor = () => {
       label: showStreamedOnly
         ? 'Unique Tweets Streamed'
         : 'Unique Tweets Observed',
-      color: 'hsl(var(--chart-1))',
+      color: 'hsl(var(--chart-accent))',
     },
   }
 

--- a/src/components/AvatarList.tsx
+++ b/src/components/AvatarList.tsx
@@ -58,6 +58,9 @@ function RecoverableArchiveAvatar({
         <AvatarImage
           src={avatarUrl}
           alt={`${avatar.username}'s avatar`}
+          // Radix only mounts the image once it has decoded, so the fade runs
+          // exactly when the photo replaces the letter fallback.
+          className="home-fade-in"
           onError={() => {
             setAvatarUrl(undefined)
             recoverAvatar()

--- a/src/components/HeroCTAButtons.tsx
+++ b/src/components/HeroCTAButtons.tsx
@@ -211,7 +211,7 @@ export default function HeroCTAButtons({
   }
 
   const getOptInButtonStyle = () => {
-    return 'bg-green-600 hover:bg-green-700 text-white dark:bg-green-400 dark:hover:bg-green-300 dark:text-green-950'
+    return 'bg-brand text-brand-foreground hover:bg-brand/90'
   }
 
   return (
@@ -244,7 +244,7 @@ export default function HeroCTAButtons({
                 variant={isOptedIn ? 'default' : 'outline'}
                 className={`h-14 w-full px-8 text-lg font-semibold ${
                   isOptedIn
-                    ? 'bg-green-600 text-white hover:bg-green-700 dark:bg-green-400 dark:text-green-950 dark:hover:bg-green-300'
+                    ? 'bg-brand text-brand-foreground hover:bg-brand/90'
                     : 'border-2'
                 }`}
                 size="lg"

--- a/src/components/UploadArchiveSection.tsx
+++ b/src/components/UploadArchiveSection.tsx
@@ -164,7 +164,7 @@ export default function UploadArchiveSection() {
             key={step.number}
             className="rounded-xl border border-border bg-card p-6 text-center"
           >
-            <div className="mx-auto mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-muted text-lg font-bold text-brand">
+            <div className="mx-auto mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-muted text-lg font-bold text-foreground">
               {step.number}
             </div>
             <h3 className="mb-2 font-semibold text-foreground">{step.title}</h3>
@@ -189,7 +189,7 @@ export default function UploadArchiveSection() {
                 <Button
                   onClick={handleUploadClick}
                   disabled={isUploadProcessing}
-                  className="bg-green-600 text-white hover:bg-green-700 dark:bg-green-400 dark:text-green-950 dark:hover:bg-green-300"
+                  className="bg-brand text-brand-foreground hover:bg-brand/90"
                 >
                   <Upload className="mr-2 h-4 w-4" />
                   {isUploadProcessing ? 'Processing...' : 'Upload .zip'}

--- a/src/components/home/ClassicHomepage.tsx
+++ b/src/components/home/ClassicHomepage.tsx
@@ -116,28 +116,31 @@ export default async function ClassicHomepage({
             <HomepageSearch />
           ) : null}
 
-          {homepagePeople}
+          {/* The backers line is a footnote to the social proof above it. */}
+          <div>
+            {homepagePeople}
 
-          <p className="text-xs text-muted-foreground/80">
-            Backed by{' '}
-            <Link
-              href="https://survivalandflourishing.fund/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-medium transition-colors hover:text-brand hover:underline"
-            >
-              Survival and Flourishing Fund
-            </Link>{' '}
-            and{' '}
-            <Link
-              href="https://x.com/VitalikButerin"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-medium transition-colors hover:text-brand hover:underline"
-            >
-              Vitalik Buterin
-            </Link>
-          </p>
+            <p className="mt-1 text-xs text-muted-foreground/80">
+              Backed by{' '}
+              <Link
+                href="https://survivalandflourishing.fund/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium transition-colors hover:text-brand hover:underline"
+              >
+                Survival and Flourishing Fund
+              </Link>{' '}
+              and{' '}
+              <Link
+                href="https://x.com/VitalikButerin"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium transition-colors hover:text-brand hover:underline"
+              >
+                Vitalik Buterin
+              </Link>
+            </p>
+          </div>
         </div>
 
         {!data.failures.historicalBangers && (

--- a/src/components/home/ClassicHomepage.tsx
+++ b/src/components/home/ClassicHomepage.tsx
@@ -81,7 +81,7 @@ export default async function ClassicHomepage({
 
   return (
     <main>
-      <section className="overflow-hidden bg-card pb-12 pt-14 dark:bg-background md:pb-16 md:pt-20">
+      <section className="overflow-hidden bg-card pb-7 pt-14 dark:bg-background md:pt-20">
         <div className="relative z-10 mx-auto w-full max-w-5xl space-y-9 px-4 text-center sm:px-6 lg:px-8">
           <div className="space-y-3">
             <h1 className="text-5xl font-bold tracking-tight text-foreground md:text-6xl">
@@ -108,26 +108,6 @@ export default async function ClassicHomepage({
                 </>
               )}
             </p>
-            <p className="text-xs text-muted-foreground/80">
-              Backed by{' '}
-              <Link
-                href="https://survivalandflourishing.fund/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="font-medium transition-colors hover:text-brand hover:underline"
-              >
-                Survival and Flourishing Fund
-              </Link>{' '}
-              and{' '}
-              <Link
-                href="https://x.com/VitalikButerin"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="font-medium transition-colors hover:text-brand hover:underline"
-              >
-                Vitalik Buterin
-              </Link>
-            </p>
           </div>
 
           {showCta ? (
@@ -137,6 +117,27 @@ export default async function ClassicHomepage({
           ) : null}
 
           {homepagePeople}
+
+          <p className="text-xs text-muted-foreground/80">
+            Backed by{' '}
+            <Link
+              href="https://survivalandflourishing.fund/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium transition-colors hover:text-brand hover:underline"
+            >
+              Survival and Flourishing Fund
+            </Link>{' '}
+            and{' '}
+            <Link
+              href="https://x.com/VitalikButerin"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium transition-colors hover:text-brand hover:underline"
+            >
+              Vitalik Buterin
+            </Link>
+          </p>
         </div>
 
         {!data.failures.historicalBangers && (

--- a/src/components/home/ClassicHomepage.tsx
+++ b/src/components/home/ClassicHomepage.tsx
@@ -5,6 +5,8 @@ import { cookies } from 'next/headers'
 import HomepageSearch from '@/components/HomepageSearch'
 import Portal from '@/components/portal/Portal'
 import Testimonials from '@/components/home/Testimonials'
+import CorpusRibbon from '@/components/home/CorpusRibbon'
+import TweetCountTicker from '@/components/home/TweetCountTicker'
 import { formatNumber } from '@/lib/formatNumber'
 import type { PortalData } from '@/lib/portal/types'
 import { createServerClient } from '@/utils/supabase'
@@ -95,7 +97,8 @@ export default async function ClassicHomepage({
                 <>
                   We preserve{' '}
                   <strong className="font-semibold text-foreground">
-                    {formatNumber(data.stats.totalTweets)} public tweets
+                    <TweetCountTicker value={data.stats.totalTweets} /> public
+                    tweets
                   </strong>{' '}
                   from{' '}
                   <strong className="font-semibold text-foreground">
@@ -135,6 +138,10 @@ export default async function ClassicHomepage({
 
           {homepagePeople}
         </div>
+
+        {!data.failures.historicalBangers && (
+          <CorpusRibbon tweets={data.historicalBangers} />
+        )}
       </section>
 
       <section className="bg-zinc-100/80 py-4 dark:bg-transparent sm:py-7">

--- a/src/components/home/CorpusRibbon.tsx
+++ b/src/components/home/CorpusRibbon.tsx
@@ -1,0 +1,62 @@
+import Link from 'next/link'
+import type { PortalTweet } from '@/lib/portal/types'
+import { MUTED, BODY } from '@/components/portal/styles'
+
+const RIBBON_SIZE = 8
+/** Long tweets break the single-line pill, so the ribbon only takes short ones. */
+const MAX_LENGTH = 110
+
+const oneLine = (text: string) =>
+  text
+    .replace(/https?:\/\/\S+/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+/**
+ * A slow marquee of real archive posts spanning the corpus, drawn from the
+ * same historical bangers the dashboard ranks below.
+ */
+export default function CorpusRibbon({ tweets }: { tweets: PortalTweet[] }) {
+  const items = tweets
+    .map((tweet) => ({
+      id: tweet.id,
+      who: tweet.username,
+      text: oneLine(tweet.text),
+      year: new Date(tweet.createdAt).getUTCFullYear(),
+    }))
+    .filter(
+      (item) =>
+        item.who &&
+        item.text.length > 0 &&
+        item.text.length <= MAX_LENGTH &&
+        Number.isFinite(item.year),
+    )
+    .slice(0, RIBBON_SIZE)
+
+  // Too few pills to fill the viewport twice would show the seam.
+  if (items.length < 4) return null
+
+  return (
+    <div className="mt-14 overflow-hidden [mask-image:linear-gradient(90deg,transparent,#000_10%,#000_90%,transparent)]">
+      <div className="flex w-max gap-3 [animation:corpus-marquee_64s_linear_infinite] hover:[animation-play-state:paused] motion-reduce:animate-none">
+        {[0, 1].map((pass) =>
+          items.map((item) => (
+            <Link
+              key={`${pass}-${item.id}`}
+              href={`/tweets/${item.id}`}
+              aria-hidden={pass === 1}
+              tabIndex={pass === 1 ? -1 : undefined}
+              className="flex items-center gap-2.5 whitespace-nowrap rounded-full border border-zinc-200 bg-white px-4 py-[9px] text-[13.5px] transition-colors hover:border-brand dark:border-[#26262a] dark:bg-[#1b1b1e]"
+            >
+              <span className="text-[12.5px] font-semibold text-brand">
+                @{item.who}
+              </span>
+              <span className={BODY}>{item.text}</span>
+              <span className={`text-[12px] ${MUTED}`}>{item.year}</span>
+            </Link>
+          )),
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/home/CorpusRibbon.tsx
+++ b/src/components/home/CorpusRibbon.tsx
@@ -48,7 +48,7 @@ export default function CorpusRibbon({ tweets }: { tweets: PortalTweet[] }) {
               tabIndex={pass === 1 ? -1 : undefined}
               className="flex items-center gap-2.5 whitespace-nowrap rounded-full border border-zinc-200 bg-white px-4 py-[9px] text-[13.5px] transition-colors hover:border-brand dark:border-[#26262a] dark:bg-[#1b1b1e]"
             >
-              <span className="text-[12.5px] font-semibold text-brand-deep dark:text-brand">
+              <span className="text-[12.5px] font-semibold text-brand-deep">
                 @{item.who}
               </span>
               <span className={BODY}>{item.text}</span>

--- a/src/components/home/CorpusRibbon.tsx
+++ b/src/components/home/CorpusRibbon.tsx
@@ -37,7 +37,7 @@ export default function CorpusRibbon({ tweets }: { tweets: PortalTweet[] }) {
   if (items.length < 4) return null
 
   return (
-    <div className="mt-14 overflow-hidden [mask-image:linear-gradient(90deg,transparent,#000_10%,#000_90%,transparent)]">
+    <div className="mt-16 overflow-hidden [mask-image:linear-gradient(90deg,transparent,#000_10%,#000_90%,transparent)]">
       <div className="flex w-max gap-3 [animation:corpus-marquee_64s_linear_infinite] hover:[animation-play-state:paused] motion-reduce:animate-none">
         {[0, 1].map((pass) =>
           items.map((item) => (
@@ -48,7 +48,7 @@ export default function CorpusRibbon({ tweets }: { tweets: PortalTweet[] }) {
               tabIndex={pass === 1 ? -1 : undefined}
               className="flex items-center gap-2.5 whitespace-nowrap rounded-full border border-zinc-200 bg-white px-4 py-[9px] text-[13.5px] transition-colors hover:border-brand dark:border-[#26262a] dark:bg-[#1b1b1e]"
             >
-              <span className="text-[12.5px] font-semibold text-brand">
+              <span className="text-[12.5px] font-semibold text-brand-deep dark:text-brand">
                 @{item.who}
               </span>
               <span className={BODY}>{item.text}</span>

--- a/src/components/home/CorpusRibbon.tsx
+++ b/src/components/home/CorpusRibbon.tsx
@@ -46,7 +46,7 @@ export default function CorpusRibbon({ tweets }: { tweets: PortalTweet[] }) {
               href={`/tweets/${item.id}`}
               aria-hidden={pass === 1}
               tabIndex={pass === 1 ? -1 : undefined}
-              className="flex items-center gap-2.5 whitespace-nowrap rounded-full border border-zinc-200 bg-white px-4 py-[9px] text-[13.5px] transition-colors hover:border-brand dark:border-[#26262a] dark:bg-[#1b1b1e]"
+              className="flex items-center gap-2.5 whitespace-nowrap rounded-full border border-zinc-200 bg-white px-4 py-[9px] text-[13.5px] transition-colors hover:border-brand dark:border-[#26262a] dark:bg-[#1b1b1e] dark:hover:border-brand"
             >
               <span className="text-[12.5px] font-semibold text-brand-deep">
                 @{item.who}

--- a/src/components/home/HomepagePeople.test.tsx
+++ b/src/components/home/HomepagePeople.test.tsx
@@ -111,7 +111,10 @@ it('shows the eight cached interaction leaders to a signed-in member', async () 
 it('shows the representative sample to guests', async () => {
   render(await HomepagePeople({ isMember: false }))
 
-  expect(screen.getByText('Featured archives')).toBeInTheDocument()
+  // The unpersonalized row carries no caption; the avatars are the proof.
+  expect(
+    screen.queryByText('People you interact with most this year'),
+  ).not.toBeInTheDocument()
   expect(screen.getByTestId('homepage-avatars')).toHaveTextContent(
     'featured:1000',
   )
@@ -126,7 +129,9 @@ it('falls back to the representative sample when interaction data is absent', as
 
   render(await HomepagePeople({ isMember: true }))
 
-  expect(screen.getByText('Featured archives')).toBeInTheDocument()
+  expect(
+    screen.queryByText('People you interact with most this year'),
+  ).not.toBeInTheDocument()
   expect(screen.getByTestId('homepage-avatars')).toHaveTextContent(
     'featured:1000',
   )

--- a/src/components/home/HomepagePeople.tsx
+++ b/src/components/home/HomepagePeople.tsx
@@ -28,7 +28,6 @@ async function personalizedArchives(): Promise<AvatarType[]> {
 export function HomepagePeopleFallback() {
   return (
     <div className="pt-2">
-      <p className={labelClassName}>Featured archives</p>
       <div
         aria-hidden="true"
         className="mx-auto flex max-w-3xl flex-wrap justify-center gap-x-3 gap-y-4 pb-2"
@@ -68,11 +67,11 @@ export default async function HomepagePeople({
 
   return (
     <div className="home-fade-in pt-2">
-      <p className={labelClassName}>
-        {personalized.length
-          ? 'People you interact with most this year'
-          : 'Featured archives'}
-      </p>
+      {personalized.length > 0 && (
+        <p className={labelClassName}>
+          People you interact with most this year
+        </p>
+      )}
       <div className="mx-auto w-full max-w-3xl">
         <AvatarList initialAvatars={archives} compact />
       </div>

--- a/src/components/home/HomepagePeople.tsx
+++ b/src/components/home/HomepagePeople.tsx
@@ -67,7 +67,7 @@ export default async function HomepagePeople({
       : featuredCandidates
 
   return (
-    <div className="pt-2">
+    <div className="home-fade-in pt-2">
       <p className={labelClassName}>
         {personalized.length
           ? 'People you interact with most this year'

--- a/src/components/home/Testimonials.test.tsx
+++ b/src/components/home/Testimonials.test.tsx
@@ -12,9 +12,10 @@ describe('Testimonials', () => {
       screen.queryByText(/Search that finds the posts people remember/i),
     ).not.toBeInTheDocument()
 
-    const links = screen.getAllByRole('link', {
-      name: /View in the archive/i,
-    })
+    // The cards link through on their own; the explicit call-to-action is gone.
+    const links = screen
+      .getAllByRole('link')
+      .filter((link) => link.getAttribute('href')?.startsWith('/tweets/'))
     expect(links).toHaveLength(15)
     const hrefs = links.map((link) => link.getAttribute('href'))
     expect(hrefs).toEqual(

--- a/src/components/home/Testimonials.tsx
+++ b/src/components/home/Testimonials.tsx
@@ -119,7 +119,7 @@ export default function Testimonials() {
             <Link
               key={testimonial.tweetId}
               href={`/tweets/${testimonial.tweetId}`}
-              className="group rounded-xl border border-border bg-background p-5 transition-colors hover:border-brand/60"
+              className="group rounded-xl border border-border bg-background p-5 transition-colors hover:border-brand-deep/60"
             >
               <blockquote className="text-[15px] leading-7 text-foreground">
                 “{testimonial.quote}”
@@ -129,9 +129,6 @@ export default function Testimonials() {
                 <span className="font-normal text-muted-foreground">
                   @{testimonial.handle}
                 </span>
-              </p>
-              <p className="mt-1 text-xs font-semibold text-brand group-hover:underline">
-                View in the archive →
               </p>
             </Link>
           ))}

--- a/src/components/home/TweetCountTicker.tsx
+++ b/src/components/home/TweetCountTicker.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+const DIGIT_HEIGHT = 28
+const COUNT_UP_MS = 1500
+/** The ramp stops just short of the total so the last digits visibly roll in. */
+const RAMP_END = 0.985
+const SETTLE_MS = 620
+const DIGITS = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
+
+type Token = { key: number; digit: number | null }
+
+/**
+ * Split a count into odometer tokens using the *target* digit width, so the
+ * strip keeps a fixed number of columns from the first frame and the sentence
+ * around it never reflows.
+ */
+function tokenize(count: number, width: number): Token[] {
+  const digits = String(Math.max(0, count)).padStart(width, '0').slice(-width)
+  const tokens: Token[] = []
+  for (let i = 0; i < width; i += 1) {
+    if (i > 0 && (width - i) % 3 === 0) {
+      tokens.push({ key: tokens.length, digit: null })
+    }
+    tokens.push({ key: tokens.length, digit: Number(digits[i]) })
+  }
+  return tokens
+}
+
+/**
+ * Counts up to the archive total on mount, then rests there. The rolling
+ * columns are decorative; assistive tech reads the plain total instead.
+ */
+export default function TweetCountTicker({ value }: { value: number }) {
+  const formatted = value.toLocaleString('en-US')
+  const width = String(Math.max(0, value)).length
+  const [count, setCount] = useState(value)
+  const [rolling, setRolling] = useState(false)
+  const frame = useRef<number>()
+
+  useEffect(() => {
+    const reduced = window.matchMedia?.('(prefers-reduced-motion: reduce)')
+    if (reduced?.matches) return
+
+    setRolling(true)
+    setCount(0)
+    const start = performance.now()
+    const step = () => {
+      const progress = Math.min(1, (performance.now() - start) / COUNT_UP_MS)
+      const eased = 1 - Math.pow(1 - progress, 4)
+      setCount(Math.floor(value * eased * RAMP_END))
+      if (progress < 1) {
+        frame.current = requestAnimationFrame(step)
+        return
+      }
+      // Turn the transition on a frame before the true total lands, otherwise
+      // the browser applies both in one recalc and the last hop snaps.
+      setRolling(false)
+      frame.current = requestAnimationFrame(() => setCount(value))
+    }
+    frame.current = requestAnimationFrame(step)
+
+    return () => {
+      if (frame.current !== undefined) cancelAnimationFrame(frame.current)
+    }
+  }, [value])
+
+  return (
+    <span className="inline-flex items-start align-bottom tabular-nums">
+      <span className="sr-only">{formatted}</span>
+      {tokenize(count, width).map((token) =>
+        token.digit === null ? (
+          <span
+            key={token.key}
+            aria-hidden
+            className="block h-[28px] leading-[28px]"
+          >
+            ,
+          </span>
+        ) : (
+          <span
+            key={token.key}
+            aria-hidden
+            className="block h-[28px] w-[1ch] overflow-hidden"
+          >
+            <span
+              className="block"
+              style={{
+                transform: `translateY(-${token.digit * DIGIT_HEIGHT}px)`,
+                transition: rolling
+                  ? 'none'
+                  : `transform ${SETTLE_MS}ms cubic-bezier(.16,.84,.24,1)`,
+              }}
+            >
+              {DIGITS.map((digit) => (
+                <span
+                  key={digit}
+                  className="block h-[28px] text-center leading-[28px]"
+                >
+                  {digit}
+                </span>
+              ))}
+            </span>
+          </span>
+        ),
+      )}
+    </span>
+  )
+}

--- a/src/components/portal/Portal.test.tsx
+++ b/src/components/portal/Portal.test.tsx
@@ -90,6 +90,13 @@ describe.each<PortalView>(['home', 'stream'])(
       jest.restoreAllMocks()
     })
 
+    // The corpus total is a live counter on /stream and the first metric in
+    // the home dashboard strip.
+    const expectCorpusCount = () =>
+      expect(
+        screen.getByText(view === 'home' ? '14,000,000' : '14,000,000 tweets'),
+      ).toBeInTheDocument()
+
     test('polls from the latest cursor without changing the corpus snapshot count', async () => {
       const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue({
         ok: true,
@@ -113,19 +120,16 @@ describe.each<PortalView>(['home', 'stream'])(
         'after=2026-08-07T12%3A00%3A00.000Z&afterId=100',
       )
       expect(screen.getByText('fresh tweet')).toBeInTheDocument()
-      expect(screen.getByText('14,000,000 tweets')).toBeInTheDocument()
+      expectCorpusCount()
       if (view === 'home') {
-        expect(screen.getByText('14,000,000')).toBeInTheDocument()
-        expect(
-          screen.getByText('+2,400 streamed in the last 24h'),
-        ).toBeInTheDocument()
+        expect(screen.getByText('+2,400 in the last 24h')).toBeInTheDocument()
       }
 
       await act(async () => {
         jest.advanceTimersByTime(30_000)
         await Promise.resolve()
       })
-      expect(screen.getByText('14,000,000 tweets')).toBeInTheDocument()
+      expectCorpusCount()
 
       await act(async () => {
         jest.advanceTimersByTime(29_999)
@@ -139,7 +143,7 @@ describe.each<PortalView>(['home', 'stream'])(
         await Promise.resolve()
       })
       expect(fetchMock).toHaveBeenCalledTimes(2)
-      expect(screen.getByText('14,000,000 tweets')).toBeInTheDocument()
+      expectCorpusCount()
       expect(String(fetchMock.mock.calls[1][0])).toContain(
         'after=2026-08-07T12%3A01%3A00.000Z&afterId=101',
       )
@@ -148,10 +152,7 @@ describe.each<PortalView>(['home', 'stream'])(
         jest.advanceTimersByTime(240_000)
         await Promise.resolve()
       })
-      expect(screen.getByText('14,000,000 tweets')).toBeInTheDocument()
-      if (view === 'home') {
-        expect(screen.getByText('14,000,000')).toBeInTheDocument()
-      }
+      expectCorpusCount()
 
       unmount()
     })

--- a/src/components/portal/Portal.tsx
+++ b/src/components/portal/Portal.tsx
@@ -1,8 +1,9 @@
 'use client'
 
+import type { ReactNode } from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Link from 'next/link'
-import { FaExternalLinkAlt } from 'react-icons/fa'
+import { FaDatabase, FaExternalLinkAlt, FaUsers } from 'react-icons/fa'
 import {
   PortalData,
   PortalTweet,
@@ -184,27 +185,32 @@ function LiveCounter({ count }: { count: number }) {
   )
 }
 
-/** Evergreen sidebar destinations, condensed into one hairline-split list. */
+/** Evergreen sidebar destinations. */
 function UtilityLink({
   href,
   destination,
   title,
   note,
   action,
+  icon,
 }: {
   href: string
   destination: DashboardDestination
   title: string
   note: string
   action: string
+  icon: ReactNode
 }) {
   return (
     <a
       href={href}
-      onClick={() => captureDashboardDestination(destination, 'list', false)}
-      className="flex items-baseline justify-between gap-2.5 border-b border-zinc-200 px-4 py-3 transition-colors last:border-b-0 hover:bg-zinc-50 dark:border-[#26262a] dark:hover:bg-[#1f1f23]"
+      onClick={() => captureDashboardDestination(destination, 'card', false)}
+      className={`${CARD} flex items-center gap-3 px-4 py-3 font-normal transition-colors hover:border-brand`}
     >
-      <span className="flex min-w-0 flex-col gap-0.5">
+      <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-[4px] border border-zinc-200 bg-zinc-100 text-brand-icon dark:border-[#2a2a2e] dark:bg-[#121214]">
+        {icon}
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col gap-px">
         <span className="text-[12.5px] font-bold">{title}</span>
         <span className={`text-[11.5px] leading-snug ${MUTED}`}>{note}</span>
       </span>
@@ -342,7 +348,7 @@ function ArchiveOverview({
 function DigestHero({ preview }: { preview: DigestPreview | null }) {
   if (!preview) {
     return (
-      <div className="mb-4 rounded-[4px] border border-dashed border-[#10516B]/50 bg-[#10516B]/5 px-6 py-6 text-center dark:border-[#7fb4cc]/40 dark:bg-[#7fb4cc]/10">
+      <div className="mb-4 rounded-[4px] border border-dashed border-brand-deep/50 bg-brand-deep/5 px-6 py-6 text-center">
         <div
           className={`text-[11px] font-bold uppercase tracking-[0.14em] ${MUTED}`}
         >
@@ -374,7 +380,7 @@ function DigestHero({ preview }: { preview: DigestPreview | null }) {
     captureDashboardDestination('daily_digest', 'card', false)
 
   return (
-    <div className="mb-4 rounded-[4px] bg-[#10516B] px-6 py-6 text-white sm:px-7">
+    <div className="mb-4 rounded-[4px] bg-brand-deep px-6 py-6 text-brand-deep-foreground sm:px-7">
       <div className="flex flex-wrap items-baseline justify-between gap-3">
         <span className="flex flex-wrap items-center gap-x-3 gap-y-1">
           <span className="text-[11px] font-bold uppercase tracking-[0.14em] text-white/75">
@@ -390,7 +396,7 @@ function DigestHero({ preview }: { preview: DigestPreview | null }) {
         <Link
           href={preview.href}
           onClick={openDigest}
-          className="inline-flex items-center gap-1.5 rounded-full bg-white px-3.5 py-1.5 text-[12.5px] font-bold text-[#10516B] transition-colors hover:bg-white/90"
+          className="inline-flex items-center gap-1.5 rounded-full bg-white px-3.5 py-1.5 text-[12.5px] font-bold text-brand-deep transition-colors hover:bg-white/90"
         >
           Read the edition &rarr;
         </Link>
@@ -944,13 +950,14 @@ export default function Portal({
                   )}
                 </div>
               </div>
-              <div className={`${CARD} overflow-hidden`}>
+              <div className="flex flex-col gap-3">
                 <UtilityLink
                   href={ARCHIVE_EXPORT_URL}
                   destination="data_export"
                   title="Bulk export paused"
                   note="Why the historical Parquet file is private"
                   action="Details"
+                  icon={<FaDatabase className="h-[17px] w-[17px]" />}
                 />
                 <UtilityLink
                   href={COMMUNITY_BUILDS_URL}
@@ -958,6 +965,7 @@ export default function Portal({
                   title="Community Builds"
                   note="Projects made with Community Archive data"
                   action="Explore"
+                  icon={<FaUsers className="h-[17px] w-[17px]" />}
                 />
               </div>
             </div>

--- a/src/components/portal/Portal.tsx
+++ b/src/components/portal/Portal.tsx
@@ -430,11 +430,8 @@ function DigestHero({ preview }: { preview: DigestPreview | null }) {
                 index > 0 ? 'lg:border-l lg:pl-7' : ''
               } ${index < preview.stories.length - 1 ? 'lg:pr-7' : ''}`}
             >
-              <div className="mb-2 flex items-baseline gap-2">
-                <span className={`text-[11px] tabular-nums ${FAINT}`}>
-                  {String(index + 1).padStart(2, '0')}
-                </span>
-                <span className="text-[10px] uppercase tracking-[0.12em] text-brand">
+              <div className="mb-2.5">
+                <span className="inline-flex items-center rounded-full border border-brand/25 bg-brand/10 px-2 py-[3px] text-[10px] font-semibold uppercase tracking-[0.1em] text-brand-deep">
                   {story.tag}
                 </span>
               </div>

--- a/src/components/portal/Portal.tsx
+++ b/src/components/portal/Portal.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Link from 'next/link'
-import { FaDatabase, FaExternalLinkAlt, FaUsers } from 'react-icons/fa'
+import { FaExternalLinkAlt } from 'react-icons/fa'
 import {
   PortalData,
   PortalTweet,
@@ -184,6 +184,77 @@ function LiveCounter({ count }: { count: number }) {
   )
 }
 
+/** Evergreen sidebar destinations, condensed into one hairline-split list. */
+function UtilityLink({
+  href,
+  destination,
+  title,
+  note,
+  action,
+}: {
+  href: string
+  destination: DashboardDestination
+  title: string
+  note: string
+  action: string
+}) {
+  return (
+    <a
+      href={href}
+      onClick={() => captureDashboardDestination(destination, 'list', false)}
+      className="flex items-baseline justify-between gap-2.5 border-b border-zinc-200 px-4 py-3 transition-colors last:border-b-0 hover:bg-zinc-50 dark:border-[#26262a] dark:hover:bg-[#1f1f23]"
+    >
+      <span className="flex min-w-0 flex-col gap-0.5">
+        <span className="text-[12.5px] font-bold">{title}</span>
+        <span className={`text-[11.5px] leading-snug ${MUTED}`}>{note}</span>
+      </span>
+      <span className="flex-shrink-0 text-[11.5px] font-semibold text-brand">
+        {action} &rarr;
+      </span>
+    </a>
+  )
+}
+
+function ArchiveMetric({
+  value,
+  label,
+  note,
+  noteClass,
+  live = false,
+  divider = false,
+}: {
+  value: string
+  label: string
+  note: string
+  noteClass?: string
+  live?: boolean
+  divider?: boolean
+}) {
+  return (
+    <span
+      className={`flex flex-wrap items-baseline gap-x-2 gap-y-0.5 border-zinc-200 py-1 dark:border-[#26262a] sm:py-0 ${
+        divider ? 'sm:mr-7 sm:border-r sm:pr-7' : ''
+      }`}
+    >
+      {live && (
+        <span
+          aria-hidden
+          className="h-[7px] w-[7px] animate-pulse self-center rounded-full bg-[#2acf80]"
+        />
+      )}
+      <span className="text-[20px] font-semibold tabular-nums" style={SERIF}>
+        {value}
+      </span>
+      <span
+        className={`text-[11px] font-bold uppercase tracking-[0.08em] ${MUTED}`}
+      >
+        {label}
+      </span>
+      <span className={`text-[12px] ${noteClass ?? MUTED}`}>{note}</span>
+    </span>
+  )
+}
+
 function ArchiveOverview({
   stats,
   generatedDate,
@@ -198,30 +269,29 @@ function ArchiveOverview({
 }) {
   return (
     <>
-      <div className="mb-[18px] flex flex-wrap items-baseline justify-between gap-2">
+      <div className="mb-3 flex flex-wrap items-baseline justify-between gap-2">
         <h2 className="text-[30px] font-semibold" style={SERIF}>
           Today on the archive
         </h2>
-        {!failures.liveAnalytics && (
-          <span className="flex items-baseline gap-3">
-            <LiveCounter count={stats.totalTweets} />
-            <span className={`text-[12.5px] ${MUTED}`}>{generatedDate}</span>
-          </span>
-        )}
+        <span className={`text-[12.5px] ${MUTED}`}>{generatedDate}</span>
       </div>
 
-      <div className="mb-4 grid grid-cols-1 gap-3.5 sm:grid-cols-2 lg:grid-cols-3">
-        <StatCard
-          label="Tweets archived"
+      <div
+        className={`${CARD} mb-4 flex flex-col px-4 py-2.5 sm:flex-row sm:flex-wrap sm:items-center`}
+      >
+        <ArchiveMetric
+          divider
+          live={!failures.liveAnalytics}
           value={
             failures.liveAnalytics
               ? 'Unavailable'
               : stats.totalTweets.toLocaleString('en-US')
           }
+          label="Tweets archived"
           note={
             failures.liveAnalytics
               ? 'Tweet totals are temporarily unavailable.'
-              : `+${stats.streamedLast24Hours.toLocaleString('en-US')} streamed in the last 24h`
+              : `+${stats.streamedLast24Hours.toLocaleString('en-US')} in the last 24h`
           }
           noteClass={
             failures.liveAnalytics
@@ -229,13 +299,14 @@ function ArchiveOverview({
               : 'text-[#16a34a] dark:text-[#2acf80]'
           }
         />
-        <StatCard
-          label="Community members"
+        <ArchiveMetric
+          divider
           value={
             failures.memberCount
               ? 'Unavailable'
               : stats.accountCount.toLocaleString('en-US')
           }
+          label="Community members"
           note={
             failures.memberCount
               ? 'Member count is temporarily unavailable.'
@@ -246,13 +317,13 @@ function ArchiveOverview({
                   : 'volunteered archives'
           }
         />
-        <StatCard
-          label="Corpus span"
+        <ArchiveMetric
           value={
             failures.corpusRange
               ? 'Unavailable'
-              : `${stats.firstYear}–${stats.currentYear}`
+              : `${stats.firstYear}\u2013${stats.currentYear}`
           }
+          label="Corpus span"
           note={
             failures.corpusRange
               ? 'Corpus range is temporarily unavailable.'
@@ -261,6 +332,107 @@ function ArchiveOverview({
         />
       </div>
     </>
+  )
+}
+
+/**
+ * Lead story of the day. The digest is the one panel that changes wholesale
+ * every morning, so it runs full width above the dashboard grid.
+ */
+function DigestHero({ preview }: { preview: DigestPreview | null }) {
+  if (!preview) {
+    return (
+      <div className="mb-4 rounded-[4px] border border-dashed border-[#10516B]/50 bg-[#10516B]/5 px-6 py-6 text-center dark:border-[#7fb4cc]/40 dark:bg-[#7fb4cc]/10">
+        <div
+          className={`text-[11px] font-bold uppercase tracking-[0.14em] ${MUTED}`}
+        >
+          What happened yesterday
+        </div>
+        <p className="mt-2 text-[24px] font-semibold" style={SERIF}>
+          Today&rsquo;s edition is being assembled
+        </p>
+        <p
+          className={`mx-auto mt-2 max-w-[520px] text-[13px] leading-normal ${MUTED}`}
+        >
+          Editions are written from a frozen 24-hour banger set and reviewed
+          before publication. Yesterday&rsquo;s is still in the editorial lab.
+        </p>
+        <Link
+          href={BANGERS_WEEK_HREF}
+          onClick={() =>
+            captureDashboardDestination('recent_bangers', 'card', false)
+          }
+          className="mt-3.5 inline-block text-[12.5px] font-bold text-brand hover:underline"
+        >
+          Explore today&rsquo;s bangers &rarr;
+        </Link>
+      </div>
+    )
+  }
+
+  const openDigest = () =>
+    captureDashboardDestination('daily_digest', 'card', false)
+
+  return (
+    <div className="mb-4 rounded-[4px] bg-[#10516B] px-6 py-6 text-white sm:px-7">
+      <div className="flex flex-wrap items-baseline justify-between gap-3">
+        <span className="flex flex-wrap items-center gap-x-3 gap-y-1">
+          <span className="text-[11px] font-bold uppercase tracking-[0.14em] text-white/75">
+            {preview.isPreview
+              ? 'What happened yesterday \u00b7 Preview'
+              : 'What happened yesterday'}
+          </span>
+          <span className="text-[11px] text-white/75">
+            {preview.digestDate} &middot; {preview.storyCount}{' '}
+            {preview.storyCount === 1 ? 'story' : 'stories'}
+          </span>
+        </span>
+        <Link
+          href={preview.href}
+          onClick={openDigest}
+          className="inline-flex items-center gap-1.5 rounded-full bg-white px-3.5 py-1.5 text-[12.5px] font-bold text-[#10516B] transition-colors hover:bg-white/90"
+        >
+          Read the edition &rarr;
+        </Link>
+      </div>
+
+      {preview.headline && (
+        <Link
+          href={preview.href}
+          onClick={openDigest}
+          className="mt-3.5 block max-w-[900px] text-[22px] font-semibold leading-[1.28] text-white decoration-1 underline-offset-[3px] hover:underline sm:text-[27px]"
+          style={SERIF}
+        >
+          {preview.headline}
+        </Link>
+      )}
+
+      {preview.stories.length > 0 && (
+        <div className="mt-5 grid grid-cols-1 gap-2 border-t border-white/25 pt-3 sm:grid-cols-2 lg:grid-cols-3">
+          {preview.stories.map((story) => (
+            <Link
+              key={story.slug}
+              href={`${preview.href}/${story.slug}`}
+              onClick={openDigest}
+              className="flex flex-col gap-1.5 rounded-[4px] px-3 py-2.5 transition-colors hover:bg-white/[0.14]"
+            >
+              <span className="text-[10.5px] font-bold uppercase tracking-[0.1em] text-white/70">
+                {story.tag}
+              </span>
+              <span className="text-[14px] font-bold leading-snug">
+                {story.title}
+              </span>
+              <span className="text-[12.5px] leading-normal text-white/80">
+                {story.blurb}
+              </span>
+              <span className="mt-0.5 text-[11.5px] font-bold text-white/80">
+                Read story &rarr;
+              </span>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
   )
 }
 
@@ -521,6 +693,8 @@ export default function Portal({
             failures={data.failures}
           />
 
+          <DigestHero preview={digestPreview} />
+
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(300px,1fr)]">
             <div className="flex h-full min-h-0 flex-col gap-4 lg:overflow-hidden">
               <div
@@ -570,7 +744,7 @@ export default function Portal({
                 historicalBanger ||
                 data.failures.recentBangers ||
                 data.failures.historicalBangers) && (
-                <div className="grid grid-cols-1 gap-4">
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                   {(recentBanger || data.failures.recentBangers) && (
                     <div className={`${CARD} min-w-0 overflow-hidden`}>
                       <PanelHeader
@@ -624,34 +798,6 @@ export default function Portal({
             </div>
 
             <div className="flex flex-col gap-4">
-              {digestPreview ? (
-                <Link
-                  href={digestPreview.href}
-                  onClick={() =>
-                    captureDashboardDestination('daily_digest', 'card', false)
-                  }
-                  className="group rounded-[4px] border border-zinc-950 bg-zinc-950 px-5 py-5 text-white transition-colors hover:border-zinc-700 hover:bg-zinc-800 dark:border-white dark:bg-white dark:text-zinc-950 dark:hover:border-zinc-200 dark:hover:bg-zinc-100"
-                >
-                  <div className="flex items-center justify-between gap-3">
-                    <span className="text-[15px] font-bold">
-                      {digestPreview.isPreview
-                        ? 'What Happened Yesterday · Preview'
-                        : 'What Happened Yesterday'}
-                    </span>
-                    <span className="text-[12px] font-semibold text-white/75 group-hover:text-white dark:text-zinc-700 dark:group-hover:text-zinc-950">
-                      Read →
-                    </span>
-                  </div>
-                  <p className="mt-2 line-clamp-3 text-[13px] leading-5 text-zinc-300 dark:text-zinc-600">
-                    {digestPreview.executiveSummary}
-                  </p>
-                  <div className="mt-3 text-[11.5px] text-zinc-300 dark:text-zinc-600">
-                    {digestPreview.digestDate} · {digestPreview.storyCount}{' '}
-                    stories ·{' '}
-                    {digestPreview.storyTitles.slice(0, 3).join(' · ')}
-                  </div>
-                </Link>
-              ) : null}
               <div className={`${CARD} flex flex-col`}>
                 <PanelHeader
                   title="Trending terms · 7 days"
@@ -693,7 +839,7 @@ export default function Portal({
                           title={`${b.last7.toLocaleString('en-US')} tweets in the last 7 days; bar is relative to ${weeklyBars[0].term}`}
                         >
                           <div
-                            className="h-full rounded bg-brand"
+                            className="h-full rounded bg-chart-accent"
                             style={{ width: `${(b.last7 / maxWeekly) * 100}%` }}
                           />
                         </div>
@@ -798,54 +944,22 @@ export default function Portal({
                   )}
                 </div>
               </div>
-              <a
-                href={ARCHIVE_EXPORT_URL}
-                onClick={() =>
-                  captureDashboardDestination('data_export', 'card', false)
-                }
-                className={`${CARD} group flex items-center gap-3 px-4 py-4 transition-colors hover:border-brand/60`}
-              >
-                <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-[4px] border border-zinc-200 bg-zinc-50 text-brand dark:border-[#2a2a2e] dark:bg-[#121214]">
-                  <FaDatabase className="h-4 w-4" />
-                </span>
-                <span className="min-w-0 flex-1">
-                  <span className="block text-[13.5px] font-bold">
-                    Bulk export paused
-                  </span>
-                  <span
-                    className={`mt-0.5 block text-[12px] leading-snug ${MUTED}`}
-                  >
-                    Learn why the historical Parquet file is private
-                  </span>
-                </span>
-                <span className="flex-shrink-0 text-[12px] font-semibold text-brand">
-                  Details →
-                </span>
-              </a>
-              <a
-                href={COMMUNITY_BUILDS_URL}
-                onClick={() =>
-                  captureDashboardDestination('community_builds', 'card', false)
-                }
-                className={`${CARD} group flex items-center gap-3 px-4 py-4 transition-colors hover:border-brand/60`}
-              >
-                <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-[4px] border border-zinc-200 bg-zinc-50 text-brand dark:border-[#2a2a2e] dark:bg-[#121214]">
-                  <FaUsers className="h-4 w-4" />
-                </span>
-                <span className="min-w-0 flex-1">
-                  <span className="block text-[13.5px] font-bold">
-                    Community Builds
-                  </span>
-                  <span
-                    className={`mt-0.5 block text-[12px] leading-snug ${MUTED}`}
-                  >
-                    Projects made with Community Archive data
-                  </span>
-                </span>
-                <span className="flex-shrink-0 text-[12px] font-semibold text-brand">
-                  Explore →
-                </span>
-              </a>
+              <div className={`${CARD} overflow-hidden`}>
+                <UtilityLink
+                  href={ARCHIVE_EXPORT_URL}
+                  destination="data_export"
+                  title="Bulk export paused"
+                  note="Why the historical Parquet file is private"
+                  action="Details"
+                />
+                <UtilityLink
+                  href={COMMUNITY_BUILDS_URL}
+                  destination="community_builds"
+                  title="Community Builds"
+                  note="Projects made with Community Archive data"
+                  action="Explore"
+                />
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/portal/Portal.tsx
+++ b/src/components/portal/Portal.tsx
@@ -431,7 +431,7 @@ function DigestHero({ preview }: { preview: DigestPreview | null }) {
               } ${index < preview.stories.length - 1 ? 'lg:pr-7' : ''}`}
             >
               <div className="mb-2.5">
-                <span className="inline-flex items-center rounded-full border border-brand/25 bg-brand/10 px-2 py-[3px] text-[10px] font-semibold uppercase tracking-[0.1em] text-brand-deep">
+                <span className="inline-flex items-center rounded-full bg-brand/10 px-2 py-[3px] text-[10px] font-semibold uppercase tracking-[0.1em] text-brand-deep">
                   {story.tag}
                 </span>
               </div>

--- a/src/components/portal/Portal.tsx
+++ b/src/components/portal/Portal.tsx
@@ -383,12 +383,12 @@ function DigestHero({ preview }: { preview: DigestPreview | null }) {
     <div className="mb-4 rounded-[4px] bg-brand-deep px-6 py-6 text-brand-deep-foreground sm:px-7">
       <div className="flex flex-wrap items-baseline justify-between gap-3">
         <span className="flex flex-wrap items-center gap-x-3 gap-y-1">
-          <span className="text-[11px] font-bold uppercase tracking-[0.14em] text-white/75">
+          <span className="text-[11px] font-bold uppercase tracking-[0.14em] text-brand-deep-foreground/75">
             {preview.isPreview
               ? 'What happened yesterday \u00b7 Preview'
               : 'What happened yesterday'}
           </span>
-          <span className="text-[11px] text-white/75">
+          <span className="text-[11px] text-brand-deep-foreground/75">
             {preview.digestDate} &middot; {preview.storyCount}{' '}
             {preview.storyCount === 1 ? 'story' : 'stories'}
           </span>
@@ -396,7 +396,7 @@ function DigestHero({ preview }: { preview: DigestPreview | null }) {
         <Link
           href={preview.href}
           onClick={openDigest}
-          className="inline-flex items-center gap-1.5 rounded-full bg-white px-3.5 py-1.5 text-[12.5px] font-bold text-brand-deep transition-colors hover:bg-white/90"
+          className="inline-flex items-center gap-1.5 rounded-full bg-brand-deep-foreground px-3.5 py-1.5 text-[12.5px] font-bold text-brand-deep transition-colors hover:bg-brand-deep-foreground/90"
         >
           Read the edition &rarr;
         </Link>
@@ -406,7 +406,7 @@ function DigestHero({ preview }: { preview: DigestPreview | null }) {
         <Link
           href={preview.href}
           onClick={openDigest}
-          className="mt-3.5 block max-w-[900px] text-[22px] font-semibold leading-[1.28] text-white decoration-1 underline-offset-[3px] hover:underline sm:text-[27px]"
+          className="mt-3.5 block max-w-[900px] text-[22px] font-semibold leading-[1.28] text-brand-deep-foreground decoration-1 underline-offset-[3px] hover:underline sm:text-[27px]"
           style={SERIF}
         >
           {preview.headline}
@@ -414,24 +414,24 @@ function DigestHero({ preview }: { preview: DigestPreview | null }) {
       )}
 
       {preview.stories.length > 0 && (
-        <div className="mt-5 grid grid-cols-1 gap-2 border-t border-white/25 pt-3 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="mt-5 grid grid-cols-1 gap-2 border-t border-brand-deep-foreground/25 pt-3 sm:grid-cols-2 lg:grid-cols-3">
           {preview.stories.map((story) => (
             <Link
               key={story.slug}
               href={`${preview.href}/${story.slug}`}
               onClick={openDigest}
-              className="flex flex-col gap-1.5 rounded-[4px] px-3 py-2.5 transition-colors hover:bg-white/[0.14]"
+              className="flex flex-col gap-1.5 rounded-[4px] px-3 py-2.5 transition-colors hover:bg-brand-deep-foreground/[0.14]"
             >
-              <span className="text-[10.5px] font-bold uppercase tracking-[0.1em] text-white/70">
+              <span className="text-[10.5px] font-bold uppercase tracking-[0.1em] text-brand-deep-foreground/70">
                 {story.tag}
               </span>
               <span className="text-[14px] font-bold leading-snug">
                 {story.title}
               </span>
-              <span className="text-[12.5px] leading-normal text-white/80">
+              <span className="text-[12.5px] leading-normal text-brand-deep-foreground/80">
                 {story.blurb}
               </span>
-              <span className="mt-0.5 text-[11.5px] font-bold text-white/80">
+              <span className="mt-0.5 text-[11.5px] font-bold text-brand-deep-foreground/80">
                 Read story &rarr;
               </span>
             </Link>

--- a/src/components/portal/Portal.tsx
+++ b/src/components/portal/Portal.tsx
@@ -343,18 +343,21 @@ function ArchiveOverview({
 
 /**
  * Lead story of the day. The digest is the one panel that changes wholesale
- * every morning, so it runs full width above the dashboard grid.
+ * every morning, so it runs full width above the dashboard grid, marked by an
+ * accent rule along its top edge rather than a filled surface.
  */
 function DigestHero({ preview }: { preview: DigestPreview | null }) {
   if (!preview) {
     return (
-      <div className="mb-4 rounded-[4px] border border-dashed border-brand-deep/50 bg-brand-deep/5 px-6 py-6 text-center">
+      <div
+        className={`${CARD} mb-4 border-t-2 border-dashed border-t-brand px-8 py-7 text-center`}
+      >
         <div
-          className={`text-[11px] font-bold uppercase tracking-[0.14em] ${MUTED}`}
+          className={`text-[11px] font-semibold uppercase tracking-[0.14em] ${MUTED}`}
         >
           What happened yesterday
         </div>
-        <p className="mt-2 text-[24px] font-semibold" style={SERIF}>
+        <p className="mt-2 text-[24px] font-medium" style={SERIF}>
           Today&rsquo;s edition is being assembled
         </p>
         <p
@@ -368,7 +371,7 @@ function DigestHero({ preview }: { preview: DigestPreview | null }) {
           onClick={() =>
             captureDashboardDestination('recent_bangers', 'card', false)
           }
-          className="mt-3.5 inline-block text-[12.5px] font-bold text-brand hover:underline"
+          className="mt-3.5 inline-block text-[13px] font-semibold text-brand hover:underline"
         >
           Explore today&rsquo;s bangers &rarr;
         </Link>
@@ -380,61 +383,72 @@ function DigestHero({ preview }: { preview: DigestPreview | null }) {
     captureDashboardDestination('daily_digest', 'card', false)
 
   return (
-    <div className="mb-4 rounded-[4px] bg-brand-deep px-6 py-6 text-brand-deep-foreground sm:px-7">
-      <div className="flex flex-wrap items-baseline justify-between gap-3">
-        <span className="flex flex-wrap items-center gap-x-3 gap-y-1">
-          <span className="text-[11px] font-bold uppercase tracking-[0.14em] text-brand-deep-foreground/75">
-            {preview.isPreview
-              ? 'What happened yesterday \u00b7 Preview'
-              : 'What happened yesterday'}
+    <div
+      className={`${CARD} mb-4 border-t-2 border-t-brand px-6 pb-[30px] pt-7 sm:px-8`}
+    >
+      <div className="mb-[18px] flex flex-wrap items-baseline justify-between gap-x-6 gap-y-2">
+        <span className="flex flex-wrap items-baseline gap-x-3.5 gap-y-1">
+          <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-brand">
+            What happened yesterday
           </span>
-          <span className="text-[11px] text-brand-deep-foreground/75">
+          <span className={`text-[12px] tabular-nums ${MUTED}`}>
             {preview.digestDate} &middot; {preview.storyCount}{' '}
             {preview.storyCount === 1 ? 'story' : 'stories'}
+            {preview.isPreview ? ' \u00b7 preview' : ''}
           </span>
         </span>
         <Link
           href={preview.href}
           onClick={openDigest}
-          className="inline-flex items-center gap-1.5 rounded-full bg-brand-deep-foreground px-3.5 py-1.5 text-[12.5px] font-bold text-brand-deep transition-colors hover:bg-brand-deep-foreground/90"
+          className="whitespace-nowrap text-[13px] font-semibold text-brand hover:underline"
         >
           Read the edition &rarr;
         </Link>
       </div>
 
       {preview.headline && (
-        <Link
-          href={preview.href}
-          onClick={openDigest}
-          className="mt-3.5 block max-w-[900px] text-[22px] font-semibold leading-[1.28] text-brand-deep-foreground decoration-1 underline-offset-[3px] hover:underline sm:text-[27px]"
+        <h2
+          className="mb-6 max-w-[22ch] text-[26px] font-medium leading-[1.2] tracking-[-0.01em] sm:text-[34px]"
           style={SERIF}
         >
-          {preview.headline}
-        </Link>
+          <Link
+            href={preview.href}
+            onClick={openDigest}
+            className="font-medium text-foreground transition-colors hover:text-brand"
+          >
+            {preview.headline}
+          </Link>
+        </h2>
       )}
 
       {preview.stories.length > 0 && (
-        <div className="mt-5 grid grid-cols-1 gap-2 border-t border-brand-deep-foreground/25 pt-3 sm:grid-cols-2 lg:grid-cols-3">
-          {preview.stories.map((story) => (
-            <Link
+        <div className="grid grid-cols-1 lg:grid-cols-3">
+          {preview.stories.map((story, index) => (
+            <div
               key={story.slug}
-              href={`${preview.href}/${story.slug}`}
-              onClick={openDigest}
-              className="flex flex-col gap-1.5 rounded-[4px] px-3 py-2.5 transition-colors hover:bg-brand-deep-foreground/[0.14]"
+              className={`border-t border-zinc-200 pt-5 dark:border-[#26262a] ${
+                index > 0 ? 'lg:border-l lg:pl-7' : ''
+              } ${index < preview.stories.length - 1 ? 'lg:pr-7' : ''}`}
             >
-              <span className="text-[10.5px] font-bold uppercase tracking-[0.1em] text-brand-deep-foreground/70">
-                {story.tag}
-              </span>
-              <span className="text-[14px] font-bold leading-snug">
+              <div className="mb-2 flex items-baseline gap-2">
+                <span className={`text-[11px] tabular-nums ${FAINT}`}>
+                  {String(index + 1).padStart(2, '0')}
+                </span>
+                <span className="text-[10px] uppercase tracking-[0.12em] text-brand">
+                  {story.tag}
+                </span>
+              </div>
+              <Link
+                href={`${preview.href}/${story.slug}`}
+                onClick={openDigest}
+                className="mb-1.5 block text-[15px] font-semibold leading-[1.35] transition-colors hover:text-brand"
+              >
                 {story.title}
-              </span>
-              <span className="text-[12.5px] leading-normal text-brand-deep-foreground/80">
+              </Link>
+              <p className={`m-0 text-[13.5px] leading-normal ${MUTED}`}>
                 {story.blurb}
-              </span>
-              <span className="mt-0.5 text-[11.5px] font-bold text-brand-deep-foreground/80">
-                Read story &rarr;
-              </span>
-            </Link>
+              </p>
+            </div>
           ))}
         </div>
       )}

--- a/src/components/portal/Portal.tsx
+++ b/src/components/portal/Portal.tsx
@@ -205,7 +205,7 @@ function UtilityLink({
     <a
       href={href}
       onClick={() => captureDashboardDestination(destination, 'card', false)}
-      className={`${CARD} flex items-center gap-3 px-4 py-3 font-normal transition-colors hover:border-brand`}
+      className={`${CARD} flex items-center gap-3 px-4 py-3 font-normal transition-colors hover:border-brand dark:hover:border-brand`}
     >
       <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-[4px] border border-zinc-200 bg-zinc-100 text-brand-icon dark:border-[#2a2a2e] dark:bg-[#121214]">
         {icon}
@@ -350,7 +350,7 @@ function DigestHero({ preview }: { preview: DigestPreview | null }) {
   if (!preview) {
     return (
       <div
-        className={`${CARD} mb-4 border-t-2 border-dashed border-t-brand px-8 py-7 text-center`}
+        className={`${CARD} mb-4 border-t-2 border-dashed border-t-brand px-8 py-7 text-center dark:border-t-brand`}
       >
         <div
           className={`text-[11px] font-semibold uppercase tracking-[0.14em] ${MUTED}`}
@@ -384,7 +384,7 @@ function DigestHero({ preview }: { preview: DigestPreview | null }) {
 
   return (
     <div
-      className={`${CARD} mb-4 border-t-2 border-t-brand px-6 pb-[30px] pt-7 sm:px-8`}
+      className={`${CARD} mb-4 border-t-2 border-t-brand px-6 pb-[30px] pt-7 dark:border-t-brand sm:px-8`}
     >
       <div className="mb-[18px] flex flex-wrap items-baseline justify-between gap-x-6 gap-y-2">
         <span className="flex flex-wrap items-baseline gap-x-3.5 gap-y-1">

--- a/src/components/ui/area-chart.tsx
+++ b/src/components/ui/area-chart.tsx
@@ -30,7 +30,7 @@ export type DataPoint = {
 const chartConfig = {
   tweet_count: {
     label: 'Tweets',
-    color: 'hsl(var(--chart-1))',
+    color: 'hsl(var(--chart-accent))',
   },
 } satisfies ChartConfig
 

--- a/src/lib/digest/data.ts
+++ b/src/lib/digest/data.ts
@@ -198,9 +198,15 @@ export async function getLatestDigestPreview(): Promise<DigestPreview | null> {
   return {
     href: `/digest/${edition.digestDate}`,
     digestDate: edition.digestDate,
-    executiveSummary: edition.content.executiveSummary.join(' '),
+    headline: edition.content.executiveSummary[0] ?? '',
     storyCount: edition.content.stories.length,
-    storyTitles: edition.content.stories.map((story) => story.title),
+    stories: edition.content.stories.slice(0, 3).map((story) => ({
+      slug: story.slug,
+      // Older saved editions predate categories; the keyword is the fallback label.
+      tag: story.category ?? story.keyword,
+      title: story.title,
+      blurb: story.subtitle,
+    })),
     isPreview: edition.isPreview,
   }
 }

--- a/src/lib/digest/types.ts
+++ b/src/lib/digest/types.ts
@@ -136,12 +136,22 @@ export interface DigestCalendarDay {
   isPreview?: boolean
 }
 
+export interface DigestPreviewStory {
+  slug: string
+  /** Editorial label shown above the story title on the homepage hero. */
+  tag: string
+  title: string
+  blurb: string
+}
+
 export interface DigestPreview {
   href: string
   digestDate: string
-  executiveSummary: string
+  /** Lead executive-summary line, used as the homepage hero headline. */
+  headline: string
   storyCount: number
-  storyTitles: string[]
+  /** The first few stories, rendered as cards under the hero headline. */
+  stories: DigestPreviewStory[]
   isPreview?: boolean
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,6 +18,12 @@ module.exports = {
           DEFAULT: 'hsl(var(--brand))',
           foreground: 'hsl(var(--brand-foreground))',
         },
+        'brand-deep': {
+          DEFAULT: 'hsl(var(--brand-deep))',
+          foreground: 'hsl(var(--brand-deep-foreground))',
+        },
+        'chart-accent': 'hsl(var(--chart-accent))',
+        'brand-icon': 'hsl(var(--brand-icon))',
         background: 'hsl(var(--background))',
         foreground: 'hsl(var(--foreground))',
         primary: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,12 +15,12 @@ module.exports = {
         input: 'hsl(var(--input))',
         ring: 'hsl(var(--ring))',
         brand: {
-          DEFAULT: 'hsl(var(--brand))',
-          foreground: 'hsl(var(--brand-foreground))',
+          DEFAULT: 'hsl(var(--brand) / <alpha-value>)',
+          foreground: 'hsl(var(--brand-foreground) / <alpha-value>)',
         },
         'brand-deep': {
-          DEFAULT: 'hsl(var(--brand-deep))',
-          foreground: 'hsl(var(--brand-deep-foreground))',
+          DEFAULT: 'hsl(var(--brand-deep) / <alpha-value>)',
+          foreground: 'hsl(var(--brand-deep-foreground) / <alpha-value>)',
         },
         'chart-accent': 'hsl(var(--chart-accent))',
         'brand-icon': 'hsl(var(--brand-icon))',


### PR DESCRIPTION
Rebuilds the homepage dashboard against a design pass on the current `main`. Structure and data sources are unchanged apart from the digest preview; most of this is layout, palette tokens, and two pieces of motion.

## Dashboard

- **The daily digest leads.** It was a truncated card in the sidebar with room for three story titles and nothing else. It is now a full-width hero above the grid, carrying the lead summary line and the first three stories as individual links (headline, each story, and the read button are separate targets). Days with no published edition get a dashed placeholder instead of an empty column.
- **Three stat cards collapse into one inline metrics strip**, so the day-fresh content starts roughly 90px higher.
- **Reordered day-fresh first**: live stream, then the two bangers side by side, with the evergreen export/builds cards last.

## Motion

- The hero tweet total counts up on mount as an odometer and **rests on the real total** — it does not keep ticking afterwards.
- A slow marquee of short historical bangers runs under the hero, fed from the ranked set the dashboard already loads (no new query).
- The avatar row arrives on a Suspense boundary and each photo mounts only once decoded, so both fade rather than snap in.

Every animation is behind `prefers-reduced-motion`.

## Palette tokens

`--brand` moves to `197 74% 46%` and three tokens join it: `--brand-deep` (deep emphasis surfaces only), `--chart-accent`, `--brand-icon`.

Two of these reach beyond the homepage and are worth a close look:

1. **`--brand` is a global recolor** — roughly 120 `text-brand`/`bg-brand`/`border-brand` usages across the app shift with it.
2. **A base `a { color: inherit; font-weight: 600 }` rule** so prose links read as emphasis in their surrounding color rather than as a second hue. Utility classes still win, but this restyles default link appearance app-wide.

I verified the homepage in both themes; the rest of the app inherits these two changes without the same scrutiny. Happy to split them into their own PR if you would rather land the layout work first.

Separately, `--chart-1` has never been defined in this repo, so the stream monitor and area chart were resolving an invalid color. Both now point at `--chart-accent`.

## API change

`DigestPreview` gains `headline` and `stories[{ slug, tag, title, blurb }]` and drops `executiveSummary`/`storyTitles`. `getLatestDigestPreview` fills them from the published edition; story tags fall back to `keyword` for older editions that predate categories.

## Not included

An "In your orbit" panel (recent posts from the accounts you reply to most) was part of the design but needs a reply-graph aggregation that does not exist yet, so it is left out.

## Testing

Full suite passes except one pre-existing `clickhouseGateway` failure that also fails on `main`. Lint and typecheck clean. Rendered locally in light and dark at desktop width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)