### PR TITLE
Publish nightly exports from the product repository

### DIFF
--- a/.github/workflows/update-data-export-release.yaml
+++ b/.github/workflows/update-data-export-release.yaml
@@ -1,16 +1,48 @@
-name: Bulk export disabled by consent policy
+name: Publish consent-safe bulk export release
 
 on:
+  schedule:
+    - cron: "30 8 * * *"
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
+
+concurrency:
+  group: public-export-release
+  cancel-in-progress: true
 
 jobs:
-  policy-gate:
+  publish-release:
+    name: Verify export and publish release
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - name: Explain fail-closed state
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Build verified release notes
+        id: export
+        shell: bash
         run: |
-          echo "The historical Parquet exporter is disabled because it does not enforce current PostgreSQL consent."
-          echo "Do not restore a public export until every nested author is policy-filtered immediately before upload."
+          export_id="$(scripts/build-public-export-release-notes.sh public-export-release)"
+          echo "export_id=$export_id" >> "$GITHUB_OUTPUT"
+          cat public-export-release/RELEASE.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Publish GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          export_id="${{ steps.export.outputs.export_id }}"
+          tag="public-export-$export_id"
+          if release_url="$(gh release view "$tag" --json url --jq .url 2>/dev/null)"; then
+            echo "Release already exists: $release_url"
+          else
+            release_url="$(gh release create "$tag" \
+              --target "$GITHUB_SHA" \
+              --title "Community Archive public export $export_id" \
+              --notes-file public-export-release/RELEASE.md \
+              --latest)"
+          fi
+          printf '\n## GitHub Release\n\n[%s](%s)\n' "$tag" "$release_url" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -7,9 +7,9 @@ Guide for AI agents working with the Community Archive database.
 
 ## Choose an access method
 
-- **Bulk or corpus-wide analysis:** the historical Parquet artifact is private
-  while its exporter is rebuilt to enforce current consent. Scope work to
-  filtered API queries in the meantime.
+- **Bulk or corpus-wide analysis:** follow the consent-safe package from the
+  [latest GitHub Release](https://github.com/TheExGenesis/community-archive/releases/latest)
+  or its `latest.json` pointer; see [api-doc.md](./api-doc.md).
 - **Filtered or application queries:** use the read-only Supabase REST API
   described below and in [api-doc.md](./api-doc.md).
 - **One user's processed archive:** only the authenticated owner may request
@@ -215,8 +215,8 @@ WHERE um.mentioned_user_id = '1680757426889342977';
    case-insensitive comparison when the original casing is unknown. Public raw
    archive storage paths use lowercase usernames.
 2. **Pagination**: API responses are capped at 1,000 rows. Use `limit` and
-   `offset` with a stable `order`. Full-corpus bulk access is paused until the
-   Parquet exporter is policy-aware (see [api-doc.md](./api-doc.md)).
+   `offset` with a stable `order`. For full-corpus analysis, prefer the
+   policy-aware Parquet package (see [api-doc.md](./api-doc.md)).
 3. **Archive Uploads**: Multiple uploads per user are possible - `all_profile` can have multiple rows per `account_id` with different `archive_upload_id`
 4. **Retweets**: Check `retweets` table to distinguish retweets from original tweets
 5. **Quote Tweets**: Use `quote_tweets` to find quoted tweet relationships

--- a/docs/api-doc.md
+++ b/docs/api-doc.md
@@ -1,9 +1,10 @@
 # API guide
 
-There are two currently supported ways to access Community Archive data:
+There are three currently supported ways to access Community Archive data:
 
-1. Query filtered records through the read-only Supabase REST API.
-2. Authenticated owners may download their own processed archive through the
+1. Download the consent-safe bulk Parquet package.
+2. Query filtered records through the read-only Supabase REST API.
+3. Authenticated owners may download their own processed archive through the
    policy-aware web endpoint.
 
 The website version of this guide is at
@@ -13,10 +14,16 @@ should start at
 
 ## Bulk Parquet export
 
-The historical `enriched_tweets.parquet` artifact is unavailable. Its exporter
-did not re-check current PostgreSQL consent for every nested author immediately
-before publication, so the bucket is private until a policy-aware replacement
-is implemented. Use filtered REST requests in the meantime.
+The current consent-safe package contains enriched `tweets.parquet`, separate
+`profiles.parquet`, and `manifest.json`. Start from the
+[`latest.json` pointer](https://fabxmporizzqflnftavs.supabase.co/storage/v1/object/public/community-archive-public-export/latest.json)
+or the repository's [latest GitHub Release](https://github.com/TheExGenesis/community-archive/releases/latest).
+
+Follow `manifest_url` instead of bookmarking a versioned object. Each nightly
+publication re-checks current PostgreSQL membership and opt-outs, publishes the
+new package atomically, and removes the superseded package. Historical releases
+remain as a publication log, but their versioned file links expire after the
+next successful dump.
 
 ## REST API
 
@@ -120,8 +127,8 @@ for a complete example. Run it from the repository root with:
 pnpm script scripts/get_all_tweets_paginated.mts
 ```
 
-Full-corpus access is paused until the replacement Parquet exporter enforces
-current consent.
+For full-corpus access, prefer the bulk Parquet package instead of paginating
+the REST API.
 
 ## Raw user archives
 

--- a/scripts/build-public-export-release-notes.sh
+++ b/scripts/build-public-export-release-notes.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+latest_url="https://fabxmporizzqflnftavs.supabase.co/storage/v1/object/public/community-archive-public-export/latest.json"
+output_dir="${1:-public-export-release}"
+
+for command in curl jq; do
+  command -v "$command" >/dev/null || {
+    echo "Required command not found: $command" >&2
+    exit 1
+  }
+done
+
+mkdir -p "$output_dir"
+curl --fail --silent --show-error --location --max-filesize 1048576 \
+  "$latest_url" --output "$output_dir/latest.json"
+
+export_id="$(jq -er '.export_id | select(type == "string" and length > 0)' "$output_dir/latest.json")"
+manifest_url="$(jq -er '.manifest_url | select(type == "string" and length > 0)' "$output_dir/latest.json")"
+object_root="${latest_url%latest.json}"
+
+if [[ ! "$export_id" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}Z$ ]]; then
+  echo "The public export ID has an unexpected format." >&2
+  exit 1
+fi
+
+case "$manifest_url" in
+  "$object_root"v1/"$export_id"/manifest.json) ;;
+  *)
+    echo "The manifest URL does not match the advertised export ID." >&2
+    exit 1
+    ;;
+esac
+
+curl --fail --silent --show-error --location --max-filesize 1048576 \
+  "$manifest_url" --output "$output_dir/manifest.json"
+
+manifest_export_id="$(jq -er '.export_id | select(type == "string" and length > 0)' "$output_dir/manifest.json")"
+publication_status="$(jq -er '.publication.status' "$output_dir/manifest.json")"
+tweets_url="$(jq -er '.publication.urls.tweets' "$output_dir/manifest.json")"
+profiles_url="$(jq -er '.publication.urls.profiles' "$output_dir/manifest.json")"
+
+if [[ "$manifest_export_id" != "$export_id" || "$publication_status" != "published" ]]; then
+  echo "The current manifest is not a matching published export." >&2
+  exit 1
+fi
+
+for entry in "tweets:$tweets_url" "profiles:$profiles_url"; do
+  name="${entry%%:*}"
+  url="${entry#*:}"
+  case "$url" in
+    "$object_root"v1/"$export_id"/"$name".parquet) ;;
+    *)
+      echo "The $name URL does not belong to the advertised export." >&2
+      exit 1
+      ;;
+  esac
+
+  magic_file="$(mktemp)"
+  trap 'rm -f "$magic_file"' EXIT
+  curl --fail --silent --show-error --location --range 0-3 --max-filesize 16 \
+    "$url" --output "$magic_file"
+  if [[ "$(LC_ALL=C tr -d '\n' < "$magic_file")" != "PAR1" ]]; then
+    echo "The $name download is not a readable Parquet file." >&2
+    exit 1
+  fi
+  rm -f "$magic_file"
+  trap - EXIT
+done
+
+tweets_rows="$(jq -er '.files.tweets.rows' "$output_dir/manifest.json")"
+profiles_rows="$(jq -er '.files.profiles.rows' "$output_dir/manifest.json")"
+created_at="$(jq -er '.created_at' "$output_dir/manifest.json")"
+
+cat > "$output_dir/RELEASE.md" <<EOF
+# Community Archive public export
+
+- Export: \`$export_id\`
+- Created: \`$created_at\`
+- Tweets: \`$tweets_rows\`
+- Profiles: \`$profiles_rows\`
+
+- [Download tweets.parquet]($tweets_url?download=tweets.parquet)
+- [Download profiles.parquet]($profiles_url?download=profiles.parquet)
+- [View manifest.json]($manifest_url)
+- [View the stable latest.json pointer]($latest_url)
+
+The Parquet files remain in the consent-managed Supabase package; this release
+does not retain a second copy in GitHub.
+
+These versioned download links work only while this export is advertised by
+\`latest.json\`. Superseded packages are removed so withdrawn accounts are not
+retained in historical downloads.
+EOF
+
+printf '%s\n' "$export_id"


### PR DESCRIPTION
## Summary
- replace the disabled historical exporter workflow with the consent-safe ClickHouse package verifier
- create one idempotent product-repository release for each nightly export ID
- update product and agent documentation for the restored bulk Parquet package

## Validation
- workflow YAML and shell syntax parsed
- current live pointer, manifest, and both Parquet headers verified
- generated release notes inspected for export `2026-08-25T07-05-39Z`

## Rollout
- manually dispatch after merge to publish the current product release immediately