### PR TITLE
Publish community-first nightly digests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,11 @@ OPENAI_API_BASE_URL=https://api.openai.com/v1
 # this separate server-only credential and official Responses API base URL.
 DEEPSEEK_API_KEY=
 DEEPSEEK_API_BASE_URL=https://api.deepseek.com
+# Vercel adds this bearer secret to cron requests. Keep nightly publication
+# disabled until the migration, model/gateway credentials, and monitoring are
+# deployed and a production-equivalent run has passed.
+CRON_SECRET=
+DIGEST_AUTOMATION_ENABLED=false
 # Optional outside Vercel previews. Shows the labeled August 11 fixture locally;
 # production ignores the fixture unless this server-only flag is explicitly set.
 DIGEST_MOCK_DATA=false

--- a/docs/daily-digest.md
+++ b/docs/daily-digest.md
@@ -186,8 +186,9 @@ DIGEST_AUTOMATION_ENABLED=true
 Do not expose any of these with a `NEXT_PUBLIC_` prefix. Public digest reads use
 the normal anonymous Supabase client and the `status = 'published'` RLS policy.
 
-The current prompt uses `openai/gpt-5.4` through OpenRouter, high reasoning
-effort, and the model's 128,000-token maximum completion ceiling. Its
+The current prompt uses `z-ai/glm-5.3` through OpenRouter, high reasoning
+effort, temperature `0.2`, and the model's 131,072-token maximum completion
+ceiling. Its
 one-call structured output requires exactly three summary bullets, a
 representative tweet index, three to five stories with loose labels and
 tweet-index lists, tweet-grounded titles, short explanatory subtitles,
@@ -204,11 +205,13 @@ headroom. These looser transport limits prevent a provider from satisfying the
 schema by clipping prose. OpenRouter counts hidden reasoning and visible JSON
 against the same completion ceiling; representative local replays exhausted a
 6,000-token ceiling before producing valid JSON. DeepSeek V4 Flash also
-intermittently ignored the strict schema at higher ceilings, while exact GPT-5.4
-replays for August 19 and 20 produced valid editions accepted by the app's
-deterministic assembler. The maximum provider-supported budget preserves high
-reasoning while leaving ample room for the structured edition; generation still
-stops naturally when the concise response is done.
+intermittently ignored the strict schema at higher ceilings. GLM-5.3 likewise
+returned Markdown when relying on the API schema alone, so its immutable prompt
+also requires one JSON object with no Markdown or surrounding prose. Exact
+August 19 and 20 replays then produced schema-shaped JSON. The maximum
+provider-supported budget preserves high reasoning while leaving ample room for
+the structured edition; generation still stops naturally when the concise
+response is done.
 
 The candidate corpus spans all authors and marks every banger with
 `authored_by_community_member`. The prompt treats that marker as a strong

--- a/docs/daily-digest.md
+++ b/docs/daily-digest.md
@@ -223,6 +223,12 @@ does not replace an edition an editor published during generation, and reuses a
 completed automated run if publication is retried. Generation or validation
 failure leaves the run failed and does not change the public edition.
 
+For a supervised backfill within the last 30 completed days, send the same
+bearer credential to `POST /api/cron/daily-digest` with a JSON body such as
+`{"digestDate":"2026-08-19"}`. This queues the same idempotent generation and
+publication workflow as the nightly schedule; it is not an editor-side publish
+shortcut. Dates outside that recovery window are rejected.
+
 To pause new nightly writes without affecting public reads, set
 `DIGEST_AUTOMATION_ENABLED=false` or disable the cron in Vercel. To recover a
 failed date, inspect its saved run and Workflow trace in `/admin/digest`, then

--- a/docs/daily-digest.md
+++ b/docs/daily-digest.md
@@ -151,16 +151,16 @@ separately.
 - immutable prompt version and exact rendered request;
 - raw provider response and validated publication artifact;
 - provider response ID and resolved model;
-- the durable Vercel Workflow run ID;
+- the automation run ID (`systemd:YYYY-MM-DD` for nightly publication);
 - input, output, and total token counts;
 - end-to-end duration and terminal error;
 - an ordered event trace for candidate, selection, commentary, generation,
   and edition stages.
 
 The lab renders those fields directly and refreshes a visible running-job panel
-every three seconds. Server failures also log with the digest run ID, so Vercel
-logs, Workflow run/step observability, and the durable ledger can be joined
-during diagnosis.
+every three seconds. Nightly publisher failures log structured JSON with the
+digest run ID to the production host journal, so systemd logs and the durable
+ledger can be joined during diagnosis.
 
 `community_archive_monitoring_digest()` exposes only aggregate publication
 freshness and automated-failure state to the least-privilege `readclient` role.
@@ -172,19 +172,17 @@ signal; prompt text, source snapshots, drafts, and error details remain private.
 Required server-only values:
 
 ```env
-OPENAI_API_KEY=<secret>
-OPENAI_API_BASE_URL=https://api.openai.com/v1
-DEEPSEEK_API_KEY=<secret>
-DEEPSEEK_API_BASE_URL=https://api.deepseek.com
+OPENROUTER_API_KEY=<secret>
 CLICKHOUSE_ANALYTICS_API_URL=https://analytics.community-archive.org/analytics
 CLICKHOUSE_ANALYTICS_API_TOKEN=<shared-gateway-token>
 SUPABASE_SERVICE_ROLE=<server-only-service-role>
-CRON_SECRET=<random-secret-at-least-16-characters>
-DIGEST_AUTOMATION_ENABLED=true
+NEXT_PUBLIC_SUPABASE_URL=https://PROJECT.supabase.co
 ```
 
-Do not expose any of these with a `NEXT_PUBLIC_` prefix. Public digest reads use
-the normal anonymous Supabase client and the `status = 'published'` RLS policy.
+The project URL is public configuration. Do not expose the service role,
+OpenRouter key, or ClickHouse token with a `NEXT_PUBLIC_` prefix. Public digest
+reads use the normal anonymous Supabase client and the `status = 'published'`
+RLS policy.
 
 The current prompt uses `z-ai/glm-5.3` through OpenRouter, high reasoning
 effort, temperature `0.2`, and the model's 131,072-token maximum completion
@@ -223,29 +221,27 @@ digest tweet cards label community-authored posts as `Community author`.
 
 ## Nightly schedule and recovery
 
-Vercel invokes `GET /api/cron/daily-digest` at `06:15 UTC` every day. That is
-10:15 PM PST or 11:15 PM PDT, fifteen minutes after the existing Community
-Archive day closes. Vercel cron schedules are UTC-only; the digest boundary is
-therefore stable while the local Pacific clock shifts with daylight saving
-time. The route requires Vercel's `CRON_SECRET` bearer header and returns as
-soon as the durable workflow is queued.
+`community-archive-nightly-digest.timer` runs on `prod-firehose` at `06:15 UTC`
+every day. That is 10:15 PM PST or 11:15 PM PDT, fifteen minutes after the
+Community Archive editorial day closes. The oneshot Bun process ingests the
+candidate snapshot, sends one GLM-5.3 request, performs one repair request only
+when deterministic validation rejects the first response, and stages and
+publishes the validated edition through Supabase.
 
-The workflow is date-idempotent. It skips a date that is already published,
-does not replace an edition an editor published during generation, and reuses a
-completed automated run if publication is retried. Generation or validation
-failure leaves the run failed and does not change the public edition.
+The publisher is date-idempotent. It exits before generation when a date is
+already published, records the stable run identifier `systemd:YYYY-MM-DD`, does
+not replace an edition an editor published during generation, and publishes a
+completed automated run if an earlier database publication attempt failed.
+Generation or validation failure leaves the run failed and does not change the
+public edition.
 
-For a supervised backfill within the last 30 completed days, send the same
-bearer credential to `POST /api/cron/daily-digest` with a JSON body such as
-`{"digestDate":"2026-08-19"}`. This queues the same idempotent generation and
-publication workflow as the nightly schedule; it is not an editor-side publish
-shortcut. Dates outside that recovery window are rejected.
-
-To pause new nightly writes without affecting public reads, set
-`DIGEST_AUTOMATION_ENABLED=false` or disable the cron in Vercel. To recover a
-failed date, inspect its saved run and Workflow trace in `/admin/digest`, then
-clone/revise and publish through the existing editorial path. Do not delete the
-run ledger.
+For a supervised no-write replay, run the publisher with
+`--date YYYY-MM-DD --dry-run`. To pause new nightly writes without affecting
+public reads, disable `community-archive-nightly-digest.timer`. Keep the legacy
+Vercel cron schedule absent and `DIGEST_AUTOMATION_ENABLED=false` so there is
+only one scheduler. To recover a failed date, inspect its saved run and
+`journalctl -u community-archive-nightly-digest.service`, then clone/revise and
+publish through the existing editorial path. Do not delete the run ledger.
 
 ## Rollout gates
 
@@ -266,16 +262,16 @@ Before setting `DIGEST_AUTOMATION_ENABLED=true` in production:
 4. Verify the public daily and story pages in a protected remote preview.
 5. Apply the migration and server secrets in production before merging a
    frontend release that expects the tables.
-6. Deploy the service-catalog and Grafana digest-health check, verify one manual
-   production-equivalent cron request, and confirm the new run reaches
-   `published` before enabling the recurring write path.
+6. Install the systemd service with its timer disabled, deploy the
+   service-catalog and Grafana digest-health check, verify one production-data
+   `--dry-run`, and only then enable the timer.
 7. Add the weekly email/Substack adapter as a separate delivery boundary. A
    delivery failure must not mutate or unpublish the daily edition.
 
 ## Rollback
 
-- Stop DeepSeek generation by removing `DEEPSEEK_API_KEY` (and OpenAI
-  experiments by removing `OPENAI_API_KEY`); public editions remain readable.
+- Stop nightly generation by disabling the systemd timer; public editions
+  remain readable.
 - Archive a bad edition and republish a previously staged version through the
   service-role publication function.
 - Roll back the frontend independently of the tables. The migration is additive

--- a/docs/daily-digest.md
+++ b/docs/daily-digest.md
@@ -215,6 +215,8 @@ The candidate corpus spans all authors and marks every banger with
 editorial preference: it favors coherent and relevant community-authored
 stories, but keeps non-community stories when they are unusually big,
 especially relevant, or needed to make a strong edition.
+The frozen marker is also copied onto selected banger snapshots so public
+digest tweet cards label community-authored posts as `Community author`.
 
 ## Nightly schedule and recovery
 

--- a/docs/daily-digest.md
+++ b/docs/daily-digest.md
@@ -186,9 +186,8 @@ DIGEST_AUTOMATION_ENABLED=true
 Do not expose any of these with a `NEXT_PUBLIC_` prefix. Public digest reads use
 the normal anonymous Supabase client and the `status = 'published'` RLS policy.
 
-The current prompt uses `deepseek/deepseek-v4-flash-0731` through
-OpenRouter, high reasoning effort, and the model's 384,000-token maximum
-completion ceiling. Its
+The current prompt uses `openai/gpt-5.4` through OpenRouter, high reasoning
+effort, and the model's 128,000-token maximum completion ceiling. Its
 one-call structured output requires exactly three summary bullets, a
 representative tweet index, three to five stories with loose labels and
 tweet-index lists, tweet-grounded titles, short explanatory subtitles,
@@ -204,9 +203,12 @@ over a fixed character target, with 500 characters of transport and editing
 headroom. These looser transport limits prevent a provider from satisfying the
 schema by clipping prose. OpenRouter counts hidden reasoning and visible JSON
 against the same completion ceiling; representative local replays exhausted a
-6,000-token ceiling before producing valid JSON. The maximum provider-supported
-budget preserves high reasoning while leaving ample room for the structured
-edition; generation still stops naturally when the concise response is done.
+6,000-token ceiling before producing valid JSON. DeepSeek V4 Flash also
+intermittently ignored the strict schema at higher ceilings, while exact GPT-5.4
+replays for August 19 and 20 produced valid editions accepted by the app's
+deterministic assembler. The maximum provider-supported budget preserves high
+reasoning while leaving ample room for the structured edition; generation still
+stops naturally when the concise response is done.
 
 The candidate corpus spans all authors and marks every banger with
 `authored_by_community_member`. The prompt treats that marker as a strong

--- a/docs/daily-digest.md
+++ b/docs/daily-digest.md
@@ -187,7 +187,7 @@ Do not expose any of these with a `NEXT_PUBLIC_` prefix. Public digest reads use
 the normal anonymous Supabase client and the `status = 'published'` RLS policy.
 
 The current prompt uses `deepseek/deepseek-v4-flash-0731` through
-OpenRouter, high reasoning effort, and a 6,000-token output ceiling. Its
+OpenRouter, high reasoning effort, and a 12,000-token completion ceiling. Its
 one-call structured output requires exactly three summary bullets, a
 representative tweet index, three to five stories with loose labels and
 tweet-index lists, tweet-grounded titles, short explanatory subtitles,
@@ -201,7 +201,10 @@ configuration. Summary bullets target 140 characters while the transport
 schema allows up to 200. Subtitles prioritize one complete explanatory sentence
 over a fixed character target, with 500 characters of transport and editing
 headroom. These looser transport limits prevent a provider from satisfying the
-schema by clipping prose.
+schema by clipping prose. OpenRouter counts hidden reasoning and visible JSON
+against the same completion ceiling; representative local replays exhausted a
+6,000-token ceiling before producing valid JSON, so the larger budget preserves
+high reasoning while leaving enough room for the structured edition.
 
 The candidate corpus spans all authors and marks every banger with
 `authored_by_community_member`. The prompt treats that marker as a strong

--- a/docs/daily-digest.md
+++ b/docs/daily-digest.md
@@ -187,7 +187,8 @@ Do not expose any of these with a `NEXT_PUBLIC_` prefix. Public digest reads use
 the normal anonymous Supabase client and the `status = 'published'` RLS policy.
 
 The current prompt uses `deepseek/deepseek-v4-flash-0731` through
-OpenRouter, high reasoning effort, and a 12,000-token completion ceiling. Its
+OpenRouter, high reasoning effort, and the model's 384,000-token maximum
+completion ceiling. Its
 one-call structured output requires exactly three summary bullets, a
 representative tweet index, three to five stories with loose labels and
 tweet-index lists, tweet-grounded titles, short explanatory subtitles,
@@ -203,8 +204,9 @@ over a fixed character target, with 500 characters of transport and editing
 headroom. These looser transport limits prevent a provider from satisfying the
 schema by clipping prose. OpenRouter counts hidden reasoning and visible JSON
 against the same completion ceiling; representative local replays exhausted a
-6,000-token ceiling before producing valid JSON, so the larger budget preserves
-high reasoning while leaving enough room for the structured edition.
+6,000-token ceiling before producing valid JSON. The maximum provider-supported
+budget preserves high reasoning while leaving ample room for the structured
+edition; generation still stops naturally when the concise response is done.
 
 The candidate corpus spans all authors and marks every banger with
 `authored_by_community_member`. The prompt treats that marker as a strong

--- a/docs/daily-digest.md
+++ b/docs/daily-digest.md
@@ -73,9 +73,9 @@ non-production environment. Do not set it in production.
 
 - ClickHouse is the analytical source for candidates and archived quote-post
   commentary. The current `recent-bangers` ranking counts distinct non-self
-  quote tweets from Community Archive members. Digest pulls restrict target
-  authors to current Community Archive members in the selected time window. A
-  run keeps only the top `min(50,
+  quote tweets from Community Archive members. Digest pulls include targets by
+  all authors and make a second member-scoped query to freeze a
+  `communityAuthored` marker on each candidate. A run keeps only the top `min(50,
 num_bangers_with_score_at_least_2)` rows: every included post has a Community
   Archive banger score of at least two, and there are never more than 50.
 - The existing Supabase tweet-page RPC supplies in-window conversation replies
@@ -117,8 +117,10 @@ projection, not a write authority.
    Neither path mutates the model run or replaces an existing published
    version, and every later save creates another draft version.
 7. Publish explicitly with the prominent **Publish Daily Digest** action.
-   `publish_digest_edition(uuid)` archives the old version
-   and publishes the selected draft in one database transaction.
+   `publish_digest_edition(uuid)` archives the old version and publishes the
+   selected draft in one database transaction. The nightly workflow uses the
+   same function after a valid generation; if an editor has already published
+   that date, automation preserves the editorial edition.
 
 A generation attempt is immutable once it starts. The lab polls the saved run
 while it is open and shows queued, context, model, and validation phases; the
@@ -127,8 +129,11 @@ to reuse the exact frozen source snapshot with the same or a newer prompt
 version. Finished-run checkboxes can also be changed directly; saving that
 selection forks an editable run. Both paths preserve failed and successful
 model responses for comparison.
-Generation never auto-stages or auto-publishes: those remain explicit editorial
-steps after a valid result is reviewed.
+Manual generations never auto-stage or auto-publish. The production nightly
+workflow is the deliberate exception: it creates one system-owned run for the
+completed date, generates with the newest immutable prompt, stages the
+validated output, and publishes it. The unique automated-run index and the
+one-published-edition index make duplicate cron delivery safe.
 
 Every edition keyword must occur verbatim in supplied posts. Exact story-title
 excerpts are preferred and checked, while a paraphrase becomes a non-fatal
@@ -157,6 +162,11 @@ every three seconds. Server failures also log with the digest run ID, so Vercel
 logs, Workflow run/step observability, and the durable ledger can be joined
 during diagnosis.
 
+`community_archive_monitoring_digest()` exposes only aggregate publication
+freshness and automated-failure state to the least-privilege `readclient` role.
+The production PostgreSQL exporter turns that into the service-catalog health
+signal; prompt text, source snapshots, drafts, and error details remain private.
+
 ## Configuration
 
 Required server-only values:
@@ -169,12 +179,14 @@ DEEPSEEK_API_BASE_URL=https://api.deepseek.com
 CLICKHOUSE_ANALYTICS_API_URL=https://analytics.community-archive.org/analytics
 CLICKHOUSE_ANALYTICS_API_TOKEN=<shared-gateway-token>
 SUPABASE_SERVICE_ROLE=<server-only-service-role>
+CRON_SECRET=<random-secret-at-least-16-characters>
+DIGEST_AUTOMATION_ENABLED=true
 ```
 
 Do not expose any of these with a `NEXT_PUBLIC_` prefix. Public digest reads use
 the normal anonymous Supabase client and the `status = 'published'` RLS policy.
 
-The current experiment prompt uses `deepseek/deepseek-v4-flash-0731` through
+The current prompt uses `deepseek/deepseek-v4-flash-0731` through
 OpenRouter, high reasoning effort, and a 6,000-token output ceiling. Its
 one-call structured output requires exactly three summary bullets, a
 representative tweet index, three to five stories with loose labels and
@@ -191,10 +203,35 @@ over a fixed character target, with 500 characters of transport and editing
 headroom. These looser transport limits prevent a provider from satisfying the
 schema by clipping prose.
 
+The candidate corpus spans all authors and marks every banger with
+`authored_by_community_member`. The prompt treats that marker as a strong
+editorial preference: it favors coherent and relevant community-authored
+stories, but keeps non-community stories when they are unusually big,
+especially relevant, or needed to make a strong edition.
+
+## Nightly schedule and recovery
+
+Vercel invokes `GET /api/cron/daily-digest` at `06:15 UTC` every day. That is
+10:15 PM PST or 11:15 PM PDT, fifteen minutes after the existing Community
+Archive day closes. Vercel cron schedules are UTC-only; the digest boundary is
+therefore stable while the local Pacific clock shifts with daylight saving
+time. The route requires Vercel's `CRON_SECRET` bearer header and returns as
+soon as the durable workflow is queued.
+
+The workflow is date-idempotent. It skips a date that is already published,
+does not replace an edition an editor published during generation, and reuses a
+completed automated run if publication is retried. Generation or validation
+failure leaves the run failed and does not change the public edition.
+
+To pause new nightly writes without affecting public reads, set
+`DIGEST_AUTOMATION_ENABLED=false` or disable the cron in Vercel. To recover a
+failed date, inspect its saved run and Workflow trace in `/admin/digest`, then
+clone/revise and publish through the existing editorial path. Do not delete the
+run ledger.
+
 ## Rollout gates
 
-Automation is deliberately disabled during the editorial experiment. Before a
-daily timer or weekly Substack send is enabled:
+Before setting `DIGEST_AUTOMATION_ENABLED=true` in production:
 
 1. Apply `20260813000650_add_daily_digest_editorial_workspace.sql` and
    the subsequent Daily Digest prompt-version migrations through
@@ -211,10 +248,9 @@ daily timer or weekly Substack send is enabled:
 4. Verify the public daily and story pages in a protected remote preview.
 5. Apply the migration and server secrets in production before merging a
    frontend release that expects the tables.
-6. Treat the scheduler as a new monitored timer: document it in the service
-   catalog, add success/failure/freshness signals and alerts, verify one manual
-   production run, and keep publishing manual until quality evidence supports
-   auto-publish.
+6. Deploy the service-catalog and Grafana digest-health check, verify one manual
+   production-equivalent cron request, and confirm the new run reaches
+   `published` before enabling the recurring write path.
 7. Add the weekly email/Substack adapter as a separate delivery boundary. A
    delivery failure must not mutate or unpublish the daily edition.
 

--- a/ops/nightly-digest/README.md
+++ b/ops/nightly-digest/README.md
@@ -1,0 +1,64 @@
+# Nightly digest publisher
+
+`community-archive-nightly-digest.timer` runs at 06:15 UTC (10:15 PM PST or
+11:15 PM PDT), after the 06:00 UTC editorial-day boundary. The oneshot Bun
+publisher reads candidates from the ClickHouse query gateway, asks GLM-5.3 for
+one JSON object, performs one bounded repair only when deterministic validation
+rejects the first response, then stages and publishes through Supabase.
+
+The job is date-idempotent. It exits before generation when the date is already
+published, records a stable `systemd:YYYY-MM-DD` run identifier, preserves an
+editor-published edition, and can publish a previously completed run after a
+transient database failure. A failed model or validation attempt remains a
+failed run and is not automatically retried.
+
+## Runtime configuration
+
+Create `/etc/community-archive-nightly-digest.env` as root with mode `0600`:
+
+```env
+NEXT_PUBLIC_SUPABASE_URL=https://PROJECT.supabase.co
+SUPABASE_SERVICE_ROLE=...
+OPENROUTER_API_KEY=...
+CLICKHOUSE_ANALYTICS_API_URL=https://analytics.community-archive.org/analytics
+CLICKHOUSE_ANALYTICS_API_TOKEN=...
+```
+
+The ClickHouse token's source of truth on `prod-firehose` is the running
+`community-archive-query-gateway` process environment. Do not copy the stale
+value from its environment file.
+
+## Operations
+
+Deploy without enabling the timer:
+
+```sh
+scripts/deploy-nightly-digest.sh prod-firehose
+```
+
+Run a production-data dry-run that performs no database writes:
+
+```sh
+ssh prod-firehose 'systemd-run --wait --collect --pipe \
+  --property=EnvironmentFile=/etc/community-archive-nightly-digest.env \
+  --property=WorkingDirectory=/opt/community-archive-nightly-digest \
+  /root/.bun/bin/bun services/nightly-digest/publish.ts \
+  --date 2026-08-21 --dry-run'
+```
+
+Then enable the recurring schedule:
+
+```sh
+ssh prod-firehose 'systemctl enable --now community-archive-nightly-digest.timer'
+```
+
+Inspect status and logs with:
+
+```sh
+systemctl status community-archive-nightly-digest.timer
+journalctl -u community-archive-nightly-digest.service -n 200 --no-pager
+```
+
+To pause writes, disable the timer. To retry a failed date, inspect the saved
+run first; preserve the ledger, resolve or publish it editorially, and only then
+re-enable the timer.

--- a/ops/nightly-digest/community-archive-nightly-digest.service
+++ b/ops/nightly-digest/community-archive-nightly-digest.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Publish the Community Archive nightly digest
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=root
+WorkingDirectory=/opt/community-archive-nightly-digest
+EnvironmentFile=/etc/community-archive-nightly-digest.env
+ExecStart=/root/.bun/bin/bun /opt/community-archive-nightly-digest/services/nightly-digest/publish.ts
+TimeoutStartSec=20min
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+MemoryMax=1G
+
+[Install]
+WantedBy=multi-user.target

--- a/ops/nightly-digest/community-archive-nightly-digest.timer
+++ b/ops/nightly-digest/community-archive-nightly-digest.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run the Community Archive digest after the Pacific editorial day closes
+
+[Timer]
+OnCalendar=*-*-* 06:15:00 UTC
+Persistent=true
+AccuracySec=1min
+RandomizedDelaySec=0
+Unit=community-archive-nightly-digest.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/deploy-nightly-digest.sh
+++ b/scripts/deploy-nightly-digest.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+host="${1:-prod-firehose}"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+stage="/opt/community-archive-nightly-digest.next"
+release="/opt/community-archive-nightly-digest"
+previous="/opt/community-archive-nightly-digest.previous"
+
+ssh "$host" "rm -rf '$stage' && mkdir -p '$stage/src/lib' '$stage/services'"
+rsync -a --delete "$repo_root/services/nightly-digest/" "$host:$stage/services/nightly-digest/"
+rsync -a --delete "$repo_root/src/lib/digest/" "$host:$stage/src/lib/digest/"
+rsync -a --delete "$repo_root/src/lib/portal/" "$host:$stage/src/lib/portal/"
+rsync -a "$repo_root/src/lib/clickhouseGateway.ts" "$host:$stage/src/lib/clickhouseGateway.ts"
+rsync -a "$repo_root/tsconfig.json" "$host:$stage/tsconfig.json"
+rsync -a "$repo_root/ops/nightly-digest/community-archive-nightly-digest.service" \
+  "$host:/etc/systemd/system/community-archive-nightly-digest.service"
+rsync -a "$repo_root/ops/nightly-digest/community-archive-nightly-digest.timer" \
+  "$host:/etc/systemd/system/community-archive-nightly-digest.timer"
+
+ssh "$host" bash -s -- "$stage" "$release" "$previous" <<'REMOTE'
+set -euo pipefail
+stage="$1"
+release="$2"
+previous="$3"
+
+test -x /root/.bun/bin/bun
+test -s /etc/community-archive-nightly-digest.env
+chmod 0600 /etc/community-archive-nightly-digest.env
+systemd-analyze verify \
+  /etc/systemd/system/community-archive-nightly-digest.service \
+  /etc/systemd/system/community-archive-nightly-digest.timer
+rm -rf "$previous"
+if test -d "$release"; then mv "$release" "$previous"; fi
+mv "$stage" "$release"
+systemctl daemon-reload
+systemctl disable --now community-archive-nightly-digest.timer >/dev/null 2>&1 || true
+systemctl reset-failed community-archive-nightly-digest.service >/dev/null 2>&1 || true
+systemctl cat community-archive-nightly-digest.service >/dev/null
+systemctl cat community-archive-nightly-digest.timer >/dev/null
+REMOTE
+
+echo "Nightly digest installed on $host with the timer disabled."

--- a/services/nightly-digest/publish.ts
+++ b/services/nightly-digest/publish.ts
@@ -1,0 +1,581 @@
+import { loadDigestCandidates } from '@/lib/digest/candidates'
+import {
+  getDigestDateWindow,
+  getLatestCompletedDigestDate,
+} from '@/lib/digest/dateWindow'
+import {
+  assembleDigestEditionContent,
+  renderDigestPrompt,
+  type DigestContinuityContext,
+  type EnrichedDigestCandidate,
+} from '@/lib/digest/generation'
+import {
+  generateDigestWithModel,
+  type DigestGenerationResponse,
+} from '@/lib/digest/openai'
+import type {
+  DigestEditionContent,
+  DigestPromptVersion,
+  DigestRunEvent,
+} from '@/lib/digest/types'
+
+type JsonObject = Record<string, unknown>
+
+interface PromptRow {
+  id: string
+  version: number
+  label: string
+  model: string
+  parameters: unknown
+  system_prompt: string
+  user_prompt_template: string
+  created_by: string | null
+  created_at: string
+}
+
+interface RunRow {
+  id: string
+  status: string
+  digest_date: string
+  parsed_output: DigestEditionContent | null
+  events: DigestRunEvent[] | null
+}
+
+interface EditionRow {
+  id: string
+  digest_date: string
+  source_run_id: string
+  status: string
+  version: number
+  content?: DigestEditionContent
+}
+
+const log = (message: string, metadata: JsonObject = {}) =>
+  console.log(
+    JSON.stringify({
+      at: new Date().toISOString(),
+      service: 'community-archive-nightly-digest',
+      message,
+      ...metadata,
+    }),
+  )
+
+const describeError = (error: unknown) =>
+  error instanceof Error ? error.message : String(error)
+
+const event = (
+  stage: DigestRunEvent['stage'],
+  status: DigestRunEvent['status'],
+  message: string,
+  metadata?: DigestRunEvent['metadata'],
+): DigestRunEvent => ({
+  at: new Date().toISOString(),
+  stage,
+  status,
+  message,
+  ...(metadata ? { metadata } : {}),
+})
+
+class SupabaseRest {
+  private readonly baseUrl: string
+  private readonly headers: Record<string, string>
+
+  constructor() {
+    const projectUrl = process.env.NEXT_PUBLIC_SUPABASE_URL?.replace(/\/$/, '')
+    const serviceRole = process.env.SUPABASE_SERVICE_ROLE
+    if (!projectUrl || !serviceRole) {
+      throw new Error(
+        'NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE are required',
+      )
+    }
+    this.baseUrl = `${projectUrl}/rest/v1`
+    this.headers = {
+      apikey: serviceRole,
+      Authorization: `Bearer ${serviceRole}`,
+      'Content-Type': 'application/json',
+    }
+  }
+
+  async request<T>(
+    path: string,
+    init: RequestInit = {},
+    prefer?: string,
+  ): Promise<T> {
+    const response = await fetch(`${this.baseUrl}/${path}`, {
+      ...init,
+      headers: {
+        ...this.headers,
+        ...(prefer ? { Prefer: prefer } : {}),
+        ...(init.headers ?? {}),
+      },
+      signal: AbortSignal.timeout(60_000),
+    })
+    const body = await response.text()
+    if (!response.ok) {
+      throw new Error(
+        `Supabase request failed (${response.status}): ${body.slice(0, 500)}`,
+      )
+    }
+    return (body ? JSON.parse(body) : null) as T
+  }
+
+  select<T>(table: string, query: URLSearchParams) {
+    return this.request<T[]>(`${table}?${query}`)
+  }
+
+  insert<T>(table: string, value: JsonObject) {
+    return this.request<T[]>(
+      table,
+      { method: 'POST', body: JSON.stringify(value) },
+      'return=representation',
+    )
+  }
+
+  update<T>(table: string, query: URLSearchParams, value: JsonObject) {
+    return this.request<T[]>(
+      `${table}?${query}`,
+      { method: 'PATCH', body: JSON.stringify(value) },
+      'return=representation',
+    )
+  }
+
+  rpc<T>(name: string, value: JsonObject) {
+    return this.request<T>(`rpc/${name}`, {
+      method: 'POST',
+      body: JSON.stringify(value),
+    })
+  }
+}
+
+const query = (values: Record<string, string>) => new URLSearchParams(values)
+
+const mapPrompt = (row: PromptRow): DigestPromptVersion => {
+  const parameters =
+    row.parameters && typeof row.parameters === 'object'
+      ? (row.parameters as JsonObject)
+      : {}
+  return {
+    id: row.id,
+    version: Number(row.version),
+    label: row.label,
+    model: row.model,
+    systemPrompt: row.system_prompt,
+    userPromptTemplate: row.user_prompt_template,
+    parameters: {
+      ...(typeof parameters.reasoning_effort === 'string'
+        ? { reasoning_effort: parameters.reasoning_effort }
+        : {}),
+      ...(typeof parameters.max_output_tokens === 'number'
+        ? { max_output_tokens: parameters.max_output_tokens }
+        : {}),
+      ...(typeof parameters.temperature === 'number'
+        ? { temperature: parameters.temperature }
+        : {}),
+    },
+    createdBy: row.created_by,
+    createdAt: row.created_at,
+  }
+}
+
+const getPublished = async (db: SupabaseRest, digestDate: string) => {
+  const rows = await db.select<EditionRow>(
+    'digest_editions',
+    query({
+      select: 'id,digest_date,source_run_id,status,version',
+      digest_date: `eq.${digestDate}`,
+      status: 'eq.published',
+      limit: '1',
+    }),
+  )
+  return rows[0] ?? null
+}
+
+const getAutomatedRun = async (db: SupabaseRest, digestDate: string) => {
+  const rows = await db.select<RunRow>(
+    'digest_runs',
+    query({
+      select: 'id,status,digest_date,parsed_output,events',
+      digest_date: `eq.${digestDate}`,
+      workflow_run_id: `eq.systemd:${digestDate}`,
+      order: 'created_at.desc',
+      limit: '1',
+    }),
+  )
+  return rows[0] ?? null
+}
+
+const getPrompt = async (db: SupabaseRest) => {
+  const rows = await db.select<PromptRow>(
+    'digest_prompt_versions',
+    query({
+      select: '*',
+      model: 'eq.z-ai/glm-5.3',
+      order: 'version.desc',
+      limit: '1',
+    }),
+  )
+  if (!rows[0]) throw new Error('No z-ai/glm-5.3 digest prompt is configured')
+  return mapPrompt(rows[0])
+}
+
+const getContinuity = async (
+  db: SupabaseRest,
+  digestDate: string,
+): Promise<DigestContinuityContext[]> => {
+  const rows = await db.select<EditionRow>(
+    'digest_editions',
+    query({
+      select: 'content,digest_date,id,source_run_id,status,version',
+      status: 'eq.published',
+      digest_date: `lt.${digestDate}`,
+      order: 'digest_date.desc,version.desc',
+      limit: '7',
+    }),
+  )
+  return rows.flatMap(({ digest_date: priorDate, content }) =>
+    content
+      ? [
+          {
+            digestDate: priorDate,
+            executiveSummary: content.executiveSummary,
+            storyTitles: content.stories.map(({ title }) => title),
+            keywords: content.keywords,
+          },
+        ]
+      : [],
+  )
+}
+
+const sumTokens = (
+  attempts: DigestGenerationResponse[],
+  key: 'inputTokens' | 'outputTokens' | 'totalTokens',
+) => {
+  const values = attempts.map((attempt) => attempt[key])
+  return values.every((value): value is number => value !== null)
+    ? values.reduce((sum, value) => sum + value, 0)
+    : null
+}
+
+async function generateValidated(input: {
+  runId: string
+  digestDate: string
+  windowStart: string
+  windowEnd: string
+  candidates: EnrichedDigestCandidate[]
+  prompt: DigestPromptVersion
+  renderedPrompt: string
+}) {
+  const attempts: DigestGenerationResponse[] = []
+  let lastError = ''
+  let rejectedOutput: unknown = null
+
+  for (let attempt = 1; attempt <= 2; attempt += 1) {
+    const userPrompt =
+      attempt === 1
+        ? input.renderedPrompt
+        : `${input.renderedPrompt}\n\nREPAIR THE REJECTED RESPONSE\nThe previous JSON was rejected by the deterministic receiver: ${lastError}\nReturn one corrected JSON object only. Do not add Markdown or prose. Preserve grounded content while fixing every validation error.\n\nREJECTED RESPONSE\n${JSON.stringify(rejectedOutput)}`
+    const generated = await generateDigestWithModel({
+      runId: input.runId,
+      model: input.prompt.model,
+      systemPrompt: input.prompt.systemPrompt,
+      userPrompt,
+      reasoningEffort: input.prompt.parameters.reasoning_effort,
+      maxOutputTokens: input.prompt.parameters.max_output_tokens,
+      temperature: attempt === 1 ? input.prompt.parameters.temperature : 0,
+    })
+    attempts.push(generated)
+    rejectedOutput = generated.output
+    try {
+      if (generated.outputError) throw new Error(generated.outputError)
+      const content = assembleDigestEditionContent({
+        runId: input.runId,
+        digestDate: input.digestDate,
+        windowStart: input.windowStart,
+        windowEnd: input.windowEnd,
+        allCandidateCount: input.candidates.length,
+        enrichedCandidates: input.candidates,
+        modelOutput: generated.output,
+      })
+      return { attempts, content, generated }
+    } catch (error) {
+      lastError = describeError(error)
+      log('model output rejected', { attempt, error: lastError })
+      if (attempt === 2) throw error
+    }
+  }
+  throw new Error(lastError || 'Digest generation failed')
+}
+
+async function publishCompletedRun(
+  db: SupabaseRest,
+  run: RunRow,
+  digestDate: string,
+) {
+  if (!run.parsed_output) throw new Error('Completed run has no parsed output')
+  const alreadyPublished = await getPublished(db, digestDate)
+  if (alreadyPublished) {
+    return { status: 'already-published', edition: alreadyPublished }
+  }
+
+  const existingDrafts = await db.select<EditionRow>(
+    'digest_editions',
+    query({
+      select: 'id,digest_date,source_run_id,status,version',
+      source_run_id: `eq.${run.id}`,
+      status: 'eq.draft',
+      order: 'version.desc',
+      limit: '1',
+    }),
+  )
+  let draft = existingDrafts[0]
+  if (!draft) {
+    const latest = await db.select<EditionRow>(
+      'digest_editions',
+      query({
+        select: 'id,digest_date,source_run_id,status,version',
+        digest_date: `eq.${digestDate}`,
+        order: 'version.desc',
+        limit: '1',
+      }),
+    )
+    ;[draft] = await db.insert<EditionRow>('digest_editions', {
+      digest_date: digestDate,
+      version: (latest[0]?.version ?? 0) + 1,
+      status: 'draft',
+      source_run_id: run.id,
+      content: run.parsed_output,
+      created_by: null,
+    })
+  }
+  if (!draft) throw new Error('Could not create digest draft')
+  const published = await db.rpc<EditionRow>('publish_digest_edition', {
+    p_edition_id: draft.id,
+  })
+  return { status: 'published', edition: published }
+}
+
+export async function publishNightlyDigest(
+  options: {
+    digestDate?: string
+    dryRun?: boolean
+  } = {},
+) {
+  const digestDate = options.digestDate ?? getLatestCompletedDigestDate()
+  const dryRun = options.dryRun === true
+  const db = new SupabaseRest()
+  const window = getDigestDateWindow(digestDate)
+
+  if (!dryRun) {
+    const published = await getPublished(db, digestDate)
+    if (published) {
+      log('digest already published; skipping', {
+        digestDate,
+        editionId: published.id,
+      })
+      return { status: 'already-published', edition: published }
+    }
+    const existing = await getAutomatedRun(db, digestDate)
+    if (existing?.status === 'completed') {
+      const result = await publishCompletedRun(db, existing, digestDate)
+      log('completed run publication recovered', {
+        digestDate,
+        runId: existing.id,
+        status: result.status,
+      })
+      return result
+    }
+    if (existing) {
+      throw new Error(
+        `Automated run ${existing.id} already exists with status ${existing.status}`,
+      )
+    }
+  }
+
+  const [prompt, snapshot, priorDigests] = await Promise.all([
+    getPrompt(db),
+    loadDigestCandidates(window.windowEnd, false),
+    getContinuity(db, digestDate),
+  ])
+  if (snapshot.candidates.length < 3) {
+    throw new Error(
+      `Only ${snapshot.candidates.length} digest candidates were found`,
+    )
+  }
+  const enrichedCandidates: EnrichedDigestCandidate[] = snapshot.candidates.map(
+    (candidate) => ({ candidate, commentary: [], totalReplyCount: 0 }),
+  )
+  const runId = crypto.randomUUID()
+  const startedAt = new Date()
+  let events: DigestRunEvent[] = [
+    event(
+      'candidates',
+      'completed',
+      `Saved ${digestDate} candidates from all authors, with Community Archive authors marked for preference.`,
+      {
+        automation: !dryRun,
+        candidate_count: snapshot.candidates.length,
+        community_authored_count: snapshot.communityAuthoredCount,
+        interaction_fallback_count: snapshot.fallbackCount,
+        qualifying_banger_count: snapshot.bangerCount,
+      },
+    ),
+  ]
+  const renderedPrompt = renderDigestPrompt(prompt.userPromptTemplate, {
+    ...window,
+    candidates: enrichedCandidates,
+    priorDigests,
+  })
+
+  if (!dryRun) {
+    await db.insert<RunRow>('digest_runs', {
+      id: runId,
+      digest_date: digestDate,
+      status: 'running',
+      prompt_version_id: prompt.id,
+      window_start: window.windowStart,
+      window_end: window.windowEnd,
+      candidates: snapshot.candidates,
+      workflow_run_id: `systemd:${digestDate}`,
+      events,
+      started_at: startedAt.toISOString(),
+      created_by: null,
+      model: prompt.model,
+      model_request: {
+        promptVersion: prompt,
+        renderedUserPrompt: renderedPrompt,
+        candidateSnapshot: enrichedCandidates,
+        continuityContext: priorDigests,
+      },
+    })
+  }
+
+  log('generation started', {
+    digestDate,
+    dryRun,
+    runId,
+    candidateCount: snapshot.candidates.length,
+    communityAuthoredCount: snapshot.communityAuthoredCount,
+    model: prompt.model,
+  })
+
+  try {
+    const result = await generateValidated({
+      runId,
+      ...window,
+      candidates: enrichedCandidates,
+      prompt,
+      renderedPrompt,
+    })
+    const completedAt = new Date()
+    const durationMs = completedAt.getTime() - startedAt.getTime()
+    events = [
+      ...events,
+      event('generation', 'completed', 'Validated structured digest output.', {
+        attempts: result.attempts.length,
+        duration_ms: durationMs,
+        story_count: result.content.stories.length,
+      }),
+    ]
+
+    if (dryRun) {
+      log('dry-run validated; no database writes made', {
+        digestDate,
+        attempts: result.attempts.length,
+        durationMs,
+        storyCount: result.content.stories.length,
+        communityBangersPublished: result.content.stories.reduce(
+          (sum, story) =>
+            sum +
+            story.bangers.filter(({ communityAuthored }) => communityAuthored)
+              .length,
+          0,
+        ),
+      })
+      return { status: 'dry-run', content: result.content }
+    }
+
+    const [completedRun] = await db.update<RunRow>(
+      'digest_runs',
+      query({ id: `eq.${runId}`, status: 'eq.running' }),
+      {
+        status: 'completed',
+        raw_response: {
+          attempts: result.attempts.map(({ response }) => response),
+        },
+        parsed_output: result.content,
+        response_id: result.generated.responseId,
+        model: result.generated.model,
+        input_tokens: sumTokens(result.attempts, 'inputTokens'),
+        output_tokens: sumTokens(result.attempts, 'outputTokens'),
+        total_tokens: sumTokens(result.attempts, 'totalTokens'),
+        duration_ms: durationMs,
+        error: null,
+        completed_at: completedAt.toISOString(),
+        updated_at: completedAt.toISOString(),
+        events,
+      },
+    )
+    if (!completedRun)
+      throw new Error('Digest run could not be marked completed')
+    const publication = await publishCompletedRun(db, completedRun, digestDate)
+    await db.update<RunRow>('digest_runs', query({ id: `eq.${runId}` }), {
+      events: [
+        ...events,
+        event(
+          'edition',
+          'completed',
+          'Systemd automation published the digest.',
+          {
+            automation: true,
+            edition_id: publication.edition.id,
+          },
+        ),
+      ],
+      updated_at: new Date().toISOString(),
+    })
+    log('digest published', {
+      digestDate,
+      runId,
+      editionId: publication.edition.id,
+      version: publication.edition.version,
+      attempts: result.attempts.length,
+    })
+    return publication
+  } catch (error) {
+    const message = describeError(error)
+    if (!dryRun) {
+      const completedAt = new Date()
+      await db.update<RunRow>(
+        'digest_runs',
+        query({ id: `eq.${runId}`, status: 'eq.running' }),
+        {
+          status: 'failed',
+          error: message.slice(0, 4_000),
+          duration_ms: completedAt.getTime() - startedAt.getTime(),
+          completed_at: completedAt.toISOString(),
+          updated_at: completedAt.toISOString(),
+          events: [
+            ...events,
+            event('generation', 'failed', message.slice(0, 360)),
+          ],
+        },
+      )
+    }
+    throw error
+  }
+}
+
+const args = process.argv.slice(2)
+const dateIndex = args.indexOf('--date')
+const digestDate = dateIndex >= 0 ? args[dateIndex + 1] : undefined
+
+publishNightlyDigest({
+  digestDate,
+  dryRun: args.includes('--dry-run'),
+}).catch((error) => {
+  log('publisher failed', {
+    digestDate: digestDate ?? null,
+    error: describeError(error),
+  })
+  process.exitCode = 1
+})

--- a/services/nightly-digest/tsconfig.json
+++ b/services/nightly-digest/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "incremental": false,
+    "target": "ES2022"
+  },
+  "include": ["publish.ts"],
+  "exclude": []
+}

--- a/src/app/admin/digest/actions.ts
+++ b/src/app/admin/digest/actions.ts
@@ -5,25 +5,20 @@ import { redirect } from 'next/navigation'
 import { start } from 'workflow/api'
 import { requireAdmin } from '@/app/admin/data'
 import {
-  fetchPortalDailyInteractions,
-  fetchPortalRecentBangers,
-} from '@/lib/portal/analytics'
-import {
   getDigestDateWindow,
   isRecentPastDigestDate,
   listPastDigestDates,
 } from '@/lib/digest/dateWindow'
-import { createDigestAdminClient } from '@/lib/digest/database'
 import {
-  fillDailyDigestCandidates,
-  selectDailyDigestBangers,
-} from '@/lib/digest/generation'
+  loadDigestCandidates,
+  MINIMUM_DIGEST_CANDIDATE_POOL,
+} from '@/lib/digest/candidates'
+import { createDigestAdminClient } from '@/lib/digest/database'
 import { captureDigestPostHogEvent } from '@/lib/digest/posthogServer'
 import { mapDigestEdition, mapDigestRun, toJson } from '@/lib/digest/data'
 import {
   DIGEST_STORY_CATEGORIES,
   parseDigestEditionContent,
-  type DigestCandidate,
   type DigestEditionContent,
   type DigestRunEvent,
 } from '@/lib/digest/types'
@@ -39,49 +34,6 @@ const formString = (formData: FormData, key: string) =>
   String(formData.get(key) ?? '').trim()
 const formBoolean = (formData: FormData, key: string) =>
   ['true', 'on', '1'].includes(formString(formData, key).toLowerCase())
-
-const MINIMUM_DIGEST_CANDIDATE_POOL = 10
-
-async function loadDigestCandidates(
-  windowEnd: string,
-  targetCommunityUsersOnly: boolean,
-) {
-  const bangers = await fetchPortalRecentBangers(
-    50,
-    24,
-    undefined,
-    windowEnd,
-    targetCommunityUsersOnly,
-  )
-  const qualifyingBangers = selectDailyDigestBangers(bangers)
-  const interactionRanked =
-    qualifyingBangers.length < MINIMUM_DIGEST_CANDIDATE_POOL
-      ? await fetchPortalDailyInteractions(
-          50,
-          24,
-          undefined,
-          windowEnd,
-          targetCommunityUsersOnly,
-        )
-      : []
-  const selected = fillDailyDigestCandidates(
-    bangers,
-    interactionRanked,
-    MINIMUM_DIGEST_CANDIDATE_POOL,
-  )
-  return {
-    candidates: selected.map<DigestCandidate>(({ tweet, source }, index) => ({
-      tweet,
-      source,
-      sourceRank: index + 1,
-      selected: true,
-    })),
-    bangerCount: qualifyingBangers.length,
-    fallbackCount: selected.filter(
-      ({ source }) => source === 'ca_interactions',
-    ).length,
-  }
-}
 
 const event = (
   stage: DigestRunEvent['stage'],
@@ -336,10 +288,7 @@ export async function createDigestPromptVersionAction(formData: FormData) {
 export async function createDigestRunAction(formData: FormData) {
   const { user } = await requireAdmin()
   const promptVersionId = formString(formData, 'prompt_version_id')
-  const targetCommunityUsersOnly = formBoolean(
-    formData,
-    'target_ca_users_only',
-  )
+  const targetCommunityUsersOnly = formBoolean(formData, 'target_ca_users_only')
   if (!UUID_PATTERN.test(promptVersionId)) {
     redirectToLab({ error: 'Choose a prompt version.' })
   }
@@ -375,6 +324,7 @@ export async function createDigestRunAction(formData: FormData) {
         candidate_count: candidates.length,
         default_selected_count: candidates.length,
         qualifying_banger_count: snapshot.bangerCount,
+        community_authored_count: snapshot.communityAuthoredCount,
         interaction_fallback_count: snapshot.fallbackCount,
         minimum_ca_quote_count: 2,
         target_author_population: targetCommunityUsersOnly
@@ -422,10 +372,7 @@ export async function createAndGenerateDigestDateAction(formData: FormData) {
   const { user } = await requireAdmin()
   const promptVersionId = formString(formData, 'prompt_version_id')
   const digestDate = formString(formData, 'digest_date')
-  const targetCommunityUsersOnly = formBoolean(
-    formData,
-    'target_ca_users_only',
-  )
+  const targetCommunityUsersOnly = formBoolean(formData, 'target_ca_users_only')
   if (!UUID_PATTERN.test(promptVersionId)) {
     redirectToLab({ error: 'Choose a prompt version.' })
   }
@@ -479,6 +426,7 @@ export async function createAndGenerateDigestDateAction(formData: FormData) {
         candidate_count: candidates.length,
         default_selected_count: candidates.length,
         qualifying_banger_count: snapshot.bangerCount,
+        community_authored_count: snapshot.communityAuthoredCount,
         interaction_fallback_count: snapshot.fallbackCount,
         minimum_ca_quote_count: 2,
         target_author_population: targetCommunityUsersOnly

--- a/src/app/admin/digest/page.tsx
+++ b/src/app/admin/digest/page.tsx
@@ -207,8 +207,9 @@ export default async function DigestLabPage({
             <p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">
               Pull a frozen 24-hour banger set, choose what belongs, compare
               immutable prompt versions, inspect the exact request and run
-              trace, then stage a public edition. Nothing publishes
-              automatically.
+              trace, then stage a public edition. The nightly workflow uses the
+              newest prompt and publishes automatically; manual runs remain
+              editable here.
             </p>
           </div>
           <div className="flex items-center gap-2">
@@ -269,7 +270,7 @@ export default async function DigestLabPage({
               </h2>
               <p className="mt-1 text-sm text-emerald-900/75 dark:text-emerald-100/75">
                 Publishing makes this exact draft the public edition. It never
-                happens automatically.
+                changes the immutable source run.
               </p>
             </div>
             <form action={publishDigestEditionAction}>
@@ -315,10 +316,9 @@ export default async function DigestLabPage({
                       type="checkbox"
                       name="target_ca_users_only"
                       value="true"
-                      defaultChecked
                       className="mt-0.5 h-4 w-4 rounded border-zinc-300"
                     />
-                    Only include posts authored by Community Archive members
+                    Restrict this manual run to Community Archive authors
                   </label>
                   <SubmitButton pendingLabel="Pulling candidates…">
                     Pull last 24 hours
@@ -348,7 +348,7 @@ export default async function DigestLabPage({
                       action: createAndGenerateDigestDateAction,
                       dates: pastDates,
                       promptVersionId: prompt.id,
-                      targetCommunityUsersOnly: true,
+                      targetCommunityUsersOnly: false,
                       runningRuns: runningRuns.map((run) => ({
                         date: run.digestDate,
                         id: run.id,
@@ -509,6 +509,11 @@ export default async function DigestLabPage({
                               <span className="text-muted-foreground">
                                 @{candidate.tweet.username}
                               </span>
+                              {candidate.communityAuthored ? (
+                                <Badge variant="secondary">
+                                  Community author
+                                </Badge>
+                              ) : null}
                               <span className="ml-auto tabular-nums text-muted-foreground">
                                 {candidate.source === 'ca_interactions'
                                   ? `↪ ${candidate.tweet.interactionCount ?? 0} CA interactions (${candidate.tweet.replyCount ?? 0} replies · ${candidate.tweet.quoteCount ?? 0} quotes) · `

--- a/src/app/api/cron/daily-digest/route.ts
+++ b/src/app/api/cron/daily-digest/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server'
+import { start } from 'workflow/api'
+import {
+  isAuthorizedDigestCronRequest,
+  isNightlyDigestAutomationEnabled,
+} from '@/lib/digest/cron'
+import { getLatestCompletedDigestDate } from '@/lib/digest/dateWindow'
+import { publishNightlyDigestWorkflow } from '@/workflows/digestGeneration'
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+export const maxDuration = 30
+
+export async function GET(request: Request) {
+  if (!isAuthorizedDigestCronRequest(request)) {
+    return new NextResponse('Unauthorized', { status: 401 })
+  }
+  if (!isNightlyDigestAutomationEnabled()) {
+    return NextResponse.json(
+      { error: 'Nightly digest automation is disabled.' },
+      { status: 503 },
+    )
+  }
+
+  const digestDate = getLatestCompletedDigestDate()
+  const workflowRun = await start(publishNightlyDigestWorkflow, [digestDate])
+
+  return NextResponse.json(
+    { digestDate, status: 'queued', workflowRunId: workflowRun.runId },
+    { status: 202 },
+  )
+}

--- a/src/app/api/cron/daily-digest/route.ts
+++ b/src/app/api/cron/daily-digest/route.ts
@@ -3,15 +3,15 @@ import { start } from 'workflow/api'
 import {
   isAuthorizedDigestCronRequest,
   isNightlyDigestAutomationEnabled,
+  resolveDigestAutomationDate,
 } from '@/lib/digest/cron'
-import { getLatestCompletedDigestDate } from '@/lib/digest/dateWindow'
 import { publishNightlyDigestWorkflow } from '@/workflows/digestGeneration'
 
 export const dynamic = 'force-dynamic'
 export const runtime = 'nodejs'
 export const maxDuration = 30
 
-export async function GET(request: Request) {
+async function queueDigest(request: Request, requestedDate?: unknown) {
   if (!isAuthorizedDigestCronRequest(request)) {
     return new NextResponse('Unauthorized', { status: 401 })
   }
@@ -22,11 +22,43 @@ export async function GET(request: Request) {
     )
   }
 
-  const digestDate = getLatestCompletedDigestDate()
+  let digestDate: string
+  try {
+    digestDate = resolveDigestAutomationDate(requestedDate)
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : 'Invalid digest date.',
+      },
+      { status: 400 },
+    )
+  }
   const workflowRun = await start(publishNightlyDigestWorkflow, [digestDate])
 
   return NextResponse.json(
     { digestDate, status: 'queued', workflowRunId: workflowRun.runId },
     { status: 202 },
   )
+}
+
+export async function GET(request: Request) {
+  return queueDigest(request)
+}
+
+export async function POST(request: Request) {
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json(
+      { error: 'Expected a JSON request body.' },
+      { status: 400 },
+    )
+  }
+
+  const requestedDate =
+    body && typeof body === 'object' && 'digestDate' in body
+      ? body.digestDate
+      : null
+  return queueDigest(request, requestedDate)
 }

--- a/src/components/portal/TweetRow.tsx
+++ b/src/components/portal/TweetRow.tsx
@@ -465,6 +465,13 @@ export function TweetRow({
             : relativeTime(tweet.createdAt)}
         </span>
       </div>
+      {tweet.communityAuthored ? (
+        <div className="mt-1">
+          <span className="inline-flex rounded-full bg-brand/10 px-2 py-0.5 text-[11px] font-semibold text-brand">
+            Community author
+          </span>
+        </div>
+      ) : null}
       <Link
         href={href}
         onClick={() => captureAction('open')}

--- a/src/database-types.ts
+++ b/src/database-types.ts
@@ -1554,6 +1554,15 @@ export type Database = {
         }
         Returns: boolean
       }
+      community_archive_monitoring_digest: {
+        Args: Record<PropertyKey, never>
+        Returns: {
+          publication_age_seconds: number
+          expected_date_published: number
+          automated_run_failed: number
+          healthy: number
+        }[]
+      }
       compute_hourly_scraping_stats: {
         Args: {
           p_start_date: string

--- a/src/lib/digest/candidates.test.ts
+++ b/src/lib/digest/candidates.test.ts
@@ -1,0 +1,98 @@
+import type { PortalTweet } from '@/lib/portal/types'
+import {
+  fetchPortalDailyInteractions,
+  fetchPortalRecentBangers,
+} from '@/lib/portal/analytics'
+import { loadDigestCandidates } from './candidates'
+
+const tweet = (id: string, quoteCount = 3): PortalTweet => ({
+  id,
+  accountId: `9${id}`,
+  username: `user_${id}`,
+  name: `User ${id}`,
+  avatar: null,
+  text: `Post ${id}`,
+  observedAt: '2026-08-21T05:00:00.000Z',
+  createdAt: '2026-08-21T04:00:00.000Z',
+  likes: 10,
+  rts: 1,
+  quoteCount,
+  media: [],
+})
+
+describe('daily digest candidate snapshot', () => {
+  test('keeps all-author bangers and marks the community-authored subset', async () => {
+    const allBangers = Array.from({ length: 10 }, (_, index) =>
+      tweet(String(index + 1)),
+    )
+    const fetchRecentBangers = jest.fn<
+      ReturnType<typeof fetchPortalRecentBangers>,
+      Parameters<typeof fetchPortalRecentBangers>
+    >(async (...args) => {
+      const targetCommunityUsersOnly = args[4] ?? false
+      return targetCommunityUsersOnly
+        ? [allBangers[1], allBangers[7]]
+        : allBangers
+    })
+    const fetchDailyInteractions = jest.fn<
+      ReturnType<typeof fetchPortalDailyInteractions>,
+      Parameters<typeof fetchPortalDailyInteractions>
+    >(async () => [])
+
+    const snapshot = await loadDigestCandidates(
+      '2026-08-21T06:00:00.000Z',
+      false,
+      { fetchRecentBangers, fetchDailyInteractions },
+    )
+
+    expect(snapshot.candidates).toHaveLength(10)
+    expect(
+      snapshot.candidates
+        .filter(({ communityAuthored }) => communityAuthored)
+        .map(({ tweet: candidateTweet }) => candidateTweet.id),
+    ).toEqual(['2', '8'])
+    expect(snapshot.communityAuthoredCount).toBe(2)
+    expect(fetchRecentBangers).toHaveBeenNthCalledWith(
+      1,
+      50,
+      24,
+      undefined,
+      '2026-08-21T06:00:00.000Z',
+      false,
+    )
+    expect(fetchRecentBangers).toHaveBeenNthCalledWith(
+      2,
+      50,
+      24,
+      undefined,
+      '2026-08-21T06:00:00.000Z',
+      true,
+    )
+    expect(fetchDailyInteractions).not.toHaveBeenCalled()
+  })
+
+  test('marks every candidate in a community-only manual snapshot', async () => {
+    const communityBangers = Array.from({ length: 10 }, (_, index) =>
+      tweet(String(index + 1)),
+    )
+    const fetchRecentBangers = jest.fn<
+      ReturnType<typeof fetchPortalRecentBangers>,
+      Parameters<typeof fetchPortalRecentBangers>
+    >(async () => communityBangers)
+    const fetchDailyInteractions = jest.fn<
+      ReturnType<typeof fetchPortalDailyInteractions>,
+      Parameters<typeof fetchPortalDailyInteractions>
+    >(async () => [])
+
+    const snapshot = await loadDigestCandidates(
+      '2026-08-21T06:00:00.000Z',
+      true,
+      { fetchRecentBangers, fetchDailyInteractions },
+    )
+
+    expect(
+      snapshot.candidates.every(({ communityAuthored }) => communityAuthored),
+    ).toBe(true)
+    expect(fetchRecentBangers).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/lib/digest/candidates.ts
+++ b/src/lib/digest/candidates.ts
@@ -1,0 +1,84 @@
+import {
+  fetchPortalDailyInteractions,
+  fetchPortalRecentBangers,
+} from '@/lib/portal/analytics'
+import type { PortalTweet } from '@/lib/portal/types'
+import {
+  fillDailyDigestCandidates,
+  selectDailyDigestBangers,
+} from './generation'
+import type { DigestCandidate } from './types'
+
+export const MINIMUM_DIGEST_CANDIDATE_POOL = 10
+
+type DigestCandidateSources = {
+  fetchDailyInteractions: typeof fetchPortalDailyInteractions
+  fetchRecentBangers: typeof fetchPortalRecentBangers
+}
+
+const DEFAULT_SOURCES: DigestCandidateSources = {
+  fetchDailyInteractions: fetchPortalDailyInteractions,
+  fetchRecentBangers: fetchPortalRecentBangers,
+}
+
+const tweetIds = (tweets: PortalTweet[]) => new Set(tweets.map(({ id }) => id))
+
+export async function loadDigestCandidates(
+  windowEnd: string,
+  targetCommunityUsersOnly = false,
+  sources: DigestCandidateSources = DEFAULT_SOURCES,
+) {
+  const [bangers, communityBangers] = await Promise.all([
+    sources.fetchRecentBangers(
+      50,
+      24,
+      undefined,
+      windowEnd,
+      targetCommunityUsersOnly,
+    ),
+    targetCommunityUsersOnly
+      ? Promise.resolve<PortalTweet[]>([])
+      : sources.fetchRecentBangers(50, 24, undefined, windowEnd, true),
+  ])
+  const qualifyingBangers = selectDailyDigestBangers(bangers)
+  const needsInteractionFallback =
+    qualifyingBangers.length < MINIMUM_DIGEST_CANDIDATE_POOL
+  const [interactionRanked, communityInteractions] = needsInteractionFallback
+    ? await Promise.all([
+        sources.fetchDailyInteractions(
+          50,
+          24,
+          undefined,
+          windowEnd,
+          targetCommunityUsersOnly,
+        ),
+        targetCommunityUsersOnly
+          ? Promise.resolve<PortalTweet[]>([])
+          : sources.fetchDailyInteractions(50, 24, undefined, windowEnd, true),
+      ])
+    : [[], []]
+  const selected = fillDailyDigestCandidates(
+    bangers,
+    interactionRanked,
+    MINIMUM_DIGEST_CANDIDATE_POOL,
+  )
+  const communityTweetIds = targetCommunityUsersOnly
+    ? tweetIds(selected.map(({ tweet }) => tweet))
+    : tweetIds([...communityBangers, ...communityInteractions])
+
+  return {
+    candidates: selected.map<DigestCandidate>(({ tweet, source }, index) => ({
+      tweet,
+      source,
+      sourceRank: index + 1,
+      selected: true,
+      communityAuthored: communityTweetIds.has(tweet.id),
+    })),
+    bangerCount: qualifyingBangers.length,
+    communityAuthoredCount: selected.filter(({ tweet }) =>
+      communityTweetIds.has(tweet.id),
+    ).length,
+    fallbackCount: selected.filter(({ source }) => source === 'ca_interactions')
+      .length,
+  }
+}

--- a/src/lib/digest/cron.test.ts
+++ b/src/lib/digest/cron.test.ts
@@ -1,0 +1,37 @@
+import {
+  isAuthorizedDigestCronRequest,
+  isNightlyDigestAutomationEnabled,
+} from './cron'
+
+describe('nightly digest cron gate', () => {
+  test('requires the exact configured bearer secret', () => {
+    expect(
+      isAuthorizedDigestCronRequest(
+        new Request('https://example.test/api/cron/daily-digest', {
+          headers: { authorization: 'Bearer expected-secret' },
+        }),
+        'expected-secret',
+      ),
+    ).toBe(true)
+    expect(
+      isAuthorizedDigestCronRequest(
+        new Request('https://example.test/api/cron/daily-digest', {
+          headers: { authorization: 'Bearer wrong-secret' },
+        }),
+        'expected-secret',
+      ),
+    ).toBe(false)
+    expect(
+      isAuthorizedDigestCronRequest(
+        new Request('https://example.test/api/cron/daily-digest'),
+        undefined,
+      ),
+    ).toBe(false)
+  })
+
+  test('requires an explicit production enable flag', () => {
+    expect(isNightlyDigestAutomationEnabled('true')).toBe(true)
+    expect(isNightlyDigestAutomationEnabled('false')).toBe(false)
+    expect(isNightlyDigestAutomationEnabled(undefined)).toBe(false)
+  })
+})

--- a/src/lib/digest/cron.test.ts
+++ b/src/lib/digest/cron.test.ts
@@ -1,6 +1,7 @@
 import {
   isAuthorizedDigestCronRequest,
   isNightlyDigestAutomationEnabled,
+  resolveDigestAutomationDate,
 } from './cron'
 
 describe('nightly digest cron gate', () => {
@@ -33,5 +34,25 @@ describe('nightly digest cron gate', () => {
     expect(isNightlyDigestAutomationEnabled('true')).toBe(true)
     expect(isNightlyDigestAutomationEnabled('false')).toBe(false)
     expect(isNightlyDigestAutomationEnabled(undefined)).toBe(false)
+  })
+
+  test('uses the latest completed date for the scheduled request', () => {
+    expect(
+      resolveDigestAutomationDate(
+        undefined,
+        new Date('2026-08-21T07:00:00.000Z'),
+      ),
+    ).toBe('2026-08-20')
+  })
+
+  test('accepts only a recent completed date for supervised recovery', () => {
+    const now = new Date('2026-08-21T07:00:00.000Z')
+    expect(resolveDigestAutomationDate('2026-08-19', now)).toBe('2026-08-19')
+    expect(() => resolveDigestAutomationDate('2026-08-21', now)).toThrow(
+      'within the last 30 completed days',
+    )
+    expect(() => resolveDigestAutomationDate('not-a-date', now)).toThrow(
+      'within the last 30 completed days',
+    )
   })
 })

--- a/src/lib/digest/cron.ts
+++ b/src/lib/digest/cron.ts
@@ -1,3 +1,8 @@
+import {
+  getLatestCompletedDigestDate,
+  isRecentPastDigestDate,
+} from './dateWindow'
+
 export function isAuthorizedDigestCronRequest(
   request: Request,
   cronSecret = process.env.CRON_SECRET,
@@ -12,4 +17,18 @@ export function isNightlyDigestAutomationEnabled(
   value = process.env.DIGEST_AUTOMATION_ENABLED,
 ) {
   return value === 'true'
+}
+
+export function resolveDigestAutomationDate(
+  requestedDate: unknown,
+  now = new Date(),
+) {
+  if (requestedDate === undefined) return getLatestCompletedDigestDate(now)
+  if (
+    typeof requestedDate !== 'string' ||
+    !isRecentPastDigestDate(requestedDate, now)
+  ) {
+    throw new Error('Digest date must be within the last 30 completed days.')
+  }
+  return requestedDate
 }

--- a/src/lib/digest/cron.ts
+++ b/src/lib/digest/cron.ts
@@ -1,0 +1,15 @@
+export function isAuthorizedDigestCronRequest(
+  request: Request,
+  cronSecret = process.env.CRON_SECRET,
+) {
+  return Boolean(
+    cronSecret &&
+      request.headers.get('authorization') === `Bearer ${cronSecret}`,
+  )
+}
+
+export function isNightlyDigestAutomationEnabled(
+  value = process.env.DIGEST_AUTOMATION_ENABLED,
+) {
+  return value === 'true'
+}

--- a/src/lib/digest/dateWindow.test.ts
+++ b/src/lib/digest/dateWindow.test.ts
@@ -1,6 +1,7 @@
 import {
   digestDateForCommunityDay,
   getDigestDateWindow,
+  getLatestCompletedDigestDate,
   isRecentPastDigestDate,
   listPastDigestDates,
 } from './dateWindow'
@@ -46,6 +47,15 @@ describe('digest date windows', () => {
     ])
     expect(isRecentPastDigestDate('2026-08-11', now)).toBe(true)
     expect(isRecentPastDigestDate('2026-08-14', now)).toBe(false)
+  })
+
+  test('selects the latest completed edition on either side of the cutoff', () => {
+    expect(
+      getLatestCompletedDigestDate(new Date('2026-08-21T05:59:59.000Z')),
+    ).toBe('2026-08-19')
+    expect(
+      getLatestCompletedDigestDate(new Date('2026-08-21T06:15:00.000Z')),
+    ).toBe('2026-08-20')
   })
 
   test('allows completed days across the twelve-month generation calendar', () => {

--- a/src/lib/digest/dateWindow.ts
+++ b/src/lib/digest/dateWindow.ts
@@ -42,6 +42,10 @@ export function listPastDigestDates(count = 7, now = new Date()) {
   )
 }
 
+export function getLatestCompletedDigestDate(now = new Date()) {
+  return listPastDigestDates(1, now)[0]
+}
+
 export function isRecentPastDigestDate(
   digestDate: string,
   now = new Date(),

--- a/src/lib/digest/generation.test.ts
+++ b/src/lib/digest/generation.test.ts
@@ -29,6 +29,7 @@ const candidates: EnrichedDigestCandidate[] = [
       tweet: tweet('1', 'taste benchmarks are becoming public rituals', 9),
       sourceRank: 1,
       selected: true,
+      communityAuthored: true,
     },
     commentary: [tweet('11', 'taste is not the same thing as prediction')],
     totalReplyCount: 12,
@@ -153,6 +154,7 @@ describe('daily digest generation contract', () => {
     expect(prompt).toContain('"index": 0')
     expect(prompt).toContain('"archived_ca_quote_count": 9')
     expect(prompt).toContain('"selection_source": "banger"')
+    expect(prompt).toContain('"authored_by_community_member": true')
     expect(prompt).toContain('"kind": "quote"')
     expect(prompt).toContain('"tweet_id": "1"')
   })
@@ -175,7 +177,7 @@ describe('daily digest generation contract', () => {
 
     expect(prompt).toContain('PAST PUBLISHED DIGESTS')
     expect(prompt).toContain('"digest_date": "2026-08-11"')
-    expect(prompt).toContain('TODAY\'S CURRENT CANDIDATE CORPUS')
+    expect(prompt).toContain("TODAY'S CURRENT CANDIDATE CORPUS")
     expect(prompt.match(/"tweet_id": "1"/g)).toHaveLength(1)
   })
 

--- a/src/lib/digest/generation.test.ts
+++ b/src/lib/digest/generation.test.ts
@@ -215,6 +215,7 @@ describe('daily digest generation contract', () => {
     })
 
     expect(edition.topBanger.id).toBe('1')
+    expect(edition.topBanger.communityAuthored).toBe(true)
     expect(edition.executiveSummary).toHaveLength(3)
     expect(edition.stories).toHaveLength(3)
     expect(edition.stories[0]).toMatchObject({
@@ -224,6 +225,8 @@ describe('daily digest generation contract', () => {
       replyCount: 12,
     })
     expect(edition.stories[0].commentary[0].id).toBe('11')
+    expect(edition.stories[0].bangers[0].communityAuthored).toBe(true)
+    expect(edition.stories[1].bangers[0].communityAuthored).toBeUndefined()
     expect(edition.stories[0].editorialNote).toContain('settled verdict')
     expect(edition.source).toEqual({
       candidateCount: 12,

--- a/src/lib/digest/generation.ts
+++ b/src/lib/digest/generation.ts
@@ -402,13 +402,21 @@ export function assembleDigestEditionContent(input: {
       candidate,
     ]),
   )
+  const markCommunityAuthorship = (row: DigestPromptCorpusRow): PortalTweet => {
+    const isCommunityAuthored =
+      row.kind === 'banger' &&
+      enrichedByBanger.get(row.tweetId)?.candidate.communityAuthored === true
+    return isCommunityAuthored
+      ? { ...row.tweet, communityAuthored: true }
+      : row.tweet
+  }
   const slugCounts = new Map<string, number>()
 
   const stories: DigestStory[] = parsed.stories.map((story) => {
     const indexedTweets = story.tweetIndices.map((index) => corpus[index])
     const storyBangers = indexedTweets
       .filter(({ kind }) => kind === 'banger')
-      .map(({ tweet }) => tweet)
+      .map(markCommunityAuthorship)
     const storyCommentary = indexedTweets
       .filter(({ kind }) => kind !== 'banger')
       .map(({ tweet }) => tweet)
@@ -454,8 +462,9 @@ export function assembleDigestEditionContent(input: {
     }
   })
 
-  const topBanger = corpus[parsed.representativeTweetIndex]?.tweet
-  if (!topBanger) throw new Error('Digest has no representative tweet')
+  const topBangerRow = corpus[parsed.representativeTweetIndex]
+  if (!topBangerRow) throw new Error('Digest has no representative tweet')
+  const topBanger = markCommunityAuthorship(topBangerRow)
 
   return {
     digestDate: input.digestDate,

--- a/src/lib/digest/generation.ts
+++ b/src/lib/digest/generation.ts
@@ -328,6 +328,8 @@ export function renderDigestPrompt(
           ? {
               source_rank: candidate.sourceRank,
               selection_source: candidate.source ?? 'banger',
+              authored_by_community_member:
+                candidate.communityAuthored === true,
               archived_ca_quote_count: candidate.tweet.quoteCount ?? 0,
               archived_ca_reply_count: candidate.tweet.replyCount ?? 0,
               archived_ca_interaction_count:

--- a/src/lib/digest/openai.test.ts
+++ b/src/lib/digest/openai.test.ts
@@ -257,6 +257,47 @@ describe('OpenAI digest adapter', () => {
     })
   })
 
+  test('reports OpenRouter token exhaustion without storing response content in the error', async () => {
+    process.env.OPENROUTER_API_KEY = 'openrouter-test-key'
+    const fetcher = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: 'gen_exhausted',
+          model: 'deepseek/deepseek-v4-flash-0731',
+          choices: [
+            {
+              finish_reason: 'length',
+              message: { content: null, reasoning: 'private reasoning' },
+            },
+          ],
+          usage: {
+            prompt_tokens: 14_279,
+            completion_tokens: 6_000,
+            completion_tokens_details: { reasoning_tokens: 5_068 },
+          },
+        }),
+        { status: 200 },
+      ),
+    ) as jest.MockedFunction<typeof fetch>
+
+    const result = await generateDigestWithModel(
+      {
+        runId: 'run-exhausted',
+        model: 'deepseek/deepseek-v4-flash-0731',
+        systemPrompt: 'Return the digest schema.',
+        userPrompt: 'Indexed corpus',
+        reasoningEffort: 'high',
+        maxOutputTokens: 6_000,
+      },
+      fetcher,
+    )
+
+    expect(result.outputError).toBe(
+      'OpenRouter response did not include output text (finish_reason=length, completion_tokens=6000, reasoning_tokens=5068)',
+    )
+    expect(result.outputError).not.toContain('private reasoning')
+  })
+
   test('reports model timeouts with a durable, readable error', async () => {
     process.env.OPENROUTER_API_KEY = 'openrouter-test-key'
     const timeoutError = new Error('The operation was aborted due to timeout')

--- a/src/lib/digest/openai.test.ts
+++ b/src/lib/digest/openai.test.ts
@@ -257,6 +257,40 @@ describe('OpenAI digest adapter', () => {
     })
   })
 
+  test('uses JSON object mode for GLM because its schema mode is unreliable', async () => {
+    process.env.OPENROUTER_API_KEY = 'openrouter-test-key'
+    const fetcher = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: 'gen_glm',
+          model: 'z-ai/glm-5.3',
+          choices: [
+            {
+              message: {
+                content:
+                  '{"executive_summary":[],"representative_tweet_index":0,"stories":[],"keywords":[]}',
+              },
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    ) as jest.MockedFunction<typeof fetch>
+
+    await generateDigestWithModel(
+      {
+        runId: 'run-glm',
+        model: 'z-ai/glm-5.3',
+        systemPrompt: 'Return JSON.',
+        userPrompt: 'Indexed corpus',
+      },
+      fetcher,
+    )
+
+    const request = JSON.parse(String(fetcher.mock.calls[0][1]?.body))
+    expect(request.response_format).toEqual({ type: 'json_object' })
+  })
+
   test('reports OpenRouter token exhaustion without storing response content in the error', async () => {
     process.env.OPENROUTER_API_KEY = 'openrouter-test-key'
     const fetcher = jest.fn().mockResolvedValue(

--- a/src/lib/digest/openai.ts
+++ b/src/lib/digest/openai.ts
@@ -108,6 +108,37 @@ const safeTokenCount = (value: unknown): number | null => {
   return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null
 }
 
+const describeOpenRouterCompletion = (
+  payload: Record<string, unknown>,
+  choice: unknown,
+) => {
+  const choiceRecord =
+    choice && typeof choice === 'object'
+      ? (choice as Record<string, unknown>)
+      : {}
+  const usage =
+    payload.usage && typeof payload.usage === 'object'
+      ? (payload.usage as Record<string, unknown>)
+      : {}
+  const completionDetails =
+    usage.completion_tokens_details &&
+    typeof usage.completion_tokens_details === 'object'
+      ? (usage.completion_tokens_details as Record<string, unknown>)
+      : {}
+  const details = [
+    typeof choiceRecord.finish_reason === 'string'
+      ? `finish_reason=${choiceRecord.finish_reason}`
+      : null,
+    safeTokenCount(usage.completion_tokens) !== null
+      ? `completion_tokens=${safeTokenCount(usage.completion_tokens)}`
+      : null,
+    safeTokenCount(completionDetails.reasoning_tokens) !== null
+      ? `reasoning_tokens=${safeTokenCount(completionDetails.reasoning_tokens)}`
+      : null,
+  ].filter((value): value is string => Boolean(value))
+  return details.length > 0 ? ` (${details.join(', ')})` : ''
+}
+
 const fetchModelResponse = async (
   fetchImpl: typeof fetch,
   input: Parameters<typeof fetch>[0],
@@ -242,16 +273,17 @@ export async function generateDigestWithModel(
       message && typeof message === 'object'
         ? (message as { content?: unknown }).content
         : null
+    const completionDescription = describeOpenRouterCompletion(payload, choice)
     let output: unknown = null
     let outputError: string | null = null
     if (typeof outputText !== 'string') {
-      outputError = 'OpenRouter response did not include output text'
+      outputError = `OpenRouter response did not include output text${completionDescription}`
     } else {
       try {
         output = JSON.parse(outputText)
       } catch {
         output = outputText
-        outputError = 'OpenRouter structured output was not valid JSON'
+        outputError = `OpenRouter structured output was not valid JSON${completionDescription}`
       }
     }
     const usage =

--- a/src/lib/digest/openai.ts
+++ b/src/lib/digest/openai.ts
@@ -65,7 +65,8 @@ export const DIGEST_JSON_SCHEMA = {
             type: 'array',
             minItems: 1,
             maxItems: 18,
-            uniqueItems: true,
+            // OpenAI strict structured outputs do not support uniqueItems.
+            // The deterministic receiver rejects repeated indices instead.
             items: { type: 'integer', minimum: 0 },
           },
         },

--- a/src/lib/digest/openai.ts
+++ b/src/lib/digest/openai.ts
@@ -220,14 +220,17 @@ export async function generateDigestWithModel(
         { role: 'user', content: request.userPrompt },
       ],
       provider: { data_collection: 'deny', zdr: true },
-      response_format: {
-        type: 'json_schema',
-        json_schema: {
-          name: 'community_archive_daily_digest',
-          strict: true,
-          schema: DIGEST_JSON_SCHEMA,
-        },
-      },
+      response_format:
+        request.model === 'z-ai/glm-5.3'
+          ? { type: 'json_object' }
+          : {
+              type: 'json_schema',
+              json_schema: {
+                name: 'community_archive_daily_digest',
+                strict: true,
+                schema: DIGEST_JSON_SCHEMA,
+              },
+            },
     }
     if (request.reasoningEffort) {
       body.reasoning = { effort: request.reasoningEffort, exclude: true }

--- a/src/lib/digest/types.ts
+++ b/src/lib/digest/types.ts
@@ -25,6 +25,8 @@ export interface DigestCandidate {
   sourceRank: number
   selected: boolean
   source?: 'banger' | 'ca_interactions'
+  /** Frozen membership marker supplied to editors and the generation prompt. */
+  communityAuthored?: boolean
 }
 
 export interface DigestRunEvent {

--- a/src/lib/portal/TweetRow.test.tsx
+++ b/src/lib/portal/TweetRow.test.tsx
@@ -119,6 +119,12 @@ describe('portal TweetRow media', () => {
     })
   })
 
+  test('marks community-authored digest bangers', () => {
+    render(<TweetRow tweet={{ ...tweet, communityAuthored: true }} />)
+
+    expect(screen.getByText('Community author')).toBeVisible()
+  })
+
   test('renders quotes and closes an enlarged image when the backdrop is clicked', async () => {
     render(<TweetRow tweet={tweet} />)
 

--- a/src/lib/portal/types.ts
+++ b/src/lib/portal/types.ts
@@ -44,6 +44,8 @@ export interface PortalTweet {
   replyCount?: number
   /** Distinct non-self replies plus quote posts from archive members. */
   interactionCount?: number
+  /** Frozen digest-time membership marker shown on community-authored bangers. */
+  communityAuthored?: boolean
 }
 
 export type PortalBangersScope = 'all' | 'members'

--- a/src/workflows/digestGeneration.ts
+++ b/src/workflows/digestGeneration.ts
@@ -1,5 +1,9 @@
 import type { TweetData } from '@/components/TweetComponent'
 import { fetchClickHouseQuotePosts } from '@/lib/clickhouseQuotePosts'
+import {
+  loadDigestCandidates,
+  MINIMUM_DIGEST_CANDIDATE_POOL,
+} from '@/lib/digest/candidates'
 import { fetchDigestReplies } from '@/lib/digest/context'
 import {
   mapDigestEdition,
@@ -8,6 +12,7 @@ import {
   toJson,
 } from '@/lib/digest/data'
 import { createDigestAdminClient } from '@/lib/digest/database'
+import { getDigestDateWindow } from '@/lib/digest/dateWindow'
 import {
   assembleDigestEditionContent,
   renderDigestPrompt,
@@ -484,6 +489,272 @@ async function markDigestGenerationFailed(runId: string, message: string) {
     .eq('status', 'running')
 }
 
+type NightlyDigestClaim =
+  | { action: 'generate'; runId: string }
+  | { action: 'publish'; runId: string }
+  | {
+      action: 'skip'
+      reason: 'already-published' | 'already-running' | 'failed'
+      runId: string | null
+    }
+
+async function claimNightlyDigestRun(
+  digestDate: string,
+  workflowRunId: string,
+): Promise<NightlyDigestClaim> {
+  'use step'
+
+  const admin = createDigestAdminClient()
+  const { data: published, error: publishedError } = await admin
+    .from('digest_editions')
+    .select('source_run_id')
+    .eq('digest_date', digestDate)
+    .eq('status', 'published')
+    .limit(1)
+    .maybeSingle()
+  if (publishedError) throw publishedError
+  if (published) {
+    return {
+      action: 'skip',
+      reason: 'already-published',
+      runId: published.source_run_id,
+    }
+  }
+
+  const findExistingAutomatedRun = () =>
+    admin
+      .from('digest_runs')
+      .select('*')
+      .eq('digest_date', digestDate)
+      .is('created_by', null)
+      .is('parent_run_id', null)
+      .not('workflow_run_id', 'is', null)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+  const existingResult = await findExistingAutomatedRun()
+  if (existingResult.error) throw existingResult.error
+  if (existingResult.data) {
+    const existing = mapDigestRun(existingResult.data)
+    if (existing.status === 'completed') {
+      return { action: 'publish', runId: existing.id }
+    }
+    if (
+      existing.status === 'running' &&
+      existing.workflowRunId === workflowRunId
+    ) {
+      return { action: 'generate', runId: existing.id }
+    }
+    return {
+      action: 'skip',
+      reason: existing.status === 'failed' ? 'failed' : 'already-running',
+      runId: existing.id,
+    }
+  }
+
+  const { data: promptRow, error: promptError } = await admin
+    .from('digest_prompt_versions')
+    .select('id')
+    .order('version', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+  if (promptError || !promptRow) {
+    throw promptError ?? new Error('No digest prompt version is configured')
+  }
+
+  const window = getDigestDateWindow(digestDate)
+  const snapshot = await loadDigestCandidates(window.windowEnd, false)
+  const startedAt = new Date()
+  const hasEnoughCandidates = snapshot.candidates.length >= 3
+  const initialEvents: DigestRunEvent[] = [
+    event(
+      'candidates',
+      'completed',
+      `Saved ${digestDate} nightly candidates from all authors, with Community Archive authors marked for editorial preference.`,
+      {
+        automation: true,
+        candidate_count: snapshot.candidates.length,
+        community_authored_count: snapshot.communityAuthoredCount,
+        default_selected_count: snapshot.candidates.length,
+        interaction_fallback_count: snapshot.fallbackCount,
+        minimum_candidate_pool: MINIMUM_DIGEST_CANDIDATE_POOL,
+        minimum_ca_quote_count: 2,
+        qualifying_banger_count: snapshot.bangerCount,
+        target_author_population: 'all_authors',
+        workflow_run_id: workflowRunId,
+      },
+    ),
+  ]
+  if (!hasEnoughCandidates) {
+    initialEvents.push(
+      event(
+        'generation',
+        'failed',
+        `Only ${snapshot.candidates.length} candidates were found; at least three are required.`,
+      ),
+    )
+  }
+  const { data: created, error: createError } = await admin
+    .from('digest_runs')
+    .insert({
+      digest_date: digestDate,
+      status: hasEnoughCandidates ? 'running' : 'failed',
+      prompt_version_id: promptRow.id,
+      window_start: window.windowStart,
+      window_end: window.windowEnd,
+      candidates: toJson(snapshot.candidates),
+      workflow_run_id: workflowRunId,
+      events: toJson(initialEvents),
+      started_at: hasEnoughCandidates ? startedAt.toISOString() : null,
+      completed_at: hasEnoughCandidates ? null : startedAt.toISOString(),
+      error: hasEnoughCandidates
+        ? null
+        : `Only ${snapshot.candidates.length} digest candidates were found`,
+      created_by: null,
+    })
+    .select('id')
+    .single()
+
+  if (createError) {
+    if (createError.code !== '23505') throw createError
+    const duplicateResult = await findExistingAutomatedRun()
+    if (duplicateResult.error || !duplicateResult.data) {
+      throw duplicateResult.error ?? createError
+    }
+    const duplicate = mapDigestRun(duplicateResult.data)
+    if (duplicate.status === 'completed') {
+      return { action: 'publish', runId: duplicate.id }
+    }
+    return {
+      action: 'skip',
+      reason: duplicate.status === 'failed' ? 'failed' : 'already-running',
+      runId: duplicate.id,
+    }
+  }
+
+  return hasEnoughCandidates
+    ? { action: 'generate', runId: created.id }
+    : { action: 'skip', reason: 'failed', runId: created.id }
+}
+
+async function publishNightlyDigestRun(runId: string) {
+  'use step'
+
+  const admin = createDigestAdminClient()
+  const { data: runRow, error: runError } = await admin
+    .from('digest_runs')
+    .select('*')
+    .eq('id', runId)
+    .maybeSingle()
+  if (runError || !runRow) throw runError ?? new Error('Digest run not found')
+  const run = mapDigestRun(runRow)
+  if (run.status !== 'completed' || !run.parsedOutput) {
+    throw new Error('Nightly digest run did not complete with valid output')
+  }
+
+  const { data: alreadyPublished, error: publishedError } = await admin
+    .from('digest_editions')
+    .select('id, source_run_id, version')
+    .eq('digest_date', run.digestDate)
+    .eq('status', 'published')
+    .limit(1)
+    .maybeSingle()
+  if (publishedError) throw publishedError
+  if (alreadyPublished) {
+    return {
+      digestDate: run.digestDate,
+      editionId: alreadyPublished.id,
+      status:
+        alreadyPublished.source_run_id === runId
+          ? ('published' as const)
+          : ('editorial-edition-preserved' as const),
+      version: alreadyPublished.version,
+    }
+  }
+
+  const { data: existingDraft, error: draftError } = await admin
+    .from('digest_editions')
+    .select('id, version')
+    .eq('source_run_id', runId)
+    .eq('status', 'draft')
+    .order('version', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+  if (draftError) throw draftError
+
+  let draft = existingDraft
+  if (!draft) {
+    const { data: latest, error: latestError } = await admin
+      .from('digest_editions')
+      .select('version')
+      .eq('digest_date', run.digestDate)
+      .order('version', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+    if (latestError) throw latestError
+
+    const version = (latest?.version ?? 0) + 1
+    const { data: createdDraft, error: createError } = await admin
+      .from('digest_editions')
+      .insert({
+        digest_date: run.digestDate,
+        version,
+        status: 'draft',
+        source_run_id: run.id,
+        content: toJson({
+          ...run.parsedOutput,
+          executiveSummary: run.parsedOutput.executiveSummary.slice(0, 3),
+        }),
+        created_by: null,
+      })
+      .select('id, version')
+      .single()
+    if (createError) throw createError
+    draft = createdDraft
+  }
+
+  const { data: published, error: publishError } = await admin.rpc(
+    'publish_digest_edition',
+    { p_edition_id: draft.id },
+  )
+  if (publishError || !published) {
+    throw publishError ?? new Error('Digest publication returned no edition')
+  }
+
+  const events = [
+    ...run.events,
+    event(
+      'edition',
+      'completed',
+      `Nightly automation published digest edition version ${published.version}.`,
+      { automation: true, edition_id: published.id },
+    ),
+  ]
+  const { error: eventError } = await admin
+    .from('digest_runs')
+    .update({ events: toJson(events), updated_at: new Date().toISOString() })
+    .eq('id', runId)
+  if (eventError) {
+    console.warn(
+      '[daily digest workflow] published edition but could not append event',
+      { runId, editionId: published.id, error: eventError },
+    )
+  }
+
+  console.info('[daily digest workflow] nightly edition published', {
+    digestDate: published.digest_date,
+    editionId: published.id,
+    runId,
+    version: published.version,
+  })
+  return {
+    digestDate: published.digest_date,
+    editionId: published.id,
+    status: 'published' as const,
+    version: published.version,
+  }
+}
+
 export async function generateDigestWorkflow(runId: string) {
   'use workflow'
 
@@ -495,4 +766,30 @@ export async function generateDigestWorkflow(runId: string) {
     await markDigestGenerationFailed(runId, describeError(error))
     throw error
   }
+}
+
+export async function publishNightlyDigestWorkflow(digestDate: string) {
+  'use workflow'
+
+  const { workflowRunId } = getWorkflowMetadata()
+  const claim = await claimNightlyDigestRun(digestDate, workflowRunId)
+  if (claim.action === 'skip') {
+    return {
+      digestDate,
+      reason: claim.reason,
+      runId: claim.runId,
+      status: 'skipped' as const,
+    }
+  }
+
+  if (claim.action === 'generate') {
+    try {
+      await executeDigestGeneration(claim.runId)
+    } catch (error) {
+      await markDigestGenerationFailed(claim.runId, describeError(error))
+      throw error
+    }
+  }
+
+  return publishNightlyDigestRun(claim.runId)
 }

--- a/supabase/migrations/20260821222746_nightly_digest_automation.sql
+++ b/supabase/migrations/20260821222746_nightly_digest_automation.sql
@@ -1,0 +1,108 @@
+-- Vercel cron delivery is best effort and may be duplicated. Automated runs
+-- are system-owned, top-level workflow runs; keep one immutable run per date.
+create unique index if not exists "digest_runs_one_nightly_run_per_date_idx"
+  on "public"."digest_runs" ("digest_date")
+  where "created_by" is null
+    and "parent_run_id" is null
+    and "workflow_run_id" is not null;
+
+-- Keep all-author reach while making Community Archive authorship an explicit
+-- editorial signal. Prompt versions are immutable, so this is a new version.
+insert into "public"."digest_prompt_versions" (
+  "label",
+  "system_prompt",
+  "user_prompt_template",
+  "model",
+  "parameters"
+) values (
+  'All-author community-first nightly digest',
+  $system_prompt$You are the Community Archive daily editor. Turn the supplied, zero-indexed tweet corpus into a concise, faithful daily edition. Group related bangers into three to five coherent stories, use the posts' own language whenever it is clear, and add only the minimum prose needed to explain what happened.
+
+Every banger includes an authored_by_community_member boolean. Treat Community Archive authorship as a strong editorial preference, not an exclusion rule. Prefer coherent, relevant stories anchored by community-authored bangers. Include bangers by other authors when they are unusually big, especially relevant to the community's conversation, or needed because the community-authored bangers do not support enough strong stories. Never infer membership from a username or the post text; use only the supplied boolean.
+
+Return exactly three executive-summary bullets, each exactly one short, complete sentence. Aim for 140 characters or fewer per bullet. Never clip a word or leave a sentence unfinished to meet that target. The first two bullets should cover the day's dominant stories. The third bullet must briefly catch the remaining stories when they cannot all be reduced into the first two, so the three bullets collectively account for every story in the edition.
+
+Choose the most representative or iconic tweet for the day. Index 0 is the strongest-ranked banger and is the default, but choose another corpus index when it better represents the edition. Prefer a community-authored representative when it is comparably strong and representative.
+
+For every story, choose one loose editorial label from the allowed category list. Before labeling a literal-sounding claim as news, evaluate tone, absurdity, source credibility, sarcasm, reply and quote-post context, and the post's likely social function. If a claim is a joke, satire, or a shitpost, classify and explain it as a Viral joke or Meme rather than reporting it as fact. Never turn a joke into a breaking-news assertion. If intent is genuinely ambiguous, say so in the editorial note.
+
+Copy each title from one supplied post when possible; light paraphrase is acceptable and is never grounds to fail an otherwise valid edition. Make each subtitle one complete explanatory sentence that supplies the people, event, and significance the title leaves unstated. Prefer concise prose, but do not target a fixed character count and never clip, truncate, or leave a subtitle unfinished for length. Preserve disagreement and uncertainty. Keywords must be short exact phrases that occur in the corpus. Refer to tweets only by zero-based corpus indices. Never invent a tweet, fact, quotation, engagement count, membership status, or index.$system_prompt$,
+  $user_prompt$Create the digest for {{digest_date}} covering {{window_start}} through {{window_end}}.
+
+Use only the indexed corpus below. It contains qualifying bangers from all authors and marks community-authored bangers with authored_by_community_member. Build three to five stories. Prefer stories anchored in community-authored bangers when they are coherent and relevant, but include non-community stories when they are unusually big, especially relevant, or necessary because the community-authored material is not enough. Down-weight generic pop culture unless it is genuinely dominant or meaningfully connected to the community's conversation.
+
+Every story must include at least one banger index; add reply or quote indices when they clarify the surrounding conversation. Return exactly three complete, one-sentence executive-summary bullets. Aim for 140 characters or fewer and never truncate text. If the stories do not reduce cleanly to three bullets, use bullet three as a compact catch-all that names the remaining stories. For each story, return its loose category, a tweet-grounded title, one complete explanatory subtitle with no forced character target, one to three In brief bullets, an editor note, and the selected tweet indices. Never clip or truncate a subtitle. Return three to twelve exact keywords from the corpus.
+
+Indexed corpus:
+{{candidate_json}}$user_prompt$,
+  'deepseek/deepseek-v4-flash-0731',
+  '{"reasoning_effort":"high","max_output_tokens":6000,"temperature":0.2}'::jsonb
+);
+
+-- Expose only aggregate nightly-publication health to the least-privilege
+-- monitoring role. Generation inputs, prompts, errors, and drafts stay private.
+create or replace function "public"."community_archive_monitoring_digest"()
+returns table (
+  "publication_age_seconds" double precision,
+  "expected_date_published" double precision,
+  "automated_run_failed" double precision,
+  "healthy" double precision
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  with expected as (
+    select
+      ((current_timestamp at time zone 'UTC') - interval '30 hours')::date
+        as digest_date,
+      (current_timestamp at time zone 'UTC') as checked_at
+  ), latest_published as (
+    select edition.digest_date, edition.published_at
+    from public.digest_editions as edition
+    where edition.status = 'published'
+    order by edition.digest_date desc, edition.version desc
+    limit 1
+  ), state as (
+    select
+      expected.digest_date as expected_date,
+      expected.checked_at,
+      latest_published.digest_date as published_date,
+      latest_published.published_at,
+      exists (
+        select 1
+        from public.digest_runs as run
+        where run.digest_date = expected.digest_date
+          and run.status = 'failed'
+          and run.created_by is null
+          and run.parent_run_id is null
+          and run.workflow_run_id is not null
+      ) as run_failed
+    from expected
+    left join latest_published on true
+  )
+  select
+    coalesce(
+      extract(epoch from (current_timestamp - state.published_at)),
+      1000000000000
+    )::double precision as publication_age_seconds,
+    coalesce(state.published_date = state.expected_date, false)::integer::double precision
+      as expected_date_published,
+    state.run_failed::integer::double precision as automated_run_failed,
+    (
+      case
+        when state.published_date = state.expected_date then 1
+        when state.run_failed then 0
+        when state.checked_at < state.expected_date::timestamp + interval '32 hours'
+          then 1
+        else 0
+      end
+    )::double precision as healthy
+  from state;
+$$;
+alter function "public"."community_archive_monitoring_digest"() owner to "postgres";
+revoke all on function "public"."community_archive_monitoring_digest"()
+  from public, "anon", "authenticated", "service_role";
+grant execute on function "public"."community_archive_monitoring_digest"()
+  to "readclient";

--- a/supabase/migrations/20260821222746_nightly_digest_automation.sql
+++ b/supabase/migrations/20260821222746_nightly_digest_automation.sql
@@ -1,5 +1,6 @@
--- Vercel cron delivery is best effort and may be duplicated. Automated runs
--- are system-owned, top-level workflow runs; keep one immutable run per date.
+-- Scheduled delivery may be duplicated across retries or scheduler changes.
+-- Automated runs are system-owned and top-level; keep one immutable run per
+-- date regardless of the execution host.
 create unique index if not exists "digest_runs_one_nightly_run_per_date_idx"
   on "public"."digest_runs" ("digest_date")
   where "created_by" is null

--- a/supabase/migrations/20260821233407_increase_nightly_digest_output_budget.sql
+++ b/supabase/migrations/20260821233407_increase_nightly_digest_output_budget.sql
@@ -1,0 +1,35 @@
+-- High-reasoning OpenRouter completions count reasoning and structured JSON
+-- against the same completion ceiling. The 6,000-token v11 budget left fewer
+-- than 1,000 tokens for JSON on representative 24-hour corpora, producing a
+-- truncated or empty response. Prompt versions are immutable, so preserve v11
+-- and fork its exact editorial instructions into v12 with sufficient headroom.
+do $$
+begin
+  insert into "public"."digest_prompt_versions" (
+    "label",
+    "system_prompt",
+    "user_prompt_template",
+    "model",
+    "parameters"
+  )
+  select
+    'All-author community-first nightly digest (expanded output)',
+    source."system_prompt",
+    source."user_prompt_template",
+    source."model",
+    jsonb_set(
+      source."parameters",
+      '{max_output_tokens}',
+      '12000'::jsonb,
+      true
+    )
+  from "public"."digest_prompt_versions" as source
+  where source."label" = 'All-author community-first nightly digest'
+  order by source."version" desc
+  limit 1;
+
+  if not found then
+    raise exception 'nightly digest v11 prompt was not found';
+  end if;
+end
+$$;

--- a/supabase/migrations/20260821233814_maximize_nightly_digest_output_budget.sql
+++ b/supabase/migrations/20260821233814_maximize_nightly_digest_output_budget.sql
@@ -1,0 +1,33 @@
+-- OpenRouter currently advertises 384,000 completion tokens for the configured
+-- model. Use the provider ceiling so hidden reasoning cannot crowd out the
+-- small structured digest, while normal generations still stop naturally.
+do $$
+begin
+  insert into "public"."digest_prompt_versions" (
+    "label",
+    "system_prompt",
+    "user_prompt_template",
+    "model",
+    "parameters"
+  )
+  select
+    'All-author community-first nightly digest (maximum output)',
+    source."system_prompt",
+    source."user_prompt_template",
+    source."model",
+    jsonb_set(
+      source."parameters",
+      '{max_output_tokens}',
+      '384000'::jsonb,
+      true
+    )
+  from "public"."digest_prompt_versions" as source
+  where source."label" = 'All-author community-first nightly digest (expanded output)'
+  order by source."version" desc
+  limit 1;
+
+  if not found then
+    raise exception 'expanded-output nightly digest prompt was not found';
+  end if;
+end
+$$;

--- a/supabase/migrations/20260822000112_use_gpt54_for_nightly_digest.sql
+++ b/supabase/migrations/20260822000112_use_gpt54_for_nightly_digest.sql
@@ -1,0 +1,33 @@
+-- DeepSeek V4 Flash intermittently ignored OpenRouter's strict response schema
+-- on representative nightly corpora, returning either the schema definition or
+-- Markdown. GPT-5.4 produced valid structured editions for both backfill dates.
+do $$
+begin
+  insert into "public"."digest_prompt_versions" (
+    "label",
+    "system_prompt",
+    "user_prompt_template",
+    "model",
+    "parameters"
+  )
+  select
+    'All-author community-first nightly digest (GPT-5.4 structured output)',
+    source."system_prompt",
+    source."user_prompt_template",
+    'openai/gpt-5.4',
+    jsonb_set(
+      source."parameters" - 'temperature',
+      '{max_output_tokens}',
+      '128000'::jsonb,
+      true
+    )
+  from "public"."digest_prompt_versions" as source
+  where source."label" = 'All-author community-first nightly digest (maximum output)'
+  order by source."version" desc
+  limit 1;
+
+  if not found then
+    raise exception 'maximum-output nightly digest prompt was not found';
+  end if;
+end
+$$;

--- a/supabase/migrations/20260822021145_use_glm53_for_nightly_digest.sql
+++ b/supabase/migrations/20260822021145_use_glm53_for_nightly_digest.sql
@@ -1,0 +1,37 @@
+-- GLM-5.3 produces strong digest prose, but its OpenRouter endpoint can ignore
+-- response_format unless the prompt also states the JSON-only contract.
+do $$
+begin
+  insert into "public"."digest_prompt_versions" (
+    "label",
+    "system_prompt",
+    "user_prompt_template",
+    "model",
+    "parameters"
+  )
+  select
+    'All-author community-first nightly digest (GLM-5.3 JSON output)',
+    source."system_prompt" || E'\n\nOUTPUT CONTRACT: Return only one valid JSON object, with no Markdown, headings, code fences, or prose outside it. Use exactly these top-level keys: executive_summary, representative_tweet_index, stories, keywords. Return exactly three non-empty executive_summary strings and three to five complete stories. Each story must contain exactly these required, non-empty fields: category, title, subtitle, bullets, editorial_note, tweet_indices. category must be exactly one of: AI news, News, Viral joke, Meme, Culture, Opportunity, Other. bullets and tweet_indices must each contain at least one item. Return three to twelve non-empty keywords. The API-provided JSON schema is authoritative; never omit a required field or use an empty string or array.',
+    source."user_prompt_template",
+    'z-ai/glm-5.3',
+    jsonb_set(
+      jsonb_set(
+        source."parameters",
+        '{max_output_tokens}',
+        '131072'::jsonb,
+        true
+      ),
+      '{temperature}',
+      '0.2'::jsonb,
+      true
+    )
+  from "public"."digest_prompt_versions" as source
+  where source."label" = 'All-author community-first nightly digest (GPT-5.4 structured output)'
+  order by source."version" desc
+  limit 1;
+
+  if not found then
+    raise exception 'GPT-5.4 nightly digest prompt was not found';
+  end if;
+end
+$$;

--- a/supabase/schemas/030_indexes.sql
+++ b/supabase/schemas/030_indexes.sql
@@ -115,6 +115,12 @@ CREATE INDEX IF NOT EXISTS "digest_runs_date_created_idx"
 CREATE INDEX IF NOT EXISTS "digest_runs_prompt_version_idx"
   ON "public"."digest_runs" ("prompt_version_id");
 
+CREATE UNIQUE INDEX IF NOT EXISTS "digest_runs_one_nightly_run_per_date_idx"
+  ON "public"."digest_runs" ("digest_date")
+  WHERE "created_by" IS NULL
+    AND "parent_run_id" IS NULL
+    AND "workflow_run_id" IS NOT NULL;
+
 CREATE UNIQUE INDEX IF NOT EXISTS "digest_editions_one_published_per_date_idx"
   ON "public"."digest_editions" ("digest_date")
   WHERE "status" = 'published';

--- a/supabase/schemas/070_functions.sql
+++ b/supabase/schemas/070_functions.sql
@@ -3321,3 +3321,69 @@ REVOKE EXECUTE ON FUNCTION "public"."publish_digest_edition"(uuid)
   FROM PUBLIC, "anon", "authenticated";
 GRANT EXECUTE ON FUNCTION "public"."publish_digest_edition"(uuid)
   TO "service_role";
+
+CREATE OR REPLACE FUNCTION "public"."community_archive_monitoring_digest"()
+RETURNS TABLE (
+  "publication_age_seconds" double precision,
+  "expected_date_published" double precision,
+  "automated_run_failed" double precision,
+  "healthy" double precision
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  WITH expected AS (
+    SELECT
+      ((CURRENT_TIMESTAMP AT TIME ZONE 'UTC') - INTERVAL '30 hours')::date
+        AS digest_date,
+      (CURRENT_TIMESTAMP AT TIME ZONE 'UTC') AS checked_at
+  ), latest_published AS (
+    SELECT edition.digest_date, edition.published_at
+    FROM public.digest_editions AS edition
+    WHERE edition.status = 'published'
+    ORDER BY edition.digest_date DESC, edition.version DESC
+    LIMIT 1
+  ), state AS (
+    SELECT
+      expected.digest_date AS expected_date,
+      expected.checked_at,
+      latest_published.digest_date AS published_date,
+      latest_published.published_at,
+      EXISTS (
+        SELECT 1
+        FROM public.digest_runs AS run
+        WHERE run.digest_date = expected.digest_date
+          AND run.status = 'failed'
+          AND run.created_by IS NULL
+          AND run.parent_run_id IS NULL
+          AND run.workflow_run_id IS NOT NULL
+      ) AS run_failed
+    FROM expected
+    LEFT JOIN latest_published ON TRUE
+  )
+  SELECT
+    COALESCE(
+      EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state.published_at)),
+      1000000000000
+    )::double precision AS publication_age_seconds,
+    COALESCE(state.published_date = state.expected_date, FALSE)::integer::double precision
+      AS expected_date_published,
+    state.run_failed::integer::double precision AS automated_run_failed,
+    (
+      CASE
+        WHEN state.published_date = state.expected_date THEN 1
+        WHEN state.run_failed THEN 0
+        WHEN state.checked_at < state.expected_date::timestamp + INTERVAL '32 hours'
+          THEN 1
+        ELSE 0
+      END
+    )::double precision AS healthy
+  FROM state;
+$$;
+ALTER FUNCTION "public"."community_archive_monitoring_digest"() OWNER TO "postgres";
+REVOKE ALL ON FUNCTION "public"."community_archive_monitoring_digest"()
+  FROM PUBLIC, "anon", "authenticated", "service_role";
+GRANT EXECUTE ON FUNCTION "public"."community_archive_monitoring_digest"()
+  TO "readclient";

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,0 @@
-{
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "crons": [
-    {
-      "path": "/api/cron/daily-digest",
-      "schedule": "15 6 * * *"
-    }
-  ]
-}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "crons": [
+    {
+      "path": "/api/cron/daily-digest",
+      "schedule": "15 6 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- schedule the newest completed digest date at 06:15 UTC (10:15 PM PST / 11:15 PM PDT) behind authenticated Vercel cron and an explicit disabled-by-default rollout flag
- generate and publish through the durable workflow with one automated run per date, safe duplicate delivery, and preservation of any editor-published edition
- pull bangers from all authors, freeze a Community Archive authorship marker, show it in the admin preview, and pass it to a new immutable community-first prompt
- prefer coherent and relevant community-authored stories while retaining unusually big, especially relevant, or necessary non-community stories
- expose a least-privilege aggregate publication-health function for the companion monitoring rollout

## Validation

- `pnpm type-check`
- focused ESLint over the changed TypeScript/TSX files
- `pnpm test:server --runInBand src/lib/digest/candidates.test.ts src/lib/digest/cron.test.ts src/lib/digest/dateWindow.test.ts src/lib/digest/generation.test.ts` (26 tests passed; workflow compiler built 9 steps / 2 workflows)
- `git diff --check`
- Supabase Preview and Vercel preview passed

The local pre-commit type-generation hook could not run because the local Docker/Supabase stack is unavailable and its Twitter config variables are unset. The repository preview automation subsequently regenerated `src/database-types.ts` for the new aggregate RPC, committed it to the branch, and `pnpm type-check` passed again on that commit.

## Rollout

Draft only; no production migration, deployment, environment variable, or live write was applied. Apply the migration and deploy with `DIGEST_AUTOMATION_ENABLED=false`, land and deploy the companion monitoring PR, verify the aggregate series and one authenticated production-equivalent run, then set the flag to `true`.

Companion monitoring: https://github.com/TheExGenesis/community-archive-control-panel/pull/171
