### PR TITLE
[codex] Default digest to member-authored bangers

### DIFF
--- a/docs/daily-digest.md
+++ b/docs/daily-digest.md
@@ -73,8 +73,9 @@ non-production environment. Do not set it in production.
 
 - ClickHouse is the analytical source for candidates and archived quote-post
   commentary. The current `recent-bangers` ranking counts distinct non-self
-  quote tweets from Community Archive members against targets authored in the
-  selected time window. A run keeps only the top `min(50,
+  quote tweets from Community Archive members. Digest pulls restrict target
+  authors to current Community Archive members in the selected time window. A
+  run keeps only the top `min(50,
 num_bangers_with_score_at_least_2)` rows: every included post has a Community
   Archive banger score of at least two, and there are never more than 50.
 - The existing Supabase tweet-page RPC supplies in-window conversation replies

--- a/src/app/admin/digest/actions.ts
+++ b/src/app/admin/digest/actions.ts
@@ -304,7 +304,13 @@ export async function createDigestRunAction(formData: FormData) {
   try {
     const windowEnd = new Date()
     const windowStart = new Date(windowEnd.getTime() - 24 * 60 * 60 * 1_000)
-    const tweets = await fetchPortalRecentBangers(50, 24)
+    const tweets = await fetchPortalRecentBangers(
+      50,
+      24,
+      undefined,
+      undefined,
+      true,
+    )
     const candidates: DigestCandidate[] = selectDailyDigestBangers(tweets).map(
       (tweet, index) => ({
         tweet,
@@ -315,11 +321,12 @@ export async function createDigestRunAction(formData: FormData) {
     const initialEvent = event(
       'candidates',
       'completed',
-      'Saved up to 50 rolling 24-hour posts with a Community Archive banger score of at least two.',
+      'Saved up to 50 rolling 24-hour posts authored by current Community Archive members with a banger score of at least two.',
       {
         candidate_count: candidates.length,
         default_selected_count: candidates.length,
         minimum_ca_quote_count: 2,
+        target_author_population: 'community_members',
       },
     )
     const { data: run, error } = await admin
@@ -404,6 +411,7 @@ export async function createAndGenerateDigestDateAction(formData: FormData) {
       24,
       undefined,
       window.windowEnd,
+      true,
     )
     const candidates: DigestCandidate[] = selectDailyDigestBangers(tweets).map(
       (tweet, index) => ({
@@ -415,11 +423,12 @@ export async function createAndGenerateDigestDateAction(formData: FormData) {
     const initialEvent = event(
       'candidates',
       'completed',
-      `Saved up to 50 bangers authored during the ${digestDate} Community Archive day (06:00 UTC to 05:59 UTC).`,
+      `Saved up to 50 bangers by current Community Archive members authored during the ${digestDate} Community Archive day (06:00 UTC to 05:59 UTC).`,
       {
         candidate_count: candidates.length,
         default_selected_count: candidates.length,
         minimum_ca_quote_count: 2,
+        target_author_population: 'community_members',
         historical_window: true,
       },
     )

--- a/src/app/admin/digest/page.tsx
+++ b/src/app/admin/digest/page.tsx
@@ -452,8 +452,9 @@ export default async function DigestLabPage({
                         Candidate selection
                       </h2>
                       <p className="mt-1 text-sm text-muted-foreground">
-                        Up to 50 posts with a Community Archive banger score of
-                        at least two, ranked strongest first.
+                        Up to 50 posts authored by current Community Archive
+                        members with a banger score of at least two, ranked
+                        strongest first.
                       </p>
                     </div>
                     <span className="text-xs text-muted-foreground">

--- a/src/lib/clickhouseGateway.ts
+++ b/src/lib/clickhouseGateway.ts
@@ -25,7 +25,7 @@ const ALLOWED_ENDPOINTS: Record<string, ReadonlySet<string>> = {
   'trend-evidence': new Set(['q', 'mode', 'since', 'until', 'limit']),
   'word-trend': new Set(['q', 'bucket', 'match', 'from', 'to']),
   'stream-stats': new Set(['start', 'end', 'granularity', 'scope']),
-  'recent-bangers': new Set(['limit', 'hours', 'end']),
+  'recent-bangers': new Set(['limit', 'hours', 'end', 'target_ca_users_only']),
   'portal-stream': new Set([
     'limit',
     'before',

--- a/src/lib/portal/analytics.test.ts
+++ b/src/lib/portal/analytics.test.ts
@@ -355,13 +355,20 @@ describe('ClickHouse-backed portal analytics', () => {
       new URLSearchParams({ limit: '50', hours: '168' }),
       { timeoutMs: 30_000, revalidate: 1_800 },
     )
-    await fetchPortalRecentBangers(50, 24, fetcher, '2026-08-12T07:00:00.000Z')
+    await fetchPortalRecentBangers(
+      50,
+      24,
+      fetcher,
+      '2026-08-12T07:00:00.000Z',
+      true,
+    )
     expect(fetcher).toHaveBeenLastCalledWith(
       ['recent-bangers'],
       new URLSearchParams({
         limit: '50',
         hours: '24',
         end: '2026-08-12T07:00:00.000Z',
+        target_ca_users_only: 'true',
       }),
       { timeoutMs: 30_000, revalidate: 1_800 },
     )

--- a/src/lib/portal/analytics.ts
+++ b/src/lib/portal/analytics.ts
@@ -454,12 +454,13 @@ export async function fetchPortalLiveAnalytics(
   }
 }
 
-/** Recent original posts from current archive uploaders and opted-in members. */
+/** Recent posts ranked by quotes from current archive uploaders and opted-in members. */
 export async function fetchPortalRecentBangers(
   limit = 50,
   hours = 48,
   fetcher: AnalyticsFetcher = fetchAnalyticsGatewayJson,
   end?: string,
+  targetCommunityUsersOnly = false,
 ): Promise<PortalTweet[]> {
   const safeLimit = Math.max(1, Math.min(50, Math.trunc(limit)))
   const safeHours = Math.max(1, Math.min(168, Math.trunc(hours)))
@@ -469,6 +470,7 @@ export async function fetchPortalRecentBangers(
       limit: String(safeLimit),
       hours: String(safeHours),
       ...(end ? { end: safeTimestamp(end, 'window end') } : {}),
+      ...(targetCommunityUsersOnly ? { target_ca_users_only: 'true' } : {}),
     }),
     { timeoutMs: 30_000, revalidate: 1_800 },
   )


### PR DESCRIPTION
## What changed

- Makes rolling and historical Daily Digest candidate pulls request only bangers authored by current Community Archive members.
- Preserves the existing score threshold of at least two qualifying CA-member quote posts.
- Updates the digest lab copy, run events, gateway forwarding allowlist, tests, and digest documentation.

## Why

Digest candidates were ranked by quotes from CA members but could be authored by accounts outside the archive. The default digest selection should represent CA authors.

## Dependency

- Requires https://github.com/TheExGenesis/community-archive-control-panel/pull/153 to be merged, deployed, and smoke-tested first.

## Validation

- `jest --selectProjects server --runTestsByPath src/lib/portal/analytics.test.ts --runInBand` (10 tests)
- `tsc --pretty --noEmit`

No deployment is included in this PR.