### PR TITLE
Move the supporters CTA onto the brand too

### DIFF
--- a/src/app/supporters/page.tsx
+++ b/src/app/supporters/page.tsx
@@ -82,7 +82,7 @@ export default async function SupportersPage() {
             href="https://opencollective.com/community-archive/donate"
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center justify-center rounded-lg bg-green-600 px-6 py-3 font-medium text-white transition-colors hover:bg-green-700 dark:bg-green-400 dark:text-green-950 dark:hover:bg-green-300"
+            className="inline-flex items-center justify-center rounded-lg bg-brand px-6 py-3 font-medium text-brand-foreground transition-colors hover:bg-brand/90"
           >
             <FaHeart className="mr-2" /> Support the Project
           </Link>


### PR DESCRIPTION
Follow-up to #772, which moved every primary action onto the brand except one. I had left the "Support the Project" donate link green on the money convention, but that argument does not survive the rest of the page being brand blue — it just made the single exception look like an oversight.

It also drops the bespoke dark-mode green pair, since `--brand` and `--brand-foreground` already flip per theme.

## Green that stays

Green now only remains where it carries meaning rather than emphasis:

- **The activity heatmap** (`activity-tracker`) — eight steps encoding activity intensity. Recolouring it would break the scale.
- **Opt-in success states** (`HomeOptInWidget`, `OptInForm`) — the "You're Opted In!" card and the success alerts, where green is the confirmation signal.

No primary action anywhere in the app is green after this.

## Testing

Verified rendered on `/supporters`: the CTA measures `#1E9BCD` on white at the 8px token radius. Full suite passes except one pre-existing `clickhouseGateway` failure that also fails on `main`. Typecheck and Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
