### PR TITLE
Load username profiles from ClickHouse

### DIFF
--- a/src/lib/clickhouseGateway.test.ts
+++ b/src/lib/clickhouseGateway.test.ts
@@ -205,11 +205,13 @@ describe('ClickHouse analytics gateway requests', () => {
   test('allows a core user read to omit interactions', () => {
     const target = analyticsGatewayRequestUrl(
       ['user', 'alice'],
-      new URLSearchParams('limit=20&include_interactions=false&raw_sql=DROP'),
+      new URLSearchParams(
+        'limit=20&include_interactions=false&include_top_tweets=false&raw_sql=DROP',
+      ),
       'https://stream.example/analytics',
     )
     expect(target.toString()).toBe(
-      'https://stream.example/analytics/user/alice?limit=20&include_interactions=false',
+      'https://stream.example/analytics/user/alice?limit=20&include_interactions=false&include_top_tweets=false',
     )
   })
 

--- a/src/lib/clickhouseGateway.ts
+++ b/src/lib/clickhouseGateway.ts
@@ -91,7 +91,11 @@ export function analyticsGatewayRequestUrl(
     cleanPath[0] === 'user' &&
     /^[A-Za-z0-9_@]{1,80}$/.test(cleanPath[1])
   ) {
-    allowedParams = new Set(['limit', 'include_interactions'])
+    allowedParams = new Set([
+      'limit',
+      'include_interactions',
+      'include_top_tweets',
+    ])
   } else if (
     cleanPath.length === 3 &&
     cleanPath[0] === 'user' &&

--- a/src/lib/clickhouseUserProfile.test.ts
+++ b/src/lib/clickhouseUserProfile.test.ts
@@ -16,12 +16,23 @@ test('maps a corpus account into the public profile contract', async () => {
         accountId: '42',
         username: 'alice',
         displayName: 'Alice',
+        createdAt: '2010-01-02T03:04:05.000Z',
         bio: 'Hello',
+        website: 'https://alice.example',
+        location: 'Internet',
         avatarUrl: 'https://pbs.twimg.com/profile_images/42/avatar_normal.jpg',
         headerUrl: 'https://example.com/header.jpg',
         followers: '12',
         following: '3',
         statusCount: '45',
+        likeCount: '67',
+      },
+      membership: {
+        isMember: true,
+        hasArchive: true,
+        isOptedIn: false,
+        joinedAt: '2024-01-02T00:00:00.000Z',
+        snapshotAt: '2026-08-17T12:00:00.000Z',
       },
       topTweets: [
         {
@@ -46,7 +57,12 @@ test('maps a corpus account into the public profile contract', async () => {
           'https://pbs.twimg.com/profile_images/42/avatar_normal.jpg',
         num_followers: 12,
         num_tweets: 45,
-        has_archive: false,
+        num_likes: 67,
+        created_at: '2010-01-02T03:04:05.000Z',
+        website: 'https://alice.example',
+        location: 'Internet',
+        joined_at: '2024-01-02T00:00:00.000Z',
+        has_archive: true,
         is_opted_in: false,
       }),
       topTweets: [
@@ -59,6 +75,7 @@ test('maps a corpus account into the public profile contract', async () => {
           retweetCount: 2,
         },
       ],
+      membershipResolved: true,
     }),
   )
   expect(fetchGateway).toHaveBeenCalledWith(
@@ -66,6 +83,7 @@ test('maps a corpus account into the public profile contract', async () => {
     new URLSearchParams({
       limit: '20',
       include_interactions: 'false',
+      include_top_tweets: 'false',
     }),
     { revalidate: 300, timeoutMs: 8_000 },
   )

--- a/src/lib/clickhouseUserProfile.ts
+++ b/src/lib/clickhouseUserProfile.ts
@@ -8,12 +8,23 @@ interface ClickHouseUserResponse {
       accountId?: unknown
       username?: unknown
       displayName?: unknown
+      createdAt?: unknown
       bio?: unknown
+      website?: unknown
+      location?: unknown
       avatarUrl?: unknown
       headerUrl?: unknown
       followers?: unknown
       following?: unknown
       statusCount?: unknown
+      likeCount?: unknown
+    }
+    membership?: {
+      isMember?: unknown
+      hasArchive?: unknown
+      isOptedIn?: unknown
+      joinedAt?: unknown
+      snapshotAt?: unknown
     }
     topTweets?: unknown
   }
@@ -40,6 +51,7 @@ export interface ClickHouseProfileTweet {
 export interface ClickHouseUserProfile {
   user: FormattedUser
   topTweets: ClickHouseProfileTweet[]
+  membershipResolved: boolean
 }
 
 const optionalText = (value: unknown): string | null =>
@@ -87,6 +99,7 @@ export async function getClickHouseUserProfile(
       new URLSearchParams({
         limit: '20',
         include_interactions: 'false',
+        include_top_tweets: 'false',
       }),
       { revalidate: 300, timeoutMs: 8_000 },
     )
@@ -95,27 +108,34 @@ export async function getClickHouseUserProfile(
     const username = optionalText(account?.username)
     if (!accountId || !/^\d{1,20}$/.test(accountId) || !username) return null
     const topTweets = response.data?.topTweets
+    const membership = response.data?.membership
+    const membershipResolved =
+      typeof membership?.isMember === 'boolean' &&
+      typeof membership?.hasArchive === 'boolean' &&
+      typeof membership?.isOptedIn === 'boolean'
 
     return {
       user: {
         account_id: accountId,
         username,
         account_display_name: optionalText(account?.displayName) || username,
-        created_at: null,
+        created_at: optionalText(account?.createdAt),
         bio: optionalText(account?.bio),
-        website: null,
-        location: null,
+        website: optionalText(account?.website),
+        location: optionalText(account?.location),
         avatar_media_url: optionalText(account?.avatarUrl),
         header_media_url: optionalText(account?.headerUrl),
         archive_at: null,
         num_tweets: optionalCount(account?.statusCount),
         num_followers: optionalCount(account?.followers),
         num_following: optionalCount(account?.following),
-        num_likes: null,
+        num_likes: optionalCount(account?.likeCount),
         archive_uploaded_at: null,
-        joined_at: null,
-        has_archive: false,
-        is_opted_in: false,
+        joined_at: membershipResolved
+          ? optionalText(membership?.joinedAt)
+          : null,
+        has_archive: membershipResolved && membership?.hasArchive === true,
+        is_opted_in: membershipResolved && membership?.isOptedIn === true,
       },
       topTweets: Array.isArray(topTweets)
         ? topTweets.flatMap((tweet) => {
@@ -123,6 +143,7 @@ export async function getClickHouseUserProfile(
             return parsed ? [parsed] : []
           })
         : [],
+      membershipResolved,
     }
   } catch {
     return null

--- a/src/lib/metaTwitter/profile.test.ts
+++ b/src/lib/metaTwitter/profile.test.ts
@@ -47,7 +47,27 @@ beforeEach(() => {
   jest.clearAllMocks()
 })
 
-test('prefers the authoritative archived profile', async () => {
+test('prefers the projected member profile without PostgreSQL lookups', async () => {
+  getClickHouseUserProfileMock.mockResolvedValue({
+    user: archivedProfile,
+    topTweets: [],
+    membershipResolved: true,
+  })
+
+  await expect(resolveProfile('alice')).resolves.toEqual({
+    accountId: '42',
+    profile: archivedProfile,
+  })
+  expect(resolveAccountIdMock).not.toHaveBeenCalled()
+  expect(getCachedProfileHeaderMock).not.toHaveBeenCalled()
+})
+
+test('uses PostgreSQL as a compatibility fallback for an older gateway', async () => {
+  getClickHouseUserProfileMock.mockResolvedValue({
+    user: archivedProfile,
+    topTweets: [],
+    membershipResolved: false,
+  })
   resolveAccountIdMock.mockResolvedValue('42')
   getCachedProfileHeaderMock.mockResolvedValue(archivedProfile)
 
@@ -55,11 +75,9 @@ test('prefers the authoritative archived profile', async () => {
     accountId: '42',
     profile: archivedProfile,
   })
-  expect(getClickHouseUserProfileMock).not.toHaveBeenCalled()
 })
 
-test('maps the analytical fallback to the shared profile shape', async () => {
-  resolveAccountIdMock.mockResolvedValue(null)
+test('maps a nonmember analytical fallback to the shared profile shape', async () => {
   getClickHouseUserProfileMock.mockResolvedValue({
     user: {
       ...archivedProfile,
@@ -72,7 +90,9 @@ test('maps the analytical fallback to the shared profile shape', async () => {
       header_media_url: undefined,
     },
     topTweets: [],
+    membershipResolved: false,
   })
+  resolveAccountIdMock.mockResolvedValue(null)
 
   await expect(resolveProfile('bob')).resolves.toMatchObject({
     accountId: '77',

--- a/src/lib/metaTwitter/profile.ts
+++ b/src/lib/metaTwitter/profile.ts
@@ -20,42 +20,54 @@ export interface ProfilePreviewStats {
   yearsArchived: number
 }
 
+const resolvedClickHouseProfile = (
+  clickHouseProfile: Awaited<ReturnType<typeof getClickHouseUserProfile>>,
+): ResolvedProfile | null => {
+  const accountId = clickHouseProfile?.user.account_id
+  if (!clickHouseProfile || !accountId) return null
+  const user = clickHouseProfile.user
+  return {
+    accountId,
+    profile: {
+      account_id: accountId,
+      username: user.username,
+      account_display_name: user.account_display_name,
+      created_at: user.created_at,
+      num_tweets: user.num_tweets,
+      num_followers: user.num_followers,
+      num_following: user.num_following,
+      num_likes: user.num_likes,
+      has_archive: user.has_archive,
+      is_opted_in: user.is_opted_in,
+      bio: user.bio,
+      website: user.website,
+      location: user.location,
+      avatar_media_url: user.avatar_media_url,
+      header_media_url: user.header_media_url ?? null,
+    },
+  }
+}
+
 /**
  * Resolves either a stable account ID or a username to the shared profile
  * payload used by the page, its metadata, and its social preview image.
  */
 export const resolveProfile = cache(
   async (param: string): Promise<ResolvedProfile | null> => {
+    const clickHouseProfile = await getClickHouseUserProfile(param)
+    if (clickHouseProfile?.membershipResolved) {
+      return resolvedClickHouseProfile(clickHouseProfile)
+    }
+
+    // Compatibility fallback for a gateway release that predates projected
+    // membership fields, or for a temporarily unavailable analytical path.
     const archiveAccountId = await resolveAccountId(param)
     if (archiveAccountId) {
       const profile = await getCachedProfileHeader(archiveAccountId)
       if (profile) return { accountId: archiveAccountId, profile }
     }
 
-    const clickHouseProfile = await getClickHouseUserProfile(param)
-    const accountId = clickHouseProfile?.user.account_id
-    if (!clickHouseProfile || !accountId) return null
-    const user = clickHouseProfile.user
-    return {
-      accountId,
-      profile: {
-        account_id: accountId,
-        username: user.username,
-        account_display_name: user.account_display_name,
-        created_at: user.created_at,
-        num_tweets: user.num_tweets,
-        num_followers: user.num_followers,
-        num_following: user.num_following,
-        num_likes: user.num_likes,
-        has_archive: user.has_archive,
-        is_opted_in: user.is_opted_in,
-        bio: user.bio,
-        website: user.website,
-        location: user.location,
-        avatar_media_url: user.avatar_media_url,
-        header_media_url: user.header_media_url ?? null,
-      },
-    }
+    return resolvedClickHouseProfile(clickHouseProfile)
   },
 )
 


### PR DESCRIPTION
## Summary
- ask the gateway for header-only profile data before the PostgreSQL compatibility path
- consume authoritative membership and complete profile fields from the ClickHouse projections
- retain the existing PostgreSQL path for an older/unavailable gateway
- keep canonical profile URLs username-based

## Validation
- profile/gateway Jest tests: 25 passed
- username navigation Jest tests: 7 passed
- git diff --check

The repository-wide TypeScript command is currently blocked by missing existing workspace dependencies (`workflow`, TipTap, Graphology/Sigma, and Markdown packages); focused changed-path tests compile and pass.

## Rollout
Depends on TheExGenesis/community-archive-control-panel#118 (or the resulting PR number). Deploy the membership projection and gateway first; the compatibility fallback makes mixed-version rollout safe. No deployment was performed.

Refs #389