### PR TITLE
Add digest authorship toggle and interaction fallback

### DIFF
--- a/src/app/admin/digest/actions.ts
+++ b/src/app/admin/digest/actions.ts
@@ -4,14 +4,20 @@ import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 import { start } from 'workflow/api'
 import { requireAdmin } from '@/app/admin/data'
-import { fetchPortalRecentBangers } from '@/lib/portal/analytics'
+import {
+  fetchPortalDailyInteractions,
+  fetchPortalRecentBangers,
+} from '@/lib/portal/analytics'
 import {
   getDigestDateWindow,
   isRecentPastDigestDate,
   listPastDigestDates,
 } from '@/lib/digest/dateWindow'
 import { createDigestAdminClient } from '@/lib/digest/database'
-import { selectDailyDigestBangers } from '@/lib/digest/generation'
+import {
+  fillDailyDigestCandidates,
+  selectDailyDigestBangers,
+} from '@/lib/digest/generation'
 import { captureDigestPostHogEvent } from '@/lib/digest/posthogServer'
 import { mapDigestEdition, mapDigestRun, toJson } from '@/lib/digest/data'
 import {
@@ -31,6 +37,51 @@ const REASONING_EFFORTS = new Set(['none', 'low', 'medium', 'high'])
 
 const formString = (formData: FormData, key: string) =>
   String(formData.get(key) ?? '').trim()
+const formBoolean = (formData: FormData, key: string) =>
+  ['true', 'on', '1'].includes(formString(formData, key).toLowerCase())
+
+const MINIMUM_DIGEST_CANDIDATE_POOL = 10
+
+async function loadDigestCandidates(
+  windowEnd: string,
+  targetCommunityUsersOnly: boolean,
+) {
+  const bangers = await fetchPortalRecentBangers(
+    50,
+    24,
+    undefined,
+    windowEnd,
+    targetCommunityUsersOnly,
+  )
+  const qualifyingBangers = selectDailyDigestBangers(bangers)
+  const interactionRanked =
+    qualifyingBangers.length < MINIMUM_DIGEST_CANDIDATE_POOL
+      ? await fetchPortalDailyInteractions(
+          50,
+          24,
+          undefined,
+          windowEnd,
+          targetCommunityUsersOnly,
+        )
+      : []
+  const selected = fillDailyDigestCandidates(
+    bangers,
+    interactionRanked,
+    MINIMUM_DIGEST_CANDIDATE_POOL,
+  )
+  return {
+    candidates: selected.map<DigestCandidate>(({ tweet, source }, index) => ({
+      tweet,
+      source,
+      sourceRank: index + 1,
+      selected: true,
+    })),
+    bangerCount: qualifyingBangers.length,
+    fallbackCount: selected.filter(
+      ({ source }) => source === 'ca_interactions',
+    ).length,
+  }
+}
 
 const event = (
   stage: DigestRunEvent['stage'],
@@ -285,6 +336,10 @@ export async function createDigestPromptVersionAction(formData: FormData) {
 export async function createDigestRunAction(formData: FormData) {
   const { user } = await requireAdmin()
   const promptVersionId = formString(formData, 'prompt_version_id')
+  const targetCommunityUsersOnly = formBoolean(
+    formData,
+    'target_ca_users_only',
+  )
   if (!UUID_PATTERN.test(promptVersionId)) {
     redirectToLab({ error: 'Choose a prompt version.' })
   }
@@ -304,29 +359,27 @@ export async function createDigestRunAction(formData: FormData) {
   try {
     const windowEnd = new Date()
     const windowStart = new Date(windowEnd.getTime() - 24 * 60 * 60 * 1_000)
-    const tweets = await fetchPortalRecentBangers(
-      50,
-      24,
-      undefined,
-      undefined,
-      true,
+    const snapshot = await loadDigestCandidates(
+      windowEnd.toISOString(),
+      targetCommunityUsersOnly,
     )
-    const candidates: DigestCandidate[] = selectDailyDigestBangers(tweets).map(
-      (tweet, index) => ({
-        tweet,
-        sourceRank: index + 1,
-        selected: true,
-      }),
-    )
+    const candidates = snapshot.candidates
+    const authorPopulation = targetCommunityUsersOnly
+      ? 'current Community Archive members'
+      : 'all authors'
     const initialEvent = event(
       'candidates',
       'completed',
-      'Saved up to 50 rolling 24-hour posts authored by current Community Archive members with a banger score of at least two.',
+      `Saved rolling 24-hour candidates by ${authorPopulation}: qualifying bangers first, then CA interaction-ranked posts up to a minimum pool of ${MINIMUM_DIGEST_CANDIDATE_POOL}.`,
       {
         candidate_count: candidates.length,
         default_selected_count: candidates.length,
+        qualifying_banger_count: snapshot.bangerCount,
+        interaction_fallback_count: snapshot.fallbackCount,
         minimum_ca_quote_count: 2,
-        target_author_population: 'community_members',
+        target_author_population: targetCommunityUsersOnly
+          ? 'community_members'
+          : 'all_authors',
       },
     )
     const { data: run, error } = await admin
@@ -369,6 +422,10 @@ export async function createAndGenerateDigestDateAction(formData: FormData) {
   const { user } = await requireAdmin()
   const promptVersionId = formString(formData, 'prompt_version_id')
   const digestDate = formString(formData, 'digest_date')
+  const targetCommunityUsersOnly = formBoolean(
+    formData,
+    'target_ca_users_only',
+  )
   if (!UUID_PATTERN.test(promptVersionId)) {
     redirectToLab({ error: 'Choose a prompt version.' })
   }
@@ -406,29 +463,27 @@ export async function createAndGenerateDigestDateAction(formData: FormData) {
   let candidateCount = 0
   try {
     const window = getDigestDateWindow(digestDate)
-    const tweets = await fetchPortalRecentBangers(
-      50,
-      24,
-      undefined,
+    const snapshot = await loadDigestCandidates(
       window.windowEnd,
-      true,
+      targetCommunityUsersOnly,
     )
-    const candidates: DigestCandidate[] = selectDailyDigestBangers(tweets).map(
-      (tweet, index) => ({
-        tweet,
-        sourceRank: index + 1,
-        selected: true,
-      }),
-    )
+    const candidates = snapshot.candidates
+    const authorPopulation = targetCommunityUsersOnly
+      ? 'current Community Archive members'
+      : 'all authors'
     const initialEvent = event(
       'candidates',
       'completed',
-      `Saved up to 50 bangers by current Community Archive members authored during the ${digestDate} Community Archive day (06:00 UTC to 05:59 UTC).`,
+      `Saved ${digestDate} Community Archive day candidates by ${authorPopulation}: qualifying bangers first, then CA interaction-ranked posts up to a minimum pool of ${MINIMUM_DIGEST_CANDIDATE_POOL}.`,
       {
         candidate_count: candidates.length,
         default_selected_count: candidates.length,
+        qualifying_banger_count: snapshot.bangerCount,
+        interaction_fallback_count: snapshot.fallbackCount,
         minimum_ca_quote_count: 2,
-        target_author_population: 'community_members',
+        target_author_population: targetCommunityUsersOnly
+          ? 'community_members'
+          : 'all_authors',
         historical_window: true,
       },
     )

--- a/src/app/admin/digest/page.tsx
+++ b/src/app/admin/digest/page.tsx
@@ -310,6 +310,16 @@ export default async function DigestLabPage({
                       </option>
                     ))}
                   </select>
+                  <label className="flex items-start gap-2 text-xs text-muted-foreground">
+                    <input
+                      type="checkbox"
+                      name="target_ca_users_only"
+                      value="true"
+                      defaultChecked
+                      className="mt-0.5 h-4 w-4 rounded border-zinc-300"
+                    />
+                    Only include posts authored by Community Archive members
+                  </label>
                   <SubmitButton pendingLabel="Pulling candidates…">
                     Pull last 24 hours
                   </SubmitButton>
@@ -338,6 +348,7 @@ export default async function DigestLabPage({
                       action: createAndGenerateDigestDateAction,
                       dates: pastDates,
                       promptVersionId: prompt.id,
+                      targetCommunityUsersOnly: true,
                       runningRuns: runningRuns.map((run) => ({
                         date: run.digestDate,
                         id: run.id,
@@ -452,9 +463,9 @@ export default async function DigestLabPage({
                         Candidate selection
                       </h2>
                       <p className="mt-1 text-sm text-muted-foreground">
-                        Up to 50 posts authored by current Community Archive
-                        members with a banger score of at least two, ranked
-                        strongest first.
+                        Qualifying bangers first, supplemented to a pool of 10
+                        by same-day posts with the most non-self replies and
+                        quotes from Community Archive members.
                       </p>
                     </div>
                     <span className="text-xs text-muted-foreground">
@@ -499,8 +510,10 @@ export default async function DigestLabPage({
                                 @{candidate.tweet.username}
                               </span>
                               <span className="ml-auto tabular-nums text-muted-foreground">
-                                ✦ {candidate.tweet.quoteCount ?? 0} · ♥{' '}
-                                {candidate.tweet.likes.toLocaleString()}
+                                {candidate.source === 'ca_interactions'
+                                  ? `↪ ${candidate.tweet.interactionCount ?? 0} CA interactions (${candidate.tweet.replyCount ?? 0} replies · ${candidate.tweet.quoteCount ?? 0} quotes) · `
+                                  : `banger ${candidate.tweet.quoteCount ?? 0} quotes · `}
+                                ♥ {candidate.tweet.likes.toLocaleString()}
                               </span>
                             </span>
                             <span className="mt-2 block whitespace-pre-wrap text-sm leading-6">
@@ -511,8 +524,8 @@ export default async function DigestLabPage({
                       ))}
                       {state.activeRun.candidates.length === 0 ? (
                         <p className="p-5 text-sm text-muted-foreground">
-                          No recent bangers met the current quote-based
-                          threshold.
+                          No qualifying bangers or same-day CA-interaction
+                          candidates were found.
                         </p>
                       ) : null}
                     </div>

--- a/src/components/digest/DigestDaySelector.test.tsx
+++ b/src/components/digest/DigestDaySelector.test.tsx
@@ -87,6 +87,14 @@ describe('DigestDaySelector', () => {
     expect(august11.closest('form')).toHaveFormValues({
       prompt_version_id: 'prompt-1',
       digest_date: '2026-08-11',
+      target_ca_users_only: 'true',
+    })
+    const authorshipToggle = screen.getByRole('checkbox', {
+      name: 'Only include posts authored by Community Archive members',
+    })
+    await user.click(authorshipToggle)
+    expect(august11.closest('form')).toHaveFormValues({
+      target_ca_users_only: 'false',
     })
     expect(screen.getByText('10').closest('button')).toBeNull()
     expect(

--- a/src/components/digest/DigestDaySelector.tsx
+++ b/src/components/digest/DigestDaySelector.tsx
@@ -30,6 +30,7 @@ export function DigestDaySelector({
     action: string | ((formData: FormData) => Promise<void>)
     dates: string[]
     promptVersionId: string
+    targetCommunityUsersOnly?: boolean
     runningRuns?: Array<{ date: string; id: string }>
   }
 }) {
@@ -49,6 +50,9 @@ export function DigestDaySelector({
   ).sort()
   const initialMonth = currentDate.slice(0, 7)
   const [visibleMonth, setVisibleMonth] = useState(initialMonth)
+  const [targetCommunityUsersOnly, setTargetCommunityUsersOnly] = useState(
+    generation?.targetCommunityUsersOnly ?? true,
+  )
   const [year, month] = visibleMonth.split('-').map(Number)
   const firstMonth = availableMonths[0] ?? initialMonth
   const lastMonth = availableMonths.at(-1) ?? initialMonth
@@ -166,6 +170,11 @@ export function DigestDaySelector({
                   value={generation.promptVersionId}
                 />
                 <input type="hidden" name="digest_date" value={date} />
+                <input
+                  type="hidden"
+                  name="target_ca_users_only"
+                  value={String(targetCommunityUsersOnly)}
+                />
                 <DigestGenerationDayButton date={date} day={day} />
               </form>
             )
@@ -215,6 +224,19 @@ export function DigestDaySelector({
           )
         })}
       </div>
+      {generation ? (
+        <label className={`mt-4 flex items-start gap-2 text-xs ${MUTED}`}>
+          <input
+            type="checkbox"
+            checked={targetCommunityUsersOnly}
+            onChange={(event) =>
+              setTargetCommunityUsersOnly(event.currentTarget.checked)
+            }
+            className="mt-0.5 h-4 w-4 rounded border-zinc-300"
+          />
+          Only include posts authored by Community Archive members
+        </label>
+      ) : null}
       <p
         className={`${editorial ? 'mt-4 text-xs leading-[1.6]' : 'mt-3 text-[11px] leading-4'} ${MUTED}`}
       >

--- a/src/lib/clickhouseGateway.ts
+++ b/src/lib/clickhouseGateway.ts
@@ -26,6 +26,12 @@ const ALLOWED_ENDPOINTS: Record<string, ReadonlySet<string>> = {
   'word-trend': new Set(['q', 'bucket', 'match', 'from', 'to']),
   'stream-stats': new Set(['start', 'end', 'granularity', 'scope']),
   'recent-bangers': new Set(['limit', 'hours', 'end', 'target_ca_users_only']),
+  'daily-interactions': new Set([
+    'limit',
+    'hours',
+    'end',
+    'target_ca_users_only',
+  ]),
   'portal-stream': new Set([
     'limit',
     'before',

--- a/src/lib/digest/generation.test.ts
+++ b/src/lib/digest/generation.test.ts
@@ -2,6 +2,7 @@ import type { PortalTweet } from '@/lib/portal/types'
 import {
   assembleDigestEditionContent,
   buildDigestPromptCorpus,
+  fillDailyDigestCandidates,
   renderDigestPrompt,
   selectDailyDigestBangers,
   type EnrichedDigestCandidate,
@@ -116,6 +117,26 @@ describe('daily digest generation contract', () => {
     expect(selected.at(-1)?.quoteCount).toBe(2)
   })
 
+  test('fills a sparse banger set with unique CA interaction-ranked posts', () => {
+    const selected = fillDailyDigestCandidates(
+      [tweet('1', 'strong', 4), tweet('2', 'weak', 1)],
+      [
+        tweet('1', 'duplicate', 4),
+        tweet('3', 'discussed', 1),
+        tweet('4', 'also discussed', 0),
+      ],
+      3,
+    )
+
+    expect(
+      selected.map(({ tweet: item, source }) => [item.id, source]),
+    ).toEqual([
+      ['1', 'banger'],
+      ['3', 'ca_interactions'],
+      ['4', 'ca_interactions'],
+    ])
+  })
+
   test('renders a reproducible prompt from the frozen candidate snapshot', () => {
     const prompt = renderDigestPrompt(
       '{{digest_date}}|{{window_start}}|{{window_end}}|{{candidate_json}}',
@@ -131,6 +152,7 @@ describe('daily digest generation contract', () => {
     expect(prompt).toContain('taste benchmarks are becoming public rituals')
     expect(prompt).toContain('"index": 0')
     expect(prompt).toContain('"archived_ca_quote_count": 9')
+    expect(prompt).toContain('"selection_source": "banger"')
     expect(prompt).toContain('"kind": "quote"')
     expect(prompt).toContain('"tweet_id": "1"')
   })

--- a/src/lib/digest/generation.ts
+++ b/src/lib/digest/generation.ts
@@ -53,6 +53,28 @@ export function selectDailyDigestBangers(tweets: PortalTweet[]): PortalTweet[] {
   return tweets.filter((tweet) => (tweet.quoteCount ?? 0) >= 2).slice(0, 50)
 }
 
+export function fillDailyDigestCandidates(
+  bangers: PortalTweet[],
+  interactionRanked: PortalTweet[],
+  minimum = 10,
+): Array<{ tweet: PortalTweet; source: 'banger' | 'ca_interactions' }> {
+  const selected: Array<{
+    tweet: PortalTweet
+    source: 'banger' | 'ca_interactions'
+  }> = selectDailyDigestBangers(bangers).map((tweet) => ({
+    tweet,
+    source: 'banger',
+  }))
+  const seen = new Set(selected.map(({ tweet }) => tweet.id))
+  for (const tweet of interactionRanked) {
+    if (selected.length >= minimum) break
+    if (seen.has(tweet.id)) continue
+    seen.add(tweet.id)
+    selected.push({ tweet, source: 'ca_interactions' })
+  }
+  return selected
+}
+
 const cleanText = (value: unknown, max: number): string | null => {
   if (typeof value !== 'string') return null
   const cleaned = value.trim().replace(/\s+/g, ' ')
@@ -305,7 +327,13 @@ export function renderDigestPrompt(
         ...(candidate
           ? {
               source_rank: candidate.sourceRank,
+              selection_source: candidate.source ?? 'banger',
               archived_ca_quote_count: candidate.tweet.quoteCount ?? 0,
+              archived_ca_reply_count: candidate.tweet.replyCount ?? 0,
+              archived_ca_interaction_count:
+                candidate.tweet.interactionCount ??
+                candidate.tweet.quoteCount ??
+                0,
             }
           : {}),
         tweet: promptTweet(row.tweet),

--- a/src/lib/digest/types.ts
+++ b/src/lib/digest/types.ts
@@ -24,6 +24,7 @@ export interface DigestCandidate {
   tweet: PortalTweet
   sourceRank: number
   selected: boolean
+  source?: 'banger' | 'ca_interactions'
 }
 
 export interface DigestRunEvent {

--- a/src/lib/portal/analytics.test.ts
+++ b/src/lib/portal/analytics.test.ts
@@ -1,5 +1,6 @@
 import {
   fetchPortalBangersPage,
+  fetchPortalDailyInteractions,
   fetchPortalTrendEvidence,
   fetchPortalTrendSeries,
   fetchPortalLiveAnalytics,
@@ -371,6 +372,55 @@ describe('ClickHouse-backed portal analytics', () => {
         target_ca_users_only: 'true',
       }),
       { timeoutMs: 30_000, revalidate: 1_800 },
+    )
+  })
+
+  test('maps same-day CA interaction rankings with the exact window and author scope', async () => {
+    const fetcher = jest.fn(async () => ({
+      data: [
+        {
+          tweetId: '2085365448686866863',
+          accountId: '14816854',
+          createdAt: '2026-08-17 14:00:41.000',
+          fullText: 'A same-day discussed post',
+          favoriteCount: '12',
+          retweetCount: '3',
+          latestObservedAt: '2026-08-17 14:00:41.000',
+          interactionCount: '8',
+          replyCount: '7',
+          quoteCount: '1',
+          username: 'katiebakes',
+          accountDisplayName: 'Katie',
+          avatarMediaUrl: null,
+        },
+      ],
+    })) as unknown as AnalyticsFetcher
+
+    await expect(
+      fetchPortalDailyInteractions(
+        50,
+        24,
+        fetcher,
+        '2026-08-18T06:00:00.000Z',
+        true,
+      ),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: '2085365448686866863',
+        interactionCount: 8,
+        replyCount: 7,
+        quoteCount: 1,
+      }),
+    ])
+    expect(fetcher).toHaveBeenCalledWith(
+      ['daily-interactions'],
+      new URLSearchParams({
+        limit: '50',
+        hours: '24',
+        end: '2026-08-18T06:00:00.000Z',
+        target_ca_users_only: 'true',
+      }),
+      { timeoutMs: 30_000, revalidate: 300 },
     )
   })
 

--- a/src/lib/portal/analytics.ts
+++ b/src/lib/portal/analytics.ts
@@ -101,6 +101,15 @@ interface ClickHouseRecentBangersResponse {
   data: ClickHouseRecentBanger[]
 }
 
+interface ClickHouseDailyInteraction extends ClickHouseRecentBanger {
+  interactionCount: string | number
+  replyCount: string | number
+}
+
+interface ClickHouseDailyInteractionsResponse {
+  data: ClickHouseDailyInteraction[]
+}
+
 interface ClickHouseTopQuote {
   tweetId: string
   quoteCount: string | number
@@ -516,6 +525,78 @@ export async function fetchPortalRecentBangers(
       likes: safeCount(row.favoriteCount, 'banger favorite count'),
       rts: safeCount(row.retweetCount, 'banger repost count'),
       quoteCount: safeCount(row.quoteCount, 'banger quote count'),
+      ...(media.length ? { media } : {}),
+    }
+  })
+}
+
+/** Same-window posts ranked by non-self replies and quotes from CA members. */
+export async function fetchPortalDailyInteractions(
+  limit = 50,
+  hours = 24,
+  fetcher: AnalyticsFetcher = fetchAnalyticsGatewayJson,
+  end?: string,
+  targetCommunityUsersOnly = false,
+): Promise<PortalTweet[]> {
+  const safeLimit = Math.max(1, Math.min(50, Math.trunc(limit)))
+  const safeHours = Math.max(1, Math.min(168, Math.trunc(hours)))
+  const response = await fetcher<ClickHouseDailyInteractionsResponse>(
+    ['daily-interactions'],
+    new URLSearchParams({
+      limit: String(safeLimit),
+      hours: String(safeHours),
+      ...(end ? { end: safeTimestamp(end, 'window end') } : {}),
+      ...(targetCommunityUsersOnly ? { target_ca_users_only: 'true' } : {}),
+    }),
+    { timeoutMs: 30_000, revalidate: 300 },
+  )
+  if (!Array.isArray(response.data)) {
+    throw new Error('ClickHouse daily-interactions returned an invalid response')
+  }
+
+  return response.data.map((row) => {
+    if (
+      !/^\d{1,32}$/.test(row.tweetId) ||
+      !/^\d{1,32}$/.test(row.accountId) ||
+      typeof row.fullText !== 'string'
+    ) {
+      throw new Error('ClickHouse daily-interactions returned an invalid tweet')
+    }
+    const username = row.username || 'unknown'
+    const media = (row.media ?? []).flatMap((item) =>
+      typeof item.mediaUrl === 'string' && typeof item.mediaType === 'string'
+        ? [
+            {
+              url: item.mediaUrl,
+              type: item.mediaType,
+              ...(typeof item.width === 'number' ? { width: item.width } : {}),
+              ...(typeof item.height === 'number'
+                ? { height: item.height }
+                : {}),
+            },
+          ]
+        : [],
+    )
+    return {
+      id: row.tweetId,
+      accountId: row.accountId,
+      username,
+      name: row.accountDisplayName || username,
+      avatar: row.avatarMediaUrl || null,
+      text: row.fullText,
+      observedAt: safeTimestamp(
+        row.latestObservedAt,
+        'interaction observation timestamp',
+      ),
+      createdAt: safeTimestamp(row.createdAt, 'interaction authored timestamp'),
+      likes: safeCount(row.favoriteCount, 'interaction favorite count'),
+      rts: safeCount(row.retweetCount, 'interaction repost count'),
+      quoteCount: safeCount(row.quoteCount, 'interaction quote count'),
+      replyCount: safeCount(row.replyCount, 'interaction reply count'),
+      interactionCount: safeCount(
+        row.interactionCount,
+        'interaction total count',
+      ),
       ...(media.length ? { media } : {}),
     }
   })

--- a/src/lib/portal/types.ts
+++ b/src/lib/portal/types.ts
@@ -40,6 +40,10 @@ export interface PortalTweet {
   quotedTweet?: PortalQuotedTweet
   /** Distinct non-self quote tweets from archive uploaders and opt-ins. */
   quoteCount?: number
+  /** Distinct non-self replies from archive uploaders and opt-ins. */
+  replyCount?: number
+  /** Distinct non-self replies plus quote posts from archive members. */
+  interactionCount?: number
 }
 
 export type PortalBangersScope = 'all' | 'members'


### PR DESCRIPTION
## Summary
- add a default-on digest editor toggle that can include either CA-authored posts only or posts by all authors
- preserve qualifying bangers first, then fill sparse candidate pools to 10 with same-CA-day posts ranked by distinct non-self replies and quotes from CA members
- label fallback candidates and include interaction counts/source in the frozen prompt corpus
- apply exact window ends to rolling and historical pulls

## Dependency
- Requires TheExGenesis/community-archive-control-panel#154 to be deployed first.

## Validation
- `pnpm test -- --runInBand src/lib/digest/generation.test.ts src/lib/portal/analytics.test.ts src/components/digest/DigestDaySelector.test.tsx` (30 passed)
- `pnpm exec tsc --noEmit --incremental`
- `git diff --check`

## Note
The normal pre-commit hook could not regenerate local Supabase types because this isolated worktree has no Supabase auth environment/local stack. It produced no generated-file diff; the focused tests and TypeScript checks above passed.