### PR TITLE
Render tweet threads from ClickHouse

### DIFF
--- a/src/lib/clickhouseGateway.test.ts
+++ b/src/lib/clickhouseGateway.test.ts
@@ -182,6 +182,24 @@ describe('ClickHouse analytics gateway requests', () => {
     ).toThrow('Unsupported ClickHouse analytics endpoint')
   })
 
+  test('allows only numeric tweet-thread paths and no query parameters', () => {
+    const target = analyticsGatewayRequestUrl(
+      ['tweet', '2085473085399150817', 'thread'],
+      new URLSearchParams('raw_sql=DROP'),
+      'https://stream.example/analytics',
+    )
+    expect(target.toString()).toBe(
+      'https://stream.example/analytics/tweet/2085473085399150817/thread',
+    )
+    expect(() =>
+      analyticsGatewayRequestUrl(
+        ['tweet', 'not-a-tweet', 'thread'],
+        new URLSearchParams(),
+        'https://stream.example/analytics',
+      ),
+    ).toThrow('Unsupported ClickHouse analytics endpoint')
+  })
+
   test('allows only scoped profile-sidebar parameters for numeric accounts', () => {
     const target = analyticsGatewayRequestUrl(
       ['user', '42', 'sidebar'],

--- a/src/lib/clickhouseGateway.ts
+++ b/src/lib/clickhouseGateway.ts
@@ -126,6 +126,13 @@ export function analyticsGatewayRequestUrl(
   ) {
     allowedParams = new Set()
   } else if (
+    cleanPath.length === 3 &&
+    cleanPath[0] === 'tweet' &&
+    /^\d{1,20}$/.test(cleanPath[1]) &&
+    cleanPath[2] === 'thread'
+  ) {
+    allowedParams = new Set()
+  } else if (
     cleanPath.length === 2 &&
     cleanPath[0] === 'quote-posts' &&
     /^\d{1,20}$/.test(cleanPath[1])

--- a/src/lib/clickhouseTweetPage.test.ts
+++ b/src/lib/clickhouseTweetPage.test.ts
@@ -1,4 +1,7 @@
-import { fetchClickHouseTweetPageData } from './clickhouseTweetPage'
+import {
+  fetchClickHouseTweetPageData,
+  fetchClickHouseTweetThreadPageData,
+} from './clickhouseTweetPage'
 
 describe('fetchClickHouseTweetPageData', () => {
   test('maps a portal tweet detail from ClickHouse into the permalink renderer', async () => {
@@ -86,5 +89,67 @@ describe('fetchClickHouseTweetPageData', () => {
       fetchClickHouseTweetPageData('not-a-tweet', fetcher),
     ).resolves.toBeNull()
     expect(fetcher).not.toHaveBeenCalled()
+  })
+
+  test('maps a ClickHouse conversation into the existing thread tree', async () => {
+    const root = {
+      tweetId: '1636679643120951297',
+      accountId: '10',
+      createdAt: '2023-03-17 10:43:29.000',
+      fullText: 'Thread root',
+      replyToTweetId: null,
+      replyToUsername: null,
+      favoriteCount: '144',
+      retweetCount: '32',
+      username: 'exgenesis',
+      accountDisplayName: 'xiq',
+      avatarMediaUrl: null,
+      quoteTweetId: null,
+      quotedTweet: null,
+      retweetedTweetId: null,
+      media: [],
+    }
+    const reply = {
+      ...root,
+      tweetId: '1636682659488301059',
+      createdAt: '2023-03-17 10:55:28.000',
+      fullText: 'this is my best tweet',
+      replyToTweetId: root.tweetId,
+      replyToUsername: 'exgenesis',
+      favoriteCount: '25',
+      retweetCount: '2',
+    }
+    const fetcher = jest.fn().mockResolvedValue({
+      data: {
+        tweet: root,
+        conversationTweets: [root, reply],
+      },
+    })
+
+    const page = await fetchClickHouseTweetThreadPageData(root.tweetId, fetcher)
+
+    expect(fetcher).toHaveBeenCalledWith(
+      ['tweet', root.tweetId, 'thread'],
+      expect.any(URLSearchParams),
+      { revalidate: 3600 },
+    )
+    expect(page?.tweet).toMatchObject({
+      tweet_id: root.tweetId,
+      full_text: 'Thread root',
+    })
+    expect(page?.threadTree).toMatchObject({
+      root: root.tweetId,
+      roots: [root.tweetId],
+      children: {
+        [root.tweetId]: [reply.tweetId],
+        [reply.tweetId]: [],
+      },
+      parents: { [reply.tweetId]: root.tweetId },
+    })
+    expect(page?.threadTree?.tweets[reply.tweetId]).toMatchObject({
+      tweet_id: reply.tweetId,
+      reply_to_tweet_id: root.tweetId,
+      username: 'exgenesis',
+    })
   })
 })

--- a/src/lib/clickhouseTweetPage.ts
+++ b/src/lib/clickhouseTweetPage.ts
@@ -1,5 +1,10 @@
 import type { TweetData } from '@/components/TweetComponent'
 import { fetchAnalyticsGatewayJson } from './clickhouseGateway'
+import {
+  buildConversationTree,
+  type ConversationTree,
+  type ThreadTweet,
+} from './threadUtils'
 
 interface ClickHouseTweetDetail {
   tweetId: string
@@ -29,6 +34,24 @@ interface ClickHouseTweetDetailResponse {
     }
     quotedTweet: ClickHouseTweetDetail | null
   }
+}
+
+interface ClickHouseThreadTweet extends ClickHouseTweetDetail {
+  quoteTweetId: string | null
+  quotedTweet: ClickHouseTweetDetail | null
+  retweetedTweetId: string | null
+}
+
+interface ClickHouseTweetThreadResponse {
+  data: {
+    tweet: ClickHouseThreadTweet
+    conversationTweets: ClickHouseThreadTweet[]
+  }
+}
+
+export interface ClickHouseTweetThreadPageData {
+  tweet: TweetData
+  threadTree: ConversationTree | null
 }
 
 function count(value: string | number | null): number {
@@ -69,22 +92,27 @@ function quotedTweet(
   }
 }
 
-export async function fetchClickHouseTweetPageData(
-  tweetId: string,
-  fetcher = fetchAnalyticsGatewayJson,
-): Promise<TweetData | null> {
-  if (!/^\d{1,20}$/.test(tweetId)) return null
+function deletedQuotedTweet(tweetId: string) {
+  return {
+    tweet_id: tweetId,
+    account_id: '',
+    created_at: '',
+    full_text: '',
+    retweet_count: 0,
+    favorite_count: 0,
+    username: '',
+    account_display_name: '',
+    is_deleted: true as const,
+  }
+}
 
-  const response = await fetcher<ClickHouseTweetDetailResponse>(
-    ['tweet', tweetId],
-    new URLSearchParams(),
-    { revalidate: 3600 },
-  )
-  if (!response.data?.tweet) return null
-
-  const tweet = response.data.tweet
+function toTweetData(
+  tweet: ClickHouseTweetDetail,
+  quoteTweetId: string | null,
+  quote: ClickHouseTweetDetail | null,
+  retweetedTweetId: string | null,
+): TweetData {
   const username = tweet.username || 'unknown_user'
-  const quote = response.data.quotedTweet
   return {
     tweet_id: tweet.tweetId,
     account_id: tweet.accountId,
@@ -95,8 +123,8 @@ export async function fetchClickHouseTweetPageData(
     favorite_count: count(tweet.favoriteCount),
     reply_to_tweet_id: tweet.replyToTweetId,
     reply_to_username: tweet.replyToUsername || undefined,
-    quote_tweet_id: tweet.quoteTweetId,
-    retweeted_tweet_id: tweet.retweetedTweetId,
+    quote_tweet_id: quoteTweetId,
+    retweeted_tweet_id: retweetedTweetId,
     avatar_media_url: tweet.avatarMediaUrl,
     username,
     account_display_name: tweet.accountDisplayName || username,
@@ -111,18 +139,83 @@ export async function fetchClickHouseTweetPageData(
     },
     quoted_tweet: quote
       ? quotedTweet(quote)
-      : tweet.quoteTweetId
-        ? {
-            tweet_id: tweet.quoteTweetId,
-            account_id: '',
-            created_at: '',
-            full_text: '',
-            retweet_count: 0,
-            favorite_count: 0,
-            username: '',
-            account_display_name: '',
-            is_deleted: true,
-          }
+      : quoteTweetId
+        ? deletedQuotedTweet(quoteTweetId)
         : undefined,
+  }
+}
+
+function toThreadTweet(tweet: ClickHouseThreadTweet): ThreadTweet {
+  const rendered = toTweetData(
+    tweet,
+    tweet.quoteTweetId,
+    tweet.quotedTweet,
+    null,
+  )
+  return {
+    tweet_id: rendered.tweet_id,
+    account_id: rendered.account_id,
+    created_at: rendered.created_at,
+    full_text: rendered.full_text,
+    retweet_count: rendered.retweet_count,
+    favorite_count: rendered.favorite_count,
+    reply_to_tweet_id: rendered.reply_to_tweet_id,
+    reply_to_user_id: null,
+    reply_to_username: rendered.reply_to_username || null,
+    username: rendered.username,
+    account_display_name: rendered.account_display_name,
+    avatar_media_url: rendered.avatar_media_url || undefined,
+    media: rendered.media,
+    quote_tweet_id: rendered.quote_tweet_id,
+    quoted_tweet: rendered.quoted_tweet || null,
+  }
+}
+
+export async function fetchClickHouseTweetPageData(
+  tweetId: string,
+  fetcher = fetchAnalyticsGatewayJson,
+): Promise<TweetData | null> {
+  if (!/^\d{1,20}$/.test(tweetId)) return null
+
+  const response = await fetcher<ClickHouseTweetDetailResponse>(
+    ['tweet', tweetId],
+    new URLSearchParams(),
+    { revalidate: 3600 },
+  )
+  if (!response.data?.tweet) return null
+
+  const tweet = response.data.tweet
+  const quote = response.data.quotedTweet
+  return toTweetData(tweet, tweet.quoteTweetId, quote, tweet.retweetedTweetId)
+}
+
+export async function fetchClickHouseTweetThreadPageData(
+  tweetId: string,
+  fetcher = fetchAnalyticsGatewayJson,
+): Promise<ClickHouseTweetThreadPageData | null> {
+  if (!/^\d{1,20}$/.test(tweetId)) return null
+
+  const response = await fetcher<ClickHouseTweetThreadResponse>(
+    ['tweet', tweetId, 'thread'],
+    new URLSearchParams(),
+    { revalidate: 3600 },
+  )
+  if (!response.data?.tweet) return null
+
+  const selected = response.data.tweet
+  const nodes = [...(response.data.conversationTweets || [])]
+  if (!nodes.some((tweet) => tweet.tweetId === selected.tweetId)) {
+    nodes.push(selected)
+  }
+  const threadTweets = nodes.map(toThreadTweet)
+  return {
+    tweet: toTweetData(
+      selected,
+      selected.quoteTweetId,
+      selected.quotedTweet,
+      selected.retweetedTweetId,
+    ),
+    threadTree:
+      threadTweets.length > 1 ? buildConversationTree(threadTweets) : null,
   }
 }

--- a/src/lib/getTweetPageData.test.ts
+++ b/src/lib/getTweetPageData.test.ts
@@ -2,7 +2,7 @@ import type { TweetData } from '@/components/TweetComponent'
 import { cookies } from 'next/headers'
 import { createServerClient } from '@/utils/supabase'
 import { isClickHouseReadsEnabled } from './clickhouseGateway'
-import { fetchClickHouseTweetPageData } from './clickhouseTweetPage'
+import { fetchClickHouseTweetThreadPageData } from './clickhouseTweetPage'
 import { fetchClickHouseQuotePosts } from './clickhouseQuotePosts'
 import { getTweetPageData } from './getTweetPageData'
 
@@ -12,7 +12,7 @@ jest.mock('./clickhouseGateway', () => ({
   isClickHouseReadsEnabled: jest.fn(),
 }))
 jest.mock('./clickhouseTweetPage', () => ({
-  fetchClickHouseTweetPageData: jest.fn(),
+  fetchClickHouseTweetThreadPageData: jest.fn(),
 }))
 jest.mock('./clickhouseQuotePosts', () => ({
   fetchClickHouseQuotePosts: jest.fn(),
@@ -24,9 +24,9 @@ jest.mock('./twitterSyndication', () => ({
 const clickHouseEnabledMock = isClickHouseReadsEnabled as jest.MockedFunction<
   typeof isClickHouseReadsEnabled
 >
-const fetchClickHouseTweetPageDataMock =
-  fetchClickHouseTweetPageData as jest.MockedFunction<
-    typeof fetchClickHouseTweetPageData
+const fetchClickHouseTweetThreadPageDataMock =
+  fetchClickHouseTweetThreadPageData as jest.MockedFunction<
+    typeof fetchClickHouseTweetThreadPageData
   >
 const fetchClickHouseQuotePostsMock =
   fetchClickHouseQuotePosts as jest.MockedFunction<
@@ -71,7 +71,7 @@ describe('getTweetPageData', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     clickHouseEnabledMock.mockReturnValue(false)
-    fetchClickHouseTweetPageDataMock.mockResolvedValue(null)
+    fetchClickHouseTweetThreadPageDataMock.mockResolvedValue(null)
     fetchClickHouseQuotePostsMock.mockResolvedValue({
       tweets: [],
       totalCount: 0,
@@ -98,8 +98,31 @@ describe('getTweetPageData', () => {
       media: [],
       urls: [],
     } satisfies TweetData
+    const threadTree = {
+      root: tweet.tweet_id,
+      roots: [tweet.tweet_id],
+      tweets: {
+        [tweet.tweet_id]: tweet,
+        '2085473085399150818': {
+          ...tweet,
+          tweet_id: '2085473085399150818',
+          reply_to_tweet_id: tweet.tweet_id,
+        },
+      },
+      children: {
+        [tweet.tweet_id]: ['2085473085399150818'],
+        '2085473085399150818': [],
+      },
+      parents: { '2085473085399150818': tweet.tweet_id },
+      paths: {
+        '2085473085399150818': [tweet.tweet_id, '2085473085399150818'],
+      },
+    }
     clickHouseEnabledMock.mockReturnValue(true)
-    fetchClickHouseTweetPageDataMock.mockResolvedValue(tweet)
+    fetchClickHouseTweetThreadPageDataMock.mockResolvedValue({
+      tweet,
+      threadTree: threadTree as never,
+    })
     fetchClickHouseQuotePostsMock.mockResolvedValue({
       totalCount: 7,
       tweets: [
@@ -114,7 +137,7 @@ describe('getTweetPageData', () => {
 
     await expect(getTweetPageData(tweet.tweet_id)).resolves.toMatchObject({
       tweet,
-      threadTree: null,
+      threadTree,
       quotingTweetCount: 7,
       quotingTweets: [
         expect.objectContaining({
@@ -123,7 +146,7 @@ describe('getTweetPageData', () => {
         }),
       ],
     })
-    expect(fetchClickHouseTweetPageDataMock).toHaveBeenCalledWith(
+    expect(fetchClickHouseTweetThreadPageDataMock).toHaveBeenCalledWith(
       tweet.tweet_id,
     )
     expect(fetchClickHouseQuotePostsMock).toHaveBeenCalledWith(tweet.tweet_id)
@@ -149,7 +172,10 @@ describe('getTweetPageData', () => {
       urls: [],
     } satisfies TweetData
     clickHouseEnabledMock.mockReturnValue(true)
-    fetchClickHouseTweetPageDataMock.mockResolvedValue(tweet)
+    fetchClickHouseTweetThreadPageDataMock.mockResolvedValue({
+      tweet,
+      threadTree: null,
+    })
     fetchClickHouseQuotePostsMock.mockRejectedValue(new Error('gateway down'))
     const consoleError = jest
       .spyOn(console, 'error')

--- a/src/lib/getTweetPageData.ts
+++ b/src/lib/getTweetPageData.ts
@@ -11,7 +11,7 @@ import {
   type SyndicatedTweet,
 } from './twitterSyndication'
 import { isClickHouseReadsEnabled } from './clickhouseGateway'
-import { fetchClickHouseTweetPageData } from './clickhouseTweetPage'
+import { fetchClickHouseTweetThreadPageData } from './clickhouseTweetPage'
 import {
   fetchClickHouseQuotePosts,
   type ClickHouseQuotePostsData,
@@ -213,8 +213,8 @@ async function fetchClickHousePage(
   if (!isClickHouseReadsEnabled()) return null
 
   try {
-    const [tweet, quotePosts] = await Promise.all([
-      fetchClickHouseTweetPageData(tweetId),
+    const [page, quotePosts] = await Promise.all([
+      fetchClickHouseTweetThreadPageData(tweetId),
       fetchClickHouseQuotePosts(tweetId).catch((error) => {
         console.error('ClickHouse quote posts failed:', {
           tweetId,
@@ -223,15 +223,14 @@ async function fetchClickHousePage(
         return { tweets: [], totalCount: 0 } satisfies ClickHouseQuotePostsData
       }),
     ])
-    if (!tweet) return null
+    if (!page) return null
     return {
-      tweet,
-      threadTree: null,
+      ...page,
       quotingTweets: quotePosts.tweets,
       quotingTweetCount: quotePosts.totalCount,
     }
   } catch (error) {
-    console.error('ClickHouse tweet detail failed; falling back to Supabase:', {
+    console.error('ClickHouse tweet thread failed; falling back to Supabase:', {
       tweetId,
       error: error instanceof Error ? error.message : String(error),
     })


### PR DESCRIPTION
## Summary
- allowlist the authenticated ClickHouse tweet-thread route
- map ClickHouse conversation nodes into the existing `ConversationTree` and `ThreadView`
- preserve media, quoted-tweet placeholders/context, selected repost metadata, quote sidebar loading, and the legacy Supabase fallback

## Validation
- `pnpm exec jest --selectProjects server --runInBand src/lib/clickhouseGateway.test.ts src/lib/clickhouseTweetPage.test.ts src/lib/getTweetPageData.test.ts` (25 tests passed)
- `pnpm type-check`
- focused Prettier check on the six changed files

## Gateway dependency
Depends on TheExGenesis/community-archive-control-panel#166. Deploy and smoke-test that gateway route before merging this frontend PR. No deployment is included here.