### PR TITLE
[codex] Gate expensive browsing behind login

### DIFF
--- a/src/app/api/portal/bangers/route.ts
+++ b/src/app/api/portal/bangers/route.ts
@@ -3,6 +3,8 @@ import {
   getPortalBangersPage,
   PORTAL_BANGERS_PAGE_SIZE,
 } from '@/lib/portal/data'
+import { getIsMember } from '@/lib/portal/auth'
+import { PUBLIC_PORTAL_PREVIEW_LIMIT } from '@/lib/portal/access'
 import type {
   PortalBangersPeriod,
   PortalBangersScope,
@@ -12,12 +14,12 @@ import type {
 export const dynamic = 'force-dynamic'
 export const maxDuration = 60
 
-function publicJson(body: unknown, status = 200) {
+function bangersJson(body: unknown, status = 200, shared = false) {
   return NextResponse.json(body, {
     status,
     headers: {
       'Cache-Control':
-        status === 200
+        status === 200 && shared
           ? 'public, s-maxage=60, stale-while-revalidate=300'
           : 'private, no-store',
     },
@@ -43,6 +45,9 @@ export async function GET(request: NextRequest) {
   try {
     const params = new URL(request.url).searchParams
     const offset = boundedInteger(params.get('offset'), 0, 0, 1_000_000)
+    if (offset > 0 && !(await getIsMember())) {
+      return bangersJson({ error: 'Log in to see more bangers' }, 401)
+    }
     const periodValue = params.get('period')
     if (
       periodValue &&
@@ -75,9 +80,10 @@ export async function GET(request: NextRequest) {
     const query = (params.get('q') || '').trim()
     if (query.length > 120) throw new Error('Banger search is too long')
 
-    return publicJson(
+    return bangersJson(
       await getPortalBangersPage({
-        limit: PORTAL_BANGERS_PAGE_SIZE,
+        limit:
+          offset === 0 ? PUBLIC_PORTAL_PREVIEW_LIMIT : PORTAL_BANGERS_PAGE_SIZE,
         offset,
         scope,
         sort,
@@ -85,13 +91,15 @@ export async function GET(request: NextRequest) {
         period,
         query,
       }),
+      200,
+      offset === 0,
     )
   } catch (error) {
     const message = error instanceof Error ? error.message : ''
     const isInputError =
       message.startsWith('Invalid') || message === 'Banger search is too long'
     if (!isInputError) console.error('Portal bangers request failed:', error)
-    return publicJson(
+    return bangersJson(
       {
         error: isInputError
           ? message

--- a/src/app/api/portal/stream/route.ts
+++ b/src/app/api/portal/stream/route.ts
@@ -5,6 +5,8 @@ import {
   type PortalStreamPageCursor,
   type PortalStreamUpdateCursor,
 } from '@/lib/portal/data'
+import { getIsMember } from '@/lib/portal/auth'
+import { PUBLIC_PORTAL_PREVIEW_LIMIT } from '@/lib/portal/access'
 
 export const dynamic = 'force-dynamic'
 export const maxDuration = 30
@@ -57,6 +59,13 @@ export async function GET(request: NextRequest) {
   }
 
   try {
+    if ((updateCursor || pageCursor) && !(await getIsMember())) {
+      return NextResponse.json(
+        { error: 'Log in to see more live-stream tweets' },
+        { status: 401, headers: { 'Cache-Control': 'private, no-store' } },
+      )
+    }
+
     if (updateCursor) {
       const tweets = await getPortalStreamUpdates(100, updateCursor)
       const edge = tweets[tweets.length - 1]
@@ -76,7 +85,7 @@ export async function GET(request: NextRequest) {
       )
     }
 
-    const pageSize = 30
+    const pageSize = pageCursor ? 30 : PUBLIC_PORTAL_PREVIEW_LIMIT
     const rows = await getPortalStreamPage(
       pageSize + 1,
       pageCursor ?? undefined,
@@ -92,9 +101,7 @@ export async function GET(request: NextRequest) {
       },
       {
         headers: {
-          'Cache-Control': pageCursor
-            ? 'public, s-maxage=15, stale-while-revalidate=30'
-            : 'private, no-store',
+          'Cache-Control': 'private, no-store',
         },
       },
     )

--- a/src/app/api/tweets/[tweet_id]/quotes/route.test.ts
+++ b/src/app/api/tweets/[tweet_id]/quotes/route.test.ts
@@ -1,0 +1,62 @@
+/** @jest-environment node */
+
+import { NextRequest } from 'next/server'
+import { cookies } from 'next/headers'
+import { createServerClient } from '@/utils/supabase'
+import { getQuotingTweetsPage } from '@/lib/quotingTweets'
+import { GET } from './route'
+
+jest.mock('next/headers', () => ({ cookies: jest.fn() }))
+jest.mock('@/utils/supabase', () => ({ createServerClient: jest.fn() }))
+jest.mock('@/lib/quotingTweets', () => ({ getQuotingTweetsPage: jest.fn() }))
+
+const createServerClientMock = jest.mocked(createServerClient)
+const getQuotingTweetsPageMock = jest.mocked(getQuotingTweetsPage)
+const getUser = jest.fn()
+
+describe('tweet quotes route', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(cookies as jest.Mock).mockResolvedValue({})
+    createServerClientMock.mockReturnValue({
+      auth: { getUser },
+    } as never)
+  })
+
+  test('rejects anonymous requests before loading quotes', async () => {
+    getUser.mockResolvedValue({ data: { user: null }, error: null })
+    const response = await GET(
+      new NextRequest(
+        'https://community-archive.org/api/tweets/123/quotes?offset=0&limit=12',
+      ),
+      { params: { tweet_id: '123' } },
+    )
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Log in to see archived quotes',
+    })
+    expect(getQuotingTweetsPageMock).not.toHaveBeenCalled()
+  })
+
+  test('returns quote pages to authenticated users', async () => {
+    getUser.mockResolvedValue({
+      data: { user: { id: 'signed-in-user' } },
+      error: null,
+    })
+    getQuotingTweetsPageMock.mockResolvedValue({
+      tweets: [],
+      totalCount: 0,
+      nextOffset: null,
+    })
+    const response = await GET(
+      new NextRequest(
+        'https://community-archive.org/api/tweets/123/quotes?offset=0&limit=12',
+      ),
+      { params: { tweet_id: '123' } },
+    )
+
+    expect(response.status).toBe(200)
+    expect(getQuotingTweetsPageMock).toHaveBeenCalledWith('123', 0, 12)
+  })
+})

--- a/src/app/api/tweets/[tweet_id]/quotes/route.ts
+++ b/src/app/api/tweets/[tweet_id]/quotes/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getQuotingTweetsPage } from '@/lib/quotingTweets'
+import { createServerClient } from '@/utils/supabase'
+import { cookies } from 'next/headers'
 
 export const dynamic = 'force-dynamic'
 export const maxDuration = 30
@@ -24,6 +26,21 @@ export async function GET(
   { params }: { params: { tweet_id: string } },
 ) {
   try {
+    const cookieStore = await cookies()
+    const supabase = createServerClient(cookieStore)
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+    if (!user) {
+      return NextResponse.json(
+        { error: 'Log in to see archived quotes' },
+        {
+          status: 401,
+          headers: { 'Cache-Control': 'private, no-store' },
+        },
+      )
+    }
+
     if (!/^\d{1,20}$/.test(params.tweet_id)) {
       return NextResponse.json({ error: 'Tweet not found' }, { status: 404 })
     }

--- a/src/app/bangers/page.tsx
+++ b/src/app/bangers/page.tsx
@@ -6,6 +6,8 @@ import type {
   PortalBangersPeriod,
   PortalBangersScope,
 } from '@/lib/portal/types'
+import { getIsMember } from '@/lib/portal/auth'
+import { PUBLIC_PORTAL_PREVIEW_LIMIT } from '@/lib/portal/access'
 
 export const metadata = { title: 'Bangers · Community Archive' }
 export const maxDuration = 60
@@ -42,12 +44,16 @@ export default async function BangersPage({
   const allTime =
     periodValue === 'all' || (period === undefined && year === undefined)
   const query = paramValue(searchParams.q).trim().slice(0, 120)
-  const initialPage = await getInitialPortalBangersPage({
-    scope,
-    sort,
-    ...(period ? { period } : { year }),
-    query,
-  })
+  const [isMember, initialPage] = await Promise.all([
+    getIsMember(),
+    getInitialPortalBangersPage({
+      limit: PUBLIC_PORTAL_PREVIEW_LIMIT,
+      scope,
+      sort,
+      ...(period ? { period } : { year }),
+      query,
+    }),
+  ])
 
   return (
     <main className="min-h-screen bg-zinc-100/80 dark:bg-transparent">
@@ -86,6 +92,7 @@ export default async function BangersPage({
           period={period}
           allTime={allTime}
           initialQuery={query}
+          isMember={isMember}
         />
       </div>
     </main>

--- a/src/app/stream/page.tsx
+++ b/src/app/stream/page.tsx
@@ -1,4 +1,5 @@
 import Portal from '@/components/portal/Portal'
+import { getIsMember } from '@/lib/portal/auth'
 import { getPortalData } from '@/lib/portal/data'
 
 export const metadata = { title: 'Stream · Community Archive' }
@@ -8,6 +9,9 @@ export const dynamic = 'force-dynamic'
 export const maxDuration = 60
 
 export default async function StreamPage() {
-  const data = await getPortalData('stream')
-  return <Portal data={data} view="stream" />
+  const [data, isMember] = await Promise.all([
+    getPortalData('stream'),
+    getIsMember(),
+  ])
+  return <Portal data={data} view="stream" isMember={isMember} />
 }

--- a/src/app/tweets/[tweet_id]/page.tsx
+++ b/src/app/tweets/[tweet_id]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from 'next/navigation'
 import TweetComponent from '@/components/TweetComponent'
 import TweetBackLink from '@/components/TweetBackLink'
 import ThreadView from '@/components/ThreadView'
-import QuotingTweetsSidebar from '@/components/QuotingTweetsSidebar'
+import AuthenticatedQuotingTweetsSidebar from '@/components/AuthenticatedQuotingTweetsSidebar'
 import { getTweetBackLink } from '@/lib/navigation'
 import { Link2, MessagesSquare } from 'lucide-react'
 
@@ -18,8 +18,9 @@ export default async function TweetPage({
   searchParams?: Record<string, string | string[] | undefined>
 }) {
   const { tweet_id } = params
-  const { tweet, threadTree, quotingTweets, quotingTweetCount } =
-    await getTweetPageData(tweet_id)
+  const { tweet, threadTree } = await getTweetPageData(tweet_id, {
+    includeQuotingTweets: false,
+  })
 
   if (!tweet) {
     notFound()
@@ -77,11 +78,7 @@ export default async function TweetPage({
             </div>
           </div>
 
-          <QuotingTweetsSidebar
-            tweets={quotingTweets}
-            totalCount={quotingTweetCount}
-            targetTweet={tweet}
-          />
+          <AuthenticatedQuotingTweetsSidebar targetTweet={tweet} />
         </div>
       </section>
     </main>

--- a/src/components/AuthenticatedQuotingTweetsSidebar.test.tsx
+++ b/src/components/AuthenticatedQuotingTweetsSidebar.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { createBrowserClient } from '@/utils/supabase'
+import AuthenticatedQuotingTweetsSidebar from './AuthenticatedQuotingTweetsSidebar'
+import type { TweetData } from './TweetComponent'
+
+jest.mock('@/utils/supabase', () => ({ createBrowserClient: jest.fn() }))
+jest.mock('@/components/QuotingTweetsSidebar', () => ({
+  __esModule: true,
+  default: ({ totalCount }: { totalCount: number }) => (
+    <div>Loaded {totalCount} archived quotes</div>
+  ),
+}))
+
+const createBrowserClientMock = jest.mocked(createBrowserClient)
+const getSession = jest.fn()
+
+const targetTweet: TweetData = {
+  tweet_id: '123',
+  account_id: '42',
+  created_at: '2026-08-01T12:00:00Z',
+  full_text: 'Original tweet',
+  retweet_count: 2,
+  favorite_count: 5,
+  reply_to_tweet_id: null,
+  quote_tweet_id: null,
+  retweeted_tweet_id: null,
+  avatar_media_url: null,
+  username: 'alice',
+  account_display_name: 'Alice',
+  media: [],
+  urls: [],
+}
+
+describe('AuthenticatedQuotingTweetsSidebar', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    createBrowserClientMock.mockReturnValue({
+      auth: { getSession },
+    } as never)
+  })
+
+  test('prompts signed-out visitors to log in without requesting quotes', async () => {
+    getSession.mockResolvedValue({ data: { session: null }, error: null })
+    const fetchMock = jest.spyOn(global, 'fetch')
+    render(<AuthenticatedQuotingTweetsSidebar targetTweet={targetTweet} />)
+
+    expect(screen.getByText('Log in to see quotes')).toBeVisible()
+    expect(screen.getByRole('link', { name: 'Log in' })).toHaveAttribute(
+      'href',
+      '/login?redirect=%2Ftweets%2F123',
+    )
+    await waitFor(() => expect(getSession).toHaveBeenCalled())
+    expect(fetchMock).not.toHaveBeenCalled()
+    fetchMock.mockRestore()
+  })
+
+  test('loads the first quote page for a signed-in visitor', async () => {
+    getSession.mockResolvedValue({
+      data: { session: { user: { id: 'signed-in-user' } } },
+      error: null,
+    })
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ tweets: [], totalCount: 4, nextOffset: null }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      )
+
+    render(<AuthenticatedQuotingTweetsSidebar targetTweet={targetTweet} />)
+
+    expect(await screen.findByText('Loaded 4 archived quotes')).toBeVisible()
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/tweets/123/quotes?offset=0&limit=12',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+    fetchMock.mockRestore()
+  })
+})

--- a/src/components/AuthenticatedQuotingTweetsSidebar.tsx
+++ b/src/components/AuthenticatedQuotingTweetsSidebar.tsx
@@ -1,0 +1,159 @@
+'use client'
+
+import { useEffect, useMemo, useState, type ReactNode } from 'react'
+import Link from 'next/link'
+import { Loader2, LogIn, Quote } from 'lucide-react'
+import type { TweetData } from '@/components/TweetComponent'
+import QuotingTweetsSidebar from '@/components/QuotingTweetsSidebar'
+import { Button } from '@/components/ui/button'
+import { createBrowserClient } from '@/utils/supabase'
+
+interface AuthenticatedQuotingTweetsSidebarProps {
+  targetTweet: TweetData
+}
+
+interface QuotesPageResponse {
+  tweets: TweetData[]
+  totalCount: number
+  error?: string
+}
+
+type QuoteAccessState =
+  | { status: 'signed-out' }
+  | { status: 'loading' }
+  | { status: 'error'; message: string }
+  | { status: 'ready'; page: QuotesPageResponse }
+
+function SidebarCard({ children }: { children: ReactNode }) {
+  return (
+    <aside className="lg:sticky lg:top-24">
+      <div className="rounded-lg border border-border bg-card px-6 py-8 text-center shadow-sm">
+        {children}
+      </div>
+    </aside>
+  )
+}
+
+export default function AuthenticatedQuotingTweetsSidebar({
+  targetTweet,
+}: AuthenticatedQuotingTweetsSidebarProps) {
+  const supabase = useMemo(() => createBrowserClient(), [])
+  const [state, setState] = useState<QuoteAccessState>({
+    status: 'signed-out',
+  })
+
+  useEffect(() => {
+    const controller = new AbortController()
+    let active = true
+
+    const loadQuotes = async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession()
+      if (!active || controller.signal.aborted) return
+      if (!session) {
+        setState({ status: 'signed-out' })
+        return
+      }
+
+      setState({ status: 'loading' })
+      try {
+        const response = await fetch(
+          `/api/tweets/${encodeURIComponent(targetTweet.tweet_id)}/quotes?offset=0&limit=12`,
+          { signal: controller.signal },
+        )
+        const body = (await response
+          .json()
+          .catch(() => null)) as QuotesPageResponse | null
+        if (!active || controller.signal.aborted) return
+        if (response.status === 401) {
+          setState({ status: 'signed-out' })
+          return
+        }
+        if (!response.ok || !body || !Array.isArray(body.tweets)) {
+          throw new Error(body?.error || 'Could not load archived quotes')
+        }
+        setState({ status: 'ready', page: body })
+      } catch (error) {
+        if (!active || controller.signal.aborted) return
+        setState({
+          status: 'error',
+          message:
+            error instanceof Error
+              ? error.message
+              : 'Could not load archived quotes',
+        })
+      }
+    }
+
+    void loadQuotes()
+    return () => {
+      active = false
+      controller.abort()
+    }
+  }, [supabase, targetTweet.tweet_id])
+
+  if (state.status === 'ready') {
+    return (
+      <QuotingTweetsSidebar
+        tweets={state.page.tweets}
+        totalCount={state.page.totalCount}
+        targetTweet={targetTweet}
+      />
+    )
+  }
+
+  if (state.status === 'loading') {
+    return (
+      <SidebarCard>
+        <Loader2
+          className="mx-auto h-7 w-7 animate-spin text-brand"
+          aria-hidden="true"
+        />
+        <p className="mt-3 text-sm font-medium text-foreground">
+          Loading archived quotes…
+        </p>
+      </SidebarCard>
+    )
+  }
+
+  if (state.status === 'error') {
+    return (
+      <SidebarCard>
+        <Quote
+          className="mx-auto h-7 w-7 text-muted-foreground/60"
+          aria-hidden="true"
+        />
+        <p className="mt-3 text-sm font-medium text-foreground">
+          Archived quotes are temporarily unavailable
+        </p>
+        <p className="mt-1 text-xs leading-5 text-muted-foreground">
+          {state.message}
+        </p>
+      </SidebarCard>
+    )
+  }
+
+  const redirect = `/tweets/${encodeURIComponent(targetTweet.tweet_id)}`
+  return (
+    <SidebarCard>
+      <Quote
+        className="mx-auto h-7 w-7 text-muted-foreground/60"
+        aria-hidden="true"
+      />
+      <h2 className="mt-3 font-semibold text-foreground">
+        Log in to see quotes
+      </h2>
+      <p className="mt-2 text-sm leading-6 text-muted-foreground">
+        Archived tweets quoting this post are available to signed-in Community
+        Archive users.
+      </p>
+      <Button asChild className="mt-5">
+        <Link href={`/login?redirect=${encodeURIComponent(redirect)}`}>
+          <LogIn className="mr-2 h-4 w-4" aria-hidden="true" />
+          Log in
+        </Link>
+      </Button>
+    </SidebarCard>
+  )
+}

--- a/src/components/home/ClassicHomepage.tsx
+++ b/src/components/home/ClassicHomepage.tsx
@@ -11,6 +11,7 @@ import type { PortalData } from '@/lib/portal/types'
 import { createServerClient } from '@/utils/supabase'
 import { getLatestDigestPreview } from '@/lib/digest/data'
 import ExtensionInstallPrompt from '@/components/ExtensionInstallPrompt'
+import { PUBLIC_PORTAL_PREVIEW_LIMIT } from '@/lib/portal/access'
 
 const DynamicHeroCTAButtons = dynamic(
   () => import('@/components/HeroCTAButtons'),
@@ -75,6 +76,7 @@ export default async function ClassicHomepage({
     ? data
     : {
         ...data,
+        initialStream: data.initialStream.slice(0, PUBLIC_PORTAL_PREVIEW_LIMIT),
         trends: { ...data.trends, years: [], series: [] },
       }
 

--- a/src/components/portal/BangersExplorer.test.tsx
+++ b/src/components/portal/BangersExplorer.test.tsx
@@ -127,10 +127,15 @@ function page(
   }
 }
 
-function renderExplorer(initialPage = page(), period?: PortalBangersPeriod) {
+function renderExplorer(
+  initialPage = page(),
+  period?: PortalBangersPeriod,
+  isMember = true,
+) {
   return render(
     <BangersExplorer
       initialPage={initialPage}
+      isMember={isMember}
       scope="all"
       sort="quotes"
       currentYear={2026}
@@ -404,6 +409,20 @@ describe('BangersExplorer', () => {
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     )
     expect(screen.getByText('All 4 matching bangers loaded.')).toBeVisible()
+  })
+
+  test('prompts logged-out visitors to sign in for continuation pages', () => {
+    const fetchMock = jest.spyOn(global, 'fetch')
+    renderExplorer(page(tweets, 3, 4), undefined, false)
+
+    expect(
+      screen.getByRole('link', { name: 'Log in to see more bangers' }),
+    ).toHaveAttribute('href', '/login?redirect=%2Fbangers%3Fperiod%3Dall')
+    expect(
+      screen.queryByRole('button', { name: 'Load more bangers' }),
+    ).not.toBeInTheDocument()
+    expect(IntersectionObserverMock.instances).toHaveLength(0)
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
   test('loads more when the masonry approaches its end', async () => {

--- a/src/components/portal/BangersExplorer.tsx
+++ b/src/components/portal/BangersExplorer.tsx
@@ -24,6 +24,7 @@ import { CARD, MUTED } from './styles'
 
 interface BangersExplorerProps {
   initialPage: PortalBangersPage
+  isMember: boolean
   scope: PortalBangersScope
   sort: PortalBangersSort
   currentYear: number
@@ -191,6 +192,7 @@ function apiHref({
 
 export function BangersExplorer({
   initialPage,
+  isMember,
   scope,
   sort,
   currentYear,
@@ -322,13 +324,13 @@ export function BangersExplorer({
 
   const loadMore = useCallback(() => {
     const nextOffset = page.pagination.nextOffset
-    if (nextOffset === null || query.trim() !== loadedQuery) return
+    if (!isMember || nextOffset === null || query.trim() !== loadedQuery) return
     void requestPage({
       offset: nextOffset,
       requestQuery: loadedQuery,
       replace: false,
     })
-  }, [loadedQuery, page.pagination.nextOffset, query, requestPage])
+  }, [isMember, loadedQuery, page.pagination.nextOffset, query, requestPage])
   const retryLoad = () => {
     const nextQuery = query.trim()
     if (nextQuery !== loadedQuery) {
@@ -348,6 +350,7 @@ export function BangersExplorer({
   }, [loadedQuery, query, requestPage])
 
   useEffect(() => {
+    if (!isMember) return
     const target = loadMoreRef.current
     if (!target || page.pagination.nextOffset === null) return
     const observer = new IntersectionObserver(
@@ -358,7 +361,7 @@ export function BangersExplorer({
     )
     observer.observe(target)
     return () => observer.disconnect()
-  }, [loadMore, page.pagination.nextOffset])
+  }, [isMember, loadMore, page.pagination.nextOffset])
 
   useEffect(
     () => () => {
@@ -750,7 +753,16 @@ export function BangersExplorer({
         </div>
       ) : null}
 
-      {page.pagination.nextOffset !== null ? (
+      {page.pagination.nextOffset !== null && !isMember ? (
+        <div className="min-h-20 flex items-center justify-center py-5">
+          <Link
+            href={`/login?redirect=${encodeURIComponent(currentReturnTo)}`}
+            className="rounded-[3px] border border-zinc-300 px-4 py-2 text-[12.5px] font-semibold text-brand hover:border-brand dark:border-[#3a3a40]"
+          >
+            Log in to see more bangers
+          </Link>
+        </div>
+      ) : page.pagination.nextOffset !== null ? (
         <div
           ref={loadMoreRef}
           data-testid="bangers-load-more-sentinel"

--- a/src/components/portal/Portal.test.tsx
+++ b/src/components/portal/Portal.test.tsx
@@ -175,7 +175,6 @@ describe.each<PortalView>(['home', 'stream'])(
       expect(screen.getByText('preview tweet 3')).toBeInTheDocument()
       expect(screen.getByText('preview tweet 4')).toBeInTheDocument()
       expect(screen.getByText('preview tweet 5')).toBeInTheDocument()
-      expect(screen.getByText('preview tweet 12')).toBeInTheDocument()
       if (view === 'home') {
         expect(screen.getByText('preview tweet 1')).toHaveAttribute(
           'data-no-clamp',
@@ -189,6 +188,8 @@ describe.each<PortalView>(['home', 'stream'])(
           'lg:h-[420px]',
           'lg:min-h-[420px]',
         )
+        expect(screen.queryByText('preview tweet 11')).not.toBeInTheDocument()
+        expect(screen.queryByText('preview tweet 12')).not.toBeInTheDocument()
         expect(screen.queryByText('preview tweet 13')).not.toBeInTheDocument()
       } else {
         expect(screen.getByText('preview tweet 1')).toHaveAttribute(
@@ -198,6 +199,7 @@ describe.each<PortalView>(['home', 'stream'])(
         expect(
           screen.queryByRole('region', { name: 'Live tweet stream' }),
         ).not.toBeInTheDocument()
+        expect(screen.getByText('preview tweet 12')).toBeInTheDocument()
         expect(screen.getByText('preview tweet 13')).toBeInTheDocument()
       }
 
@@ -304,6 +306,32 @@ describe('portal stream page', () => {
     expect(screen.queryByText('Cooling this week')).not.toBeInTheDocument()
 
     unmount()
+  })
+
+  test('keeps the public preview static and prompts for login', async () => {
+    const fetchMock = jest.spyOn(global, 'fetch')
+
+    render(
+      <Portal
+        data={{ ...data, initialStream: previewTweets.slice(0, 10) }}
+        view="stream"
+        isMember={false}
+      />,
+    )
+    await act(async () => {
+      await Promise.resolve()
+      jest.advanceTimersByTime(60_000)
+      await Promise.resolve()
+    })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(screen.getByText('preview tweet 10')).toBeInTheDocument()
+    expect(screen.queryByText('preview tweet 11')).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('link', {
+        name: 'Log in to see more live-stream tweets',
+      }),
+    ).toHaveAttribute('href', '/login?redirect=%2Fstream')
   })
 
   test('jumps a truncated update backlog to the current stream head', async () => {

--- a/src/components/portal/Portal.tsx
+++ b/src/components/portal/Portal.tsx
@@ -23,10 +23,11 @@ import { capturePostHogEvent } from '@/lib/posthog'
 import type { DigestPreview } from '@/lib/digest/types'
 import ExtensionInstallPrompt from '@/components/ExtensionInstallPrompt'
 import { CHROME_EXTENSION_URL } from '@/lib/browserExtension'
+import { PUBLIC_PORTAL_PREVIEW_LIMIT } from '@/lib/portal/access'
 
 export type PortalView = 'home' | 'stream'
 
-const HOME_LIVE_STREAM_LIMIT = 12
+const HOME_LIVE_STREAM_LIMIT = PUBLIC_PORTAL_PREVIEW_LIMIT
 const ARCHIVE_EXPORT_URL = '/docs#bulk-dump'
 const COMMUNITY_BUILDS_URL = '/tweets/1835411943735140798'
 
@@ -498,13 +499,16 @@ export default function Portal({
   const loadingMoreRef = useRef(false)
   const loadMoreTarget = useRef<HTMLDivElement>(null)
   const [hasMore, setHasMore] = useState(
-    !data.failures.initialStream && data.initialStream.length >= 30,
+    isMember &&
+      !data.failures.initialStream &&
+      data.initialStream.length >= PUBLIC_PORTAL_PREVIEW_LIMIT,
   )
   const [isLoadingMore, setIsLoadingMore] = useState(false)
 
   const loadMore = useCallback(async () => {
     if (
       view !== 'stream' ||
+      !isMember ||
       !hasMore ||
       loadingMoreRef.current ||
       !pageCursor.current
@@ -549,9 +553,10 @@ export default function Portal({
       loadingMoreRef.current = false
       setIsLoadingMore(false)
     }
-  }, [hasMore, view])
+  }, [hasMore, isMember, view])
 
   useEffect(() => {
+    if (!isMember) return
     const controller = new AbortController()
     let polling = false
     const applyHead = (tweets: PortalTweet[], nextHasMore: boolean) => {
@@ -654,10 +659,17 @@ export default function Portal({
       controller.abort()
       window.clearInterval(interval)
     }
-  }, [view])
+  }, [isMember, view])
 
   useEffect(() => {
-    if (view !== 'stream' || !hasMore) return
+    if (
+      !isMember ||
+      view !== 'stream' ||
+      !hasMore ||
+      typeof IntersectionObserver === 'undefined'
+    ) {
+      return
+    }
     const target = loadMoreTarget.current
     if (!target) return
     const observer = new IntersectionObserver(
@@ -668,7 +680,7 @@ export default function Portal({
     )
     observer.observe(target)
     return () => observer.disconnect()
-  }, [hasMore, loadMore, view])
+  }, [hasMore, isMember, loadMore, view])
 
   // ---- derived trend views ----------------------------------------------
   const weeklyRanked = useMemo(
@@ -1030,19 +1042,30 @@ export default function Portal({
               </div>
             )}
           </div>
-          <div
-            ref={loadMoreTarget}
-            aria-live="polite"
-            className={`py-5 text-center text-[12.5px] ${MUTED}`}
-          >
-            {isLoadingMore
-              ? 'Loading older tweets…'
-              : hasMore
-                ? 'Scroll for older tweets'
-                : visible.length > 0
-                  ? 'You’ve reached the end.'
-                  : ''}
-          </div>
+          {!isMember && visible.length > 0 ? (
+            <div className="py-5 text-center">
+              <Link
+                href={signInHref('/stream')}
+                className="text-[12.5px] font-semibold text-brand hover:underline"
+              >
+                Log in to see more live-stream tweets
+              </Link>
+            </div>
+          ) : (
+            <div
+              ref={loadMoreTarget}
+              aria-live="polite"
+              className={`py-5 text-center text-[12.5px] ${MUTED}`}
+            >
+              {isLoadingMore
+                ? 'Loading older tweets…'
+                : hasMore
+                  ? 'Scroll for older tweets'
+                  : visible.length > 0
+                    ? 'You’ve reached the end.'
+                    : ''}
+            </div>
+          )}
         </div>
       )}
     </Root>

--- a/src/lib/getTweetPageData.test.ts
+++ b/src/lib/getTweetPageData.test.ts
@@ -131,6 +131,38 @@ describe('getTweetPageData', () => {
     expect(rpc).not.toHaveBeenCalled()
   })
 
+  test('can load a public ClickHouse permalink without requesting quote posts', async () => {
+    const tweet = {
+      tweet_id: '2085473085399150817',
+      account_id: '10',
+      created_at: '2026-08-07T12:00:00.000Z',
+      full_text: 'The linked portal tweet',
+      retweet_count: 4,
+      favorite_count: 25,
+      reply_to_tweet_id: null,
+      quote_tweet_id: null,
+      retweeted_tweet_id: null,
+      avatar_media_url: null,
+      username: 'alice',
+      account_display_name: 'Alice',
+      media: [],
+      urls: [],
+    } satisfies TweetData
+    clickHouseEnabledMock.mockReturnValue(true)
+    fetchClickHouseTweetPageDataMock.mockResolvedValue(tweet)
+
+    await expect(
+      getTweetPageData(tweet.tweet_id, { includeQuotingTweets: false }),
+    ).resolves.toEqual({
+      tweet,
+      threadTree: null,
+      quotingTweets: [],
+      quotingTweetCount: 0,
+    })
+    expect(fetchClickHouseQuotePostsMock).not.toHaveBeenCalled()
+    expect(createServerClientMock).not.toHaveBeenCalled()
+  })
+
   test('keeps the ClickHouse permalink available when quote posts fail', async () => {
     const tweet = {
       tweet_id: '2085473085399150817',

--- a/src/lib/getTweetPageData.ts
+++ b/src/lib/getTweetPageData.ts
@@ -102,6 +102,10 @@ interface TweetPageResult {
   quotingTweetCount: number
 }
 
+interface TweetPageOptions {
+  includeQuotingTweets?: boolean
+}
+
 /**
  * Load portal permalink records and incoming quote posts from the same
  * ClickHouse snapshot when enabled. The Supabase RPC remains the complete
@@ -109,8 +113,12 @@ interface TweetPageResult {
  */
 export async function getTweetPageData(
   tweetId: string,
+  { includeQuotingTweets = true }: TweetPageOptions = {},
 ): Promise<TweetPageResult> {
-  const clickHousePage = await fetchClickHousePage(tweetId)
+  const clickHousePage = await fetchClickHousePage(
+    tweetId,
+    includeQuotingTweets,
+  )
   if (clickHousePage) return clickHousePage
 
   const cookieStore = await cookies()
@@ -133,10 +141,12 @@ export async function getTweetPageData(
   }
 
   const result = data as unknown as RpcResult
-  const quotingTweets = (result.quoting_tweets ?? []).map(buildQuotingTweetData)
-  const quotingTweetCount = Number(
-    result.quoting_tweet_count ?? quotingTweets.length,
-  )
+  const quotingTweets = includeQuotingTweets
+    ? (result.quoting_tweets ?? []).map(buildQuotingTweetData)
+    : []
+  const quotingTweetCount = includeQuotingTweets
+    ? Number(result.quoting_tweet_count ?? quotingTweets.length)
+    : 0
 
   if (!result.tweet) {
     return {
@@ -209,19 +219,30 @@ export async function getTweetPageData(
 
 async function fetchClickHousePage(
   tweetId: string,
+  includeQuotingTweets: boolean,
 ): Promise<TweetPageResult | null> {
   if (!isClickHouseReadsEnabled()) return null
 
   try {
-    const [tweet, quotePosts] = await Promise.all([
-      fetchClickHouseTweetPageData(tweetId),
-      fetchClickHouseQuotePosts(tweetId).catch((error) => {
-        console.error('ClickHouse quote posts failed:', {
-          tweetId,
-          error: error instanceof Error ? error.message : String(error),
+    const tweetPromise = fetchClickHouseTweetPageData(tweetId)
+    const quotePostsPromise = includeQuotingTweets
+      ? fetchClickHouseQuotePosts(tweetId).catch((error) => {
+          console.error('ClickHouse quote posts failed:', {
+            tweetId,
+            error: error instanceof Error ? error.message : String(error),
+          })
+          return {
+            tweets: [],
+            totalCount: 0,
+          } satisfies ClickHouseQuotePostsData
         })
-        return { tweets: [], totalCount: 0 } satisfies ClickHouseQuotePostsData
-      }),
+      : Promise.resolve({
+          tweets: [],
+          totalCount: 0,
+        } satisfies ClickHouseQuotePostsData)
+    const [tweet, quotePosts] = await Promise.all([
+      tweetPromise,
+      quotePostsPromise,
     ])
     if (!tweet) return null
     return {

--- a/src/lib/portal/access.ts
+++ b/src/lib/portal/access.ts
@@ -1,0 +1,1 @@
+export const PUBLIC_PORTAL_PREVIEW_LIMIT = 10

--- a/src/lib/portal/data.ts
+++ b/src/lib/portal/data.ts
@@ -25,6 +25,7 @@ import type {
   PortalTrends,
   PortalTweet,
 } from './types'
+import { PUBLIC_PORTAL_PREVIEW_LIMIT } from './access'
 
 interface PortalReadConfig {
   url: string
@@ -908,6 +909,7 @@ export async function getPortalBangersPage(
 
 export async function getInitialPortalBangersPage(
   options: {
+    limit?: number
     sort?: PortalBangersSort
     scope?: PortalBangersScope
     year?: number
@@ -918,9 +920,13 @@ export async function getInitialPortalBangersPage(
   const scope = options.scope ?? 'all'
   const sort = options.sort ?? 'quotes'
   const query = options.query?.trim() ?? ''
-  if (query || options.period) {
+  const limit = Math.max(
+    1,
+    Math.min(100, Math.trunc(options.limit ?? PORTAL_BANGERS_PAGE_SIZE)),
+  )
+  if (query || options.period || limit !== PORTAL_BANGERS_PAGE_SIZE) {
     return getPortalBangersPage({
-      limit: PORTAL_BANGERS_PAGE_SIZE,
+      limit,
       scope,
       sort,
       ...(options.period ? { period: options.period } : { year: options.year }),
@@ -1010,7 +1016,7 @@ export async function getPortalData(
       () =>
         view === 'home'
           ? getCachedHomepageStreamCandidates(sourceKey)
-          : getPortalStreamPage(30),
+          : getPortalStreamPage(PUBLIC_PORTAL_PREVIEW_LIMIT),
       [],
     ),
     view === 'home'

--- a/src/lib/portalBangersRoute.test.ts
+++ b/src/lib/portalBangersRoute.test.ts
@@ -1,19 +1,24 @@
 import { NextRequest } from 'next/server'
 import { GET } from '@/app/api/portal/bangers/route'
 import { getPortalBangersPage } from '@/lib/portal/data'
+import { getIsMember } from '@/lib/portal/auth'
 
 jest.mock('@/lib/portal/data', () => ({
   getPortalBangersPage: jest.fn(),
   PORTAL_BANGERS_PAGE_SIZE: 30,
 }))
+jest.mock('@/lib/portal/auth', () => ({ getIsMember: jest.fn() }))
 
 const getPortalBangersPageMock = getPortalBangersPage as jest.MockedFunction<
   typeof getPortalBangersPage
 >
+const getIsMemberMock = getIsMember as jest.MockedFunction<typeof getIsMember>
 
 describe('portal bangers route', () => {
   beforeEach(() => {
     getPortalBangersPageMock.mockReset()
+    getIsMemberMock.mockReset()
+    getIsMemberMock.mockResolvedValue(true)
     getPortalBangersPageMock.mockResolvedValue({
       tweets: [],
       pagination: {
@@ -35,7 +40,9 @@ describe('portal bangers route', () => {
 
     expect(response.status).toBe(200)
     expect(response.headers.get('cache-control')).toContain('public')
-    expect(getPortalBangersPageMock).toHaveBeenCalled()
+    expect(getPortalBangersPageMock).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 10, offset: 0 }),
+    )
   })
 
   test('forwards bounded paging, ranking, scope, year, and search', async () => {
@@ -46,6 +53,7 @@ describe('portal bangers route', () => {
     )
 
     expect(response.status).toBe(200)
+    expect(response.headers.get('cache-control')).toBe('private, no-store')
     expect(getPortalBangersPageMock).toHaveBeenCalledWith({
       limit: 30,
       offset: 5001,
@@ -57,6 +65,20 @@ describe('portal bangers route', () => {
     })
   })
 
+  test('requires login for continuation pages', async () => {
+    getIsMemberMock.mockResolvedValue(false)
+
+    const response = await GET(
+      new NextRequest(
+        'https://community-archive.org/api/portal/bangers?offset=10',
+      ),
+    )
+
+    expect(response.status).toBe(401)
+    expect(response.headers.get('cache-control')).toBe('private, no-store')
+    expect(getPortalBangersPageMock).not.toHaveBeenCalled()
+  })
+
   test('forwards this-week filtering instead of a year', async () => {
     const response = await GET(
       new NextRequest(
@@ -66,7 +88,7 @@ describe('portal bangers route', () => {
 
     expect(response.status).toBe(200)
     expect(getPortalBangersPageMock).toHaveBeenCalledWith({
-      limit: 30,
+      limit: 10,
       offset: 0,
       scope: 'all',
       sort: 'quotes',

--- a/src/lib/portalStreamRoute.test.ts
+++ b/src/lib/portalStreamRoute.test.ts
@@ -1,22 +1,27 @@
 import { NextRequest } from 'next/server'
 import { GET } from '@/app/api/portal/stream/route'
 import { getPortalStreamPage, getPortalStreamUpdates } from '@/lib/portal/data'
+import { getIsMember } from '@/lib/portal/auth'
 
 jest.mock('@/lib/portal/data', () => ({
   getPortalStreamPage: jest.fn(),
   getPortalStreamUpdates: jest.fn(),
 }))
+jest.mock('@/lib/portal/auth', () => ({ getIsMember: jest.fn() }))
 
 const getPortalStreamPageMock = getPortalStreamPage as jest.MockedFunction<
   typeof getPortalStreamPage
 >
 const getPortalStreamUpdatesMock =
   getPortalStreamUpdates as jest.MockedFunction<typeof getPortalStreamUpdates>
+const getIsMemberMock = getIsMember as jest.MockedFunction<typeof getIsMember>
 
 describe('portal stream route', () => {
   beforeEach(() => {
     getPortalStreamPageMock.mockReset()
     getPortalStreamUpdatesMock.mockReset()
+    getIsMemberMock.mockReset()
+    getIsMemberMock.mockResolvedValue(true)
   })
 
   test('forwards a validated composite observation cursor', async () => {
@@ -108,9 +113,7 @@ describe('portal stream route', () => {
       createdAt: '2026-08-07T12:00:00.000Z',
       id: '201',
     })
-    expect(response.headers.get('cache-control')).toBe(
-      'public, s-maxage=15, stale-while-revalidate=30',
-    )
+    expect(response.headers.get('cache-control')).toBe('private, no-store')
     await expect(response.json()).resolves.toMatchObject({
       tweets: expect.arrayContaining([expect.objectContaining({ id: '200' })]),
       nextCursor: {
@@ -129,6 +132,23 @@ describe('portal stream route', () => {
     )
 
     expect(response.headers.get('cache-control')).toBe('private, no-store')
+    expect(getPortalStreamPageMock).toHaveBeenCalledWith(11, undefined)
+    expect(getIsMemberMock).not.toHaveBeenCalled()
+  })
+
+  test('requires login for polling and older pages', async () => {
+    getIsMemberMock.mockResolvedValue(false)
+
+    const response = await GET(
+      new NextRequest(
+        'https://community-archive.org/api/portal/stream?before=2026-08-07T12%3A00%3A00.000Z&beforeId=201',
+      ),
+    )
+
+    expect(response.status).toBe(401)
+    expect(response.headers.get('cache-control')).toBe('private, no-store')
+    expect(getPortalStreamPageMock).not.toHaveBeenCalled()
+    expect(getPortalStreamUpdatesMock).not.toHaveBeenCalled()
   })
 
   test('rejects malformed cursors before reading data', async () => {


### PR DESCRIPTION
## What changed

- stop public tweet-page renders from fetching ClickHouse quote evidence
- show logged-out visitors a “Log in to see quotes” prompt and enforce authentication in the quote API
- keep the first 10 Bangers and live-stream tweets public
- require login for Bangers continuation pages, live-stream polling, and older live-stream pages
- show login prompts instead of anonymous infinite-scroll controls

## Why

Automated anonymous traffic was amplifying public page views into expensive analytics gateway queries. Tweet permalinks and small discovery previews remain public, while quote evidence and bulk browsing now require a signed-in account.

Archive downloads were reviewed but did not need a change: the existing route already requires an authenticated session, matches the requested archive to the signed-in Twitter username, checks upload policy, and returns only a 60-second signed URL.

## Validation

- focused Jest run: 8 suites, 67 tests passed
- `git diff --check` passed
- repository pre-commit hook could not generate local Supabase types because Docker/Supabase was not running; no schema or generated-type files changed
