### PR TITLE
Ignore the temp file gen-types leaves behind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ __pycache__/
 
 # local scratch / dev notes (kept out of the repo; move keepers into docs/)
 scratchpad/
+
+# Left behind when `gen-types` fails before it can mv the file into place.
+src/database-types.ts.tmp


### PR DESCRIPTION
Both `gen-types` scripts in `package.json` write to `src/database-types.ts.tmp` and then `mv` it into place:

```
supabase gen types typescript ... > src/database-types.ts.tmp && mv src/database-types.ts.tmp src/database-types.ts
```

If the generate step fails before the `mv` — a missing `SUPABASE_ACCESS_TOKEN` is the usual way, and the pre-commit hook runs this — the temp file is stranded in the working tree as an untracked file. It is easy to sweep into an unrelated commit by accident with a `git add src/` or `git add -A`; I did exactly that twice while working on the homepage PRs and had to back it out.

One line, so it stays out of the way.

## Testing

`git check-ignore -v src/database-types.ts.tmp` matches the new rule, and the file no longer appears in `git status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
