### PR TITLE
Spin the homepage counter up from zero

### DIFF
--- a/src/components/home/HomepagePeople.test.tsx
+++ b/src/components/home/HomepagePeople.test.tsx
@@ -89,9 +89,8 @@ it('shows the eight cached interaction leaders to a signed-in member', async () 
 
   render(await HomepagePeople({ isMember: true }))
 
-  expect(
-    screen.getByText('People you interact with most this year'),
-  ).toBeInTheDocument()
+  // The personalized row is uncaptioned too; the avatars are the whole message.
+  expect(screen.queryByText(/interact with most/i)).not.toBeInTheDocument()
   expect(screen.getByTestId('homepage-avatars')).toHaveTextContent(
     Array.from(
       { length: 8 },
@@ -111,10 +110,6 @@ it('shows the eight cached interaction leaders to a signed-in member', async () 
 it('shows the representative sample to guests', async () => {
   render(await HomepagePeople({ isMember: false }))
 
-  // The unpersonalized row carries no caption; the avatars are the proof.
-  expect(
-    screen.queryByText('People you interact with most this year'),
-  ).not.toBeInTheDocument()
   expect(screen.getByTestId('homepage-avatars')).toHaveTextContent(
     'featured:1000',
   )
@@ -129,9 +124,6 @@ it('falls back to the representative sample when interaction data is absent', as
 
   render(await HomepagePeople({ isMember: true }))
 
-  expect(
-    screen.queryByText('People you interact with most this year'),
-  ).not.toBeInTheDocument()
   expect(screen.getByTestId('homepage-avatars')).toHaveTextContent(
     'featured:1000',
   )

--- a/src/components/home/HomepagePeople.tsx
+++ b/src/components/home/HomepagePeople.tsx
@@ -9,9 +9,6 @@ import { getCurrentUser } from '@/lib/portal/auth'
 import { getSessionTwitterUsername } from '@/lib/sessionTwitterUsername'
 import type { AvatarType } from '@/lib/types'
 
-const labelClassName =
-  'mb-5 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground/80'
-
 async function personalizedArchives(): Promise<AvatarType[]> {
   const user = await getCurrentUser()
   const username = user ? getSessionTwitterUsername(user) : null
@@ -67,11 +64,6 @@ export default async function HomepagePeople({
 
   return (
     <div className="home-fade-in pt-2">
-      {personalized.length > 0 && (
-        <p className={labelClassName}>
-          People you interact with most this year
-        </p>
-      )}
       <div className="mx-auto w-full max-w-3xl">
         <AvatarList initialAvatars={archives} compact />
       </div>

--- a/src/components/home/TweetCountTicker.test.tsx
+++ b/src/components/home/TweetCountTicker.test.tsx
@@ -1,0 +1,119 @@
+import { act, render, screen } from '@testing-library/react'
+import TweetCountTicker from './TweetCountTicker'
+
+const VALUE = 15_425_771
+
+function columns() {
+  const strip = screen.getByText(VALUE.toLocaleString('en-US')).parentElement!
+  return Array.from(strip.querySelectorAll<HTMLElement>('span[aria-hidden]'))
+}
+
+/** Read the strip back as the number the columns are currently showing. */
+function displayed() {
+  return columns()
+    .map((column) => {
+      const inner = column.firstElementChild as HTMLElement | null
+      if (!inner) return column.textContent
+      return String(offsetOf(inner) % 10)
+    })
+    .join('')
+}
+
+/** How many digit rows a column is translated up by. */
+function offsetOf(inner: HTMLElement) {
+  return (
+    Number(/translateY\(-(\d+)px\)/.exec(inner.style.transform)?.[1] ?? 0) / 28
+  )
+}
+
+function transitions() {
+  return columns()
+    .map(
+      (column) =>
+        (column.firstElementChild as HTMLElement | null)?.style.transition,
+    )
+    .filter(Boolean)
+}
+
+let frames: FrameRequestCallback[] = []
+let matches = false
+
+/** Run every frame callback queued so far, without draining ones they queue. */
+function flushFrame() {
+  const queued = frames
+  frames = []
+  act(() => {
+    queued.forEach((frame) => frame(0))
+  })
+}
+
+beforeEach(() => {
+  frames = []
+  matches = false
+  jest.useFakeTimers()
+  jest
+    .spyOn(window, 'requestAnimationFrame')
+    .mockImplementation((cb) => frames.push(cb) as unknown as number)
+  jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
+  window.matchMedia = jest.fn().mockImplementation(() => ({ matches })) as never
+})
+
+afterEach(() => {
+  jest.useRealTimers()
+  jest.restoreAllMocks()
+})
+
+it('opens on zeros untransitioned, then spins up to the total', () => {
+  render(<TweetCountTicker value={VALUE} />)
+
+  expect(displayed()).toBe('00,000,000')
+  expect(transitions().every((value) => value === 'none')).toBe(true)
+
+  // The first frame only yields the paint. Settling here would collapse both
+  // positions into one paint and the columns would never move.
+  flushFrame()
+  expect(displayed()).toBe('00,000,000')
+
+  flushFrame()
+  expect(displayed()).toBe('15,425,771')
+  expect(transitions()[0]).toContain('620ms')
+})
+
+it('spins the columns different distances so the total stays unreadable', () => {
+  render(<TweetCountTicker value={VALUE} />)
+  flushFrame()
+  flushFrame()
+
+  const revolutions = columns()
+    .map((column) => column.firstElementChild as HTMLElement | null)
+    .filter((inner): inner is HTMLElement => inner !== null)
+    .map((inner) => Math.floor(offsetOf(inner) / 10))
+
+  // Every column travels at least two full revolutions, and they differ from
+  // one another — mid-flight the strip is noise, not the total counting up.
+  expect(Math.min(...revolutions)).toBeGreaterThanOrEqual(2)
+  expect(new Set(revolutions).size).toBeGreaterThan(1)
+})
+
+it('lands the total even when the frame callback never runs', () => {
+  render(<TweetCountTicker value={VALUE} />)
+  expect(displayed()).toBe('00,000,000')
+
+  // A hidden tab never fires requestAnimationFrame; the timer has to finish it.
+  act(() => {
+    jest.advanceTimersByTime(250)
+  })
+
+  expect(displayed()).toBe('15,425,771')
+})
+
+it('renders the total outright when motion is reduced', () => {
+  matches = true
+  render(<TweetCountTicker value={VALUE} />)
+
+  expect(displayed()).toBe('15,425,771')
+  act(() => {
+    jest.advanceTimersByTime(1_000)
+  })
+  expect(displayed()).toBe('15,425,771')
+})

--- a/src/components/home/TweetCountTicker.tsx
+++ b/src/components/home/TweetCountTicker.tsx
@@ -3,73 +3,72 @@
 import { useEffect, useRef, useState } from 'react'
 
 const DIGIT_HEIGHT = 28
-const COUNT_UP_MS = 1500
-/** The ramp stops just short of the total so the last digits visibly roll in. */
-const RAMP_END = 0.985
-const SETTLE_MS = 620
+const ROLL_MS = 620
+const SETTLE_FALLBACK_MS = 250
 const DIGITS = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
 
-type Token = { key: number; digit: number | null }
+type Token = { key: number; digit: number | null; spins: number }
 
 /**
- * Split a count into odometer tokens using the *target* digit width, so the
- * strip keeps a fixed number of columns from the first frame and the sentence
- * around it never reflows.
+ * Split the total into odometer tokens. Columns are derived from the *target*
+ * number, so the strip keeps a fixed width and the sentence around it never
+ * reflows. Each column also carries its own count of full revolutions: spun
+ * different distances, the digits read as noise until they land.
  */
-function tokenize(count: number, width: number): Token[] {
-  const digits = String(Math.max(0, count)).padStart(width, '0').slice(-width)
+function tokenize(value: number): Token[] {
+  const digits = String(Math.max(0, value))
   const tokens: Token[] = []
-  for (let i = 0; i < width; i += 1) {
-    if (i > 0 && (width - i) % 3 === 0) {
-      tokens.push({ key: tokens.length, digit: null })
+  for (let i = 0; i < digits.length; i += 1) {
+    const fromRight = digits.length - i - 1
+    if (i > 0 && (fromRight + 1) % 3 === 0) {
+      tokens.push({ key: tokens.length, digit: null, spins: 0 })
     }
-    tokens.push({ key: tokens.length, digit: Number(digits[i]) })
+    tokens.push({
+      key: tokens.length,
+      digit: Number(digits[i]),
+      spins: 2 + (fromRight % 3),
+    })
   }
   return tokens
 }
 
 /**
- * Counts up to the archive total on mount, then rests there. The rolling
- * columns are decorative; assistive tech reads the plain total instead.
+ * Spins up from zero to the archive total once on mount, then rests there. The
+ * rolling columns are decorative; assistive tech reads the plain total instead.
  */
 export default function TweetCountTicker({ value }: { value: number }) {
   const formatted = value.toLocaleString('en-US')
-  const width = String(Math.max(0, value)).length
-  const [count, setCount] = useState(value)
-  const [rolling, setRolling] = useState(false)
+  const [spinning, setSpinning] = useState(false)
   const frame = useRef<number>()
+  const fallback = useRef<ReturnType<typeof setTimeout>>()
 
   useEffect(() => {
     const reduced = window.matchMedia?.('(prefers-reduced-motion: reduce)')
     if (reduced?.matches) return
 
-    setRolling(true)
-    setCount(0)
-    const start = performance.now()
-    const step = () => {
-      const progress = Math.min(1, (performance.now() - start) / COUNT_UP_MS)
-      const eased = 1 - Math.pow(1 - progress, 4)
-      setCount(Math.floor(value * eased * RAMP_END))
-      if (progress < 1) {
-        frame.current = requestAnimationFrame(step)
-        return
-      }
-      // Turn the transition on a frame before the true total lands, otherwise
-      // the browser applies both in one recalc and the last hop snaps.
-      setRolling(false)
-      frame.current = requestAnimationFrame(() => setCount(value))
-    }
-    frame.current = requestAnimationFrame(step)
+    // Drop to all zeros untransitioned, then transition away from them.
+    setSpinning(true)
+    const settle = () => setSpinning(false)
+    // Two frames deep: a callback registered here runs *before* the next frame
+    // paints, so settling in it collapses both positions into one paint and
+    // nothing moves. The nested frame waits for the zeros to land.
+    frame.current = requestAnimationFrame(() => {
+      frame.current = requestAnimationFrame(settle)
+    })
+    // A hidden tab never runs the frame callback, which would strand the strip
+    // on zero. Nobody is watching the spin there, so land the total.
+    fallback.current = setTimeout(settle, SETTLE_FALLBACK_MS)
 
     return () => {
       if (frame.current !== undefined) cancelAnimationFrame(frame.current)
+      clearTimeout(fallback.current)
     }
   }, [value])
 
   return (
     <span className="inline-flex items-start align-bottom tabular-nums">
       <span className="sr-only">{formatted}</span>
-      {tokenize(count, width).map((token) =>
+      {tokenize(value).map((token) =>
         token.digit === null ? (
           <span
             key={token.key}
@@ -87,18 +86,20 @@ export default function TweetCountTicker({ value }: { value: number }) {
             <span
               className="block"
               style={{
-                transform: `translateY(-${token.digit * DIGIT_HEIGHT}px)`,
-                transition: rolling
+                transform: `translateY(-${
+                  spinning ? 0 : (token.spins * 10 + token.digit) * DIGIT_HEIGHT
+                }px)`,
+                transition: spinning
                   ? 'none'
-                  : `transform ${SETTLE_MS}ms cubic-bezier(.16,.84,.24,1)`,
+                  : `transform ${ROLL_MS}ms cubic-bezier(.16,.84,.24,1)`,
               }}
             >
-              {DIGITS.map((digit) => (
+              {Array.from({ length: token.spins * 10 + 10 }, (_, index) => (
                 <span
-                  key={digit}
+                  key={index}
                   className="block h-[28px] text-center leading-[28px]"
                 >
-                  {digit}
+                  {DIGITS[index % 10]}
                 </span>
               ))}
             </span>


### PR DESCRIPTION
The tweet counter ran two animations back to back: a 1.5s count-up ramp, then an eased roll over the last 1.5% of the total. This keeps only the roll.

- Starts from zero over 620ms, the same duration and easing the roll had before.
- Each column spins two to four full revolutions, with neighbouring columns spinning different distances, so mid-flight the strip reads as noise rather than as a total counting up.
- Columns are now derived from the target number and only the transform moves, so the digit count is fixed from the first paint and the sentence cannot reflow mid-spin.
- Settling waits two frames. A callback registered in the effect runs before the next frame paints, so flipping there collapses both positions into one paint and nothing moves at all — a real bug caught in the preview, not a theoretical one.
- A 250ms timer backstops the frame callback. A hidden tab never runs `requestAnimationFrame`, which previously stranded the strip on its opening number.

Also drops the "People you interact with most this year" caption above the homepage avatars. The avatar row itself is unchanged — members still get their interaction leaders, guests still get the featured sample.

New tests cover the zero opening, the two-frame paint requirement, the varied revolution counts, the hidden-tab fallback, and reduced motion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
