### PR TITLE
Finish moving primary actions off green

### DIFF
--- a/src/components/AdvancedSearchForm.tsx
+++ b/src/components/AdvancedSearchForm.tsx
@@ -114,7 +114,7 @@ export default function AdvancedSearchForm() {
         </div>
         <Button
           type="submit"
-          className="h-10 bg-green-600 px-6 text-white hover:bg-green-700 dark:bg-green-400 dark:text-green-950 dark:hover:bg-green-300"
+          className="h-10 bg-brand px-6 text-brand-foreground hover:bg-brand/90"
         >
           <Search className="mr-2 h-4 w-4" />
           Search

--- a/src/components/HomeOptInWidget.tsx
+++ b/src/components/HomeOptInWidget.tsx
@@ -244,7 +244,7 @@ export default function HomeOptInWidget() {
         <Button
           onClick={handleOptIn}
           disabled={isLoading}
-          className="bg-green-600 text-white hover:bg-green-700 dark:bg-green-400 dark:text-green-950 dark:hover:bg-green-300"
+          className="bg-brand text-brand-foreground hover:bg-brand/90"
         >
           <Users className="mr-2 h-4 w-4" />
           {isLoading ? 'Processing...' : 'Opt In to Tweet Streaming'}

--- a/src/components/HomepageSearch.tsx
+++ b/src/components/HomepageSearch.tsx
@@ -49,7 +49,7 @@ export default function HomepageSearch() {
         <Button
           type="submit"
           size="icon"
-          className="absolute right-2.5 top-1/2 h-11 w-11 -translate-y-1/2 rounded-full bg-green-600 text-white shadow-sm hover:bg-green-700 focus-visible:ring-green-600 dark:bg-green-400 dark:text-green-950 dark:hover:bg-green-300 dark:focus-visible:ring-green-400 sm:right-3"
+          className="absolute right-2.5 top-1/2 h-11 w-11 -translate-y-1/2 rounded-full bg-brand text-brand-foreground shadow-sm hover:bg-brand/90 focus-visible:ring-brand sm:right-3"
           aria-label="Search archive"
         >
           <Search className="h-5 w-5" />

--- a/src/components/MemberSearchLanding.tsx
+++ b/src/components/MemberSearchLanding.tsx
@@ -88,7 +88,7 @@ export default function MemberSearchLanding({
             type="submit"
             size="lg"
             disabled={!query.trim()}
-            className="h-14 bg-green-600 px-7 text-white hover:bg-green-700 dark:bg-green-400 dark:text-green-950 dark:hover:bg-green-300"
+            className="h-14 bg-brand px-7 text-brand-foreground hover:bg-brand/90"
           >
             Search
             <ArrowRight className="ml-2 h-4 w-4" />

--- a/src/components/SignIn.tsx
+++ b/src/components/SignIn.tsx
@@ -142,7 +142,7 @@ export default function SignIn() {
           className={`rounded-[8px] border border-transparent px-4 py-2 text-sm font-medium text-white transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-background ${
             isDevLoginEnabled
               ? 'bg-yellow-600 hover:bg-yellow-700 focus:ring-yellow-500 dark:bg-yellow-500 dark:hover:bg-yellow-600'
-              : 'bg-green-600 hover:bg-green-700 focus:ring-green-500 dark:bg-green-400 dark:text-green-950 dark:hover:bg-green-300'
+              : 'bg-brand text-brand-foreground hover:bg-brand/90 focus:ring-brand'
           }`}
         >
           {isStagingLogin ? (


### PR DESCRIPTION
#766 moved the hero buttons onto the brand, but the same action kept its green everywhere else. A signed-in visitor saw a green submit sitting inside an otherwise brand-blue page — the button in the homepage search bar.

Moved onto `bg-brand`:

| Where | Action |
| --- | --- |
| `HomepageSearch` | the signed-in search submit (the one that prompted this) |
| `AdvancedSearchForm` | Search, on `/search` |
| `MemberSearchLanding` | Search |
| `HomeOptInWidget` | Opt In to Tweet Streaming |
| `SignIn` | Sign in |

Each also drops its bespoke dark-mode green pair, since `--brand` and `--brand-foreground` already flip per theme.

## Left green on purpose

- **The activity heatmap** (`activity-tracker`) — its greens encode activity intensity across eight steps. That is data, not emphasis, and recolouring it would break the scale.
- **Dev mode's yellow sign-in** — an intentional warning state, untouched. Only the real sign-in branch of that ternary moved.
- **"Support the Project"** on `/supporters` — a donate link to Open Collective. Green reads as a money convention there and it is not part of the homepage CTA system, so I left it. Happy to fold it in if you would rather have one rule with no exceptions.

## Testing

Verified rendered: the `/search` submit measures `#1E9BCD` on white. Full suite passes except one pre-existing `clickhouseGateway` failure that also fails on `main`. Typecheck, lint, and Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
