### PR TITLE
Reorder Community Gallery tools

### DIFF
--- a/src/components/community/CommunityGallery.test.tsx
+++ b/src/components/community/CommunityGallery.test.tsx
@@ -58,6 +58,44 @@ describe('CommunityGallery', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('shows the curated Tools cards in the requested order', async () => {
+    const user = userEvent.setup()
+    render(<CommunityGallery />)
+
+    expect(
+      screen
+        .getAllByRole('button')
+        .filter((button) =>
+          /Bangers\.page|Tweet Harvest|Semantic Search/.test(
+            button.textContent ?? '',
+          ),
+        )
+        .map((button) => button.textContent),
+    ).toEqual([
+      expect.stringContaining('Bangers.page'),
+      expect.stringContaining('Tweet Harvest'),
+      expect.stringContaining('Semantic Search'),
+    ])
+
+    await user.click(screen.getByRole('button', { name: 'Tools' }))
+
+    expect(
+      screen
+        .getAllByRole('button')
+        .filter((button) =>
+          /Bangers\.page|Tweet Harvest|Semantic Search|Malcolm Ocean's Links/.test(
+            button.textContent ?? '',
+          ),
+        )
+        .map((button) => button.textContent),
+    ).toEqual([
+      expect.stringContaining('Bangers.page'),
+      expect.stringContaining('Tweet Harvest'),
+      expect.stringContaining('Semantic Search'),
+      expect.stringContaining("Malcolm Ocean's Links"),
+    ])
+  })
+
   it('submits a project to the approval queue', async () => {
     const user = userEvent.setup()
     const FetchFormData = global.FormData

--- a/src/lib/communityProjects.test.ts
+++ b/src/lib/communityProjects.test.ts
@@ -10,7 +10,6 @@ describe('community project catalog', () => {
       expect.arrayContaining([
         expect.objectContaining({ name: 'Ratio Radar' }),
         expect.objectContaining({ name: 'Bangers' }),
-        expect.objectContaining({ name: 'Semantic Search' }),
       ]),
     )
 
@@ -58,5 +57,21 @@ describe('community project catalog', () => {
         .map((project) => project.name)
         .sort((left, right) => left.localeCompare(right)),
     )
+  })
+
+  it('keeps the featured Tools order curated for the Gallery', () => {
+    const tools = filterCommunityProjects(
+      COMMUNITY_PROJECTS,
+      '',
+      'Tools',
+      'Featured',
+    )
+
+    expect(tools.map((project) => project.name)).toEqual([
+      'Bangers.page',
+      'Tweet Harvest',
+      'Semantic Search',
+      "Malcolm Ocean's Links",
+    ])
   })
 })

--- a/src/lib/communityProjects.ts
+++ b/src/lib/communityProjects.ts
@@ -40,6 +40,25 @@ export interface CommunityProject {
  */
 export const COMMUNITY_PROJECTS: CommunityProject[] = [
   {
+    slug: 'bangers-page',
+    name: 'Bangers.page',
+    creator: 'Sam Clarke',
+    summary:
+      'Browse high-signal posts through a community-made thematic index.',
+    description:
+      'A third-party Community Archive build that organizes standout posts with high-quality thematic tags for a faster way into the corpus.',
+    archiveUse:
+      'Groups standout archived posts into thematic collections that can be browsed without writing a search query.',
+    category: 'Tools',
+    tags: ['Themes', 'Discovery', 'Curated browsing'],
+    projectUrl: 'https://bangers.page/',
+    sourceTweetId: '2089848291416850870',
+    image: '/images/community/bangers-page.jpg',
+    coverClass: 'from-[#f1eee6] via-[#d7e4ef] to-[#75c9eb]',
+    featured: true,
+    publishedAt: '2026-08-18',
+  },
+  {
     slug: 'tweet-harvest',
     name: 'Tweet Harvest',
     creator: 'Loopy',
@@ -96,6 +115,25 @@ export const COMMUNITY_PROJECTS: CommunityProject[] = [
     publishedAt: '2025-08-28',
   },
   {
+    slug: 'vector-search',
+    name: 'Semantic Search',
+    creator: 'Corbin',
+    creatorHandle: 'corbindreams',
+    summary: 'Search favorite accounts by meaning instead of exact wording.',
+    description:
+      'A focused vector-search interface for finding memorable posts from a hand-picked set of favorite accounts when native keyword search falls short.',
+    archiveUse:
+      'Indexes posts from selected archived accounts as vectors so related ideas can be found without exact keyword matches.',
+    category: 'Tools',
+    tags: ['Vector search', 'Reference', 'Favorite accounts'],
+    projectUrl: 'https://tweets-search-811136861157.us-central1.run.app',
+    sourceTweetId: '2087250967527870861',
+    image: '/images/community/tweet-semantic-search-cover.png',
+    coverClass: 'from-[#17171a] via-[#10516b] to-[#25aadf]',
+    featured: false,
+    publishedAt: '2026-08-11',
+  },
+  {
     slug: 'malcolm-ocean-links',
     name: "Malcolm Ocean's Links",
     creator: 'Malcolm Ocean',
@@ -111,25 +149,6 @@ export const COMMUNITY_PROJECTS: CommunityProject[] = [
     sourceTweetId: '2087049518177210837',
     image: '/images/community/malcolm-ocean-links-cover.png',
     coverClass: 'from-[#f4f0ff] via-[#b8a7ff] to-[#5940d6]',
-    featured: false,
-    publishedAt: '2026-08-11',
-  },
-  {
-    slug: 'vector-search',
-    name: 'Vector Search',
-    creator: 'Corbin',
-    creatorHandle: 'corbindreams',
-    summary: 'Search favorite accounts by meaning instead of exact wording.',
-    description:
-      'A focused vector-search interface for finding memorable posts from a hand-picked set of favorite accounts when native keyword search falls short.',
-    archiveUse:
-      'Indexes posts from selected archived accounts as vectors so related ideas can be found without exact keyword matches.',
-    category: 'Tools',
-    tags: ['Vector search', 'Reference', 'Favorite accounts'],
-    projectUrl: 'https://tweets-search-811136861157.us-central1.run.app',
-    sourceTweetId: '2087250967527870861',
-    image: '/images/community/tweet-semantic-search-cover.png',
-    coverClass: 'from-[#17171a] via-[#10516b] to-[#25aadf]',
     featured: false,
     publishedAt: '2026-08-11',
   },
@@ -151,25 +170,6 @@ export const COMMUNITY_PROJECTS: CommunityProject[] = [
     coverClass: 'from-[#352b70] via-[#7956d8] to-[#8bd2ee]',
     featured: false,
     publishedAt: '2026-08-16',
-  },
-  {
-    slug: 'bangers-page',
-    name: 'Bangers.page',
-    creator: 'Sam Clarke',
-    summary:
-      'Browse high-signal posts through a community-made thematic index.',
-    description:
-      'A third-party Community Archive build that organizes standout posts with high-quality thematic tags for a faster way into the corpus.',
-    archiveUse:
-      'Groups standout archived posts into thematic collections that can be browsed without writing a search query.',
-    category: 'Tools',
-    tags: ['Themes', 'Discovery', 'Curated browsing'],
-    projectUrl: 'https://bangers.page/',
-    sourceTweetId: '2089848291416850870',
-    image: '/images/community/bangers-page.jpg',
-    coverClass: 'from-[#f1eee6] via-[#d7e4ef] to-[#75c9eb]',
-    featured: false,
-    publishedAt: '2026-08-18',
   },
   {
     slug: 'followle',


### PR DESCRIPTION
## Summary
- put Bangers.page, Tweet Harvest, and Semantic Search first in the curated Tools row
- keep Malcolm Ocean's Links fourth in the full Tools view
- rename the existing Vector Search card to Semantic Search
- add regression coverage for the curated and full Tools ordering

## Verification
- focused Community Gallery and project catalog tests
- TypeScript type-check
- ESLint on changed files
- visual verification at 1280px and 390px widths