### PR TITLE
Remove unused authenticated write policies

### DIFF
--- a/supabase/migrations/20260817190000_remove_unused_authenticated_write_policies.sql
+++ b/supabase/migrations/20260817190000_remove_unused_authenticated_write_policies.sql
@@ -1,0 +1,35 @@
+-- Direct client writes to these tables have been retired. Archive ingestion and
+-- profile customization now reach them only through trusted service-role code.
+
+DROP POLICY IF EXISTS "Data is modifiable by their users" ON public.all_profile;
+DROP POLICY IF EXISTS "Data is modifiable by their users" ON public.followers;
+DROP POLICY IF EXISTS "Data is modifiable by their users" ON public.following;
+DROP POLICY IF EXISTS "Data is modifiable by their users" ON public.likes;
+DROP POLICY IF EXISTS "Data is modifiable by their users" ON public.tweets;
+
+DROP POLICY IF EXISTS "Entities are modifiable by their users" ON public.tweet_media;
+DROP POLICY IF EXISTS "Entities are modifiable by their users" ON public.tweet_urls;
+DROP POLICY IF EXISTS "Entities are modifiable by their users" ON public.user_mentions;
+
+DROP POLICY IF EXISTS "Users can create own opt-in record" ON public.optin;
+DROP POLICY IF EXISTS "Users can update own opt-in status" ON public.optin;
+
+DROP POLICY IF EXISTS "Owners can insert profile settings" ON public.profile_settings;
+DROP POLICY IF EXISTS "Owners can update profile settings" ON public.profile_settings;
+DROP POLICY IF EXISTS "Owners can insert profile curation" ON public.profile_curation;
+DROP POLICY IF EXISTS "Owners can update profile curation" ON public.profile_curation;
+DROP POLICY IF EXISTS "Owners can delete profile curation" ON public.profile_curation;
+
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLE
+  public.all_profile,
+  public.followers,
+  public.following,
+  public.likes,
+  public.tweets,
+  public.tweet_media,
+  public.tweet_urls,
+  public.user_mentions,
+  public.optin,
+  public.profile_settings,
+  public.profile_curation
+FROM anon, authenticated;

--- a/supabase/schemas/060_grants.sql
+++ b/supabase/schemas/060_grants.sql
@@ -34,14 +34,26 @@ GRANT SELECT ON TABLE "public"."tweet_link_previews" TO "readclient";
 -- The app uses live public.tweets rows instead.
 REVOKE ALL ON TABLE "public"."account_activity_summary" FROM PUBLIC, "anon", "authenticated", "readclient";
 
--- Public profile projections are readable by everyone and owner-writable.
+-- These tables are populated only by trusted service-role routes and workers.
+-- Public/authenticated clients retain read access but no direct write grants.
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLE
+  "public"."all_profile",
+  "public"."followers",
+  "public"."following",
+  "public"."likes",
+  "public"."tweets",
+  "public"."tweet_media",
+  "public"."tweet_urls",
+  "public"."user_mentions",
+  "public"."optin"
+FROM "anon", "authenticated";
+
+-- Public profile projections are readable by everyone and service-role writable.
 REVOKE ALL PRIVILEGES ON TABLE "public"."profile_settings" FROM "anon", "authenticated";
 REVOKE ALL PRIVILEGES ON TABLE "public"."profile_curation" FROM "anon", "authenticated";
 REVOKE ALL PRIVILEGES ON TABLE "public"."tweet_link_previews" FROM "anon", "authenticated";
 GRANT SELECT ON TABLE "public"."profile_settings" TO "anon", "authenticated";
-GRANT INSERT, UPDATE ON TABLE "public"."profile_settings" TO "authenticated";
 GRANT SELECT ON TABLE "public"."profile_curation" TO "anon", "authenticated";
-GRANT INSERT, UPDATE, DELETE ON TABLE "public"."profile_curation" TO "authenticated";
 
 -- Link metadata is populated only by trusted server enrichment code.
 GRANT SELECT ON TABLE "public"."tweet_link_previews" TO "anon", "authenticated";

--- a/supabase/schemas/060_policies.sql
+++ b/supabase/schemas/060_policies.sql
@@ -81,14 +81,10 @@ CREATE POLICY "Users can delete their own archive" ON "storage"."objects"
     )
   );
 
--- Modification policies for authenticated users
+-- Browser writes are limited to archive ownership and upload bookkeeping.
+-- All other archive corpus writes are performed by trusted service-role workers.
 CREATE POLICY "Data is modifiable by their users" ON "public"."all_account" TO "authenticated" USING (("account_id" = ((( SELECT "auth"."jwt"() AS "jwt") -> 'app_metadata'::"text") ->> 'provider_id'::"text"))) WITH CHECK (("account_id" = ((( SELECT "auth"."jwt"() AS "jwt") -> 'app_metadata'::"text") ->> 'provider_id'::"text")));
-CREATE POLICY "Data is modifiable by their users" ON "public"."all_profile" TO "authenticated" USING (("account_id" = ((( SELECT "auth"."jwt"() AS "jwt") -> 'app_metadata'::"text") ->> 'provider_id'::"text"))) WITH CHECK (("account_id" = ((( SELECT "auth"."jwt"() AS "jwt") -> 'app_metadata'::"text") ->> 'provider_id'::"text")));
 CREATE POLICY "Data is modifiable by their users" ON "public"."archive_upload" TO "authenticated" USING (("account_id" = ((( SELECT "auth"."jwt"() AS "jwt") -> 'app_metadata'::"text") ->> 'provider_id'::"text"))) WITH CHECK (("account_id" = ((( SELECT "auth"."jwt"() AS "jwt") -> 'app_metadata'::"text") ->> 'provider_id'::"text")));
-CREATE POLICY "Data is modifiable by their users" ON "public"."followers" TO "authenticated" USING (("account_id" = ((( SELECT "auth"."jwt"() AS "jwt") -> 'app_metadata'::"text") ->> 'provider_id'::"text"))) WITH CHECK (("account_id" = ((( SELECT "auth"."jwt"() AS "jwt") -> 'app_metadata'::"text") ->> 'provider_id'::"text")));
-CREATE POLICY "Data is modifiable by their users" ON "public"."following" TO "authenticated" USING (("account_id" = ((( SELECT "auth"."jwt"() AS "jwt") -> 'app_metadata'::"text") ->> 'provider_id'::"text"))) WITH CHECK (("account_id" = ((( SELECT "auth"."jwt"() AS "jwt") -> 'app_metadata'::"text") ->> 'provider_id'::"text")));
-CREATE POLICY "Data is modifiable by their users" ON "public"."likes" TO "authenticated" USING (("account_id" = ((( SELECT "auth"."jwt"() AS "jwt") -> 'app_metadata'::"text") ->> 'provider_id'::"text"))) WITH CHECK (("account_id" = ((( SELECT "auth"."jwt"() AS "jwt") -> 'app_metadata'::"text") ->> 'provider_id'::"text")));
-CREATE POLICY "Data is modifiable by their users" ON "public"."tweets" TO "authenticated" USING (("account_id" = ((( SELECT "auth"."jwt"() AS "jwt") -> 'app_metadata'::"text") ->> 'provider_id'::"text"))) WITH CHECK (("account_id" = ((( SELECT "auth"."jwt"() AS "jwt") -> 'app_metadata'::"text") ->> 'provider_id'::"text")));
 
 -- Public read policies
 CREATE POLICY "Data is publicly visible" ON "public"."all_account" FOR SELECT USING (("is_tombstone" IS NOT TRUE));
@@ -98,27 +94,11 @@ CREATE POLICY "Data is publicly visible" ON "public"."followers" FOR SELECT USIN
 CREATE POLICY "Data is publicly visible" ON "public"."following" FOR SELECT USING (true);
 CREATE POLICY "Data is publicly visible" ON "public"."likes" FOR SELECT USING (true);
 
--- Entity-specific modify/read policies
+-- Entity read policies
 -- NOTE: liked_tweets and mentioned_users are global dedup tables written only by
 -- the service_role worker (which bypasses RLS). They intentionally have NO
 -- authenticated write policy: the previous "modifiable by their users" policy was
 -- uncorrelated to the row being changed and allowed cross-user modification (#370).
-CREATE POLICY "Entities are modifiable by their users" ON "public"."tweet_media" TO "authenticated" USING ((EXISTS ( SELECT 1
-   FROM "public"."tweets" "dt"
-  WHERE (("dt"."tweet_id" = "tweet_media"."tweet_id") AND ("dt"."account_id" = ( SELECT ("auth"."jwt"() ->> 'sub'::"text"))))))) WITH CHECK ((EXISTS ( SELECT 1
-   FROM "public"."tweets" "dt"
-  WHERE (("dt"."tweet_id" = "tweet_media"."tweet_id") AND ("dt"."account_id" = ( SELECT ("auth"."jwt"() ->> 'sub'::"text")))))));
-CREATE POLICY "Entities are modifiable by their users" ON "public"."tweet_urls" TO "authenticated" USING ((EXISTS ( SELECT 1
-   FROM "public"."tweets" "dt"
-  WHERE (("dt"."tweet_id" = "tweet_urls"."tweet_id") AND ("dt"."account_id" = ( SELECT ("auth"."jwt"() ->> 'sub'::"text"))))))) WITH CHECK ((EXISTS ( SELECT 1
-   FROM "public"."tweets" "dt"
-  WHERE (("dt"."tweet_id" = "tweet_urls"."tweet_id") AND ("dt"."account_id" = ( SELECT ("auth"."jwt"() ->> 'sub'::"text")))))));
-CREATE POLICY "Entities are modifiable by their users" ON "public"."user_mentions" TO "authenticated" USING ((EXISTS ( SELECT 1
-   FROM "public"."tweets" "dt"
-  WHERE (("dt"."tweet_id" = "user_mentions"."tweet_id") AND ("dt"."account_id" = ( SELECT ("auth"."jwt"() ->> 'sub'::"text"))))))) WITH CHECK ((EXISTS ( SELECT 1
-   FROM "public"."tweets" "dt"
-  WHERE (("dt"."tweet_id" = "user_mentions"."tweet_id") AND ("dt"."account_id" = ( SELECT ("auth"."jwt"() ->> 'sub'::"text")))))));
-
 CREATE POLICY "Entities are publicly visible" ON "public"."liked_tweets" FOR SELECT USING (
   "author_account_id" IS NOT NULL
   OR ("is_tombstone" = true AND "full_text" = '')
@@ -137,8 +117,6 @@ CREATE POLICY "Retweets are publicly visible" ON "public"."retweets" FOR SELECT 
 
 -- Opt-in table policies
 CREATE POLICY "Public can view opted-in users" ON "public"."optin" FOR SELECT USING (("opted_in" = true));
-CREATE POLICY "Users can create own opt-in record" ON "public"."optin" FOR INSERT WITH CHECK (("auth"."uid"() = "user_id"));
-CREATE POLICY "Users can update own opt-in status" ON "public"."optin" FOR UPDATE USING (("auth"."uid"() = "user_id")) WITH CHECK (("auth"."uid"() = "user_id"));
 CREATE POLICY "Users can view own opt-in status" ON "public"."optin" FOR SELECT USING (("auth"."uid"() = "user_id"));
 
 -- Tweets public read policy
@@ -173,39 +151,10 @@ ALTER TABLE "public"."tweet_link_previews" ENABLE ROW LEVEL SECURITY;
 CREATE POLICY "Profile settings are publicly visible"
   ON "public"."profile_settings" FOR SELECT
   TO "anon", "authenticated" USING (true);
-CREATE POLICY "Owners can insert profile settings"
-  ON "public"."profile_settings" FOR INSERT
-  TO "authenticated" WITH CHECK (
-    "account_id" = (SELECT "auth"."jwt"()->'app_metadata'->>'provider_id')
-  );
-CREATE POLICY "Owners can update profile settings"
-  ON "public"."profile_settings" FOR UPDATE
-  TO "authenticated" USING (
-    "account_id" = (SELECT "auth"."jwt"()->'app_metadata'->>'provider_id')
-  ) WITH CHECK (
-    "account_id" = (SELECT "auth"."jwt"()->'app_metadata'->>'provider_id')
-  );
 
 CREATE POLICY "Profile curation is publicly visible"
   ON "public"."profile_curation" FOR SELECT
   TO "anon", "authenticated" USING (true);
-CREATE POLICY "Owners can insert profile curation"
-  ON "public"."profile_curation" FOR INSERT
-  TO "authenticated" WITH CHECK (
-    "account_id" = (SELECT "auth"."jwt"()->'app_metadata'->>'provider_id')
-  );
-CREATE POLICY "Owners can update profile curation"
-  ON "public"."profile_curation" FOR UPDATE
-  TO "authenticated" USING (
-    "account_id" = (SELECT "auth"."jwt"()->'app_metadata'->>'provider_id')
-  ) WITH CHECK (
-    "account_id" = (SELECT "auth"."jwt"()->'app_metadata'->>'provider_id')
-  );
-CREATE POLICY "Owners can delete profile curation"
-  ON "public"."profile_curation" FOR DELETE
-  TO "authenticated" USING (
-    "account_id" = (SELECT "auth"."jwt"()->'app_metadata'->>'provider_id')
-  );
 
 CREATE POLICY "Tweet link previews are publicly visible"
   ON "public"."tweet_link_previews" FOR SELECT

--- a/tests/admin-auth-write-policy-contract.test.ts
+++ b/tests/admin-auth-write-policy-contract.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const read = (path: string) => readFileSync(join(process.cwd(), path), 'utf8')
+
+describe('authenticated write policy contract', () => {
+  const policies = read('supabase/schemas/060_policies.sql')
+  const grants = read('supabase/schemas/060_grants.sql')
+  const migration = read(
+    'supabase/migrations/20260817190000_remove_unused_authenticated_write_policies.sql',
+  )
+
+  test('keeps only browser write policies used by current direct clients', () => {
+    expect(policies).toContain(
+      '"Data is modifiable by their users" ON "public"."all_account"',
+    )
+    expect(policies).toContain(
+      '"Data is modifiable by their users" ON "public"."archive_upload"',
+    )
+    expect(policies).toContain('"Users can insert own action log"')
+    expect(policies).toContain('"Users can upload their own archive"')
+
+    for (const policy of [
+      'Entities are modifiable by their users',
+      'Users can create own opt-in record',
+      'Users can update own opt-in status',
+      'Owners can insert profile settings',
+      'Owners can update profile settings',
+      'Owners can insert profile curation',
+      'Owners can update profile curation',
+      'Owners can delete profile curation',
+    ]) {
+      expect(policies).not.toContain(`CREATE POLICY "${policy}"`)
+    }
+
+    for (const table of [
+      'all_profile',
+      'followers',
+      'following',
+      'likes',
+      'tweets',
+    ]) {
+      expect(policies).not.toContain(
+        `"Data is modifiable by their users" ON "public"."${table}"`,
+      )
+    }
+  })
+
+  test('migration drops all fifteen unused policies and revokes table writes', () => {
+    expect((migration.match(/DROP POLICY IF EXISTS/g) ?? []).length).toBe(15)
+    expect(migration).toContain(
+      'REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLE',
+    )
+    expect(migration).toContain('public.profile_curation\nFROM anon, authenticated;')
+    expect(grants).not.toContain(
+      'GRANT INSERT, UPDATE ON TABLE "public"."profile_settings"',
+    )
+    expect(grants).not.toContain(
+      'GRANT INSERT, UPDATE, DELETE ON TABLE "public"."profile_curation"',
+    )
+  })
+})


### PR DESCRIPTION
## What changed

- Remove 15 authenticated write policies that no current browser path uses.
- Revoke anon/authenticated write privileges on service-role-owned corpus, opt-in, and profile tables.
- Retain direct-client policies for archive storage, all_account, archive_upload, and user_action_log.
- Add a static contract test for the browser-write allowlist.

## Why

These legacy policies expose write paths that have been replaced by authenticated server routes and service-role workers. Removing them reduces the database policy surface without changing public read behavior.

## Validation

- Authenticated write-policy contract passed: 2 tests.
- git diff --check passed.

## Rollout

The migration is included but has not been applied to Supabase.