### PR TITLE
fix: add upload error recovery guidance

### DIFF
--- a/src/components/file-upload-dialog.test.tsx
+++ b/src/components/file-upload-dialog.test.tsx
@@ -12,6 +12,8 @@ jest.mock('@/lib/upload-archive/uploadArchive', () => ({
 }))
 jest.mock('@/lib/posthog', () => ({ capturePostHogEvent: jest.fn() }))
 
+const mockedUploadArchive = jest.mocked(uploadArchive)
+
 const archive: Archive = {
   profile: [
     {
@@ -54,18 +56,20 @@ const archive: Archive = {
   like: [],
 }
 
+beforeEach(() => {
+  mockedUploadArchive.mockReset()
+})
+
 test('shows one concise upload status while progress is active', async () => {
-  jest
-    .mocked(uploadArchive)
-    .mockImplementation(
-      (
-        _supabase,
-        onProgress: (progress: { phase: string; percent: number }) => void,
-      ) => {
-        onProgress({ phase: 'Uploading archive to storage', percent: 0 })
-        return new Promise(() => {})
-      },
-    )
+  mockedUploadArchive.mockImplementation(
+    (
+      _supabase,
+      onProgress: (progress: { phase: string; percent: number }) => void,
+    ) => {
+      onProgress({ phase: 'Uploading archive to storage', percent: 0 })
+      return new Promise(() => {})
+    },
+  )
   const user = userEvent.setup()
 
   render(
@@ -85,4 +89,31 @@ test('shows one concise upload status while progress is active', async () => {
     await screen.findByText('Uploading archive to storage: 0.00%'),
   ).toBeVisible()
   expect(screen.getAllByText(/uploading/i)).toHaveLength(1)
+})
+
+test('suggests recovery steps when an upload fails', async () => {
+  mockedUploadArchive.mockRejectedValue(
+    new Error('new row violates row-level security policy'),
+  )
+  const user = userEvent.setup()
+
+  render(
+    <FileUploadDialog
+      supabase={{} as SupabaseClient<Database>}
+      isOpen
+      onClose={jest.fn()}
+      archive={archive}
+    />,
+  )
+
+  await user.click(screen.getByRole('button', { name: 'Upload' }))
+
+  expect(
+    await screen.findByRole('heading', { name: 'Upload Error' }),
+  ).toBeVisible()
+  expect(
+    screen.getByText('new row violates row-level security policy'),
+  ).toBeVisible()
+  expect(screen.getByText(/try signing out and back in/i)).toBeVisible()
+  expect(screen.getByText(/try a different browser/i)).toBeVisible()
 })

--- a/src/components/file-upload-dialog.tsx
+++ b/src/components/file-upload-dialog.tsx
@@ -191,6 +191,10 @@ export function FileUploadDialog({
             <pre className="whitespace-pre-wrap break-words rounded bg-muted p-2 font-mono text-sm text-foreground dark:bg-muted dark:text-foreground">
               {state.error}
             </pre>
+            <p className="text-sm text-muted-foreground">
+              Try signing out and back in, then retry the upload. If it still
+              fails, try a different browser.
+            </p>
           </div>
         ) : state.uploadStatus === 'not_started' ? (
           <div className="grid gap-4 py-4">


### PR DESCRIPTION
## Summary

- suggest signing out and back in after an upload failure
- suggest retrying in a different browser if the failure persists
- add regression coverage for the recovery guidance

## Testing

- `jest --selectProjects client --runInBand src/components/file-upload-dialog.test.tsx`
- `tsc --pretty --noEmit`
- `next lint`
- `prettier --check src/components/file-upload-dialog.tsx src/components/file-upload-dialog.test.tsx`

Fixes #147