### PR TITLE
Move navigation auth out of root layout

### DIFF
--- a/src/app/api/auth/navigation/route.ts
+++ b/src/app/api/auth/navigation/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server'
+import { isAdminUser } from '@/app/admin/data'
+import { getCurrentUser, getIsMember } from '@/lib/portal/auth'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  const [user, isMember] = await Promise.all([getCurrentUser(), getIsMember()])
+
+  return NextResponse.json(
+    {
+      isMember,
+      isAdmin: user ? isAdminUser(user) : false,
+    },
+    {
+      headers: {
+        'Cache-Control': 'private, no-store, max-age=0',
+      },
+    },
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,16 +10,16 @@ import Link from 'next/link'
 import Image from 'next/image'
 import ThemeToggle from '@/components/ThemeToggle'
 import dynamic from 'next/dynamic'
-import HeaderNavigation from '@/components/HeaderNavigation'
 import HeaderSearch from '@/components/HeaderSearch'
 import MobileMenu from '@/components/MobileMenu'
-import MobileNavigation from '@/components/MobileNavigation'
 import Footer from '@/components/Footer'
 import HashScrollHandler from '@/components/HashScrollHandler'
-import { checkIsAdmin } from '@/app/admin/data'
-import { Shield } from 'lucide-react'
-import { getIsMember } from '@/lib/portal/auth'
-import { getPrimaryNav, getUtilityNav, getMobileNav } from '@/lib/navigation'
+import {
+  AdminNavigationLink,
+  AudienceHeaderNavigation,
+  AudienceMobileNavigation,
+  NavigationAudienceProvider,
+} from '@/components/NavigationAudience'
 
 const DynamicSignIn = dynamic(() => import('@/components/SignIn'), {
   ssr: false,
@@ -50,15 +50,11 @@ export const metadata = {
   description: "A public archive of everyone's tweets ",
 }
 
-export default async function RootLayout({
+export default function RootLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
-  const [isAdmin, isMember] = await Promise.all([checkIsAdmin(), getIsMember()])
-  const primaryNav = getPrimaryNav(isMember, isAdmin)
-  const utilityNav = getUtilityNav(isMember)
-  const mobileNav = getMobileNav(isMember, isAdmin)
   return (
     <html
       lang="en"
@@ -76,57 +72,48 @@ export default async function RootLayout({
           >
             <ReactQueryProvider>
               <HashScrollHandler />
-              <header className="sticky top-0 z-50 w-full border-b border-border bg-background/90 backdrop-blur-md">
-                <div className="flex h-14 items-center justify-between px-4 sm:px-6 lg:px-8">
-                  <div className="flex min-w-0 items-center gap-3">
-                    <MobileNavigation items={mobileNav} />
-                    <Link
-                      href="/"
-                      className="flex flex-shrink-0 items-center space-x-2"
-                    >
-                      <Image
-                        src="/images/logo.png"
-                        alt="Community Archive logo"
-                        width={28}
-                        height={28}
-                        className="h-7 w-7 flex-shrink-0"
-                        priority
-                      />
-                      <span
-                        className="hidden whitespace-nowrap text-lg font-bold text-foreground sm:inline"
-                        style={{
-                          fontFamily:
-                            'var(--font-petrona), Georgia, "Times New Roman", serif',
-                        }}
-                      >
-                        Community Archive
-                      </span>
-                    </Link>
-                    <HeaderNavigation items={primaryNav} />
-                  </div>
-                  <div className="flex flex-shrink-0 items-center space-x-3">
-                    {utilityNav.length > 0 && (
-                      <HeaderNavigation items={utilityNav} />
-                    )}
-                    <HeaderSearch />
-                    <div className="text-sm">
-                      <DynamicSignIn />
-                    </div>
-                    <ThemeToggle side="bottom" />
-                    {isAdmin ? (
+              <NavigationAudienceProvider>
+                <header className="sticky top-0 z-50 w-full border-b border-border bg-background/90 backdrop-blur-md">
+                  <div className="flex h-14 items-center justify-between px-4 sm:px-6 lg:px-8">
+                    <div className="flex min-w-0 items-center gap-3">
+                      <AudienceMobileNavigation />
                       <Link
-                        href="/admin"
-                        aria-label="Admin dashboard"
-                        title="Admin dashboard"
-                        className="inline-flex h-10 w-10 items-center justify-center rounded-md border border-input bg-background transition-colors hover:bg-accent hover:text-accent-foreground"
+                        href="/"
+                        className="flex flex-shrink-0 items-center space-x-2"
                       >
-                        <Shield className="h-5 w-5" />
+                        <Image
+                          src="/images/logo.png"
+                          alt="Community Archive logo"
+                          width={28}
+                          height={28}
+                          className="h-7 w-7 flex-shrink-0"
+                          priority
+                        />
+                        <span
+                          className="hidden whitespace-nowrap text-lg font-bold text-foreground sm:inline"
+                          style={{
+                            fontFamily:
+                              'var(--font-petrona), Georgia, "Times New Roman", serif',
+                          }}
+                        >
+                          Community Archive
+                        </span>
                       </Link>
-                    ) : null}
-                    <MobileMenu />
+                      <AudienceHeaderNavigation kind="primary" />
+                    </div>
+                    <div className="flex flex-shrink-0 items-center space-x-3">
+                      <AudienceHeaderNavigation kind="utility" />
+                      <HeaderSearch />
+                      <div className="text-sm">
+                        <DynamicSignIn />
+                      </div>
+                      <ThemeToggle side="bottom" />
+                      <AdminNavigationLink />
+                      <MobileMenu />
+                    </div>
                   </div>
-                </div>
-              </header>
+                </header>
+              </NavigationAudienceProvider>
               <div className="flex min-h-[calc(100vh-3.5rem)] flex-col">
                 {children}
                 <Analytics />

--- a/src/components/NavigationAudience.test.tsx
+++ b/src/components/NavigationAudience.test.tsx
@@ -1,0 +1,63 @@
+/** @jest-environment jsdom */
+
+import '@testing-library/jest-dom'
+import { render, screen, waitFor } from '@testing-library/react'
+import {
+  AdminNavigationLink,
+  AudienceHeaderNavigation,
+  NavigationAudienceProvider,
+} from './NavigationAudience'
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/',
+}))
+
+describe('NavigationAudience', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(() => new Promise(() => {}))
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('server-renders public navigation before checking the session', () => {
+    render(
+      <NavigationAudienceProvider>
+        <AudienceHeaderNavigation kind="primary" />
+        <AdminNavigationLink />
+      </NavigationAudienceProvider>,
+    )
+
+    expect(screen.getByRole('link', { name: 'Docs' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: 'Upload archive' }),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Trends' })).toBeNull()
+    expect(screen.queryByRole('link', { name: 'Admin dashboard' })).toBeNull()
+  })
+
+  it('adds member and admin navigation after session hydration', async () => {
+    jest.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ isMember: true, isAdmin: true }),
+    } as Response)
+
+    render(
+      <NavigationAudienceProvider>
+        <AudienceHeaderNavigation kind="primary" />
+        <AdminNavigationLink />
+      </NavigationAudienceProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: 'Trends' })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Graph' })).toBeInTheDocument()
+      expect(
+        screen.getByRole('link', { name: 'Admin dashboard' }),
+      ).toBeInTheDocument()
+    })
+    expect(screen.queryByRole('link', { name: 'Upload archive' })).toBeNull()
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/NavigationAudience.tsx
+++ b/src/components/NavigationAudience.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import Link from 'next/link'
+import { Shield } from 'lucide-react'
+import { createContext, useContext, useEffect, useMemo, useState } from 'react'
+import HeaderNavigation from '@/components/HeaderNavigation'
+import MobileNavigation from '@/components/MobileNavigation'
+import { getMobileNav, getPrimaryNav, getUtilityNav } from '@/lib/navigation'
+
+type NavigationAudience = {
+  isMember: boolean
+  isAdmin: boolean
+}
+
+const PUBLIC_AUDIENCE: NavigationAudience = {
+  isMember: false,
+  isAdmin: false,
+}
+
+const NavigationAudienceContext =
+  createContext<NavigationAudience>(PUBLIC_AUDIENCE)
+
+export function NavigationAudienceProvider({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const [audience, setAudience] = useState(PUBLIC_AUDIENCE)
+
+  useEffect(() => {
+    const controller = new AbortController()
+
+    void fetch('/api/auth/navigation', {
+      cache: 'no-store',
+      credentials: 'same-origin',
+      signal: controller.signal,
+    })
+      .then((response) => {
+        if (!response.ok) throw new Error('Navigation session check failed')
+        return response.json() as Promise<NavigationAudience>
+      })
+      .then((nextAudience) => {
+        setAudience({
+          isMember: nextAudience.isMember === true,
+          isAdmin: nextAudience.isAdmin === true,
+        })
+      })
+      .catch((error: unknown) => {
+        if (error instanceof Error && error.name === 'AbortError') return
+        // A failed optional enhancement leaves the server-rendered public nav.
+      })
+
+    return () => controller.abort()
+  }, [])
+
+  return (
+    <NavigationAudienceContext.Provider value={audience}>
+      {children}
+    </NavigationAudienceContext.Provider>
+  )
+}
+
+export function AudienceHeaderNavigation({
+  kind,
+}: {
+  kind: 'primary' | 'utility'
+}) {
+  const { isMember, isAdmin } = useContext(NavigationAudienceContext)
+  const items = useMemo(
+    () =>
+      kind === 'primary'
+        ? getPrimaryNav(isMember, isAdmin)
+        : getUtilityNav(isMember),
+    [isAdmin, isMember, kind],
+  )
+
+  if (items.length === 0) return null
+  return <HeaderNavigation items={items} />
+}
+
+export function AudienceMobileNavigation() {
+  const { isMember, isAdmin } = useContext(NavigationAudienceContext)
+  const items = useMemo(
+    () => getMobileNav(isMember, isAdmin),
+    [isAdmin, isMember],
+  )
+  return <MobileNavigation items={items} />
+}
+
+export function AdminNavigationLink() {
+  const { isAdmin } = useContext(NavigationAudienceContext)
+  if (!isAdmin) return null
+
+  return (
+    <Link
+      href="/admin"
+      aria-label="Admin dashboard"
+      title="Admin dashboard"
+      className="inline-flex h-10 w-10 items-center justify-center rounded-md border border-input bg-background transition-colors hover:bg-accent hover:text-accent-foreground"
+    >
+      <Shield className="h-5 w-5" />
+    </Link>
+  )
+}

--- a/src/lib/rootLayoutAuthBoundary.test.ts
+++ b/src/lib/rootLayoutAuthBoundary.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const read = (path: string) => readFileSync(join(process.cwd(), path), 'utf8')
+
+describe('root layout authentication boundary', () => {
+  test('keeps Supabase Auth out of the root server render', () => {
+    const layout = read('src/app/layout.tsx')
+
+    for (const serverAuthReference of [
+      'checkIsAdmin',
+      'getIsMember',
+      'getCurrentUser',
+      'createServerClient',
+      'cookies()',
+    ]) {
+      expect(layout).not.toContain(serverAuthReference)
+    }
+    expect(layout).not.toContain('async function RootLayout')
+    expect(layout).toContain('<NavigationAudienceProvider>')
+  })
+
+  test('checks the session after hydration and preserves route-level guards', () => {
+    const audience = read('src/components/NavigationAudience.tsx')
+    const adminPage = read('src/app/admin/page.tsx')
+    const graphPage = read('src/app/social-graph/page.tsx')
+
+    expect(audience).toContain("fetch('/api/auth/navigation'")
+    expect(audience.indexOf('PUBLIC_AUDIENCE')).toBeLessThan(
+      audience.indexOf("fetch('/api/auth/navigation'"),
+    )
+    expect(adminPage).toContain('await requireAdmin()')
+    expect(graphPage).toContain("await requireAdmin('/social-graph')")
+  })
+})


### PR DESCRIPTION
## What changed

- Make the root server layout synchronous and remove its Supabase Auth calls.
- Server-render public desktop and mobile navigation by default.
- Hydrate member links, the admin-only Graph link, and the admin shield from one no-store client session check.
- Keep admin and social-graph authorization at their existing requireAdmin route boundaries.

## Why

The shared root layout previously awaited member and admin checks for every route. That made the common rendering boundary request-dependent and prevented otherwise-public routes from using static or ISR caching.

## Acceptance

- The root server render contains no Supabase Auth call.
- Public navigation is the initial HTML state.
- Signed-in members and admins receive the correct navigation after hydration.
- Admin and social-graph pages remain independently protected.

## Validation

- 4 focused test suites passed: 12 tests covering public-first navigation, member/admin hydration, navigation mappings, and the social-graph guard.
- TypeScript no-emit check passed.
- git diff --check passed.