### PR TITLE
Show five progressive search previews

### DIFF
--- a/src/components/TweetList.test.tsx
+++ b/src/components/TweetList.test.tsx
@@ -53,9 +53,13 @@ const previewTweet = {
   media: [],
 }
 
-const previewTweets = ['preview-1', 'preview-2', 'preview-3'].map(
-  (tweet_id) => ({ ...previewTweet, tweet_id }),
-)
+const previewTweets = [
+  'preview-1',
+  'preview-2',
+  'preview-3',
+  'preview-4',
+  'preview-5',
+].map((tweet_id) => ({ ...previewTweet, tweet_id }))
 
 function deferred<T>() {
   let resolve!: (value: T) => void
@@ -105,7 +109,7 @@ describe('TweetList progressive search', () => {
     )
 
     expect(await screen.findByTestId('tweet-ids')).toHaveTextContent(
-      'preview-1,preview-2,preview-3',
+      'preview-1,preview-2,preview-3,preview-4,preview-5',
     )
     expect(screen.getByRole('status')).toHaveTextContent(
       'Loading the remaining results…',

--- a/src/lib/clickhouseSearch.test.ts
+++ b/src/lib/clickhouseSearch.test.ts
@@ -96,14 +96,14 @@ describe('searchTweetsWithClickHouse', () => {
     expect(fetchImpl).not.toHaveBeenCalled()
   })
 
-  test('requests three newest non-retweets as a progressive preview', async () => {
+  test('requests five newest non-retweets as a progressive preview', async () => {
     const fetchImpl = jest.fn().mockResolvedValue({
       ok: true,
       status: 200,
       text: jest.fn().mockResolvedValue(
         JSON.stringify({
           data: {
-            tweets: ['123', '122', '121'].map((tweetId) => ({
+            tweets: ['123', '122', '121', '120', '119'].map((tweetId) => ({
               tweetId,
               accountId: '42',
               createdAt: '2026-08-13 00:00:00.000',
@@ -131,7 +131,7 @@ describe('searchTweetsWithClickHouse', () => {
     )
 
     expect(fetchImpl).toHaveBeenCalledWith(
-      '/api/tweet-search?q=Open+source&mode=phrase&limit=3&offset=0&preview=true&exclude_retweets=true',
+      '/api/tweet-search?q=Open+source&mode=phrase&limit=5&offset=0&preview=true&exclude_retweets=true',
       { cache: 'no-store' },
     )
     expect(tweets.definitiveEmpty).toBe(false)
@@ -139,6 +139,8 @@ describe('searchTweetsWithClickHouse', () => {
       '123',
       '122',
       '121',
+      '120',
+      '119',
     ])
   })
 

--- a/src/lib/clickhouseSearch.ts
+++ b/src/lib/clickhouseSearch.ts
@@ -159,7 +159,7 @@ export async function searchTweetPreviewsWithClickHouse(
   criteria: FilterCriteria,
   fetchImpl: typeof fetch = fetch,
 ): Promise<MappedClickHouseSearchResponse> {
-  return requestClickHouseSearch(criteria, 1, 3, fetchImpl, {
+  return requestClickHouseSearch(criteria, 1, 5, fetchImpl, {
     preview: true,
     excludeRetweets: criteria.excludeRetweets,
   })


### PR DESCRIPTION
## Summary
- request five newest preview results before the canonical search page
- preserve the existing progressive replacement and empty-result behavior
- update the request and rendering regression fixtures

## Dependency
Requires the gateway contract in https://github.com/TheExGenesis/community-archive-control-panel/pull/184 to be deployed and verified first.

## Validation
- focused Jest: 2 suites, 8 tests passed
- targeted Prettier check passed
- image-path audit: tweet media already uses Next Image with dimensions and lazy loading by default; avatars show fallbacks while loading; link-preview images mount after card text. No image load gates result rendering.

The unrelated pre-commit Supabase type-generation step could not run because the isolated worktree has no local Supabase/Twitter auth environment; no database types are touched by this PR.