### PR TITLE
Infinite-scroll long tweet threads

### DIFF
--- a/src/app/api/tweets/[tweet_id]/thread/route.ts
+++ b/src/app/api/tweets/[tweet_id]/thread/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { fetchClickHouseTweetThreadPageData } from '@/lib/clickhouseTweetPage'
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 30
+
+function pageInput(searchParams: URLSearchParams) {
+  const limitValue = searchParams.get('limit')
+  const limit = limitValue === null ? 12 : Number(limitValue)
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 50) {
+    throw new Error('Invalid thread pagination')
+  }
+
+  const after = searchParams.get('after')
+  const afterId = searchParams.get('after_id')
+  if (Boolean(after) !== Boolean(afterId)) {
+    throw new Error('Invalid thread pagination')
+  }
+  if (!after || !afterId) return { limit }
+  const createdAt = new Date(after)
+  if (Number.isNaN(createdAt.getTime()) || !/^\d{1,20}$/.test(afterId)) {
+    throw new Error('Invalid thread pagination')
+  }
+  return {
+    limit,
+    after: { createdAt: createdAt.toISOString(), tweetId: afterId },
+  }
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { tweet_id: string } },
+) {
+  try {
+    if (!/^\d{1,20}$/.test(params.tweet_id)) {
+      return NextResponse.json({ error: 'Tweet not found' }, { status: 404 })
+    }
+    const input = pageInput(new URL(request.url).searchParams)
+    const page = await fetchClickHouseTweetThreadPageData(
+      params.tweet_id,
+      undefined,
+      input,
+    )
+    if (!page) {
+      return NextResponse.json({ error: 'Tweet not found' }, { status: 404 })
+    }
+    return NextResponse.json(
+      {
+        tweets: page.threadTweets,
+        totalCount: page.totalCount,
+        nextCursor: page.nextCursor,
+      },
+      { headers: { 'Cache-Control': 'private, no-store' } },
+    )
+  } catch (error) {
+    const message = error instanceof Error ? error.message : ''
+    const invalid = message === 'Invalid thread pagination'
+    if (!invalid) console.error('Thread pagination failed:', error)
+    return NextResponse.json(
+      { error: invalid ? message : 'Thread is temporarily unavailable' },
+      { status: invalid ? 400 : 502 },
+    )
+  }
+}

--- a/src/app/tweets/[tweet_id]/page.tsx
+++ b/src/app/tweets/[tweet_id]/page.tsx
@@ -18,14 +18,16 @@ export default async function TweetPage({
   searchParams?: Record<string, string | string[] | undefined>
 }) {
   const { tweet_id } = params
-  const { tweet, threadTree, quotingTweets, quotingTweetCount } =
+  const { tweet, threadTree, threadPage, quotingTweets, quotingTweetCount } =
     await getTweetPageData(tweet_id)
 
   if (!tweet) {
     notFound()
   }
 
-  const isThread = threadTree && Object.keys(threadTree.tweets).length > 1
+  const isThread =
+    threadTree &&
+    (threadPage?.totalCount ?? Object.keys(threadTree.tweets).length) > 1
   const backLink = getTweetBackLink(searchParams)
 
   return (
@@ -59,7 +61,12 @@ export default async function TweetPage({
         <div className="grid items-start gap-8 lg:grid-cols-[minmax(0,1fr)_22rem] xl:gap-10">
           <div className="min-w-0">
             {isThread && threadTree ? (
-              <ThreadView tree={threadTree} highlightTweetId={tweet_id} />
+              <ThreadView
+                tree={threadTree}
+                highlightTweetId={tweet_id}
+                totalCount={threadPage?.totalCount}
+                nextCursor={threadPage?.nextCursor}
+              />
             ) : (
               <article className="rounded-lg border border-border bg-card p-5 shadow-sm sm:p-6">
                 <TweetComponent

--- a/src/components/ThreadView.test.tsx
+++ b/src/components/ThreadView.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import ThreadView from './ThreadView'
 import type { ConversationTree, ThreadTweet } from '@/lib/threadUtils'
 
@@ -76,5 +76,60 @@ describe('ThreadView', () => {
 
     expect(screen.getByText('tweet 1')).toBeVisible()
     expect(screen.getByText('tweet 2 (permalink)')).toBeVisible()
+  })
+
+  test('appends the next chronological page without duplicating tweets', async () => {
+    const originalIntersectionObserver = global.IntersectionObserver
+    const originalFetch = global.fetch
+    Object.defineProperty(global, 'IntersectionObserver', {
+      configurable: true,
+      value: class {
+        observe() {}
+        disconnect() {}
+      },
+    })
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        tweets: [tweet('2', '1')],
+        totalCount: 2,
+        nextCursor: null,
+      }),
+    }) as jest.Mock
+
+    const tree: ConversationTree = {
+      root: '1',
+      roots: ['1'],
+      tweets: { '1': tweet('1', null) },
+      children: { '1': [] },
+      parents: {},
+      paths: { '1': ['1'] },
+    }
+    render(
+      <ThreadView
+        tree={tree}
+        highlightTweetId="1"
+        totalCount={2}
+        nextCursor={{
+          createdAt: '2026-08-10T12:01:00.000Z',
+          tweetId: '1',
+        }}
+      />,
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Load more of this thread' }),
+    )
+    await waitFor(() => expect(screen.getByText('tweet 2')).toBeVisible())
+    expect(screen.getAllByText('tweet 1 (permalink)')).toHaveLength(1)
+    expect(
+      screen.queryByText('Load more of this thread'),
+    ).not.toBeInTheDocument()
+
+    global.fetch = originalFetch
+    Object.defineProperty(global, 'IntersectionObserver', {
+      configurable: true,
+      value: originalIntersectionObserver,
+    })
   })
 })

--- a/src/components/ThreadView.tsx
+++ b/src/components/ThreadView.tsx
@@ -1,18 +1,137 @@
-import React from 'react'
+'use client'
+
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { Loader2 } from 'lucide-react'
 import TweetComponent from './TweetComponent'
-import { ConversationTree, ThreadTweet } from '@/lib/threadUtils'
+import {
+  buildConversationTree,
+  type ConversationTree,
+  type ThreadTweet,
+} from '@/lib/threadTree'
 
 interface ThreadViewProps {
   tree: ConversationTree
   highlightTweetId?: string
   className?: string
+  totalCount?: number
+  nextCursor?: ThreadCursor | null
+}
+
+interface ThreadCursor {
+  createdAt: string
+  tweetId: string
+}
+
+interface ThreadPageResponse {
+  tweets: ThreadTweet[]
+  totalCount: number
+  nextCursor: ThreadCursor | null
+  error?: string
+}
+
+const PAGE_SIZE = 12
+
+function realTweets(tree: ConversationTree): ThreadTweet[] {
+  return Object.values(tree.tweets).filter(
+    (tweet) => !tweet.is_deleted_placeholder,
+  )
 }
 
 export const ThreadView: React.FC<ThreadViewProps> = ({
-  tree,
+  tree: initialTree,
   highlightTweetId,
   className = '',
+  totalCount: initialTotalCount,
+  nextCursor: initialNextCursor,
 }) => {
+  const [tree, setTree] = useState(initialTree)
+  const [totalCount, setTotalCount] = useState(
+    () => initialTotalCount ?? realTweets(initialTree).length,
+  )
+  const [nextCursor, setNextCursor] = useState<ThreadCursor | null>(
+    initialNextCursor ?? null,
+  )
+  const [isLoading, setIsLoading] = useState(false)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const loadMoreRef = useRef<HTMLDivElement | null>(null)
+  const loadingRef = useRef(false)
+  const requestControllerRef = useRef<AbortController | null>(null)
+
+  const loadMore = useCallback(async () => {
+    if (!nextCursor || !highlightTweetId || loadingRef.current) return
+
+    const controller = new AbortController()
+    requestControllerRef.current = controller
+    loadingRef.current = true
+    setIsLoading(true)
+    setLoadError(null)
+
+    try {
+      const searchParams = new URLSearchParams({
+        limit: String(PAGE_SIZE),
+        after: nextCursor.createdAt,
+        after_id: nextCursor.tweetId,
+      })
+      const response = await fetch(
+        `/api/tweets/${encodeURIComponent(highlightTweetId)}/thread?${searchParams}`,
+        { signal: controller.signal },
+      )
+      const body = (await response
+        .json()
+        .catch(() => null)) as ThreadPageResponse | null
+      if (!response.ok || !body || !Array.isArray(body.tweets)) {
+        throw new Error(body?.error || 'Could not load more of this thread')
+      }
+
+      setTree((current) =>
+        buildConversationTree(
+          Array.from(
+            new Map(
+              [...realTweets(current), ...body.tweets].map((tweet) => [
+                tweet.tweet_id,
+                tweet,
+              ]),
+            ).values(),
+          ),
+        ),
+      )
+      setTotalCount(body.totalCount)
+      setNextCursor(body.nextCursor)
+    } catch (error) {
+      if (controller.signal.aborted) return
+      setLoadError(
+        error instanceof Error
+          ? error.message
+          : 'Could not load more of this thread',
+      )
+    } finally {
+      if (!controller.signal.aborted) {
+        loadingRef.current = false
+        setIsLoading(false)
+      }
+    }
+  }, [highlightTweetId, nextCursor])
+
+  useEffect(() => {
+    const target = loadMoreRef.current
+    if (!target || !nextCursor) return
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) void loadMore()
+      },
+      { rootMargin: '320px 0px' },
+    )
+    observer.observe(target)
+    return () => observer.disconnect()
+  }, [loadMore, nextCursor])
+
+  useEffect(
+    () => () => {
+      requestControllerRef.current?.abort()
+    },
+    [],
+  )
+
   // Convert ThreadTweet to TweetData format for TweetComponent
   const convertToTweetData = (tweet: ThreadTweet) => ({
     tweet_id: tweet.tweet_id,
@@ -75,7 +194,7 @@ export const ThreadView: React.FC<ThreadViewProps> = ({
 
         {children.length > 0 && (
           <div className="thread-children">
-            {children
+            {[...children]
               .sort((a, b) => {
                 const tweetA = tree.tweets[a]
                 const tweetB = tree.tweets[b]
@@ -109,17 +228,12 @@ export const ThreadView: React.FC<ThreadViewProps> = ({
     )
   }
 
-  // Header count excludes placeholders.
-  const realCount = Object.values(tree.tweets).filter(
-    (t) => !t.is_deleted_placeholder,
-  ).length
-
   return (
     <div className={`thread-view ${className}`}>
       <div className="mb-5 flex items-center justify-between gap-4">
         <h2 className="text-xl font-semibold text-foreground">Thread</h2>
         <span className="rounded-full bg-muted px-3 py-1 text-xs font-medium text-muted-foreground">
-          {realCount} {realCount === 1 ? 'tweet' : 'tweets'}
+          {totalCount} {totalCount === 1 ? 'tweet' : 'tweets'}
         </span>
       </div>
       <div className="thread-container">
@@ -129,6 +243,41 @@ export const ThreadView: React.FC<ThreadViewProps> = ({
           </React.Fragment>
         ))}
       </div>
+
+      {loadError ? (
+        <div className="py-4 text-center">
+          <p className="text-xs text-red-600 dark:text-red-400">{loadError}</p>
+          <button
+            type="button"
+            onClick={() => void loadMore()}
+            className="mt-2 text-xs font-semibold text-brand hover:underline"
+          >
+            Try again
+          </button>
+        </div>
+      ) : null}
+
+      {nextCursor ? (
+        <div
+          ref={loadMoreRef}
+          className="min-h-16 flex items-center justify-center py-3"
+        >
+          <button
+            type="button"
+            onClick={() => void loadMore()}
+            disabled={isLoading}
+            className="inline-flex items-center gap-2 text-xs font-semibold text-brand disabled:cursor-wait disabled:opacity-60"
+          >
+            {isLoading ? (
+              <Loader2
+                aria-hidden="true"
+                className="h-3.5 w-3.5 animate-spin"
+              />
+            ) : null}
+            {isLoading ? 'Loading thread…' : 'Load more of this thread'}
+          </button>
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/src/lib/clickhouseGateway.test.ts
+++ b/src/lib/clickhouseGateway.test.ts
@@ -278,4 +278,17 @@ describe('ClickHouse analytics gateway requests', () => {
       ),
     ).toThrow('Unsupported ClickHouse analytics endpoint')
   })
+
+  test('allows only stable tweet-thread cursor parameters', () => {
+    const target = analyticsGatewayRequestUrl(
+      ['tweet', '2085375983708692599', 'thread'],
+      new URLSearchParams(
+        'limit=12&after=2026-08-20T12%3A00%3A00.000Z&after_id=2085375983708692600&offset=12',
+      ),
+      'https://stream.example/analytics',
+    )
+    expect(target.toString()).toBe(
+      'https://stream.example/analytics/tweet/2085375983708692599/thread?limit=12&after=2026-08-20T12%3A00%3A00.000Z&after_id=2085375983708692600',
+    )
+  })
 })

--- a/src/lib/clickhouseGateway.ts
+++ b/src/lib/clickhouseGateway.ts
@@ -131,7 +131,7 @@ export function analyticsGatewayRequestUrl(
     /^\d{1,20}$/.test(cleanPath[1]) &&
     cleanPath[2] === 'thread'
   ) {
-    allowedParams = new Set()
+    allowedParams = new Set(['limit', 'after', 'after_id'])
   } else if (
     cleanPath.length === 2 &&
     cleanPath[0] === 'quote-posts' &&

--- a/src/lib/clickhouseTweetPage.test.ts
+++ b/src/lib/clickhouseTweetPage.test.ts
@@ -124,6 +124,13 @@ describe('fetchClickHouseTweetPageData', () => {
         tweet: root,
         conversationTweets: [root, reply],
       },
+      query: {
+        total: 18,
+        nextCursor: {
+          createdAt: reply.createdAt,
+          tweetId: reply.tweetId,
+        },
+      },
     })
 
     const page = await fetchClickHouseTweetThreadPageData(root.tweetId, fetcher)
@@ -150,6 +157,13 @@ describe('fetchClickHouseTweetPageData', () => {
       tweet_id: reply.tweetId,
       reply_to_tweet_id: root.tweetId,
       username: 'exgenesis',
+    })
+    expect(page).toMatchObject({
+      totalCount: 18,
+      nextCursor: {
+        createdAt: reply.createdAt,
+        tweetId: reply.tweetId,
+      },
     })
   })
 })

--- a/src/lib/clickhouseTweetPage.ts
+++ b/src/lib/clickhouseTweetPage.ts
@@ -47,11 +47,31 @@ interface ClickHouseTweetThreadResponse {
     tweet: ClickHouseThreadTweet
     conversationTweets: ClickHouseThreadTweet[]
   }
+  query: {
+    total: string | number
+    nextCursor: {
+      createdAt: string
+      tweetId: string
+    } | null
+  }
+}
+
+export interface TweetThreadCursor {
+  createdAt: string
+  tweetId: string
 }
 
 export interface ClickHouseTweetThreadPageData {
   tweet: TweetData
   threadTree: ConversationTree | null
+  threadTweets: ThreadTweet[]
+  totalCount: number
+  nextCursor: TweetThreadCursor | null
+}
+
+interface TweetThreadPageOptions {
+  limit?: number
+  after?: TweetThreadCursor | null
 }
 
 function count(value: string | number | null): number {
@@ -192,12 +212,19 @@ export async function fetchClickHouseTweetPageData(
 export async function fetchClickHouseTweetThreadPageData(
   tweetId: string,
   fetcher = fetchAnalyticsGatewayJson,
+  options: TweetThreadPageOptions = {},
 ): Promise<ClickHouseTweetThreadPageData | null> {
   if (!/^\d{1,20}$/.test(tweetId)) return null
 
+  const limit = Math.max(1, Math.min(50, Math.trunc(options.limit || 12)))
+  const searchParams = new URLSearchParams({ limit: String(limit) })
+  if (options.after) {
+    searchParams.set('after', options.after.createdAt)
+    searchParams.set('after_id', options.after.tweetId)
+  }
   const response = await fetcher<ClickHouseTweetThreadResponse>(
     ['tweet', tweetId, 'thread'],
-    new URLSearchParams(),
+    searchParams,
     { revalidate: 3600 },
   )
   if (!response.data?.tweet) return null
@@ -207,7 +234,8 @@ export async function fetchClickHouseTweetThreadPageData(
   if (!nodes.some((tweet) => tweet.tweetId === selected.tweetId)) {
     nodes.push(selected)
   }
-  const threadTweets = nodes.map(toThreadTweet)
+  const pageTweets = (response.data.conversationTweets || []).map(toThreadTweet)
+  const treeTweets = nodes.map(toThreadTweet)
   return {
     tweet: toTweetData(
       selected,
@@ -216,6 +244,9 @@ export async function fetchClickHouseTweetThreadPageData(
       selected.retweetedTweetId,
     ),
     threadTree:
-      threadTweets.length > 1 ? buildConversationTree(threadTweets) : null,
+      treeTweets.length > 1 ? buildConversationTree(treeTweets) : null,
+    threadTweets: pageTweets,
+    totalCount: Math.max(count(response.query?.total), pageTweets.length),
+    nextCursor: response.query?.nextCursor || null,
   }
 }

--- a/src/lib/getTweetPageData.test.ts
+++ b/src/lib/getTweetPageData.test.ts
@@ -122,6 +122,12 @@ describe('getTweetPageData', () => {
     fetchClickHouseTweetThreadPageDataMock.mockResolvedValue({
       tweet,
       threadTree: threadTree as never,
+      threadTweets: Object.values(threadTree.tweets) as never,
+      totalCount: 18,
+      nextCursor: {
+        createdAt: '2026-08-07T12:05:00.000Z',
+        tweetId: '2085473085399150818',
+      },
     })
     fetchClickHouseQuotePostsMock.mockResolvedValue({
       totalCount: 7,
@@ -138,6 +144,13 @@ describe('getTweetPageData', () => {
     await expect(getTweetPageData(tweet.tweet_id)).resolves.toMatchObject({
       tweet,
       threadTree,
+      threadPage: {
+        totalCount: 18,
+        nextCursor: {
+          createdAt: '2026-08-07T12:05:00.000Z',
+          tweetId: '2085473085399150818',
+        },
+      },
       quotingTweetCount: 7,
       quotingTweets: [
         expect.objectContaining({
@@ -175,6 +188,9 @@ describe('getTweetPageData', () => {
     fetchClickHouseTweetThreadPageDataMock.mockResolvedValue({
       tweet,
       threadTree: null,
+      threadTweets: [tweet as never],
+      totalCount: 1,
+      nextCursor: null,
     })
     fetchClickHouseQuotePostsMock.mockRejectedValue(new Error('gateway down'))
     const consoleError = jest
@@ -184,6 +200,7 @@ describe('getTweetPageData', () => {
     await expect(getTweetPageData(tweet.tweet_id)).resolves.toEqual({
       tweet,
       threadTree: null,
+      threadPage: null,
       quotingTweets: [],
       quotingTweetCount: 0,
     })

--- a/src/lib/getTweetPageData.ts
+++ b/src/lib/getTweetPageData.ts
@@ -98,6 +98,13 @@ interface RpcResult {
 interface TweetPageResult {
   tweet: TweetData | null
   threadTree: ConversationTree | null
+  threadPage?: {
+    totalCount: number
+    nextCursor: {
+      createdAt: string
+      tweetId: string
+    } | null
+  } | null
   quotingTweets: TweetData[]
   quotingTweetCount: number
 }
@@ -225,7 +232,15 @@ async function fetchClickHousePage(
     ])
     if (!page) return null
     return {
-      ...page,
+      tweet: page.tweet,
+      threadTree: page.threadTree,
+      threadPage:
+        page.totalCount > 1
+          ? {
+              totalCount: page.totalCount,
+              nextCursor: page.nextCursor,
+            }
+          : null,
       quotingTweets: quotePosts.tweets,
       quotingTweetCount: quotePosts.totalCount,
     }

--- a/src/lib/threadTree.ts
+++ b/src/lib/threadTree.ts
@@ -1,0 +1,111 @@
+export interface ThreadTweet {
+  tweet_id: string
+  account_id: string
+  created_at: string
+  full_text: string
+  retweet_count: number | null
+  favorite_count: number
+  reply_to_tweet_id: string | null
+  reply_to_user_id: string | null
+  reply_to_username: string | null
+  username: string
+  account_display_name: string
+  avatar_media_url?: string
+  media?: any[]
+  quote_tweet_id?: string | null
+  quoted_tweet?: {
+    tweet_id: string
+    account_id: string
+    created_at: string
+    full_text: string
+    retweet_count: number | null
+    favorite_count: number
+    avatar_media_url?: string
+    username: string
+    account_display_name: string
+    media?: any[]
+    is_deleted?: boolean
+    from_external?: boolean
+  } | null
+  is_deleted_placeholder?: boolean
+  from_external?: boolean
+}
+
+export interface ConversationTree {
+  root: string
+  roots: string[]
+  tweets: { [tweet_id: string]: ThreadTweet }
+  children: { [tweet_id: string]: string[] }
+  parents: { [tweet_id: string]: string }
+  paths: { [leaf_id: string]: string[] }
+}
+
+export const makeDeletedPlaceholder = (tweet_id: string): ThreadTweet => ({
+  tweet_id,
+  account_id: '',
+  created_at: '',
+  full_text: '',
+  retweet_count: 0,
+  favorite_count: 0,
+  reply_to_tweet_id: null,
+  reply_to_user_id: null,
+  reply_to_username: null,
+  username: '',
+  account_display_name: '',
+  is_deleted_placeholder: true,
+})
+
+export const buildConversationTree = (
+  tweets: ThreadTweet[],
+): ConversationTree => {
+  const tree: ConversationTree = {
+    root: '',
+    roots: [],
+    tweets: {},
+    children: {},
+    parents: {},
+    paths: {},
+  }
+
+  for (const tweet of tweets) {
+    tree.tweets[tweet.tweet_id] = tweet
+    if (!tree.children[tweet.tweet_id]) tree.children[tweet.tweet_id] = []
+  }
+
+  for (const tweet of tweets) {
+    const replyTo = tweet.reply_to_tweet_id
+    if (replyTo && !tree.tweets[replyTo]) {
+      tree.tweets[replyTo] = makeDeletedPlaceholder(replyTo)
+      tree.children[replyTo] = []
+    }
+  }
+
+  for (const id of Object.keys(tree.tweets)) {
+    const replyTo = tree.tweets[id].reply_to_tweet_id
+    if (replyTo && tree.tweets[replyTo]) {
+      tree.children[replyTo].push(id)
+      tree.parents[id] = replyTo
+    }
+  }
+
+  for (const id of Object.keys(tree.tweets)) {
+    if (!tree.parents[id]) tree.roots.push(id)
+  }
+  const realRoots = tree.roots.filter(
+    (id) => !tree.tweets[id].is_deleted_placeholder,
+  )
+  tree.root = realRoots[0] ?? tree.roots[0] ?? ''
+
+  const buildPaths = (currentId: string, path: string[] = []): void => {
+    const newPath = [...path, currentId]
+    const children = tree.children[currentId] || []
+    if (children.length === 0) {
+      tree.paths[currentId] = newPath
+      return
+    }
+    for (const childId of children) buildPaths(childId, newPath)
+  }
+  for (const rootId of tree.roots) buildPaths(rootId)
+
+  return tree
+}

--- a/src/lib/threadUtils.ts
+++ b/src/lib/threadUtils.ts
@@ -1,84 +1,28 @@
 import { createServerClient } from '@/utils/supabase'
 import { cookies } from 'next/headers'
+import {
+  buildConversationTree,
+  makeDeletedPlaceholder,
+  type ConversationTree,
+  type ThreadTweet,
+} from './threadTree'
 
-export interface ThreadTweet {
-  tweet_id: string
-  account_id: string
-  created_at: string
-  full_text: string
-  retweet_count: number | null
-  favorite_count: number
-  reply_to_tweet_id: string | null
-  reply_to_user_id: string | null
-  reply_to_username: string | null
-  username: string
-  account_display_name: string
-  avatar_media_url?: string
-  media?: any[]
-  quote_tweet_id?: string | null
-  quoted_tweet?: {
-    tweet_id: string
-    account_id: string
-    created_at: string
-    full_text: string
-    retweet_count: number | null
-    favorite_count: number
-    avatar_media_url?: string
-    username: string
-    account_display_name: string
-    media?: any[]
-    // True when the quoted tweet isn't in our archive AND syndication didn't find it
-    // either — renderer shows a tombstone.
-    is_deleted?: boolean
-    // True when the quoted tweet content was hydrated from Twitter's public
-    // syndication endpoint rather than our DB. Renderer marks it as "not in archive".
-    from_external?: boolean
-  } | null
-  // True when this node was synthesized for a tweet that's missing from our archive
-  // AND Twitter syndication also couldn't supply it. Renderer shows a tombstone.
-  is_deleted_placeholder?: boolean
-  // True when this tweet was hydrated at render time from Twitter's syndication
-  // endpoint, not from our DB. Renderer marks it as "not in archive".
-  from_external?: boolean
-}
-
-export interface ConversationTree {
-  // Primary root for backward compat — the first non-placeholder top-level tweet, or any
-  // root if no real root survived. Prefer iterating `roots` for rendering.
-  root: string
-  // All top-level nodes in the tree (one or more). Synthesized placeholders for missing
-  // deleted parents appear here too so their orphan replies still render.
-  roots: string[]
-  tweets: { [tweet_id: string]: ThreadTweet }
-  children: { [tweet_id: string]: string[] }
-  parents: { [tweet_id: string]: string }
-  paths: { [leaf_id: string]: string[] }
-}
-
-// Synthesized stand-in for a parent tweet that no longer exists. The renderer detects
-// is_deleted_placeholder and shows a muted "[Tweet deleted]" card in its place.
-export const makeDeletedPlaceholder = (tweet_id: string): ThreadTweet => ({
-  tweet_id,
-  account_id: '',
-  created_at: '',
-  full_text: '',
-  retweet_count: 0,
-  favorite_count: 0,
-  reply_to_tweet_id: null,
-  reply_to_user_id: null,
-  reply_to_username: null,
-  username: '',
-  account_display_name: '',
-  is_deleted_placeholder: true,
-})
+export {
+  buildConversationTree,
+  makeDeletedPlaceholder,
+  type ConversationTree,
+  type ThreadTweet,
+} from './threadTree'
 
 /**
  * Get tweets in a conversation thread by following reply chains
  */
-export const getConversationTweets = async (tweet_id: string): Promise<ThreadTweet[]> => {
+export const getConversationTweets = async (
+  tweet_id: string,
+): Promise<ThreadTweet[]> => {
   const cookieStore = await cookies()
   const supabase = createServerClient(cookieStore)
-  
+
   // First get the initial tweet using enriched_tweets view
   const { data: initialTweet, error: initialError } = await supabase
     .schema('public')
@@ -93,11 +37,11 @@ export const getConversationTweets = async (tweet_id: string): Promise<ThreadTwe
 
   // Get all tweets in the same conversation
   let conversationTweets: any[] = []
-  
+
   // If we have a conversation_id, use it to get all related tweets
   if (initialTweet.conversation_id) {
     const { data, error } = await supabase
-      .schema('public') 
+      .schema('public')
       .from('enriched_tweets')
       .select('*')
       .eq('conversation_id', initialTweet.conversation_id)
@@ -107,13 +51,13 @@ export const getConversationTweets = async (tweet_id: string): Promise<ThreadTwe
   } else {
     // Fallback: manually find all replies recursively
     const allReplies = await getReplyChain(supabase, tweet_id)
-    
+
     // Include the original tweet plus all replies
     conversationTweets = [initialTweet, ...allReplies]
   }
 
   // Get media and quote tweets for each tweet
-  const tweetIds = conversationTweets.map(t => t.tweet_id)
+  const tweetIds = conversationTweets.map((t) => t.tweet_id)
   if (tweetIds.length > 0) {
     // Get media
     const { data: mediaData } = await supabase
@@ -130,8 +74,11 @@ export const getConversationTweets = async (tweet_id: string): Promise<ThreadTwe
       .in('tweet_id', tweetIds)
 
     // Get all quoted tweet IDs
-    const quotedTweetIds = (quoteData?.map(q => q.quoted_tweet_id).filter((id): id is string => id !== null) || [])
-    
+    const quotedTweetIds =
+      quoteData
+        ?.map((q) => q.quoted_tweet_id)
+        .filter((id): id is string => id !== null) || []
+
     // Fetch quoted tweets if any
     let quotedTweets: any[] = []
     if (quotedTweetIds.length > 0) {
@@ -140,7 +87,7 @@ export const getConversationTweets = async (tweet_id: string): Promise<ThreadTwe
         .from('enriched_tweets')
         .select('*')
         .in('tweet_id', quotedTweetIds)
-      
+
       if (quotedTweetData) {
         // Get media for quoted tweets
         const { data: quotedMediaData } = await supabase
@@ -148,27 +95,33 @@ export const getConversationTweets = async (tweet_id: string): Promise<ThreadTwe
           .from('tweet_media')
           .select('*')
           .in('tweet_id', quotedTweetIds)
-        
+
         // Add media to quoted tweets
-        quotedTweets = quotedTweetData.map(qt => ({
+        quotedTweets = quotedTweetData.map((qt) => ({
           ...qt,
-          media: quotedMediaData?.filter(m => m.tweet_id === qt.tweet_id) || []
+          media:
+            quotedMediaData?.filter((m) => m.tweet_id === qt.tweet_id) || [],
         }))
       }
     }
 
     // Transform to ThreadTweet format with media and quote tweets
-    return conversationTweets.map(tweet => {
-      const media = mediaData?.filter(m => m.tweet_id === tweet.tweet_id) || []
-      
+    return conversationTweets.map((tweet) => {
+      const media =
+        mediaData?.filter((m) => m.tweet_id === tweet.tweet_id) || []
+
       // Find quote tweet relationship
-      const quoteRelation = quoteData?.find(q => q.tweet_id === tweet.tweet_id)
+      const quoteRelation = quoteData?.find(
+        (q) => q.tweet_id === tweet.tweet_id,
+      )
       let quote_tweet_id = null
       let quoted_tweet = null
-      
+
       if (quoteRelation) {
         quote_tweet_id = quoteRelation.quoted_tweet_id
-        const quotedTweet = quotedTweets.find(qt => qt.tweet_id === quoteRelation.quoted_tweet_id)
+        const quotedTweet = quotedTweets.find(
+          (qt) => qt.tweet_id === quoteRelation.quoted_tweet_id,
+        )
         if (quotedTweet) {
           quoted_tweet = {
             tweet_id: quotedTweet.tweet_id,
@@ -180,7 +133,7 @@ export const getConversationTweets = async (tweet_id: string): Promise<ThreadTwe
             avatar_media_url: quotedTweet.avatar_media_url,
             username: quotedTweet.username,
             account_display_name: quotedTweet.account_display_name,
-            media: quotedTweet.media || []
+            media: quotedTweet.media || [],
           }
         } else {
           // Quote relation exists but the target tweet was deleted — keep the id so the
@@ -198,7 +151,7 @@ export const getConversationTweets = async (tweet_id: string): Promise<ThreadTwe
           }
         }
       }
-      
+
       return {
         tweet_id: tweet.tweet_id,
         account_id: tweet.account_id,
@@ -214,11 +167,11 @@ export const getConversationTweets = async (tweet_id: string): Promise<ThreadTwe
         avatar_media_url: tweet.avatar_media_url,
         media,
         quote_tweet_id,
-        quoted_tweet
+        quoted_tweet,
       }
     })
   }
-  
+
   // If no tweets, return empty array
   return []
 }
@@ -226,10 +179,14 @@ export const getConversationTweets = async (tweet_id: string): Promise<ThreadTwe
 /**
  * Get replies to a tweet including nested replies (recursive)
  */
-async function getReplyChain(supabase: any, tweetId: string, visited: Set<string> = new Set()): Promise<any[]> {
+async function getReplyChain(
+  supabase: any,
+  tweetId: string,
+  visited: Set<string> = new Set(),
+): Promise<any[]> {
   if (visited.has(tweetId)) return []
   visited.add(tweetId)
-  
+
   const { data: replies, error } = await supabase
     .schema('public')
     .from('enriched_tweets')
@@ -238,7 +195,7 @@ async function getReplyChain(supabase: any, tweetId: string, visited: Set<string
     .order('created_at')
 
   const allReplies = replies || []
-  
+
   // Get media for replies
   const replyIds = allReplies.map((r: any) => r.tweet_id)
   if (replyIds.length > 0) {
@@ -249,98 +206,42 @@ async function getReplyChain(supabase: any, tweetId: string, visited: Set<string
       .in('tweet_id', replyIds)
 
     allReplies.forEach((reply: any) => {
-      reply.media = mediaData?.filter((m: any) => m.tweet_id === reply.tweet_id) || []
+      reply.media =
+        mediaData?.filter((m: any) => m.tweet_id === reply.tweet_id) || []
     })
   }
-  
+
   // Recursively get replies to replies
-  for (const reply of allReplies.slice()) { // Use slice() to avoid modifying array during iteration
+  for (const reply of allReplies.slice()) {
+    // Use slice() to avoid modifying array during iteration
     const nestedReplies = await getReplyChain(supabase, reply.tweet_id, visited)
     allReplies.push(...nestedReplies)
   }
-  
+
   return allReplies
-}
-
-/**
- * Build conversation tree structure from tweets
- * Based on the reference implementation in birdseye
- */
-export const buildConversationTree = (tweets: ThreadTweet[]): ConversationTree => {
-  const tree: ConversationTree = {
-    root: '',
-    roots: [],
-    tweets: {},
-    children: {},
-    parents: {},
-    paths: {}
-  }
-
-  // Phase 1: index every real tweet
-  for (const tweet of tweets) {
-    tree.tweets[tweet.tweet_id] = tweet
-    if (!tree.children[tweet.tweet_id]) tree.children[tweet.tweet_id] = []
-  }
-
-  // Phase 2: synthesize placeholders for any reply target that didn't survive
-  for (const tweet of tweets) {
-    const reply_to = tweet.reply_to_tweet_id
-    if (reply_to && !tree.tweets[reply_to]) {
-      tree.tweets[reply_to] = makeDeletedPlaceholder(reply_to)
-      tree.children[reply_to] = []
-    }
-  }
-
-  // Phase 3: wire parent/child relationships using the (now complete) tweet index
-  for (const id of Object.keys(tree.tweets)) {
-    const tweet = tree.tweets[id]
-    const reply_to = tweet.reply_to_tweet_id
-    if (reply_to && tree.tweets[reply_to]) {
-      tree.children[reply_to].push(id)
-      tree.parents[id] = reply_to
-    }
-  }
-
-  // Phase 4: collect every top-level node (no parent in the tree). Placeholders without
-  // a parent become roots so their orphan-reply descendants are reachable from rendering.
-  for (const id of Object.keys(tree.tweets)) {
-    if (!tree.parents[id]) tree.roots.push(id)
-  }
-  // Backward-compat: pick the primary `root`. Prefer real tweets over placeholders.
-  const realRoots = tree.roots.filter((id) => !tree.tweets[id].is_deleted_placeholder)
-  tree.root = realRoots[0] ?? tree.roots[0] ?? ''
-
-  // Phase 5: build root-to-leaf paths for every root.
-  const buildPaths = (currentId: string, path: string[] = []): void => {
-    const newPath = [...path, currentId]
-    const children = tree.children[currentId] || []
-    if (children.length === 0) {
-      tree.paths[currentId] = newPath
-    } else {
-      for (const childId of children) buildPaths(childId, newPath)
-    }
-  }
-  for (const rootId of tree.roots) buildPaths(rootId)
-
-  return tree
 }
 
 /**
  * Get a thread tree for a specific tweet
  */
-export const getThreadTree = async (tweet_id: string): Promise<ConversationTree | null> => {
+export const getThreadTree = async (
+  tweet_id: string,
+): Promise<ConversationTree | null> => {
   const tweets = await getConversationTweets(tweet_id)
   if (tweets.length === 0) {
     return null
   }
-  
+
   return buildConversationTree(tweets)
 }
 
 /**
  * Get the path from root to a specific tweet in the conversation
  */
-export const getPathToTweet = (tree: ConversationTree, tweet_id: string): string[] => {
+export const getPathToTweet = (
+  tree: ConversationTree,
+  tweet_id: string,
+): string[] => {
   // If this is a leaf, we have the path
   if (tree.paths[tweet_id]) {
     return tree.paths[tweet_id]
@@ -349,15 +250,15 @@ export const getPathToTweet = (tree: ConversationTree, tweet_id: string): string
   // Otherwise, build path from root
   const path: string[] = []
   let current = tweet_id
-  
+
   while (current && current !== tree.root) {
     path.unshift(current)
     current = tree.parents[current]
   }
-  
+
   if (tree.root) {
     path.unshift(tree.root)
   }
-  
+
   return path
 }


### PR DESCRIPTION
## Summary

- server-render the first 12 conversation nodes
- automatically append stable cursor pages near the viewport
- retain a manual load/retry control and deduplicate appended nodes
- preserve the existing 12-item infinite-scroll behavior for quote tweets
- keep the complete thread count visible while only rendering loaded nodes

## Validation

- 31 focused server/client tests passed
- `pnpm type-check`
- focused Prettier and diff checks

## Dependency

Requires gateway PR https://github.com/TheExGenesis/community-archive-control-panel/pull/169 to be deployed and smoked first. No production deployment is included in this PR.