### PR TITLE
Curate featured research posts

### DIFF
--- a/src/lib/portal/research.test.ts
+++ b/src/lib/portal/research.test.ts
@@ -1,6 +1,6 @@
 jest.mock('server-only', () => ({}), { virtual: true })
 
-import { selectFeaturedResearchPosts } from './research'
+import { getResearchPosts, selectFeaturedResearchPosts } from './research'
 import type { ResearchPost } from './types'
 
 function post(title: string): ResearchPost {
@@ -23,12 +23,44 @@ test('selects the four featured research posts in editorial order', () => {
     post('opportunity mining | lab notes #6'),
     post('a theory of tpot (postrat twitter)'),
     post('Agentic Taste Modeling | lab notes #8'),
+    post('Towards a Pattern Language of Serendipity Online'),
   ])
 
   expect(selected.map(({ title }) => title)).toEqual([
+    'Towards a Pattern Language of Serendipity Online',
     'Agentic Taste Modeling | lab notes #8',
     'a theory of tpot (postrat twitter)',
     'opportunity mining | lab notes #6',
-    'discovering the postrat canon in the community archive | lab notes #4',
   ])
+})
+
+test('shows the serendipity post and hides the phoenix post', async () => {
+  const item = (title: string, url: string) => `
+    <item>
+      <title><![CDATA[${title}]]></title>
+      <link>${url}</link>
+      <pubDate>Sun, 23 Aug 2026 12:00:00 GMT</pubDate>
+      <description><![CDATA[Excerpt]]></description>
+    </item>`
+  const xml = `<rss><channel>
+    ${item(
+      'Towards a Pattern Language of Serendipity Online',
+      'https://xiqo.substack.com/p/why-do-i-care-about-twitter-so-much',
+    )}
+    ${item(
+      'New on the Community Archive: User Pages, Bangers, Daily Digest',
+      'https://xiqo.substack.com/p/the-community-archive-rises-from',
+    )}
+  </channel></rss>`
+  const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({
+    ok: true,
+    text: jest.fn().mockResolvedValue(xml),
+  } as unknown as Response)
+
+  const posts = await getResearchPosts(24)
+
+  expect(posts.map(({ url }) => url)).toEqual([
+    'https://xiqo.substack.com/p/why-do-i-care-about-twitter-so-much',
+  ])
+  fetchSpy.mockRestore()
 })

--- a/src/lib/portal/research.ts
+++ b/src/lib/portal/research.ts
@@ -33,19 +33,25 @@ const RELEVANT_TITLE_KEYWORDS = [
   'social media',
   'hackathon',
   'sensemaking',
+  'serendipity',
   'epistemic garden',
 ]
 
-const isRelevant = (title: string): boolean => {
+const EXCLUDED_RESEARCH_URLS = new Set([
+  'https://xiqo.substack.com/p/the-community-archive-rises-from',
+])
+
+const isRelevant = (title: string, url: string): boolean => {
+  if (EXCLUDED_RESEARCH_URLS.has(url)) return false
   const lower = title.toLowerCase()
   return RELEVANT_TITLE_KEYWORDS.some((k) => lower.includes(k))
 }
 
 const FEATURED_RESEARCH_TITLES = [
+  'towards a pattern language of serendipity online',
   'agentic taste modeling',
   'a theory of tpot',
   'opportunity mining',
-  'discovering the postrat canon',
 ] as const
 
 /** Select the four editorial homepage posts in their intended display order. */
@@ -99,7 +105,7 @@ export async function getResearchPosts(limit = 12): Promise<ResearchPost[]> {
       const block = raw.split('</item>')[0]
       const title = pickTag(block, 'title')
       const url = pickTag(block, 'link')
-      if (!title || !url || !isRelevant(title)) return []
+      if (!title || !url || !isRelevant(title, url)) return []
       const pubDate = pickTag(block, 'pubDate')
       const image = block.match(/<enclosure url="([^"]+)"/)?.[1] ?? null
       return [


### PR DESCRIPTION
## Summary
- hide the Phoenix update post from the Research feed
- include the new serendipity pattern-language post
- place the new post first in the homepage featured research set

## Validation
- pnpm exec jest src/lib/portal/research.test.ts --selectProjects server --runInBand
- pnpm exec prettier --check src/lib/portal/research.ts src/lib/portal/research.test.ts
- git diff --check