### PR TITLE
Bangers page styling polish

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "dependencies": {
     "@next/bundle-analyzer": "^14.2.23",
+    "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-avatar": "^1.1.2",
     "@radix-ui/react-checkbox": "^1.1.3",
     "@radix-ui/react-dialog": "^1.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@next/bundle-analyzer':
         specifier: ^14.2.23
         version: 14.2.23
+      '@phosphor-icons/react':
+        specifier: ^2.1.10
+        version: 2.1.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@radix-ui/react-avatar':
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@18.2.5)(@types/react@18.2.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -1267,6 +1270,13 @@ packages:
   '@oclif/plugin-help@6.2.37':
     resolution: {integrity: sha512-5N/X/FzlJaYfpaHwDC0YHzOzKDWa41s9t+4FpCDu4f9OMReds4JeNBaaWk9rlIzdKjh2M6AC5Q18ORfECRkHGA==}
     engines: {node: '>=18.0.0'}
+
+  '@phosphor-icons/react@2.1.10':
+    resolution: {integrity: sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>= 16.8'
+      react-dom: '>= 16.8'
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -7851,6 +7861,11 @@ snapshots:
     dependencies:
       '@oclif/core': 4.11.4
 
+  '@phosphor-icons/react@2.1.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -10629,8 +10644,8 @@ snapshots:
       '@typescript-eslint/parser': 6.21.0(eslint@8.56.0)(typescript@5.1.3)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@8.56.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.1.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0(eslint@8.56.0))(eslint@8.56.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.1.3))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.56.0)
       eslint-plugin-react: 7.37.4(eslint@8.56.0)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.56.0)
@@ -10649,7 +10664,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.56.0):
+  eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(eslint@8.56.0))(eslint@8.56.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0
@@ -10661,22 +10676,22 @@ snapshots:
       is-glob: 4.0.3
       stable-hash: 0.0.4
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.1.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.56.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.1.3))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.1.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.56.0))(eslint@8.56.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.1.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.21.0(eslint@8.56.0)(typescript@5.1.3)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0(eslint@8.56.0))(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.1.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.56.0):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.1.3))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -10687,7 +10702,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.1.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.1.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/src/app/bangers/page.tsx
+++ b/src/app/bangers/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { BangersExplorer } from '@/components/portal/BangersExplorer'
+import { BangersInfoTip } from '@/components/portal/BangersInfoTip'
 import { MUTED, SERIF } from '@/components/portal/styles'
 import { getInitialPortalBangersPage } from '@/lib/portal/data'
 import type {
@@ -59,21 +60,17 @@ export default async function BangersPage({
           ← Dashboard
         </Link>
         <header className="mb-7 max-w-[760px]">
-          <p className="mb-1.5 flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-[0.12em] text-brand">
-            <span aria-hidden="true">✦</span>
-            The archive&apos;s standout posts
-          </p>
           <h1
             className="mb-2 text-[34px] font-semibold leading-tight sm:text-[38px]"
             style={SERIF}
           >
             Bangers
           </h1>
-          <p className={`text-[13.5px] leading-relaxed ${MUTED}`}>
-            The archive&apos;s best tweets, ranked by distinct archived quotes
-            from archive uploaders and opted-in members. Quotes by the original
-            author do not count. Best of all time is selected by default, with
-            recent ranges available below.
+          <p
+            className={`inline-flex items-center gap-1.5 text-[13.5px] leading-relaxed ${MUTED}`}
+          >
+            The best tweets in the Community Archive.
+            <BangersInfoTip />
           </p>
         </header>
         <BangersExplorer

--- a/src/app/bangers/page.tsx
+++ b/src/app/bangers/page.tsx
@@ -54,11 +54,11 @@ export default async function BangersPage({
       <div className="mx-auto w-full max-w-[1280px] px-4 py-7 sm:px-6 sm:py-9 lg:px-8">
         <Link
           href="/"
-          className={`mb-5 inline-flex text-[12.5px] font-semibold ${MUTED} hover:text-brand`}
+          className={`mb-3 inline-flex text-[12.5px] font-semibold ${MUTED} hover:text-brand`}
         >
           ← Dashboard
         </Link>
-        <header className="mb-7 max-w-[760px]">
+        <header className="mb-5 max-w-[760px]">
           <h1
             className="text-[34px] font-semibold leading-tight sm:text-[38px]"
             style={SERIF}

--- a/src/app/bangers/page.tsx
+++ b/src/app/bangers/page.tsx
@@ -1,6 +1,5 @@
 import Link from 'next/link'
 import { BangersExplorer } from '@/components/portal/BangersExplorer'
-import { BangersInfoTip } from '@/components/portal/BangersInfoTip'
 import { MUTED, SERIF } from '@/components/portal/styles'
 import { getInitialPortalBangersPage } from '@/lib/portal/data'
 import type {
@@ -61,17 +60,11 @@ export default async function BangersPage({
         </Link>
         <header className="mb-7 max-w-[760px]">
           <h1
-            className="mb-2 text-[34px] font-semibold leading-tight sm:text-[38px]"
+            className="text-[34px] font-semibold leading-tight sm:text-[38px]"
             style={SERIF}
           >
             Bangers
           </h1>
-          <p
-            className={`inline-flex items-center gap-1.5 text-[13.5px] leading-relaxed ${MUTED}`}
-          >
-            The best tweets in the Community Archive.
-            <BangersInfoTip />
-          </p>
         </header>
         <BangersExplorer
           key={`${scope}:${sort}:${period ?? year ?? 'all'}:${query}`}

--- a/src/app/bangers/page.tsx
+++ b/src/app/bangers/page.tsx
@@ -54,7 +54,7 @@ export default async function BangersPage({
       <div className="mx-auto w-full max-w-[1280px] px-4 py-7 sm:px-6 sm:py-9 lg:px-8">
         <Link
           href="/"
-          className={`mb-3 inline-flex text-[12.5px] font-semibold ${MUTED} hover:text-brand`}
+          className={`mb-2 inline-flex text-[12.5px] font-semibold ${MUTED} hover:text-brand`}
         >
           ← Dashboard
         </Link>

--- a/src/components/portal/BangersExplorer.test.tsx
+++ b/src/components/portal/BangersExplorer.test.tsx
@@ -197,8 +197,8 @@ describe('BangersExplorer', () => {
     expect(
       screen.getByRole('combobox', { name: 'Filter by time' }),
     ).toHaveTextContent('All time')
-    const when = screen.getByText('When')
-    const tweetsBy = screen.getByText('Tweets by')
+    const when = screen.getByRole('combobox', { name: 'Filter by time' })
+    const tweetsBy = screen.getByRole('group', { name: 'Tweets by' })
     expect(
       when.compareDocumentPosition(tweetsBy) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy()
@@ -207,7 +207,8 @@ describe('BangersExplorer', () => {
     expect(screen.getByTestId('bangers-masonry')).toHaveClass(
       'grid',
       'items-start',
-      'gap-5',
+      'gap-3',
+      'lg:gap-4',
     )
     expect(screen.getByTestId('bangers-masonry')).toHaveStyle({
       gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',

--- a/src/components/portal/BangersExplorer.tsx
+++ b/src/components/portal/BangersExplorer.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Loader2, Search, X } from 'lucide-react'
 import TweetCard from '@/components/TweetCard'
+import { BangersInfoTip } from '@/components/portal/BangersInfoTip'
 import {
   Select,
   SelectContent,
@@ -592,9 +593,12 @@ export function BangersExplorer({
 
       <div className="min-h-12 mb-4 flex flex-wrap items-end justify-between gap-2 px-0.5">
         <div>
-          <h2 className="text-[19px] font-bold uppercase tracking-[0.035em]">
-            {bangersHeading({ year, period })}
-          </h2>
+          <div className="flex items-center gap-1.5">
+            <h2 className="text-[19px] font-bold uppercase tracking-[0.035em]">
+              {bangersHeading({ year, period })}
+            </h2>
+            <BangersInfoTip />
+          </div>
           <p
             aria-live="polite"
             className={`mt-0.5 inline-flex items-center gap-1.5 text-[12.5px] tabular-nums ${MUTED}`}

--- a/src/components/portal/BangersExplorer.tsx
+++ b/src/components/portal/BangersExplorer.tsx
@@ -415,204 +415,177 @@ export function BangersExplorer({
   })
   return (
     <section aria-label="Browse bangers">
-      <div className={`${CARD} mb-6 p-4 shadow-sm sm:p-5`}>
-        <label className="block">
-          <span
-            className={`mb-1.5 block text-[11px] font-bold uppercase tracking-[0.08em] ${MUTED}`}
-          >
-            Search
-          </span>
-          <span className="relative block">
-            <Search
-              aria-hidden="true"
-              className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-400"
-            />
-            <input
-              type="search"
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder="Search all ranked bangers…"
-              className="h-10 w-full rounded-[3px] border border-zinc-300 bg-transparent pl-9 pr-9 text-[14px] outline-none transition placeholder:text-zinc-400 focus:border-brand focus:ring-2 focus:ring-brand/20 dark:border-[#3a3a40]"
-            />
-            {query ? (
-              <button
-                type="button"
-                onClick={() => setQuery('')}
-                aria-label="Clear search"
-                className="absolute right-1.5 top-1/2 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-sm text-zinc-400 hover:bg-zinc-200 hover:text-zinc-700 dark:hover:bg-[#303036] dark:hover:text-white"
-              >
-                <X aria-hidden="true" className="h-4 w-4" />
-              </button>
-            ) : null}
-          </span>
+      <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <label className="relative block w-full sm:w-[280px]">
+          <span className="sr-only">Search</span>
+          <Search
+            aria-hidden="true"
+            className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-400"
+          />
+          <input
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search all ranked bangers…"
+            className="h-9 w-full rounded-[3px] border border-zinc-300 bg-transparent pl-9 pr-9 text-[14px] outline-none transition placeholder:text-zinc-400 focus:border-brand focus:ring-2 focus:ring-brand/20 dark:border-[#3a3a40]"
+          />
+          {query ? (
+            <button
+              type="button"
+              onClick={() => setQuery('')}
+              aria-label="Clear search"
+              className="absolute right-1.5 top-1/2 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-sm text-zinc-400 hover:bg-zinc-200 hover:text-zinc-700 dark:hover:bg-[#303036] dark:hover:text-white"
+            >
+              <X aria-hidden="true" className="h-4 w-4" />
+            </button>
+          ) : null}
         </label>
 
-        <div className="mt-3 flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-          <label>
-            <span
-              className={`mb-1.5 block text-[11px] font-bold uppercase tracking-[0.08em] ${MUTED}`}
-            >
-              When
-            </span>
-            <Select
-              value={selectedTime}
-              onValueChange={(value) => {
-                const nextPeriod =
-                  value === 'today' ||
-                  value === 'week' ||
-                  value === 'three-months'
-                    ? value
-                    : undefined
-                const nextYear = value.startsWith('year-')
-                  ? Number(value.slice(5))
+        <div className="flex flex-wrap items-center gap-3">
+          <Select
+            value={selectedTime}
+            onValueChange={(value) => {
+              const nextPeriod =
+                value === 'today' ||
+                value === 'week' ||
+                value === 'three-months'
+                  ? value
                   : undefined
-                captureBangersAction({
-                  action: 'time_filter_changed',
+              const nextYear = value.startsWith('year-')
+                ? Number(value.slice(5))
+                : undefined
+              captureBangersAction({
+                action: 'time_filter_changed',
+                query,
+                scope,
+                sort,
+                year: nextYear,
+                period: nextPeriod,
+                resultCount: page.pagination.totalAvailable,
+              })
+              setIsNavigating(true)
+              router.push(
+                bangersHref({
                   query,
                   scope,
                   sort,
                   year: nextYear,
                   period: nextPeriod,
-                  resultCount: page.pagination.totalAvailable,
-                })
-                setIsNavigating(true)
-                router.push(
-                  bangersHref({
-                    query,
-                    scope,
-                    sort,
-                    year: nextYear,
-                    period: nextPeriod,
-                    allTime: value === 'all',
-                  }),
-                )
-              }}
+                  allTime: value === 'all',
+                }),
+              )
+            }}
+          >
+            <SelectTrigger
+              aria-label="Filter by time"
+              aria-busy={isNavigating}
+              disabled={isNavigating}
+              className="h-9 w-auto gap-2 rounded-[3px] border-zinc-300 bg-transparent px-3 text-[12px] font-semibold shadow-none focus:ring-brand/30 focus:ring-offset-0 dark:border-[#3a3a40]"
             >
-              <SelectTrigger
-                aria-label="Filter by time"
-                aria-busy={isNavigating}
-                disabled={isNavigating}
-                className="h-9 w-[148px] rounded-[3px] border-zinc-300 bg-transparent px-3 text-[12px] font-semibold shadow-none focus:ring-brand/30 focus:ring-offset-0 dark:border-[#3a3a40]"
-              >
-                <SelectValue />
-                {isNavigating ? (
-                  <Loader2
-                    aria-label="Loading bangers"
-                    className="ml-auto h-3.5 w-3.5 animate-spin"
-                  />
-                ) : null}
-              </SelectTrigger>
-              <SelectContent className="rounded-[3px]">
-                <SelectItem value="all">All time</SelectItem>
-                <SelectItem value="today">Today</SelectItem>
-                <SelectItem value="week">Last 7 days</SelectItem>
-                <SelectItem value="three-months">Last 3 months</SelectItem>
-                {availableYears.map((availableYear) => (
-                  <SelectItem
-                    key={availableYear}
-                    value={`year-${availableYear}`}
-                  >
-                    {availableYear}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </label>
+              <SelectValue />
+              {isNavigating ? (
+                <Loader2
+                  aria-label="Loading bangers"
+                  className="ml-auto h-3.5 w-3.5 animate-spin"
+                />
+              ) : null}
+            </SelectTrigger>
+            <SelectContent className="rounded-[3px]">
+              <SelectItem value="all">All time</SelectItem>
+              <SelectItem value="today">Today</SelectItem>
+              <SelectItem value="week">Last 7 days</SelectItem>
+              <SelectItem value="three-months">Last 3 months</SelectItem>
+              {availableYears.map((availableYear) => (
+                <SelectItem key={availableYear} value={`year-${availableYear}`}>
+                  {availableYear}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
 
-          <div className="flex flex-wrap items-end gap-x-5 gap-y-3 lg:justify-end">
-            <div>
-              <span
-                className={`mb-1.5 block text-[11px] font-bold uppercase tracking-[0.08em] ${MUTED}`}
-              >
-                Tweets by
-              </span>
-              <div className="flex">
-                <Link
-                  href={bangersHref({
+          <div className="flex" role="group" aria-label="Tweets by">
+            <Link
+              href={bangersHref({
+                query,
+                scope: 'all',
+                sort,
+                year,
+                period,
+                allTime: isAllTime,
+              })}
+              onClick={(event) => {
+                const href = event.currentTarget.getAttribute('href')
+                if (scope !== 'all') {
+                  captureBangersAction({
+                    action: 'scope_changed',
                     query,
                     scope: 'all',
                     sort,
                     year,
                     period,
-                    allTime: isAllTime,
-                  })}
-                  onClick={(event) => {
-                    const href = event.currentTarget.getAttribute('href')
-                    if (scope !== 'all') {
-                      captureBangersAction({
-                        action: 'scope_changed',
-                        query,
-                        scope: 'all',
-                        sort,
-                        year,
-                        period,
-                        resultCount: page.pagination.totalAvailable,
-                      })
-                    }
-                    if (
-                      event.button === 0 &&
-                      !event.metaKey &&
-                      !event.ctrlKey &&
-                      !event.shiftKey &&
-                      !event.altKey &&
-                      href !== currentReturnTo
-                    ) {
-                      setIsNavigating(true)
-                    }
-                  }}
-                  aria-current={scope === 'all' ? 'page' : undefined}
-                  className={`${segmentClassName} rounded-l-[3px] ${
-                    scope === 'all'
-                      ? activeSegmentClassName
-                      : idleSegmentClassName
-                  }`}
-                >
-                  Anyone
-                </Link>
-                <Link
-                  href={bangersHref({
+                    resultCount: page.pagination.totalAvailable,
+                  })
+                }
+                if (
+                  event.button === 0 &&
+                  !event.metaKey &&
+                  !event.ctrlKey &&
+                  !event.shiftKey &&
+                  !event.altKey &&
+                  href !== currentReturnTo
+                ) {
+                  setIsNavigating(true)
+                }
+              }}
+              aria-current={scope === 'all' ? 'page' : undefined}
+              className={`${segmentClassName} rounded-l-[3px] ${
+                scope === 'all' ? activeSegmentClassName : idleSegmentClassName
+              }`}
+            >
+              Anyone
+            </Link>
+            <Link
+              href={bangersHref({
+                query,
+                scope: 'members',
+                sort,
+                year,
+                period,
+                allTime: isAllTime,
+              })}
+              onClick={(event) => {
+                const href = event.currentTarget.getAttribute('href')
+                if (scope !== 'members') {
+                  captureBangersAction({
+                    action: 'scope_changed',
                     query,
                     scope: 'members',
                     sort,
                     year,
                     period,
-                    allTime: isAllTime,
-                  })}
-                  onClick={(event) => {
-                    const href = event.currentTarget.getAttribute('href')
-                    if (scope !== 'members') {
-                      captureBangersAction({
-                        action: 'scope_changed',
-                        query,
-                        scope: 'members',
-                        sort,
-                        year,
-                        period,
-                        resultCount: page.pagination.totalAvailable,
-                      })
-                    }
-                    if (
-                      event.button === 0 &&
-                      !event.metaKey &&
-                      !event.ctrlKey &&
-                      !event.shiftKey &&
-                      !event.altKey &&
-                      href !== currentReturnTo
-                    ) {
-                      setIsNavigating(true)
-                    }
-                  }}
-                  aria-current={scope === 'members' ? 'page' : undefined}
-                  className={`${segmentClassName} -ml-px rounded-r-[3px] ${
-                    scope === 'members'
-                      ? activeSegmentClassName
-                      : idleSegmentClassName
-                  }`}
-                >
-                  Archive members
-                </Link>
-              </div>
-            </div>
+                    resultCount: page.pagination.totalAvailable,
+                  })
+                }
+                if (
+                  event.button === 0 &&
+                  !event.metaKey &&
+                  !event.ctrlKey &&
+                  !event.shiftKey &&
+                  !event.altKey &&
+                  href !== currentReturnTo
+                ) {
+                  setIsNavigating(true)
+                }
+              }}
+              aria-current={scope === 'members' ? 'page' : undefined}
+              className={`${segmentClassName} -ml-px rounded-r-[3px] ${
+                scope === 'members'
+                  ? activeSegmentClassName
+                  : idleSegmentClassName
+              }`}
+            >
+              Archive members
+            </Link>
           </div>
         </div>
       </div>
@@ -665,7 +638,7 @@ export function BangersExplorer({
           <button
             type="button"
             onClick={clearFilters}
-            className="text-[12px] font-semibold text-brand hover:underline"
+            className="text-[12px] font-semibold text-brand"
           >
             Clear filters
           </button>
@@ -691,7 +664,7 @@ export function BangersExplorer({
       ) : (
         <div
           data-testid="bangers-masonry"
-          className="grid items-start gap-5"
+          className="grid items-start gap-3 lg:gap-4"
           style={{
             gridTemplateColumns: `repeat(${masonryColumnCount}, minmax(0, 1fr))`,
           }}
@@ -700,13 +673,12 @@ export function BangersExplorer({
             <div
               key={columnIndex}
               data-testid={`bangers-masonry-column-${columnIndex}`}
-              className="contents lg:block lg:space-y-6"
+              className="contents lg:block lg:space-y-4"
             >
               {column.map(({ tweet, order }) => (
                 <div
                   key={tweet.id}
                   data-masonry-order={order + 1}
-                  className="mb-6 lg:mb-0"
                   style={{ order }}
                 >
                   <TweetCard
@@ -743,7 +715,7 @@ export function BangersExplorer({
               })
               retryLoad()
             }}
-            className="mt-2 text-[12px] font-semibold text-brand hover:underline"
+            className="mt-2 text-[12px] font-semibold text-brand"
           >
             Try again
           </button>

--- a/src/components/portal/BangersInfoTip.tsx
+++ b/src/components/portal/BangersInfoTip.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { Info } from '@phosphor-icons/react'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+
+export function BangersInfoTip() {
+  return (
+    <TooltipProvider delayDuration={100}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label="How bangers are ranked"
+            className="inline-flex text-zinc-400 transition-colors hover:text-zinc-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/30 dark:text-[#6d6d78] dark:hover:text-[#a7a7b4]"
+          >
+            <Info aria-hidden="true" className="h-4 w-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" className="max-w-[300px] text-[12.5px]">
+          Bangers are ranked by distinct archived quotes from archive uploaders
+          and opted-in members. Quotes by the original author do not count.
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}


### PR DESCRIPTION
## Summary
Styling pass on `/bangers`:

- **Header**: the eyebrow label and the long subcopy paragraph are gone — the header is now just the "Bangers" title. The ranking explanation (distinct archived quotes from uploaders and opted-in members, self-quotes excluded) lives in a tooltip on an unfilled Phosphor info icon next to the "Best of all time" results heading.
- **Filter row**: the search input and "All time" select now fit their content instead of stretching across the page, and the time filter + scope toggle sit on the right; search stays full-width on mobile.
- **Masonry spacing**: uniform 16px gaps (horizontal and vertical) on desktop, 12px on mobile — previously 20px/24px on desktop and an accidental 44px on mobile from a margin stacking on the grid gap.

Adds `@phosphor-icons/react` for the info icon (tree-shakeable).

## Testing
- `jest --selectProjects server client`: all pass except the pre-existing `clickhouseGateway.test.ts` env-leak failure (fails on a clean tree too).
- `tsc --noEmit` clean.
- Verified in the browser at desktop and mobile widths, light and dark mode, including tooltip hover and exact gap measurements via the DOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)