### PR TITLE
[codex] Add Christine to admin access

### DIFF
--- a/src/app/admin/data.ts
+++ b/src/app/admin/data.ts
@@ -4,6 +4,7 @@ import { notFound, redirect } from 'next/navigation'
 import { getCurrentUser } from '@/lib/portal/auth'
 
 export const ADMIN_USERNAME = 'exgenesis'
+export const ADMIN_USERNAMES = [ADMIN_USERNAME, 'christineist'] as const
 const PRODUCTION_SUPABASE_HOST = 'fabxmporizzqflnftavs.supabase.co'
 
 export const ACCOUNTS_PAGE_SIZE = 25
@@ -125,6 +126,13 @@ export const getTwitterProviderId = (user: User): string | null => {
 const ADMIN_TWITTER_PROVIDER_ID =
   process.env.ADMIN_TWITTER_PROVIDER_ID?.trim() || null
 
+const ADMIN_TWITTER_IDENTITIES = new Map<string, string | null>([
+  [ADMIN_USERNAME, ADMIN_TWITTER_PROVIDER_ID],
+  // Public X account id for @christineist. Binding the handle to the immutable
+  // provider id prevents a future handle transfer from granting admin access.
+  ['christineist', '826134955549790208'],
+])
+
 const isKnownProductionSupabase = () =>
   process.env.NEXT_PUBLIC_SUPABASE_URL?.includes(PRODUCTION_SUPABASE_HOST) ??
   false
@@ -155,10 +163,10 @@ function getStagingAdminUsername(user: User): string | null {
 // Pure predicate: is this user the configured real admin? No redirects.
 // Two paths:
 //
-//   1. Real Twitter OAuth identity matches ADMIN_USERNAME. On prod, this
-//      is the only path that returns true — guarded by username plus,
-//      when ADMIN_TWITTER_PROVIDER_ID is set, the immutable Twitter
-//      numeric id (belt-and-suspenders against a future handle takeover).
+//   1. Real Twitter OAuth identity matches an entry in
+//      ADMIN_TWITTER_IDENTITIES. On prod, this is the only path that returns
+//      true. Each configured immutable Twitter numeric id must match too.
+//      ADMIN_USERNAME keeps its legacy environment-configured id behavior.
 //
 //   2. (staging only) app_metadata.user_name is in the
 //      STAGING_ADMIN_USERNAMES allowlist. The dev-login route sets
@@ -167,9 +175,10 @@ function getStagingAdminUsername(user: User): string | null {
 //      regular auth API — so this is a safe identity claim on staging.
 export function isAdminUser(user: User): boolean {
   const twitterUsername = getTwitterUsername(user)
-  if (twitterUsername === ADMIN_USERNAME) {
-    if (ADMIN_TWITTER_PROVIDER_ID === null) return true
-    return getTwitterProviderId(user) === ADMIN_TWITTER_PROVIDER_ID
+  if (twitterUsername && ADMIN_TWITTER_IDENTITIES.has(twitterUsername)) {
+    const requiredProviderId = ADMIN_TWITTER_IDENTITIES.get(twitterUsername)
+    if (requiredProviderId === null) return true
+    return getTwitterProviderId(user) === requiredProviderId
   }
   const stagingName = getStagingAdminUsername(user)
   if (stagingName && STAGING_ADMIN_USERNAMES.has(stagingName)) return true

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -12,7 +12,7 @@ import { AdminTable } from './AdminTable'
 import { RecentPrivacyActivity } from './RecentPrivacyActivity'
 import { loadRecentPrivacyActivity } from './activity'
 import {
-  ADMIN_USERNAME,
+  ADMIN_USERNAMES,
   getDisplayUsername,
   loadInitialAccounts,
   normalizeUsername,
@@ -102,9 +102,11 @@ export default async function AdminPage({
                 Community Archive admin dashboard
               </h1>
               <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
-                Visible only to @{ADMIN_USERNAME}, with staging-only dev access
-                when enabled. Reads and mutations use the server-side Supabase
-                service role after the identity gate passes.
+                Visible only to{' '}
+                {ADMIN_USERNAMES.map((name) => `@${name}`).join(' and ')}, with
+                staging-only dev access when enabled. Reads and mutations use
+                the server-side Supabase service role after the identity gate
+                passes.
               </p>
             </div>
             <Badge variant="secondary">@{twitterUsername}</Badge>

--- a/tests/admin-access.test.ts
+++ b/tests/admin-access.test.ts
@@ -1,0 +1,49 @@
+import { isAdminUser } from '@/app/admin/data'
+import type { User } from '@supabase/supabase-js'
+
+const twitterUser = (username: string, providerId: string) =>
+  ({
+    id: 'auth-user-id',
+    app_metadata: {},
+    user_metadata: {},
+    aud: 'authenticated',
+    created_at: '2026-08-19T00:00:00Z',
+    identities: [
+      {
+        id: providerId,
+        user_id: 'auth-user-id',
+        identity_data: {
+          user_name: username,
+          provider_id: providerId,
+        },
+        provider: 'twitter',
+        created_at: '2026-08-19T00:00:00Z',
+        updated_at: '2026-08-19T00:00:00Z',
+      },
+    ],
+  }) as User
+
+describe('admin identity gate', () => {
+  it('grants Christine admin access using her X handle and immutable account id', () => {
+    expect(
+      isAdminUser(twitterUser('@ChristineIst', '826134955549790208')),
+    ).toBe(true)
+  })
+
+  it('rejects the same handle when the immutable X account id does not match', () => {
+    expect(isAdminUser(twitterUser('christineist', 'different-account'))).toBe(
+      false,
+    )
+  })
+
+  it('rejects Twitter identities outside the explicit admin allowlist', () => {
+    expect(isAdminUser(twitterUser('not_an_admin', '123'))).toBe(false)
+  })
+
+  it('does not trust user-mutable metadata for admin identity', () => {
+    const user = twitterUser('not_an_admin', '123')
+    user.user_metadata = { user_name: 'christineist' }
+
+    expect(isAdminUser(user)).toBe(false)
+  })
+})


### PR DESCRIPTION
## What changed

- add `christineist` to the production admin identity allowlist
- bind the handle to immutable X account ID `826134955549790208`
- update the admin dashboard access description for both admins
- add focused regression tests for valid access, provider-ID mismatch, unknown identities, and mutable-metadata spoofing

## Why

Christine needs access to the Community Archive admin dashboard. The immutable provider-ID check ensures a future transfer of the `christineist` handle would not transfer admin access.

## Validation

- `pnpm jest --selectProjects server --runInBand tests/admin-access.test.ts`
- 4 tests passed

The repository pre-commit hook could not generate local Supabase types because the fresh worktree did not have `SUPABASE_AUTH_TWITTER_CLIENT_ID` or a running local Supabase instance. No generated type files are part of this change.
