### PR TITLE
Put card surfaces on the radius token at 8px

### DIFF
--- a/src/app/admin/digest/page.tsx
+++ b/src/app/admin/digest/page.tsx
@@ -259,7 +259,7 @@ export default async function DigestLabPage({
         ) : null}
 
         {activeDraft && state.activeRun ? (
-          <section className="mb-6 flex flex-col gap-4 rounded-xl border-2 border-emerald-500 bg-emerald-50 p-5 shadow-sm dark:bg-emerald-950/25 sm:flex-row sm:items-center sm:justify-between">
+          <section className="mb-6 flex flex-col gap-4 rounded-lg border-2 border-emerald-500 bg-emerald-50 p-5 shadow-sm dark:bg-emerald-950/25 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <div className="text-xs font-bold uppercase tracking-[0.12em] text-emerald-800 dark:text-emerald-200">
                 Draft v{activeDraft.version} ready

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -86,7 +86,7 @@ export default function DocsPage() {
               Query policy-filtered public records through the API or give an
               agent one canonical starting point.
             </p>
-            <div className="rounded-xl border border-brand/30 bg-brand/5 p-5">
+            <div className="rounded-lg border border-brand/30 bg-brand/5 p-5">
               <p className="mb-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
                 Point an agent here
               </p>
@@ -114,7 +114,7 @@ export default function DocsPage() {
           </div>
 
           <div className="grid gap-4 md:grid-cols-3">
-            <article className="rounded-xl border border-border bg-card p-6">
+            <article className="rounded-lg border border-border bg-card p-6">
               <Database className="h-6 w-6 text-brand" aria-hidden="true" />
               <h3 className="mt-4 text-lg font-semibold text-foreground">
                 Bulk export paused
@@ -125,7 +125,7 @@ export default function DocsPage() {
               </p>
             </article>
 
-            <article className="rounded-xl border border-border bg-card p-6">
+            <article className="rounded-lg border border-border bg-card p-6">
               <Braces className="h-6 w-6 text-brand" aria-hidden="true" />
               <h3 className="mt-4 text-lg font-semibold text-foreground">
                 Live API
@@ -142,7 +142,7 @@ export default function DocsPage() {
               </div>
             </article>
 
-            <article className="rounded-xl border border-border bg-card p-6">
+            <article className="rounded-lg border border-border bg-card p-6">
               <Database className="h-6 w-6 text-brand" aria-hidden="true" />
               <h3 className="mt-4 text-lg font-semibold text-foreground">
                 One raw archive
@@ -199,7 +199,7 @@ export default function DocsPage() {
           </div>
 
           <div className="grid gap-4 sm:grid-cols-2">
-            <div className="rounded-xl border border-border bg-card p-5">
+            <div className="rounded-lg border border-border bg-card p-5">
               <h3 className="font-semibold text-foreground">
                 Useful resources
               </h3>
@@ -221,7 +221,7 @@ export default function DocsPage() {
                 </li>
               </ul>
             </div>
-            <div className="rounded-xl border border-border bg-card p-5">
+            <div className="rounded-lg border border-border bg-card p-5">
               <h3 className="font-semibold text-foreground">Query rules</h3>
               <ul className="mt-3 list-disc space-y-2 pl-5 text-sm leading-6 text-muted-foreground">
                 <li>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,7 +26,7 @@
     --ring: 240 5.9% 10%;
     --brand: 217 91% 60%;
     --brand-foreground: 0 0% 100%;
-    --radius: 0.3rem;
+    --radius: 0.5rem;
   }
 
   .dark {

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -118,7 +118,7 @@ function SearchPageContent() {
               }
             />
           ) : (
-            <div className="rounded-xl border border-dashed border-border bg-card px-6 py-10 text-center sm:px-10">
+            <div className="rounded-lg border border-dashed border-border bg-card px-6 py-10 text-center sm:px-10">
               <SlidersHorizontal className="mx-auto h-8 w-8 text-muted-foreground" />
               <h2 className="mt-4 text-2xl font-semibold text-foreground">
                 Start with a topic or phrase

--- a/src/app/supporters/page.tsx
+++ b/src/app/supporters/page.tsx
@@ -22,7 +22,7 @@ export default async function SupportersPage() {
           </p>
         </div>
 
-        <div className="mx-auto max-w-4xl rounded-2xl border border-border bg-card p-6 md:p-8">
+        <div className="mx-auto max-w-4xl rounded-lg border border-border bg-card p-6 md:p-8">
           <div className="mb-6 text-center">
             <p className="mb-4 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
               Major Backers
@@ -82,7 +82,7 @@ export default async function SupportersPage() {
             href="https://opencollective.com/community-archive/donate"
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center justify-center rounded-xl bg-green-600 px-6 py-3 font-medium text-white transition-colors hover:bg-green-700 dark:bg-green-400 dark:text-green-950 dark:hover:bg-green-300"
+            className="inline-flex items-center justify-center rounded-lg bg-green-600 px-6 py-3 font-medium text-white transition-colors hover:bg-green-700 dark:bg-green-400 dark:text-green-950 dark:hover:bg-green-300"
           >
             <FaHeart className="mr-2" /> Support the Project
           </Link>

--- a/src/app/tweets/[tweet_id]/page.tsx
+++ b/src/app/tweets/[tweet_id]/page.tsx
@@ -61,7 +61,7 @@ export default async function TweetPage({
             {isThread && threadTree ? (
               <ThreadView tree={threadTree} highlightTweetId={tweet_id} />
             ) : (
-              <article className="rounded-xl border border-border bg-card p-5 shadow-sm sm:p-6">
+              <article className="rounded-lg border border-border bg-card p-5 shadow-sm sm:p-6">
                 <TweetComponent
                   key={tweet.tweet_id}
                   tweet={tweet}
@@ -70,7 +70,7 @@ export default async function TweetPage({
               </article>
             )}
 
-            <div className="mt-8 rounded-xl border border-dashed border-border bg-card px-5 py-4 text-sm leading-6 text-muted-foreground">
+            <div className="mt-8 rounded-lg border border-dashed border-border bg-card px-5 py-4 text-sm leading-6 text-muted-foreground">
               This permalink preserves the archived version. Use the Twitter
               link on the tweet to compare it with the live post when it is
               still available.

--- a/src/app/user-dir/UserDirectoryClient.tsx
+++ b/src/app/user-dir/UserDirectoryClient.tsx
@@ -216,12 +216,12 @@ export default function UserDirectoryClient({
             placeholder="Search by name or username…"
             value={searchQuery}
             onChange={(event) => setSearchQuery(event.target.value)}
-            className="h-12 rounded-xl border-border bg-card pl-11 shadow-sm dark:border-border dark:bg-background"
+            className="h-12 rounded-lg border-border bg-card pl-11 shadow-sm dark:border-border dark:bg-background"
           />
         </div>
 
         <div
-          className="overflow-hidden rounded-2xl border border-border bg-card shadow-sm dark:border-border dark:bg-card"
+          className="overflow-hidden rounded-lg border border-border bg-card shadow-sm dark:border-border dark:bg-card"
           aria-busy={loading}
         >
           <Table>

--- a/src/app/user/[account_id]/page.tsx
+++ b/src/app/user/[account_id]/page.tsx
@@ -145,7 +145,7 @@ export default async function UserPage({ params, searchParams }: PageProps) {
 
   return (
     <div className="flex justify-center px-4 pb-8 pt-4 sm:px-6">
-      <div className="h-fit w-full max-w-[1220px] overflow-hidden rounded-2xl border border-border bg-card shadow-[0_2px_16px_rgba(0,0,0,0.06)]">
+      <div className="h-fit w-full max-w-[1220px] overflow-hidden rounded-lg border border-border bg-card shadow-[0_2px_16px_rgba(0,0,0,0.06)]">
         <ProfileEditingProvider>
           <ProfileHeader
             profile={profile}

--- a/src/components/AdvancedSearchForm.tsx
+++ b/src/components/AdvancedSearchForm.tsx
@@ -95,7 +95,7 @@ export default function AdvancedSearchForm() {
   return (
     <form
       onSubmit={handleSubmit}
-      className="rounded-xl border border-border bg-card p-3 shadow-sm sm:p-4"
+      className="rounded-lg border border-border bg-card p-3 shadow-sm sm:p-4"
     >
       <Label htmlFor="main-search" className="sr-only">
         Search the archive

--- a/src/components/AppGallery.tsx
+++ b/src/components/AppGallery.tsx
@@ -63,7 +63,7 @@ function GalleryAppCard({ app }: { app: GalleryApp }) {
       href={app.link}
       target="_blank"
       rel="noopener noreferrer"
-      className="group flex items-center gap-4 rounded-xl border border-border bg-card p-4 transition-colors hover:bg-accent"
+      className="group flex items-center gap-4 rounded-lg border border-border bg-card p-4 transition-colors hover:bg-accent"
     >
       <div className="flex-shrink-0 text-2xl text-brand">{app.icon}</div>
       <div className="min-w-0 flex-1">

--- a/src/components/FeaturedAppsSection.tsx
+++ b/src/components/FeaturedAppsSection.tsx
@@ -44,7 +44,7 @@ function FeaturedAppCard({ app }: { app: FeaturedApp }) {
       href={app.link}
       target="_blank"
       rel="noopener noreferrer"
-      className="group flex flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-sm transition-all duration-300 hover:shadow-lg"
+      className="group flex flex-col overflow-hidden rounded-lg border border-border bg-card shadow-sm transition-all duration-300 hover:shadow-lg"
     >
       {/* Thumbnail header — gradient + icon stay behind as a fallback if the image is missing */}
       <div

--- a/src/components/HomepageSearch.tsx
+++ b/src/components/HomepageSearch.tsx
@@ -36,7 +36,7 @@ export default function HomepageSearch() {
     <div className="mx-auto w-full max-w-3xl">
       <form
         onSubmit={handleSubmit}
-        className="relative rounded-2xl border border-border bg-card p-1.5 text-left shadow-[0_12px_30px_rgba(15,23,42,0.10)] sm:p-2"
+        className="relative rounded-lg border border-border bg-card p-1.5 text-left shadow-[0_12px_30px_rgba(15,23,42,0.10)] sm:p-2"
       >
         <UserSearchInput
           value={query}

--- a/src/components/MemberSearchLanding.tsx
+++ b/src/components/MemberSearchLanding.tsx
@@ -70,7 +70,7 @@ export default function MemberSearchLanding({
 
         <form
           onSubmit={handleSubmit}
-          className="mt-10 flex w-full max-w-3xl flex-col gap-3 rounded-xl border border-border bg-card p-2 shadow-lg sm:flex-row"
+          className="mt-10 flex w-full max-w-3xl flex-col gap-3 rounded-lg border border-border bg-card p-2 shadow-lg sm:flex-row"
         >
           <div className="relative flex-1">
             <Search className="absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />
@@ -112,7 +112,7 @@ export default function MemberSearchLanding({
         <div className="mt-14 grid w-full max-w-3xl gap-3 text-left sm:grid-cols-3">
           <Link
             href="/search"
-            className="group rounded-xl border border-border bg-card p-5 transition-colors hover:bg-accent"
+            className="group rounded-lg border border-border bg-card p-5 transition-colors hover:bg-accent"
           >
             <SlidersHorizontal className="h-5 w-5 text-brand" />
             <h2 className="mt-4 text-base font-semibold text-foreground">
@@ -124,7 +124,7 @@ export default function MemberSearchLanding({
           </Link>
           <Link
             href="/user-dir"
-            className="group rounded-xl border border-border bg-card p-5 transition-colors hover:bg-accent"
+            className="group rounded-lg border border-border bg-card p-5 transition-colors hover:bg-accent"
           >
             <Users className="h-5 w-5 text-brand" />
             <h2 className="mt-4 text-base font-semibold text-foreground">
@@ -136,7 +136,7 @@ export default function MemberSearchLanding({
           </Link>
           <Link
             href="/#products"
-            className="group rounded-xl border border-border bg-card p-5 transition-colors hover:bg-accent"
+            className="group rounded-lg border border-border bg-card p-5 transition-colors hover:bg-accent"
           >
             <Boxes className="h-5 w-5 text-brand" />
             <h2 className="mt-4 text-base font-semibold text-foreground">

--- a/src/components/OptInForm.tsx
+++ b/src/components/OptInForm.tsx
@@ -169,7 +169,7 @@ export default function OptInForm({
       </div>
     </section>
   ) : (
-    <section className="mx-auto max-w-4xl overflow-hidden rounded-2xl border border-green-200 bg-green-50/60 p-6 text-left shadow-sm dark:border-green-900 dark:bg-green-950/20 sm:p-8">
+    <section className="mx-auto max-w-4xl overflow-hidden rounded-lg border border-green-200 bg-green-50/60 p-6 text-left shadow-sm dark:border-green-900 dark:bg-green-950/20 sm:p-8">
       {mockOptIn && (
         <Alert className="mb-6 border-sky-200 bg-sky-50 dark:border-sky-900 dark:bg-sky-950/30">
           <AlertDescription className="text-sky-900 dark:text-sky-100">
@@ -225,7 +225,7 @@ export default function OptInForm({
         </div>
 
         <ol className="mx-auto mt-6 grid max-w-3xl gap-4 sm:grid-cols-2">
-          <li className="flex h-full flex-col items-center rounded-xl border border-green-200 bg-background p-5 text-center dark:border-green-900">
+          <li className="flex h-full flex-col items-center rounded-lg border border-green-200 bg-background p-5 text-center dark:border-green-900">
             <div className="flex h-10 w-10 items-center justify-center rounded-full bg-green-100 text-lg font-bold text-green-700 dark:bg-green-900/70 dark:text-green-300">
               1
             </div>
@@ -246,7 +246,7 @@ export default function OptInForm({
             </Button>
           </li>
 
-          <li className="flex h-full flex-col items-center rounded-xl border border-green-200 bg-background p-5 text-center dark:border-green-900">
+          <li className="flex h-full flex-col items-center rounded-lg border border-green-200 bg-background p-5 text-center dark:border-green-900">
             <div className="flex h-10 w-10 items-center justify-center rounded-full bg-green-100 text-lg font-bold text-green-700 dark:bg-green-900/70 dark:text-green-300">
               2
             </div>
@@ -272,7 +272,7 @@ export default function OptInForm({
             <Link
               key={step.href}
               href={step.href}
-              className="group overflow-hidden rounded-xl border bg-background shadow-sm transition hover:-translate-y-0.5 hover:border-foreground/20 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              className="group overflow-hidden rounded-lg border bg-background shadow-sm transition hover:-translate-y-0.5 hover:border-foreground/20 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             >
               <div className="relative aspect-video overflow-hidden border-b bg-muted">
                 <Image

--- a/src/components/QuotingTweetsSidebar.tsx
+++ b/src/components/QuotingTweetsSidebar.tsx
@@ -169,7 +169,7 @@ export default function QuotingTweetsSidebar({
       aria-labelledby="quoting-tweets-heading"
       className="lg:sticky lg:top-24 lg:h-[calc(100vh-7rem)] lg:min-h-0"
     >
-      <div className="flex overflow-hidden rounded-xl border border-border bg-card shadow-sm lg:h-full lg:min-h-0 lg:flex-col">
+      <div className="flex overflow-hidden rounded-lg border border-border bg-card shadow-sm lg:h-full lg:min-h-0 lg:flex-col">
         <div className="flex min-w-0 flex-1 flex-col lg:min-h-0">
           <div className="flex flex-none items-center justify-between gap-3 border-b border-border px-5 py-4">
             <div className="flex items-center gap-2">

--- a/src/components/ShowcasedApps.tsx
+++ b/src/components/ShowcasedApps.tsx
@@ -80,7 +80,7 @@ const AppCard: React.FC<AppItem> = ({ icon, name, description, link }) => (
     <a
       target="_blank"
       rel="noopener noreferrer"
-      className="flex h-full cursor-pointer flex-col items-center rounded-xl bg-muted p-6 transition-shadow duration-300 dark:bg-card"
+      className="flex h-full cursor-pointer flex-col items-center rounded-lg bg-muted p-6 transition-shadow duration-300 dark:bg-card"
     >
       <div className="mb-4 text-4xl text-brand">{icon}</div>
       <h3 className="mb-2 text-center text-xl font-semibold text-foreground">

--- a/src/components/ThreadView.tsx
+++ b/src/components/ThreadView.tsx
@@ -56,7 +56,7 @@ export const ThreadView: React.FC<ThreadViewProps> = ({
           <div
             className={`
             ${isHighlighted ? 'border-brand/50 bg-card ring-1 ring-brand/20' : tweet.from_external ? 'border-dashed border-amber-300 bg-amber-50/60 dark:border-amber-700 dark:bg-amber-900/10' : 'border-border bg-card'}
-            relative mb-4 rounded-xl border p-4 sm:p-5
+            relative mb-4 rounded-lg border p-4 sm:p-5
           `}
           >
             {tweet.from_external && (

--- a/src/components/TweetList.tsx
+++ b/src/components/TweetList.tsx
@@ -167,7 +167,7 @@ export default function TweetList({
         {[0, 1, 2].map((item) => (
           <div
             key={item}
-            className="rounded-xl border border-border bg-card p-5"
+            className="rounded-lg border border-border bg-card p-5"
           >
             <div className="flex gap-3">
               <Skeleton className="h-11 w-11 rounded-full" />

--- a/src/components/UnifiedTweetList.tsx
+++ b/src/components/UnifiedTweetList.tsx
@@ -106,7 +106,7 @@ export default function UnifiedTweetList({
 
   if (!tweets.length) {
     return (
-      <div className="rounded-xl border border-dashed border-border bg-card px-6 py-12 text-center">
+      <div className="rounded-lg border border-dashed border-border bg-card px-6 py-12 text-center">
         <SearchX className="mx-auto h-8 w-8 text-muted-foreground" />
         <div className="mt-4 text-base font-medium text-foreground">
           {emptyMessage}
@@ -290,7 +290,7 @@ export default function UnifiedTweetList({
           {tweets.map((tweet) => (
             <div
               key={tweet.tweet_id}
-              className="rounded-xl border border-border bg-card p-4 transition-colors hover:border-foreground/20 sm:p-5"
+              className="rounded-lg border border-border bg-card p-4 transition-colors hover:border-foreground/20 sm:p-5"
             >
               <TweetComponent
                 tweet={tweet}

--- a/src/components/UploadArchiveSection.tsx
+++ b/src/components/UploadArchiveSection.tsx
@@ -162,7 +162,7 @@ export default function UploadArchiveSection() {
         {steps.map((step) => (
           <div
             key={step.number}
-            className="rounded-xl border border-border bg-card p-6 text-center"
+            className="rounded-lg border border-border bg-card p-6 text-center"
           >
             <div className="mx-auto mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-muted text-lg font-bold text-brand">
               {step.number}

--- a/src/components/UserSearchInput.tsx
+++ b/src/components/UserSearchInput.tsx
@@ -198,7 +198,7 @@ export default function UserSearchInput({
           id={listboxId}
           role="listbox"
           aria-label="User suggestions"
-          className="absolute left-0 top-full z-50 mt-2 max-h-80 w-full min-w-[18rem] overflow-y-auto rounded-xl border border-border bg-popover p-1.5 text-popover-foreground shadow-xl"
+          className="absolute left-0 top-full z-50 mt-2 max-h-80 w-full min-w-[18rem] overflow-y-auto rounded-lg border border-border bg-popover p-1.5 text-popover-foreground shadow-xl"
         >
           {suggestions.map((suggestion, index) => {
             const displayName =

--- a/src/components/home/ClassicHomepage.tsx
+++ b/src/components/home/ClassicHomepage.tsx
@@ -17,9 +17,9 @@ const DynamicHeroCTAButtons = dynamic(
     ssr: false,
     loading: () => (
       <div className="flex flex-col justify-center gap-4 sm:flex-row sm:gap-6">
-        <div className="h-14 w-48 animate-pulse rounded-xl bg-muted" />
-        <div className="h-14 w-48 animate-pulse rounded-xl bg-muted" />
-        <div className="h-14 w-48 animate-pulse rounded-xl bg-muted" />
+        <div className="h-14 w-48 animate-pulse rounded-lg bg-muted" />
+        <div className="h-14 w-48 animate-pulse rounded-lg bg-muted" />
+        <div className="h-14 w-48 animate-pulse rounded-lg bg-muted" />
       </div>
     ),
   },
@@ -30,7 +30,7 @@ const DynamicUploadArchiveSection = dynamic(
   {
     ssr: false,
     loading: () => (
-      <div className="h-48 w-full animate-pulse rounded-xl bg-muted dark:bg-card" />
+      <div className="h-48 w-full animate-pulse rounded-lg bg-muted dark:bg-card" />
     ),
   },
 )

--- a/src/components/home/Testimonials.tsx
+++ b/src/components/home/Testimonials.tsx
@@ -119,7 +119,7 @@ export default function Testimonials() {
             <Link
               key={testimonial.tweetId}
               href={`/tweets/${testimonial.tweetId}`}
-              className="group rounded-xl border border-border bg-background p-5 transition-colors hover:border-brand/60"
+              className="group rounded-lg border border-border bg-background p-5 transition-colors hover:border-brand/60"
             >
               <blockquote className="text-[15px] leading-7 text-foreground">
                 “{testimonial.quote}”

--- a/src/components/metaTwitter/ProfilePageSkeleton.tsx
+++ b/src/components/metaTwitter/ProfilePageSkeleton.tsx
@@ -16,8 +16,8 @@ export function ProfileArchiveSkeleton() {
         <section className="space-y-3">
           <Pulse className="h-7 w-52" />
           <Pulse className="h-4 w-72 max-w-full" />
-          <Pulse className="h-48 w-full rounded-xl" />
-          <Pulse className="h-48 w-full rounded-xl" />
+          <Pulse className="h-48 w-full rounded-lg" />
+          <Pulse className="h-48 w-full rounded-lg" />
         </section>
         <aside className="space-y-5">
           <Pulse className="h-32 w-full" />
@@ -31,7 +31,7 @@ export function ProfileArchiveSkeleton() {
 export function ProfilePageSkeleton() {
   return (
     <div className="flex justify-center px-4 py-8 sm:px-6">
-      <div className="h-fit w-full max-w-[1220px] overflow-hidden rounded-2xl border border-border bg-card">
+      <div className="h-fit w-full max-w-[1220px] overflow-hidden rounded-lg border border-border bg-card">
         <Pulse className="h-[210px] w-full rounded-none" />
         <div className="space-y-3 px-6 pb-5">
           <Pulse className="-mt-[58px] h-[116px] w-[116px] rounded-full" />

--- a/src/components/metaTwitter/Workspace.tsx
+++ b/src/components/metaTwitter/Workspace.tsx
@@ -186,7 +186,7 @@ export function Workspace({
       {editing && (
         <form
           onSubmit={submitTweet}
-          className="flex flex-col gap-2 rounded-xl border border-dashed border-border bg-muted/20 p-3 sm:flex-row sm:flex-wrap sm:items-end"
+          className="flex flex-col gap-2 rounded-lg border border-dashed border-border bg-muted/20 p-3 sm:flex-row sm:flex-wrap sm:items-end"
         >
           <label className="min-w-0 flex-1 text-xs font-semibold text-muted-foreground">
             Add one of your archived tweets
@@ -254,18 +254,18 @@ export function Workspace({
           className="flex flex-col gap-3"
         >
           {!bangersAvailable && (
-            <div className="rounded-xl border border-dashed border-border p-7 text-center text-sm text-muted-foreground">
+            <div className="rounded-lg border border-dashed border-border p-7 text-center text-sm text-muted-foreground">
               Bangers are temporarily unavailable. The rest of this profile is
               still here.
             </div>
           )}
           {bangersAvailable && bangersLoading && tweets.length === 0 && (
-            <div className="rounded-xl border border-dashed border-border p-7 text-center text-sm text-muted-foreground">
+            <div className="rounded-lg border border-dashed border-border p-7 text-center text-sm text-muted-foreground">
               Loading bangers…
             </div>
           )}
           {bangersAvailable && !bangersLoading && tweets.length === 0 && (
-            <div className="rounded-xl border border-dashed border-border p-7 text-center text-sm text-muted-foreground">
+            <div className="rounded-lg border border-dashed border-border p-7 text-center text-sm text-muted-foreground">
               No posts in this chapter have at least two Community Archive
               quotes yet.
             </div>

--- a/src/components/portal/PortalPageLoading.tsx
+++ b/src/components/portal/PortalPageLoading.tsx
@@ -17,7 +17,7 @@ export function PortalPageLoading({ label }: PortalPageLoadingProps) {
           {Array.from({ length: 5 }, (_, index) => (
             <div
               key={index}
-              className="rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-950"
+              className="rounded-lg border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-950"
             >
               <div className="mb-4 flex items-center gap-3">
                 <div className="h-10 w-10 rounded-full bg-zinc-200 dark:bg-zinc-800" />

--- a/src/components/portal/styles.ts
+++ b/src/components/portal/styles.ts
@@ -1,6 +1,6 @@
 /** Shared style vocabulary for portal surfaces (light + dark). */
 export const CARD =
-  'rounded-[4px] border border-zinc-200 bg-white dark:border-[#26262a] dark:bg-[#1b1b1e]'
+  'rounded-lg border border-zinc-200 bg-white dark:border-[#26262a] dark:bg-[#1b1b1e]'
 export const MUTED = 'text-zinc-500 dark:text-[#a7a7b4]'
 export const FAINT = 'text-zinc-400 dark:text-[#6d6d78]'
 export const BODY = 'text-zinc-700 dark:text-[#d9d9de]'


### PR DESCRIPTION
Surface radius currently disagrees across the product because most of it opts out of the scale:

| Surface | Today |
| --- | --- |
| Portal dashboard cards | hardcoded `rounded-[4px]` |
| Anything on the `Card` primitive | 4.8px, inherited from `--radius: 0.3rem` |
| Upload steps, testimonials, docs panels, tweet cards | fixed `rounded-xl` (12px) |
| Supporters, user directory, featured apps, opt-in | fixed `rounded-2xl` (16px) |

This moves the token to `0.5rem` and puts all 46 of those surfaces back on `rounded-lg`, so `--radius` becomes the single lever for surface radius. `rounded-xl` and `rounded-2xl` are now unused.

Search inputs are included, so they match the cards they sit above.

## Deliberately left off the token

- **Buttons** keep their own literal `rounded-[8px]`. Same value today, but they will not follow if `--radius` moves later — that is intentional.
- **Pills and avatars** stay `rounded-full`.
- **Inner chrome** — media thumbnails, icon tiles, quoted-tweet boxes, trend controls — keeps its tighter fixed 4px/3px. At 8px a 74x52 thumbnail reads as a pill.

## Knock-on

The derived steps move with the token: `rounded-md` 2.8px -> 6px and `rounded-sm` 0.8px -> 4px, across roughly 96 usages (inputs, dropdowns, badges). The old values were near-square enough to look accidental, but this is a product-wide shift, not a scoped one — worth a look if you disagree.

## Relationship to #766

Split out of #766 so that PR stays homepage-shaped. The two are logically independent and can merge in either order, but whichever lands second needs a small conflict resolution in two files — I checked with a trial merge rather than assuming:

- `src/app/globals.css` — both touch the same `:root` block. #766 adds brand tokens, this changes `--radius`. Keep both.
- `src/components/home/Testimonials.tsx` — both edit the same card `className`. #766 changes `hover:border-brand/60` to `hover:border-brand-deep/60`, this changes `rounded-xl` to `rounded-lg`. Keep both.

`UploadArchiveSection.tsx` and `ClassicHomepage.tsx` also appear in both but auto-merge cleanly.

## Testing

Every change is a one-class swap, verified rendered rather than only grepped: on `/user-dir` both search inputs and the table card measure 8px, and on `/docs` every large surface is a uniform 8px with no `xl` left in the DOM. Full suite passes except one pre-existing `clickhouseGateway` failure that also fails on `main`. Typecheck, lint, and Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
