### PR TITLE
Profile chapters: quoted-title sections, curated + auto-generated

### DIFF
--- a/src/app/user/[account_id]/page.tsx
+++ b/src/app/user/[account_id]/page.tsx
@@ -18,10 +18,15 @@ import {
 } from '@/lib/metaTwitter/profilePagination'
 import { getCachedArchivedAt } from '@/lib/metaTwitter/data'
 import { resolveProfile } from '@/lib/metaTwitter/profile'
+import {
+  curatedSectionsByYear,
+  type SectionsByYear,
+} from '@/lib/metaTwitter/chapterSections'
+import { getGeneratedSections } from '@/lib/metaTwitter/generatedSections'
 
 interface PageProps {
   params: { account_id: string }
-  searchParams: { chapter?: string; username?: string }
+  searchParams: { chapter?: string; section?: string; username?: string }
 }
 
 export async function generateMetadata({
@@ -61,12 +66,14 @@ async function ProfileArchiveContent({
   avatarUrl,
   basePath,
   candidateYear,
+  candidateSection,
   displayName,
 }: {
   accountId: string
   avatarUrl: string | null
   basePath: string
   candidateYear: number | null
+  candidateSection: string | null
   displayName: string
 }) {
   const candidatePage = await getCuratedProfileBangersPage(accountId, {
@@ -84,6 +91,30 @@ async function ProfileArchiveContent({
 
   const navChapters: NavChapter[] = initialPage.yearCounts
 
+  // Hand-curated sections win; anyone else gets a one-time generated split,
+  // cached server-side. When banger data is unavailable we make no claim
+  // about sections at all.
+  let sectionsByYear: SectionsByYear = {}
+  let sectionsNote: string | null = null
+  if (initialPage.available) {
+    const curated = curatedSectionsByYear(accountId)
+    if (curated) {
+      sectionsByYear = curated
+    } else {
+      const bangerCount = navChapters.reduce(
+        (total, chapter) => total + chapter.count,
+        0,
+      )
+      const generated = await getGeneratedSections(accountId, bangerCount)
+      if (generated.status === 'generated') {
+        sectionsByYear = generated.sectionsByYear
+      } else if (generated.status === 'insufficient') {
+        sectionsNote =
+          'Not enough widely-quoted posts yet to split this archive into sections.'
+      }
+    }
+  }
+
   return (
     <ProfileArchive
       accountId={accountId}
@@ -92,7 +123,10 @@ async function ProfileArchiveContent({
       chapters={navChapters}
       displayName={displayName}
       initialYear={year}
+      initialSectionSlug={year === candidateYear ? candidateSection : null}
       initialPage={initialPage}
+      sectionsByYear={sectionsByYear}
+      sectionsNote={sectionsNote}
     />
   )
 }
@@ -131,12 +165,21 @@ export default async function UserPage({ params, searchParams }: PageProps) {
     requestedYear <= new Date().getUTCFullYear() + 1
       ? requestedYear
       : null
+  // Sections may be generated during render, so the slug is validated inside
+  // the archive content; here it only has to be shaped like a slug.
+  const candidateSection =
+    candidateYear &&
+    searchParams.section &&
+    /^[a-z0-9-]{1,64}$/.test(searchParams.section)
+      ? searchParams.section
+      : null
 
   const requestedProfilePath = `/user/${encodeURIComponent(params.account_id)}`
   const canonicalProfilePath = userProfileHref(profile.username, accountId)
   if (canonicalProfilePath !== requestedProfilePath) {
     const canonicalParams = new URLSearchParams()
     if (candidateYear) canonicalParams.set('chapter', String(candidateYear))
+    if (candidateSection) canonicalParams.set('section', candidateSection)
     const canonicalQuery = canonicalParams.toString()
     redirect(
       `${canonicalProfilePath}${canonicalQuery ? `?${canonicalQuery}` : ''}`,
@@ -166,6 +209,7 @@ export default async function UserPage({ params, searchParams }: PageProps) {
               avatarUrl={profile.avatar_media_url}
               basePath={canonicalProfilePath}
               candidateYear={candidateYear}
+              candidateSection={candidateSection}
               displayName={profile.account_display_name}
             />
           </Suspense>

--- a/src/components/metaTwitter/ArchiveNav.tsx
+++ b/src/components/metaTwitter/ArchiveNav.tsx
@@ -1,19 +1,26 @@
 'use client'
 
 import Link from 'next/link'
-import type { MouseEvent } from 'react'
+import { Fragment, type MouseEvent, type ReactNode } from 'react'
 import { formatNumber } from '@/lib/formatNumber'
+import type { ChapterSection } from '@/lib/metaTwitter/chapterSections'
 
 export interface NavChapter {
   year: number
   count: number
 }
 
-export const archiveChapterHref = (basePath: string, year: number | null) => {
+export const archiveChapterHref = (
+  basePath: string,
+  year: number | null,
+  sectionSlug: string | null = null,
+) => {
   const [pathname, query = ''] = basePath.split('?', 2)
   const params = new URLSearchParams(query)
   if (year === null) params.delete('chapter')
   else params.set('chapter', String(year))
+  if (year === null || sectionSlug === null) params.delete('section')
+  else params.set('section', sectionSlug)
   const serialized = params.toString()
   return serialized ? `${pathname}?${serialized}` : pathname
 }
@@ -22,29 +29,45 @@ export function ArchiveNav({
   basePath,
   chapters,
   activeYear,
+  sectionsByYear = {},
+  activeSectionSlug = null,
   onSelect,
+  onSelectSection,
+  footer,
 }: {
   basePath: string
   chapters: NavChapter[]
   activeYear: number | null
+  /** Curated sections per chapter year; every chapter lists its own. */
+  sectionsByYear?: Record<number, ChapterSection[]>
+  activeSectionSlug?: string | null
   onSelect?: (year: number | null) => void
+  onSelectSection?: (year: number, slug: string | null) => void
+  /** Rendered after the chapter list; wide layout only. */
+  footer?: ReactNode
 }) {
+  const intercepts = (event: MouseEvent<HTMLAnchorElement>) =>
+    event.button === 0 &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.shiftKey &&
+    !event.altKey
   const select = (
     event: MouseEvent<HTMLAnchorElement>,
     year: number | null,
   ) => {
-    if (
-      !onSelect ||
-      event.button !== 0 ||
-      event.metaKey ||
-      event.ctrlKey ||
-      event.shiftKey ||
-      event.altKey
-    ) {
-      return
-    }
+    if (!onSelect || !intercepts(event)) return
     event.preventDefault()
     onSelect(year)
+  }
+  const selectSection = (
+    event: MouseEvent<HTMLAnchorElement>,
+    year: number,
+    slug: string | null,
+  ) => {
+    if (!onSelectSection || !intercepts(event)) return
+    event.preventDefault()
+    onSelectSection(year, slug)
   }
   const isOverall = activeYear === null
   return (
@@ -70,26 +93,73 @@ export function ArchiveNav({
       </Link>
       {chapters.map((chapter) => {
         const active = activeYear === chapter.year
+        const sections = sectionsByYear[chapter.year] ?? []
         return (
-          <Link
-            key={chapter.year}
-            href={archiveChapterHref(basePath, chapter.year)}
-            prefetch={false}
-            onClick={(event) => select(event, chapter.year)}
-            aria-current={active ? 'page' : undefined}
-            className={`flex whitespace-nowrap rounded-lg px-3 py-2 text-sm lg:mt-1 lg:justify-between ${
-              active
-                ? 'bg-accent font-bold text-accent-foreground'
-                : 'text-foreground/80 hover:bg-muted hover:text-foreground'
-            }`}
-          >
-            <span>{chapter.year}</span>
-            <span className="ml-2 text-xs text-muted-foreground">
-              {formatNumber(chapter.count)}
-            </span>
-          </Link>
+          <Fragment key={chapter.year}>
+            {/* The compact nav hides sections, so the year is always its
+                control there; the wide nav keeps the year clickable only for
+                chapters with no sections of their own. */}
+            <Link
+              href={archiveChapterHref(basePath, chapter.year)}
+              prefetch={false}
+              onClick={(event) => select(event, chapter.year)}
+              aria-current={active ? 'page' : undefined}
+              className={`flex whitespace-nowrap rounded-lg px-3 py-2 text-sm ${
+                sections.length ? 'lg:hidden' : 'lg:mt-1 lg:justify-between'
+              } ${
+                active
+                  ? 'bg-accent font-bold text-accent-foreground'
+                  : 'text-foreground/80 hover:bg-muted hover:text-foreground'
+              }`}
+            >
+              <span>{chapter.year}</span>
+              <span className="ml-2 text-xs text-muted-foreground">
+                {formatNumber(chapter.count)}
+              </span>
+            </Link>
+            {sections.length > 0 && (
+              <div className="hidden whitespace-nowrap px-3 py-2 text-sm text-foreground/80 lg:mt-1 lg:flex lg:justify-between">
+                <span>{chapter.year}</span>
+                <span className="ml-2 text-xs text-muted-foreground">
+                  {formatNumber(chapter.count)}
+                </span>
+              </div>
+            )}
+            {sections.map((section) => {
+              const sectionActive = active && activeSectionSlug === section.slug
+              return (
+                <Link
+                  key={section.slug}
+                  href={archiveChapterHref(
+                    basePath,
+                    chapter.year,
+                    section.slug,
+                  )}
+                  prefetch={false}
+                  onClick={(event) =>
+                    selectSection(
+                      event,
+                      chapter.year,
+                      sectionActive ? null : section.slug,
+                    )
+                  }
+                  aria-current={sectionActive ? 'page' : undefined}
+                  // Titles like "everything else" repeat across chapters.
+                  aria-label={`${section.title}, ${chapter.year}`}
+                  className={`hidden rounded-lg px-3 py-1.5 text-[13px] leading-snug lg:mt-0.5 lg:line-clamp-2 lg:block ${
+                    sectionActive
+                      ? 'bg-muted font-semibold text-foreground'
+                      : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                  }`}
+                >
+                  {section.title}
+                </Link>
+              )
+            })}
+          </Fragment>
         )
       })}
+      {footer ? <div className="hidden lg:block">{footer}</div> : null}
     </nav>
   )
 }

--- a/src/components/metaTwitter/ProfileArchive.test.tsx
+++ b/src/components/metaTwitter/ProfileArchive.test.tsx
@@ -5,6 +5,7 @@ import { archiveChapterHref } from './ArchiveNav'
 import { ProfileArchive } from './ProfileArchive'
 import { ProfileEditButton } from './ProfileEditButton'
 import { ProfileEditingProvider } from './ProfileEditingContext'
+import { curatedSectionsByYear } from '@/lib/metaTwitter/chapterSections'
 import type { BangerTweet } from '@/lib/metaTwitter/types'
 import { mutateProfileCuration } from '@/app/user/[account_id]/actions'
 
@@ -774,4 +775,214 @@ test('does not start a stale chapter preload over an in-flight active feed', asy
       String(input).includes('offset=0&limit=2&sort=quotes&year=2025'),
     ),
   ).toHaveLength(1)
+})
+
+const CURATED_ACCOUNT_ID = '826134955549790208'
+const curatedSections = curatedSectionsByYear(CURATED_ACCOUNT_ID)!
+
+test('opens a chapter subsection and titles the workspace with its quote', async () => {
+  const user = userEvent.setup()
+  jest.spyOn(global, 'fetch').mockImplementation(() => new Promise(() => {}))
+  const [section] = curatedSections[2025]
+  const [otherSection] = curatedSections[2024]
+
+  renderProfileArchive(
+    <ProfileArchive
+      accountId={CURATED_ACCOUNT_ID}
+      avatarUrl={null}
+      basePath="/user/alice"
+      chapters={chapters}
+      displayName="Alice"
+      sectionsByYear={curatedSections}
+      initialYear={2025}
+      initialPage={{
+        tweets: [banger(1, 2025)],
+        yearCounts: chapters,
+        total: 1,
+        nextOffset: null,
+        available: true,
+      }}
+      initialSidebar={initialSidebar}
+    />,
+  )
+
+  // Every chapter lists its sections, open or not.
+  expect(
+    screen.getByRole('link', { name: `${otherSection.title}, 2024` }),
+  ).toBeVisible()
+
+  await user.click(screen.getByRole('link', { name: `${section.title}, 2025` }))
+
+  expect(window.location.pathname + window.location.search).toBe(
+    `/user/alice?chapter=2025&section=${section.slug}`,
+  )
+  expect(screen.getByRole('heading', { name: section.title })).toBeVisible()
+  // One per breakpoint: the compact nav marks the year, the wide nav the
+  // section it lists under that year.
+  expect(screen.getAllByRole('link', { current: 'page' })).toHaveLength(2)
+
+  // A section from another chapter switches chapters with it.
+  await user.click(
+    screen.getByRole('link', { name: `${otherSection.title}, 2024` }),
+  )
+  expect(window.location.pathname + window.location.search).toBe(
+    `/user/alice?chapter=2024&section=${otherSection.slug}`,
+  )
+  expect(
+    screen.getByRole('heading', { name: otherSection.title }),
+  ).toBeVisible()
+
+  // Leaving the chapter drops the section from the URL.
+  await user.click(screen.getByRole('link', { name: '2024 3' }))
+  expect(window.location.pathname + window.location.search).toBe(
+    '/user/alice?chapter=2024',
+  )
+  expect(screen.getByRole('heading', { name: 'Best of 2024' })).toBeVisible()
+})
+
+test('restores a subsection from an initial URL and from browser history', async () => {
+  const user = userEvent.setup()
+  jest.spyOn(global, 'fetch').mockImplementation(() => new Promise(() => {}))
+  const [section] = curatedSections[2025]
+  window.history.replaceState(
+    null,
+    '',
+    `/user/alice?chapter=2025&section=${section.slug}`,
+  )
+
+  renderProfileArchive(
+    <ProfileArchive
+      accountId={CURATED_ACCOUNT_ID}
+      avatarUrl={null}
+      basePath="/user/alice"
+      chapters={chapters}
+      displayName="Alice"
+      sectionsByYear={curatedSections}
+      initialYear={2025}
+      initialSectionSlug={section.slug}
+      initialPage={{
+        tweets: [banger(1, 2025)],
+        yearCounts: chapters,
+        total: 1,
+        nextOffset: null,
+        available: true,
+      }}
+      initialSidebar={initialSidebar}
+    />,
+  )
+
+  expect(screen.getByRole('heading', { name: section.title })).toBeVisible()
+
+  await user.click(screen.getByRole('link', { name: '2025 4' }))
+  expect(screen.getByRole('heading', { name: 'Best of 2025' })).toBeVisible()
+
+  act(() => {
+    window.history.back()
+    window.dispatchEvent(new PopStateEvent('popstate'))
+  })
+
+  await waitFor(() =>
+    expect(screen.getByRole('heading', { name: section.title })).toBeVisible(),
+  )
+})
+
+test('filters a chapter down to the selected section, catch-all included', async () => {
+  const user = userEvent.setup()
+  jest.spyOn(global, 'fetch').mockImplementation(() => new Promise(() => {}))
+  const sections = curatedSections[2025]
+  const [curated] = sections
+  const everythingElse = sections[sections.length - 1]
+  const tweets = [
+    { ...banger(1, 2025), tweet_id: curated.tweetIds[0], full_text: 'curated' },
+    { ...banger(2, 2025), tweet_id: '999', full_text: 'uncurated' },
+  ]
+
+  renderProfileArchive(
+    <ProfileArchive
+      accountId={CURATED_ACCOUNT_ID}
+      avatarUrl={null}
+      basePath="/user/alice"
+      chapters={chapters}
+      displayName="Alice"
+      sectionsByYear={curatedSections}
+      initialYear={2025}
+      initialPage={{
+        tweets,
+        yearCounts: chapters,
+        total: tweets.length,
+        nextOffset: null,
+        available: true,
+      }}
+      initialSidebar={initialSidebar}
+    />,
+  )
+
+  // The whole chapter until a section narrows it.
+  expect(screen.getByText('curated')).toBeVisible()
+  expect(screen.getByText('uncurated')).toBeVisible()
+
+  await user.click(screen.getByRole('link', { name: `${curated.title}, 2025` }))
+  expect(screen.getByText('curated')).toBeVisible()
+  expect(screen.queryByText('uncurated')).not.toBeInTheDocument()
+
+  await user.click(
+    screen.getByRole('link', { name: `${everythingElse.title}, 2025` }),
+  )
+  expect(screen.getByText('uncurated')).toBeVisible()
+  expect(screen.queryByText('curated')).not.toBeInTheDocument()
+})
+
+test('shows the sections note under the chapter list', () => {
+  jest.spyOn(global, 'fetch').mockImplementation(() => new Promise(() => {}))
+
+  renderProfileArchive(
+    <ProfileArchive
+      accountId="43"
+      avatarUrl={null}
+      basePath="/user/carol"
+      chapters={[{ year: 2025, count: 2 }]}
+      displayName="Carol"
+      initialYear={null}
+      initialPage={{
+        tweets: [],
+        yearCounts: [{ year: 2025, count: 2 }],
+        total: 2,
+        nextOffset: null,
+        available: true,
+      }}
+      initialSidebar={initialSidebar}
+      sectionsNote="Not enough widely-quoted posts yet to split this archive into sections."
+    />,
+  )
+
+  expect(screen.getByText(/Not enough widely-quoted posts yet/)).toBeVisible()
+})
+
+test('shows no note or sections when none are provided', () => {
+  jest.spyOn(global, 'fetch').mockImplementation(() => new Promise(() => {}))
+
+  renderProfileArchive(
+    <ProfileArchive
+      accountId="42"
+      avatarUrl={null}
+      basePath="/user/bob"
+      chapters={chapters}
+      displayName="Bob"
+      initialYear={null}
+      initialPage={{
+        tweets: [banger(1, 2025)],
+        yearCounts: chapters,
+        total: 7,
+        nextOffset: null,
+        available: true,
+      }}
+      initialSidebar={initialSidebar}
+    />,
+  )
+
+  expect(
+    screen.queryByText(/Not enough widely-quoted posts/),
+  ).not.toBeInTheDocument()
+  // Sectionless chapters stay directly clickable.
+  expect(screen.getAllByRole('link', { name: '2025 4' })).not.toHaveLength(0)
 })

--- a/src/components/metaTwitter/ProfileArchive.tsx
+++ b/src/components/metaTwitter/ProfileArchive.tsx
@@ -9,6 +9,11 @@ import {
   type ProfileBangerSort,
   type ProfileBangersPageState,
 } from '@/lib/metaTwitter/profilePagination'
+import { chapterSectionTweets } from '@/lib/metaTwitter/chapterSections'
+import type {
+  ChapterSection,
+  SectionsByYear,
+} from '@/lib/metaTwitter/chapterSections'
 import type {
   ArchiveMediaItem,
   ArchivePerson,
@@ -46,6 +51,9 @@ interface DismissedItem {
   section: ProfileCurationSection
 }
 
+const EMPTY_SECTIONS: ChapterSection[] = []
+const EMPTY_SECTIONS_BY_YEAR: SectionsByYear = {}
+
 const scopeKey = (year: number | null) => year?.toString() ?? 'overall'
 const feedKey = (year: number | null, sort: ProfileBangerSort) =>
   `${scopeKey(year)}:${sort}`
@@ -69,6 +77,9 @@ const yearFromLocation = (chapters: NavChapter[]): number | null => {
   return chapters.some((chapter) => chapter.year === year) ? year : null
 }
 
+const sectionFromLocation = () =>
+  new URL(window.location.href).searchParams.get('section')
+
 export function ProfileArchive({
   accountId,
   avatarUrl,
@@ -76,8 +87,11 @@ export function ProfileArchive({
   chapters,
   displayName,
   initialYear,
+  initialSectionSlug = null,
   initialPage,
   initialSidebar,
+  sectionsByYear = EMPTY_SECTIONS_BY_YEAR,
+  sectionsNote = null,
 }: {
   accountId: string
   avatarUrl: string | null
@@ -85,13 +99,25 @@ export function ProfileArchive({
   chapters: NavChapter[]
   displayName: string
   initialYear: number | null
+  initialSectionSlug?: string | null
   initialPage: ProfileBangersPageState
   initialSidebar?: SidebarData
+  /** Curated or generated sections per chapter year, catch-alls included. */
+  sectionsByYear?: SectionsByYear
+  /** Shown under the chapter list, e.g. why there are no sections. */
+  sectionsNote?: string | null
 }) {
   const initialFeedKey = feedKey(initialYear, 'quotes')
   const initialScopeKey = scopeKey(initialYear)
   const hasInitialSidebar = initialSidebar?.available !== false
   const [activeYear, setActiveYear] = useState<number | null>(initialYear)
+  const [activeSectionSlug, setActiveSectionSlug] = useState<string | null>(
+    (initialYear !== null &&
+      sectionsByYear[initialYear]?.find(
+        (section) => section.slug === initialSectionSlug,
+      )?.slug) ||
+      null,
+  )
   const [sort, setSort] = useState<ProfileBangerSort>('quotes')
   const [feeds, setFeeds] = useState<Record<string, FeedState>>({
     [initialFeedKey]: initialPage,
@@ -358,15 +384,54 @@ export function ProfileArchive({
   const activeMediaFailed = Boolean(failedMedia[activeScopeKey])
   const activePeopleFailed = Boolean(failedPeople[activeScopeKey])
   const hasMore = activeFeedLoaded && activeNextOffset !== null
+  const activeSections =
+    activeYear === null
+      ? EMPTY_SECTIONS
+      : (sectionsByYear[activeYear] ?? EMPTY_SECTIONS)
+  const activeSection =
+    activeSections.find((section) => section.slug === activeSectionSlug) ?? null
+  const sectionTweets = activeSection
+    ? chapterSectionTweets(
+        activeSections,
+        activeSection,
+        activeFeed?.tweets ?? [],
+      )
+    : (activeFeed?.tweets ?? [])
+
+  // A section filters the chapter in the client, so the rest of the chapter's
+  // pages have to arrive before an empty section means anything.
+  useEffect(() => {
+    if (!activeSection || !hasMore || activeFeedLoading || activeFeedFailed) {
+      return
+    }
+    void loadNextPage(activeYear, sort)
+  }, [
+    activeFeedFailed,
+    activeFeedLoading,
+    activeNextOffset,
+    activeSection,
+    activeYear,
+    hasMore,
+    loadNextPage,
+    sort,
+  ])
 
   useEffect(() => {
     const onPopState = () => {
+      const year = yearFromLocation(chapters)
       setSort('quotes')
-      setActiveYear(yearFromLocation(chapters))
+      setActiveYear(year)
+      const slug = sectionFromLocation()
+      setActiveSectionSlug(
+        (year !== null &&
+          sectionsByYear[year]?.find((section) => section.slug === slug)
+            ?.slug) ||
+          null,
+      )
     }
     window.addEventListener('popstate', onPopState)
     return () => window.removeEventListener('popstate', onPopState)
-  }, [chapters])
+  }, [chapters, sectionsByYear])
 
   useEffect(() => {
     const current = feedsRef.current[activeKey]
@@ -444,11 +509,29 @@ export function ProfileArchive({
 
   const selectChapter = useCallback(
     (year: number | null) => {
-      if (year === activeYear) return
+      if (year === activeYear && activeSectionSlug === null) return
       setEditing(false)
       setSort('quotes')
       setActiveYear(year)
+      setActiveSectionSlug(null)
       window.history.pushState(null, '', archiveChapterHref(basePath, year))
+    },
+    [activeSectionSlug, activeYear, basePath, setEditing],
+  )
+
+  const selectSection = useCallback(
+    (year: number, slug: string | null) => {
+      if (year !== activeYear) {
+        setEditing(false)
+        setSort('quotes')
+        setActiveYear(year)
+      }
+      setActiveSectionSlug(slug)
+      window.history.pushState(
+        null,
+        '',
+        archiveChapterHref(basePath, year, slug),
+      )
     },
     [activeYear, basePath, setEditing],
   )
@@ -457,6 +540,7 @@ export function ProfileArchive({
     if (!editing || activeYear === null) return
     setSort('quotes')
     setActiveYear(null)
+    setActiveSectionSlug(null)
     window.history.pushState(null, '', archiveChapterHref(basePath, null))
   }, [activeYear, basePath, editing])
 
@@ -795,11 +879,17 @@ export function ProfileArchive({
     [accountId, activeKey, loadFeedPage, runEditMutation, sort],
   )
 
-  const contextTitle = activeYear
-    ? `Best of ${activeYear}`
-    : `Best of ${displayName}`
+  const contextTitle = activeSection
+    ? activeSection.title
+    : activeYear
+      ? `Best of ${activeYear}`
+      : `Best of ${displayName}`
 
-  const returnTo = archiveChapterHref(basePath, activeYear)
+  const returnTo = archiveChapterHref(
+    basePath,
+    activeYear,
+    activeSection?.slug ?? null,
+  )
 
   return (
     <div className="grid grid-cols-1 items-start border-t border-border lg:grid-cols-[250px_1fr]">
@@ -807,13 +897,23 @@ export function ProfileArchive({
         basePath={basePath}
         chapters={chapters}
         activeYear={activeYear}
+        sectionsByYear={sectionsByYear}
+        activeSectionSlug={activeSection?.slug ?? null}
         onSelect={selectChapter}
+        onSelectSection={selectSection}
+        footer={
+          sectionsNote ? (
+            <p className="mt-3 border-t border-border px-3 pt-3 text-xs leading-relaxed text-muted-foreground">
+              {sectionsNote}
+            </p>
+          ) : null
+        }
       />
       <Workspace
         key={`${activeKey}:${activeFeed ? 'ready' : 'loading'}`}
         avatarUrl={avatarUrl}
         contextTitle={contextTitle}
-        tweets={activeFeed?.tweets ?? []}
+        tweets={sectionTweets}
         bangersAvailable={activeFeed?.available !== false}
         bangersLoading={activeFeedLoading || (!activeFeed && !activeFeedFailed)}
         media={activeMedia?.media ?? []}

--- a/src/lib/metaTwitter/chapterSections.test.ts
+++ b/src/lib/metaTwitter/chapterSections.test.ts
@@ -1,0 +1,74 @@
+import {
+  OTHER_SECTION_SLUG,
+  chapterSectionTweets,
+  curatedSectionsByYear,
+  withCatchAll,
+} from '@/lib/metaTwitter/chapterSections'
+
+const CURATED_ACCOUNT_ID = '826134955549790208'
+
+test('serves curated sections only for accounts that have them', () => {
+  expect(curatedSectionsByYear(CURATED_ACCOUNT_ID)).not.toBeNull()
+  expect(curatedSectionsByYear('42')).toBeNull()
+})
+
+test('closes every curated chapter with a catch-all', () => {
+  const byYear = curatedSectionsByYear(CURATED_ACCOUNT_ID)!
+  expect(Object.keys(byYear).length).toBeGreaterThan(0)
+  for (const sections of Object.values(byYear)) {
+    expect(sections.length).toBeGreaterThan(1)
+    expect(sections.at(-1)?.slug).toBe(OTHER_SECTION_SLUG)
+    expect(sections.filter((s) => s.slug === OTHER_SECTION_SLUG)).toHaveLength(
+      1,
+    )
+  }
+  expect(withCatchAll([])).toEqual([])
+})
+
+test('keeps every curated section addressable, titled, and worth opening', () => {
+  const byYear = curatedSectionsByYear(CURATED_ACCOUNT_ID)!
+  for (const [year, sections] of Object.entries(byYear)) {
+    const slugs = sections.map((section) => {
+      expect(section.slug).toMatch(/^[a-z0-9-]+$/)
+      expect(section.title.trim()).toBe(section.title)
+      expect(section.title).not.toHaveLength(0)
+      if (section.slug !== OTHER_SECTION_SLUG) {
+        // Below three tweets a section is a footnote, not a chapter.
+        expect(section.tweetIds.length).toBeGreaterThanOrEqual(3)
+        for (const id of section.tweetIds) expect(id).toMatch(/^\d{1,20}$/)
+      }
+      return `${year}:${section.slug}`
+    })
+    expect(new Set(slugs).size).toBe(slugs.length)
+  }
+})
+
+test('files each tweet under one section, uncurated ones included', () => {
+  const sections = curatedSectionsByYear(CURATED_ACCOUNT_ID)![2024]
+  const [first] = sections
+  const tweets = [
+    ...first.tweetIds.map((tweet_id) => ({ tweet_id })),
+    { tweet_id: '1' },
+  ]
+
+  expect(chapterSectionTweets(sections, first, tweets)).toEqual(
+    first.tweetIds.map((tweet_id) => ({ tweet_id })),
+  )
+  expect(chapterSectionTweets(sections, sections.at(-1)!, tweets)).toEqual([
+    { tweet_id: '1' },
+  ])
+
+  const filed = sections.flatMap((section) =>
+    chapterSectionTweets(sections, section, tweets),
+  )
+  expect(filed).toHaveLength(tweets.length)
+})
+
+test('never lists the same tweet in two sections of a chapter', () => {
+  for (const sections of Object.values(
+    curatedSectionsByYear(CURATED_ACCOUNT_ID)!,
+  )) {
+    const ids = sections.flatMap((section) => section.tweetIds)
+    expect(new Set(ids).size).toBe(ids.length)
+  }
+})

--- a/src/lib/metaTwitter/chapterSections.ts
+++ b/src/lib/metaTwitter/chapterSections.ts
@@ -1,0 +1,233 @@
+/**
+ * Curated subsections inside a chapter (a year) of an account's archive.
+ *
+ * A section title is a phrase quoted verbatim from one of the tweets it holds,
+ * so a chapter reads as an idea the person was actually chewing on rather than
+ * a generic label. Membership is an explicit list of tweet IDs: the chapters
+ * are small enough to curate by hand, and matching on terms would quietly
+ * mis-file posts. Every chapter with curated sections also gets a trailing
+ * catch-all so no banger becomes unreachable.
+ *
+ * Accounts without an entry render their chapters unsectioned.
+ */
+
+export interface ChapterSection {
+  /** URL-safe identifier, kept stable once published. */
+  slug: string
+  /** Quoted phrase from one of the section's tweets. */
+  title: string
+  /** Tweets in the section; empty for the catch-all. */
+  tweetIds: string[]
+}
+
+export type SectionsByYear = Record<number, ChapterSection[]>
+
+export const OTHER_SECTION_SLUG = 'other'
+
+const CURATED_SECTIONS: Record<string, Record<number, ChapterSection[]>> = {
+  // @christineist
+  '826134955549790208': {
+    2022: [
+      {
+        slug: 'unabashedly-weird',
+        title: 'unabashedly weird on this app',
+        tweetIds: [
+          '1551996871584796672', // I made a guide to tpot!
+          '1605591960810446848', // Try my fake twitter
+          '1502765137714835456', // thankful to those who are unabashedly weird
+          '1591536191459196928', // full fractal buy in
+        ],
+      },
+      {
+        slug: 'more-agreeable-less-agreeable',
+        title: 'be more agreeable, less agreeable',
+        tweetIds: [
+          '1569948792384012291', // ways to play with your identity, life, frame
+          '1567309182248034305', // IRL//URL Persona Party
+          '1570639073194409986', // give me your mildest roast
+        ],
+      },
+    ],
+    2023: [
+      {
+        slug: 'languishing',
+        title: 'languishing is an important aspect of the creative process',
+        tweetIds: [
+          '1657102796418842624', // languishing
+          '1677708469363933186', // where to direct my creative compulsion
+          '1668994334652350464', // Alone Time (2023)
+          '1673936919250731008', // self healing platter
+          '1613664220662616065', // book club
+          '1694804705640390736', // last selfie / last meme
+        ],
+      },
+      {
+        slug: 'five-dollars-back-and-forth',
+        title: 'sending $5 back and forth for arbitrary small tasks',
+        tweetIds: [
+          '1675937321437519872', // era of tpot people sending $5
+          '1673783325746659330', // tpot x grand budapest hotel
+          '1682229717829832704', // dating app I made for this twitter scene
+          '1623445824658104320', // was made for this scenario
+        ],
+      },
+      {
+        slug: 'beginnings-of-a-relationship',
+        title: 'how you start a relationship',
+        tweetIds: [
+          '1720092106335899905', // beginnings of a relationship
+          '1683951437716549636', // decisions compound in your late twenties
+          '1723096316354625924', // processed a lot of grief
+          '1691315356760240128', // smell depression on other people
+        ],
+      },
+    ],
+    2024: [
+      {
+        slug: 'what-is-your-gift',
+        title: 'what is your gift?',
+        tweetIds: [
+          '1870511170354102435', // what is your gift?
+          '1816257836764258420', // default rules for your life
+          '1816636343545659896', // what other people seem weirdly bad at
+          '1870173258135547978', // developing your intuition
+        ],
+      },
+      {
+        slug: 'lush-and-full-of-sinkholes',
+        title: 'the mind is lush and full of sinkholes',
+        tweetIds: [
+          '1821940561861042286', // the mind is lush and full of sinkholes
+          '1765572833793740802', // speech coaching
+          '1765594671101977059', // speech coaching notes
+          '1768063040409481645', // after the IFS rabbit hole
+          '1742695713006637298', // relax my mind's grip
+          '1744918785801490664', // Heidi Priebe nuggets
+        ],
+      },
+      {
+        slug: 'little-groups',
+        title: 'little groups of 3-4 friends',
+        tweetIds: [
+          '1851528581190496499', // little groups of 3-4 friends
+          '1812364916906471452', // an unsurpassable chasm
+          '1780801621011685885', // oh my god what a love story
+          '1824491550732325364', // dating is so cute
+          '1790530430317506689', // desire for status vs unconditional love
+        ],
+      },
+    ],
+    2025: [
+      {
+        slug: 'self-reinforcing-life',
+        title: 'a self reinforcing life',
+        tweetIds: [
+          '1939336962634379386', // build a self reinforcing life
+          '2000745322880852135', // life experiments doc
+          '1944559102417359198', // learning to exist body-first
+          '1986965809239920944', // trying again is such an important skill
+          '1964084312816419274', // don't sell yourself short
+          '1998839022924210200', // ch 11 on self actualizing people
+          '1999745513134977102', // much evil lies downstream of insecurity
+        ],
+      },
+      {
+        slug: 'nyc-in-october',
+        title: 'everyone should come to nyc in october',
+        tweetIds: [
+          '1953280891641270684', // everyone should come to nyc in october
+          '1984328799865967079', // last day of Vibetober
+          '1972660631011574032', // hyperstition for vibetober
+          '1985133318451466320', // Post-Vibetober Hyperstition Market
+          '1988722741252616437', // set your friends up this lovember
+        ],
+      },
+      {
+        slug: 'write-every-day',
+        title: 'write/publish every day for the month of jan',
+        tweetIds: [
+          '1999747201338343708', // inkuary
+          '1979975666326986822', // christianuary
+          '1951278607772303389', // I started a podcast!
+          '1966155567048839547', // yin vs yang community building
+        ],
+      },
+      {
+        slug: 'things-my-friends-made',
+        title: 'things my friends made',
+        tweetIds: [
+          '1888964775301759170', // consumption diet of things my friends made
+          '1941739989487730765', // little groups start to collaborate
+          '1961102726173180257', // I want this conversation to end
+          '1950593989276578034', // let my nervous system dictate my dating life
+          '1974548861537652901', // omg new cutie!
+        ],
+      },
+    ],
+    2026: [
+      {
+        slug: 'friends-to-close-friends',
+        title: 'how to go from friends to close friends',
+        tweetIds: [
+          '2056850826845434327', // friends to close friends
+          '2056139632262218232', // what do your friends ask you for
+          '2047059484564926742', // you need shared social context
+          '2027274733209731578', // traits most missing in friendships
+          '2035720176839057792', // on parenthood and male friendships
+        ],
+      },
+      {
+        slug: 'a-new-brain',
+        title: 'my brain opened a new brain',
+        tweetIds: [
+          '2030656994969854120', // my brain opened a new brain
+          '2007502981386907946', // extrinsic to intrinsic motivation
+          '2051042129254965667', // adult children of emotionally immature parents
+          '2054259444226183553', // how often has your gut led you astray
+          '2030860958449504707', // fuck around and find out: the cult
+        ],
+      },
+    ],
+  },
+}
+
+const otherSection = (): ChapterSection => ({
+  slug: OTHER_SECTION_SLUG,
+  title: 'everything else',
+  tweetIds: [],
+})
+
+/** Closes a non-empty section list with the catch-all. */
+export const withCatchAll = (sections: ChapterSection[]): ChapterSection[] =>
+  sections.length ? [...sections, otherSection()] : []
+
+/** Hand-curated sections for an account, or null to fall back to generation. */
+export const curatedSectionsByYear = (
+  accountId: string,
+): SectionsByYear | null => {
+  const curated = CURATED_SECTIONS[accountId]
+  if (!curated) return null
+  return Object.fromEntries(
+    Object.entries(curated).map(([year, sections]) => [
+      year,
+      withCatchAll(sections),
+    ]),
+  )
+}
+
+/**
+ * The catch-all holds whatever the curated sections left behind, so a chapter
+ * that gains bangers after curation still shows all of them somewhere.
+ */
+export const chapterSectionTweets = <T extends { tweet_id: string }>(
+  sections: ChapterSection[],
+  section: ChapterSection,
+  tweets: T[],
+): T[] => {
+  if (section.slug !== OTHER_SECTION_SLUG) {
+    const ids = new Set(section.tweetIds)
+    return tweets.filter((tweet) => ids.has(tweet.tweet_id))
+  }
+  const curated = new Set(sections.flatMap((entry) => entry.tweetIds))
+  return tweets.filter((tweet) => !curated.has(tweet.tweet_id))
+}

--- a/src/lib/metaTwitter/generatedSections.test.ts
+++ b/src/lib/metaTwitter/generatedSections.test.ts
@@ -1,0 +1,106 @@
+import { OTHER_SECTION_SLUG } from '@/lib/metaTwitter/chapterSections'
+import {
+  bangersByYear,
+  parseGeneratedSections,
+  sectionPrompt,
+} from '@/lib/metaTwitter/generatedSections'
+
+const tweet = (id: string, year: number, text: string) => ({
+  tweet_id: id,
+  created_at: `${year}-06-01T00:00:00.000Z`,
+  full_text: text,
+})
+
+const CORPUS = [
+  tweet('1', 2025, 'the mind is lush and full of sinkholes'),
+  tweet('2', 2025, 'more sinkholes over here'),
+  tweet('3', 2025, 'sinkholes, concluded'),
+  tweet('4', 2025, 'unrelated banger about soup'),
+  tweet('5', 2025, 'soup thoughts, continued'),
+  tweet('6', 2025, 'soup: the finale'),
+  tweet('7', 2024, 'a lonely tweet'),
+]
+
+test('groups bangers by their created year', () => {
+  const byYear = bangersByYear(CORPUS)
+  expect(Array.from(byYear.keys()).sort()).toEqual([2024, 2025])
+  expect(byYear.get(2025)).toHaveLength(6)
+})
+
+test('prompt carries every tweet id', () => {
+  const prompt = sectionPrompt(bangersByYear(CORPUS))
+  for (const { tweet_id } of CORPUS) {
+    expect(prompt).toContain(`id ${tweet_id}:`)
+  }
+})
+
+test('accepts a clean model grouping and appends the catch-all', () => {
+  const byYear = bangersByYear(CORPUS)
+  const result = parseGeneratedSections(
+    [
+      {
+        year: 2025,
+        sections: [
+          { title: 'full of sinkholes', tweet_ids: ['1', '2', '3'] },
+          { title: 'soup thoughts', tweet_ids: ['4', '5', '6'] },
+        ],
+      },
+      { year: 2024, sections: [] },
+    ],
+    byYear,
+  )
+  expect(result[2025].map((s) => s.slug)).toEqual([
+    'full-of-sinkholes',
+    'soup-thoughts',
+    OTHER_SECTION_SLUG,
+  ])
+  expect(result[2024]).toEqual([])
+})
+
+test('drops fabricated ids, non-verbatim titles, and thin years', () => {
+  const byYear = bangersByYear(CORPUS)
+  const result = parseGeneratedSections(
+    [
+      {
+        year: 2025,
+        sections: [
+          // "999" is not a real banger; still three valid ids -> kept
+          { title: 'full of sinkholes', tweet_ids: ['1', '2', '3', '999'] },
+          // title not verbatim in any member tweet -> dropped
+          { title: 'culinary musings', tweet_ids: ['4', '5', '6'] },
+        ],
+      },
+      // unknown year -> ignored entirely
+      { year: 1999, sections: [{ title: 'x', tweet_ids: ['1', '2', '3'] }] },
+    ],
+    byYear,
+  )
+  // only one surviving section -> below the two-section minimum -> no split
+  expect(result[2025]).toEqual([])
+  expect(result[1999]).toBeUndefined()
+})
+
+test('never files one tweet into two sections', () => {
+  const byYear = bangersByYear(CORPUS)
+  const result = parseGeneratedSections(
+    [
+      {
+        year: 2025,
+        sections: [
+          { title: 'full of sinkholes', tweet_ids: ['1', '2', '3'] },
+          // overlaps ids 1-2; only 4,5,6... but claims 1,2,4 -> "4" alone is too few
+          { title: 'soup thoughts', tweet_ids: ['1', '2', '4'] },
+          { title: 'soup: the finale', tweet_ids: ['4', '5', '6'] },
+        ],
+      },
+    ],
+    byYear,
+  )
+  const ids = result[2025].flatMap((s) => s.tweetIds)
+  expect(new Set(ids).size).toBe(ids.length)
+  expect(result[2025].map((s) => s.slug)).toEqual([
+    'full-of-sinkholes',
+    'soup-the-finale',
+    OTHER_SECTION_SLUG,
+  ])
+})

--- a/src/lib/metaTwitter/generatedSections.ts
+++ b/src/lib/metaTwitter/generatedSections.ts
@@ -1,0 +1,237 @@
+import 'server-only'
+
+import { unstable_cache } from 'next/cache'
+import { devLog } from '@/lib/devLog'
+import { getProfileBangers } from './bangers'
+import {
+  withCatchAll,
+  type ChapterSection,
+  type SectionsByYear,
+} from './chapterSections'
+import type { BangerTweet } from './types'
+
+/**
+ * Splits an uncurated archive's bangers into named chapter sections with one
+ * model call, the first time anyone views the profile. The result is cached
+ * server-side, so an account is read once per revalidation window rather than
+ * per visitor; accounts below MIN_BANGERS are never sent to the model at all.
+ */
+
+/** The only model section generation may use. */
+const SECTIONS_MODEL = 'deepseek/deepseek-v4-flash-0731'
+
+/** Two sections of three posts each is the smallest split worth showing. */
+export const MIN_BANGERS = 6
+const MIN_SECTION_TWEETS = 3
+const MIN_YEAR_SECTIONS = 2
+const REVALIDATE_SECONDS = 7 * 86_400
+const REQUEST_TIMEOUT_MS = 120_000
+/** After a failed model call, how long to serve "unavailable" before retrying. */
+const FAILURE_COOLDOWN_MS = 10 * 60_000
+
+export type GeneratedSectionsState =
+  | { status: 'insufficient' }
+  | { status: 'unavailable' }
+  | { status: 'generated'; sectionsByYear: SectionsByYear }
+
+interface ModelYear {
+  year: number
+  sections: { title: string; tweet_ids: string[] }[]
+}
+
+export const bangersByYear = (
+  tweets: Pick<BangerTweet, 'tweet_id' | 'created_at' | 'full_text'>[],
+) => {
+  const byYear = new Map<number, typeof tweets>()
+  for (const tweet of tweets) {
+    const year = new Date(tweet.created_at).getUTCFullYear()
+    byYear.set(year, [...(byYear.get(year) ?? []), tweet])
+  }
+  return byYear
+}
+
+export const sectionPrompt = (
+  byYear: Map<number, Pick<BangerTweet, 'tweet_id' | 'full_text'>[]>,
+): string => {
+  const years = Array.from(byYear.entries())
+    .sort(([a], [b]) => a - b)
+    .map(
+      ([year, tweets]) =>
+        `## ${year}\n` +
+        tweets
+          .map(
+            (tweet) =>
+              `- id ${tweet.tweet_id}: ${tweet.full_text.replace(/\s+/g, ' ').slice(0, 280)}`,
+          )
+          .join('\n'),
+    )
+    .join('\n\n')
+  return `These are one Twitter account's most-quoted posts, grouped by year. Split each year into thematic sections.
+
+Rules:
+- Each section holds at least ${MIN_SECTION_TWEETS} of that year's posts; a post appears in at most one section.
+- A year that doesn't support ${MIN_YEAR_SECTIONS} such sections gets an empty sections list.
+- Not every post needs a section; leave the stragglers out.
+- A section's title is a short phrase (2-8 words) copied verbatim from one of the posts INSIDE that section - an idea the author was chewing on, not a generic label. No surrounding quotes.
+- Group by what the posts are about; prefer fewer, sharper sections over many loose ones.
+
+Respond with JSON only, in exactly this shape:
+{"years": [{"year": 2024, "sections": [{"title": "...", "tweet_ids": ["..."]}]}]}
+
+${years}`
+}
+
+const normalize = (text: string) =>
+  text
+    .toLowerCase()
+    .replace(/[‘’]/g, "'")
+    .replace(/[“”]/g, '"')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+const slugify = (title: string) =>
+  normalize(title)
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40)
+    .replace(/-+$/, '')
+
+/**
+ * Turns the model's grouping into chapter sections, dropping anything that
+ * doesn't hold up: unknown or repeated tweet IDs, sections below the minimum,
+ * titles that aren't verbatim from a tweet inside the section, and years left
+ * with fewer than two sections.
+ */
+export const parseGeneratedSections = (
+  years: ModelYear[],
+  byYear: Map<number, Pick<BangerTweet, 'tweet_id' | 'full_text'>[]>,
+): SectionsByYear => {
+  const result: SectionsByYear = {}
+  byYear.forEach((_tweets, year) => {
+    result[year] = []
+  })
+
+  for (const entry of years) {
+    const tweets = byYear.get(entry.year)
+    if (!tweets) continue
+    const textById = new Map(
+      tweets.map((tweet) => [tweet.tweet_id, tweet.full_text]),
+    )
+    const claimed = new Set<string>()
+    const slugs = new Set<string>()
+    const sections: ChapterSection[] = []
+
+    for (const candidate of entry.sections) {
+      const ids = Array.from(new Set(candidate.tweet_ids)).filter(
+        (id) => textById.has(id) && !claimed.has(id),
+      )
+      if (ids.length < MIN_SECTION_TWEETS) continue
+      const title = candidate.title.trim().replace(/^["'“]+|["'”]+$/g, '')
+      if (!title) continue
+      const verbatim = ids.some((id) =>
+        normalize(textById.get(id) ?? '').includes(normalize(title)),
+      )
+      if (!verbatim) continue
+      const slug = slugify(title)
+      if (!slug || slugs.has(slug)) continue
+      slugs.add(slug)
+      for (const id of ids) claimed.add(id)
+      sections.push({ slug, title, tweetIds: ids })
+    }
+
+    result[entry.year] =
+      sections.length >= MIN_YEAR_SECTIONS ? withCatchAll(sections) : []
+  }
+  return result
+}
+
+const requestSections = async (
+  prompt: string,
+  apiKey: string,
+): Promise<ModelYear[]> => {
+  const baseUrl =
+    process.env.OPENROUTER_BASE_URL ?? 'https://openrouter.ai/api/v1'
+  const response = await fetch(
+    `${baseUrl.replace(/\/$/, '')}/chat/completions`,
+    {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: SECTIONS_MODEL,
+        max_tokens: 8000,
+        // Left to reason, this model spends its whole token budget thinking
+        // and returns nothing; grouping short posts doesn't need it.
+        reasoning: { enabled: false },
+        // The shape is spelled out in the prompt and enforced by
+        // parseGeneratedSections, so plain JSON mode is enough.
+        response_format: { type: 'json_object' },
+        messages: [{ role: 'user', content: prompt }],
+      }),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      cache: 'no-store',
+    },
+  )
+  if (!response.ok) {
+    throw new Error(`Section generation failed with HTTP ${response.status}`)
+  }
+  const body = (await response.json()) as {
+    choices?: { finish_reason?: string; message?: { content?: string } }[]
+  }
+  const choice = body.choices?.[0]
+  if (!choice || choice.finish_reason !== 'stop') {
+    throw new Error(
+      `Section generation stopped early: ${choice?.finish_reason}`,
+    )
+  }
+  const text = choice.message?.content
+  if (!text) throw new Error('Section generation returned no text')
+  const parsed = JSON.parse(text) as { years?: ModelYear[] }
+  if (!Array.isArray(parsed.years)) {
+    throw new Error('Section generation returned no years array')
+  }
+  return parsed.years
+}
+
+const getCachedGeneratedSections = unstable_cache(
+  async (accountId: string): Promise<SectionsByYear> => {
+    const bangers = await getProfileBangers(accountId)
+    if (!bangers.available) throw new Error('Bangers unavailable')
+    const byYear = bangersByYear(bangers.tweets)
+    const raw = await requestSections(
+      sectionPrompt(byYear),
+      process.env.OPENROUTER_API_KEY as string,
+    )
+    return parseGeneratedSections(raw, byYear)
+  },
+  ['meta-twitter-generated-sections-v1'],
+  { revalidate: REVALIDATE_SECONDS },
+)
+
+const failedUntil = new Map<string, number>()
+
+/**
+ * Sections for an account without hand-curated ones. Cheap gates run before
+ * the model is ever involved: no API key or too few bangers short-circuit,
+ * and a recent failure backs off instead of retrying on every page view.
+ */
+export async function getGeneratedSections(
+  accountId: string,
+  bangerCount: number,
+): Promise<GeneratedSectionsState> {
+  if (bangerCount < MIN_BANGERS) return { status: 'insufficient' }
+  if (!process.env.OPENROUTER_API_KEY) return { status: 'unavailable' }
+  if ((failedUntil.get(accountId) ?? 0) > Date.now()) {
+    return { status: 'unavailable' }
+  }
+  try {
+    const sectionsByYear = await getCachedGeneratedSections(accountId)
+    return { status: 'generated', sectionsByYear }
+  } catch (error) {
+    devLog('generated sections failed', { accountId, error })
+    failedUntil.set(accountId, Date.now() + FAILURE_COOLDOWN_MS)
+    return { status: 'unavailable' }
+  }
+}


### PR DESCRIPTION
## What

Archive profile chapters (years) can now be split into **sections** — subsections titled with a phrase quoted verbatim from the account's own posts (e.g. 2023 › *"darling effect"*). Sections list under their year in the chapter nav; selecting one filters the chapter's bangers to its tweets, with a trailing **everything else** holding whatever the sections don't claim, so no banger becomes unreachable. URL state is `?chapter=<year>&section=<slug>`, server-validated, restored on back/forward.

- **Desktop:** a year with sections becomes a plain heading and the sections carry the links; sectionless years stay clickable.
- **Mobile:** sections are hidden; the year chips work as before.

## Where sections come from

1. **Hand-curated** (`chapterSections.ts`): explicit tweet-ID lists per account/year — @christineist's 2022–2026 are curated here (titles like *"5-10% more chaos"*, *"little groups of 3-4 friends"*). Curated always wins.
2. **Generated** (`generatedSections.ts`): any other archive with ≥6 bangers gets a one-time split on first view — one `deepseek/deepseek-v4-flash-0731` call via OpenRouter over just the account's bangers (~4K tokens, ~$0.0007, ~5s), cached with `unstable_cache` for 7 days. The response is distrusted by construction: fabricated tweet IDs are stripped, titles must be verbatim from a tweet inside their own section, sections need ≥3 real tweets, years need ≥2 surviving sections, double-claimed tweets go to the first claimant.
3. **Neither:** <6 bangers shows *"Not enough widely-quoted posts yet…"*; no key / gateway outage / model failure (10-min in-memory backoff) renders the profile exactly as today.

## Config

- `OPENROUTER_API_KEY` — required for generation; absent = feature silently off.
- `OPENROUTER_BASE_URL` — optional override (used in dev to point at a mock).
- Model quirk worth knowing: v4-flash is a reasoner — without `reasoning: {enabled: false}` it spends the entire `max_tokens` thinking and returns `finish_reason: "length"` with null content. With it: ~5s.

## Notes for review

- The model call is raw `fetch` rather than an SDK dependency; happy to swap if you'd rather take a package.
- Generation output varies per cache refresh — a year can gain/lose a section weekly. Curated config is the stability lever.
- The curated tweet-ID sets were derived from the public archive's `quote_tweets` table (distinct quoting accounts ≥2, self-quotes excluded); a few IDs may differ from ClickHouse's banger set — strays land in *everything else* by design.

## Testing

- 24 suites / 88 tests pass (new: section config invariants, generation parser/validator, nav + filtering behavior, note states).
- Verified live: real OpenRouter generation on a config-less profile (sections render, filter, deep-link), curated profile unaffected, mobile/desktop breakpoints, unavailable-data and thin-archive states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)