### PR TITLE
Show net corpus growth on homepage

### DIFF
--- a/src/components/home/ClassicHomepage.test.tsx
+++ b/src/components/home/ClassicHomepage.test.tsx
@@ -44,7 +44,7 @@ const data = {
   stats: {
     totalTweets: 14_000_000,
     accountCount: 700,
-    streamedLast24Hours: 0,
+    tweetCountDeltaLast24Hours: 0,
     joinedThisWeek: 0,
     firstYear: 2006,
     currentYear: 2026,

--- a/src/components/portal/Portal.test.tsx
+++ b/src/components/portal/Portal.test.tsx
@@ -47,7 +47,7 @@ const data: PortalData = {
   stats: {
     totalTweets: 14_000_000,
     accountCount: 600,
-    streamedLast24Hours: 2_400,
+    tweetCountDeltaLast24Hours: 2_400,
     joinedThisWeek: 3,
     firstYear: 2006,
     currentYear: 2026,
@@ -122,7 +122,9 @@ describe.each<PortalView>(['home', 'stream'])(
       expect(screen.getByText('fresh tweet')).toBeInTheDocument()
       expectCorpusCount()
       if (view === 'home') {
-        expect(screen.getByText('+2,400 in the last 24h')).toBeInTheDocument()
+        expect(
+          screen.getByText('+2,400 net in the last 24h'),
+        ).toBeInTheDocument()
       }
 
       await act(async () => {

--- a/src/components/portal/Portal.tsx
+++ b/src/components/portal/Portal.tsx
@@ -59,6 +59,9 @@ const compact = (n: number) =>
     maximumFractionDigits: 1,
   }).format(n)
 
+const signedCount = (n: number) =>
+  `${n > 0 ? '+' : n < 0 ? '\u2212' : ''}${Math.abs(n).toLocaleString('en-US')}`
+
 const signInHref = (returnTo: string) =>
   `/login?redirect=${encodeURIComponent(returnTo)}`
 
@@ -297,7 +300,7 @@ function ArchiveOverview({
           note={
             failures.liveAnalytics
               ? 'Tweet totals are temporarily unavailable.'
-              : `+${stats.streamedLast24Hours.toLocaleString('en-US')} in the last 24h`
+              : `${signedCount(stats.tweetCountDeltaLast24Hours)} net in the last 24h`
           }
           noteClass={
             failures.liveAnalytics

--- a/src/components/portal/PortalLayout.test.tsx
+++ b/src/components/portal/PortalLayout.test.tsx
@@ -34,7 +34,7 @@ const data: PortalData = {
   stats: {
     totalTweets: 14_000_000,
     accountCount: 600,
-    streamedLast24Hours: 2_400,
+    tweetCountDeltaLast24Hours: 2_400,
     joinedThisWeek: 3,
     firstYear: 2006,
     currentYear: 2026,

--- a/src/lib/portal/data.test.ts
+++ b/src/lib/portal/data.test.ts
@@ -5,7 +5,6 @@ jest.mock('next/cache', () => ({
 jest.mock('./analytics', () => ({
   fetchPortalBangersPage: jest.fn(),
   fetchPortalHistoricalBangers: jest.fn(),
-  fetchPortalLiveAnalytics: jest.fn(),
   fetchPortalRecentBangers: jest.fn(),
   fetchPortalTrends: jest.fn(),
 }))
@@ -32,7 +31,6 @@ import {
 import {
   fetchPortalBangersPage,
   fetchPortalHistoricalBangers,
-  fetchPortalLiveAnalytics,
   fetchPortalRecentBangers,
   fetchPortalTrends,
 } from './analytics'
@@ -45,10 +43,6 @@ const fetchPortalHistoricalBangersMock =
   >
 const fetchPortalBangersPageMock =
   fetchPortalBangersPage as jest.MockedFunction<typeof fetchPortalBangersPage>
-const fetchPortalLiveAnalyticsMock =
-  fetchPortalLiveAnalytics as jest.MockedFunction<
-    typeof fetchPortalLiveAnalytics
-  >
 const fetchPortalRecentBangersMock =
   fetchPortalRecentBangers as jest.MockedFunction<
     typeof fetchPortalRecentBangers
@@ -163,10 +157,6 @@ describe('portal page resilience', () => {
       weekly: [],
       computedAt: '2026-08-07T20:00:00.000Z',
     })
-    fetchPortalLiveAnalyticsMock.mockResolvedValue({
-      streamedLast24Hours: 25,
-      latestObservedAt: '2026-08-07T20:00:00.000Z',
-    })
     fetchPortalRecentBangersMock.mockResolvedValue([])
     fetchPortalHistoricalBangersMock.mockResolvedValue([])
     getResearchPostsMock.mockResolvedValue([])
@@ -178,6 +168,8 @@ describe('portal page resilience', () => {
           JSON.stringify({
             data: {
               totalTweets: '15334092',
+              tweetCountDeltaLast24Hours: '16441',
+              deltaStartAt: '2026-08-12 18:34:20.907',
               memberAccounts: '42',
               sourceUpdatedAt: '2026-08-13 18:34:09.903',
               collectedAt: '2026-08-13 18:34:20.907',
@@ -261,6 +253,7 @@ describe('portal page resilience', () => {
     await expect(getPortalData()).resolves.toMatchObject({
       stats: {
         totalTweets: 15_334_092,
+        tweetCountDeltaLast24Hours: 16_441,
         accountCount: 42,
         firstYear: 2007,
         currentYear: 2026,
@@ -275,20 +268,17 @@ describe('portal page resilience', () => {
     })
   })
 
-  test('preserves the shared ClickHouse counts when live analytics fails', async () => {
-    fetchPortalLiveAnalyticsMock.mockRejectedValueOnce(
-      new Error('live analytics unavailable'),
-    )
-
+  test('uses the shared corpus delta without a separate firehose query', async () => {
     await expect(getPortalData()).resolves.toMatchObject({
       stats: {
         totalTweets: 15_334_092,
+        tweetCountDeltaLast24Hours: 16_441,
         accountCount: 42,
         firstYear: 2007,
         currentYear: 2026,
       },
       failures: {
-        liveAnalytics: true,
+        liveAnalytics: false,
         memberCount: false,
         corpusRange: false,
       },
@@ -406,6 +396,8 @@ describe('portal reads', () => {
         JSON.stringify({
           data: {
             totalTweets: '15334092',
+            tweetCountDeltaLast24Hours: '16441',
+            deltaStartAt: '2026-08-12 18:34:20.907',
             memberAccounts: '658',
             sourceUpdatedAt: '2026-08-13 18:34:09.903',
             collectedAt: '2026-08-13 18:34:20.907',
@@ -421,6 +413,7 @@ describe('portal reads', () => {
 
     await expect(fetchPortalGlobalStats()).resolves.toEqual({
       totalTweets: 15_334_092,
+      tweetCountDeltaLast24Hours: 16_441,
       memberCount: 658,
       generatedAt: '2026-08-13T18:34:20.907Z',
     })

--- a/src/lib/portal/data.ts
+++ b/src/lib/portal/data.ts
@@ -7,7 +7,6 @@ import {
 import {
   fetchPortalBangersPage,
   fetchPortalHistoricalBangers,
-  fetchPortalLiveAnalytics,
   fetchPortalRecentBangers,
   fetchPortalTrends,
 } from './analytics'
@@ -49,6 +48,7 @@ interface PortalCorpusRange {
 
 interface PortalGlobalStats {
   totalTweets: number
+  tweetCountDeltaLast24Hours: number
   memberCount: number
   generatedAt: string
 }
@@ -56,6 +56,8 @@ interface PortalGlobalStats {
 interface ClickHouseSummaryResponse {
   data: {
     totalTweets: unknown
+    tweetCountDeltaLast24Hours: unknown
+    deltaStartAt: unknown
     memberAccounts: unknown
     sourceUpdatedAt: unknown
     collectedAt: unknown
@@ -248,6 +250,17 @@ function portalClickHouseCount(value: unknown, label: string): number {
   return portalSnapshotCount(Number(value), label)
 }
 
+function portalClickHouseDelta(value: unknown, label: string): number {
+  if (
+    (typeof value !== 'string' && typeof value !== 'number') ||
+    (typeof value === 'string' && !/^-?\d+$/.test(value)) ||
+    !Number.isSafeInteger(Number(value))
+  ) {
+    throw new Error(`Portal ${label} returned an invalid response`)
+  }
+  return Number(value)
+}
+
 /** Shared ClickHouse-backed counts used by every public count display. */
 export async function fetchPortalGlobalStats(): Promise<PortalGlobalStats> {
   const response = await fetchAnalyticsGatewayJson<ClickHouseSummaryResponse>(
@@ -259,6 +272,10 @@ export async function fetchPortalGlobalStats(): Promise<PortalGlobalStats> {
     totalTweets: portalClickHouseCount(
       response.data.totalTweets,
       'ClickHouse corpus tweet count',
+    ),
+    tweetCountDeltaLast24Hours: portalClickHouseDelta(
+      response.data.tweetCountDeltaLast24Hours,
+      'ClickHouse 24-hour corpus delta',
     ),
     memberCount: portalClickHouseCount(
       response.data.memberAccounts,
@@ -741,11 +758,6 @@ const getCachedGlobalStats = unstable_cache(
   ['portal-global-stats-v1'],
   { revalidate: 60 },
 )
-const getCachedLiveAnalytics = unstable_cache(
-  async (_sourceKey: string) => fetchPortalLiveAnalytics(),
-  ['portal-live-analytics-v1'],
-  { revalidate: 300 },
-)
 const getCachedJoinedThisWeek = unstable_cache(
   async (_sourceKey: string) => fetchPortalJoinedThisWeek(),
   ['portal-joined-this-week-v1'],
@@ -949,7 +961,6 @@ export async function getPortalData(
     trends,
     corpusRange,
     globalStats,
-    liveAnalytics,
     joinedThisWeek,
     initialStream,
     research,
@@ -981,23 +992,11 @@ export async function getPortalData(
       () => getCachedGlobalStats(sourceKey),
       {
         totalTweets: 0,
+        tweetCountDeltaLast24Hours: 0,
         memberCount: 0,
         generatedAt: new Date().toISOString(),
       },
     ),
-    view === 'home'
-      ? loadPortalComponentData(
-          'live-analytics',
-          () => getCachedLiveAnalytics(sourceKey),
-          {
-            streamedLast24Hours: 0,
-            latestObservedAt: null,
-          },
-        )
-      : Promise.resolve({
-          data: { streamedLast24Hours: 0, latestObservedAt: null },
-          failed: false,
-        }),
     view === 'home'
       ? loadPortalComponentData(
           'joined-this-week',
@@ -1038,7 +1037,7 @@ export async function getPortalData(
   const stats: PortalStats = {
     totalTweets: globalStats.data.totalTweets,
     accountCount: globalStats.data.memberCount,
-    streamedLast24Hours: liveAnalytics.data.streamedLast24Hours,
+    tweetCountDeltaLast24Hours: globalStats.data.tweetCountDeltaLast24Hours,
     joinedThisWeek: joinedThisWeek.data,
     firstYear: corpusRange.data.firstYear,
     currentYear: corpusRange.data.currentYear,
@@ -1060,7 +1059,7 @@ export async function getPortalData(
     recentBangers: recentBangers.data,
     historicalBangers: historicalBangers.data,
     failures: {
-      liveAnalytics: globalStats.failed || liveAnalytics.failed,
+      liveAnalytics: globalStats.failed,
       memberCount: globalStats.failed,
       joinedThisWeek: joinedThisWeek.failed,
       corpusRange: corpusRange.failed,

--- a/src/lib/portal/types.ts
+++ b/src/lib/portal/types.ts
@@ -70,7 +70,7 @@ export interface PortalBangersPage {
 export interface PortalStats {
   totalTweets: number
   accountCount: number
-  streamedLast24Hours: number
+  tweetCountDeltaLast24Hours: number
   joinedThisWeek: number
   firstYear: number
   currentYear: number


### PR DESCRIPTION
## Summary
- replace the firehose-only 24-hour count with the signed canonical corpus delta from the shared summary response
- label the figure as net change and keep positive/negative formatting correct
- remove the homepage's separate stream-stats request

## Dependency
Deploy and verify https://github.com/TheExGenesis/community-archive-control-panel/pull/185 before this website change.

## Evidence
- canonical live delta at verification: +16,441 over 24 hours
- autorefresh fetched 116,049 tweet objects; the canonical count jumped by about 14,166 during its ingestion, so the 100k-scale work total is mostly re-observation rather than net corpus growth
- 13,567 fetched objects had recent tweet creation times; creation-time windows do not by themselves distinguish already archived IDs from newly discovered older context
- 35 focused server/client tests passed
- TypeScript and focused Prettier checks passed

The pre-commit database type-generation step could not run because local Docker/Supabase was unavailable. It does not cover these files; the relevant tests and TypeScript checks passed directly. No deployment was performed.