### PR TITLE
Restrict typeahead to Community Archive members

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -12,6 +12,7 @@ import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { Suspense } from 'react'
 import { capturePostHogEvent } from '@/lib/posthog'
+import UserMatchResults from '@/components/UserMatchResults'
 
 const starterSearches = [
   { label: 'Open source', query: 'open source' },
@@ -115,19 +116,22 @@ function SearchPageContent() {
 
         <div className={hasSearch ? 'mt-5' : 'mt-10'}>
           {hasSearch ? (
-            <TweetList
-              key={tweetListKey}
-              filterCriteria={filterCriteria}
-              resultsHeading="Search results"
-              resultsDescription={searchDescription}
-              collapseLongTweets
-              compact
-              permalinkOrigin="search"
-              permalinkReturnTo={`/search?${tweetListKey}`}
-              onSearchSortChange={
-                canSortSearchResults ? handleSortChange : undefined
-              }
-            />
+            <>
+              <UserMatchResults query={cleanRawText} />
+              <TweetList
+                key={tweetListKey}
+                filterCriteria={filterCriteria}
+                resultsHeading="Search results"
+                resultsDescription={searchDescription}
+                collapseLongTweets
+                compact
+                permalinkOrigin="search"
+                permalinkReturnTo={`/search?${tweetListKey}`}
+                onSearchSortChange={
+                  canSortSearchResults ? handleSortChange : undefined
+                }
+              />
+            </>
           ) : (
             <div className="rounded-lg border border-dashed border-border bg-card px-6 py-10 text-center sm:px-10">
               <SlidersHorizontal className="mx-auto h-8 w-8 text-muted-foreground" />

--- a/src/components/UserMatchResults.test.tsx
+++ b/src/components/UserMatchResults.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import UserMatchResults from './UserMatchResults'
+import {
+  fetchAccountSuggestions,
+  fetchMemberSuggestions,
+} from '@/lib/queries/fetchUsers'
+
+jest.mock('@/utils/supabase', () => ({
+  createBrowserClient: () => ({}),
+}))
+
+jest.mock('@/lib/queries/fetchUsers', () => ({
+  fetchAccountSuggestions: jest.fn(),
+  fetchMemberSuggestions: jest.fn(),
+}))
+
+const accountMatch = {
+  account_id: '123',
+  directory_id: 'account:123',
+  username: 'christineist',
+  account_display_name: 'Christine Shiba',
+  avatar_media_url: null,
+  num_followers: 100,
+}
+
+describe('UserMatchResults', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.mocked(fetchAccountSuggestions).mockResolvedValue([accountMatch])
+    jest.mocked(fetchMemberSuggestions).mockResolvedValue([])
+  })
+
+  it('shows possible people for a standalone username-like search', async () => {
+    render(<UserMatchResults query="christine" />)
+
+    expect(
+      await screen.findByRole('heading', {
+        name: 'People matching “christine”',
+      }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: /Christine Shiba/ }),
+    ).toHaveAttribute('href', '/user/christineist')
+  })
+
+  it('does not run user matching for a topic phrase', () => {
+    render(<UserMatchResults query="community archive" />)
+
+    expect(fetchAccountSuggestions).not.toHaveBeenCalled()
+    expect(fetchMemberSuggestions).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/UserMatchResults.tsx
+++ b/src/components/UserMatchResults.tsx
@@ -1,0 +1,109 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useMemo, useState } from 'react'
+import { UserRound } from 'lucide-react'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import {
+  fetchAccountSuggestions,
+  fetchMemberSuggestions,
+} from '@/lib/queries/fetchUsers'
+import {
+  getStandaloneUserSearchTerm,
+  mergeUserSuggestions,
+} from '@/lib/searchSuggestions'
+import type { UserSuggestion } from '@/lib/searchSuggestions'
+import { userProfileHref } from '@/lib/navigation'
+import { createBrowserClient } from '@/utils/supabase'
+
+const RESULT_LIMIT = 3
+
+export default function UserMatchResults({ query }: { query?: string }) {
+  const supabase = useMemo(() => createBrowserClient(), [])
+  const searchTerm = getStandaloneUserSearchTerm(query || '')
+  const [matches, setMatches] = useState<UserSuggestion[]>([])
+
+  useEffect(() => {
+    let active = true
+    let memberMatches: UserSuggestion[] = []
+    let accountMatches: UserSuggestion[] = []
+
+    if (!searchTerm) {
+      setMatches([])
+      return () => {
+        active = false
+      }
+    }
+
+    const publish = () => {
+      if (!active) return
+      setMatches(
+        mergeUserSuggestions(memberMatches, accountMatches, RESULT_LIMIT),
+      )
+    }
+
+    void fetchAccountSuggestions(supabase, searchTerm, RESULT_LIMIT)
+      .then((users) => {
+        accountMatches = users
+        publish()
+      })
+      .catch(() => undefined)
+
+    void fetchMemberSuggestions(searchTerm, RESULT_LIMIT)
+      .then((users) => {
+        memberMatches = users
+        publish()
+      })
+      .catch(() => undefined)
+
+    return () => {
+      active = false
+    }
+  }, [searchTerm, supabase])
+
+  if (matches.length === 0) return null
+
+  return (
+    <section aria-labelledby="people-results-heading" className="mb-6">
+      <div className="mb-3 flex items-center gap-2">
+        <UserRound className="h-4 w-4 text-brand" aria-hidden="true" />
+        <h2
+          id="people-results-heading"
+          className="text-sm font-semibold text-foreground"
+        >
+          People matching “{searchTerm}”
+        </h2>
+      </div>
+      <div className="grid gap-2 sm:grid-cols-3">
+        {matches.map((match) => {
+          const displayName = match.account_display_name || match.username
+          return (
+            <Link
+              key={match.directory_id}
+              href={userProfileHref(
+                match.username,
+                match.account_id || match.directory_id,
+              )}
+              className="flex min-w-0 items-center gap-3 rounded-lg border border-border bg-card px-3 py-3 transition-colors hover:bg-accent"
+            >
+              <Avatar className="h-9 w-9 shrink-0 border border-border">
+                <AvatarImage src={match.avatar_media_url || undefined} alt="" />
+                <AvatarFallback className="text-xs font-semibold uppercase">
+                  {displayName.slice(0, 1)}
+                </AvatarFallback>
+              </Avatar>
+              <span className="min-w-0">
+                <span className="block truncate text-sm font-medium text-foreground">
+                  {displayName}
+                </span>
+                <span className="block truncate text-xs text-muted-foreground">
+                  @{match.username}
+                </span>
+              </span>
+            </Link>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/src/components/UserSearchInput.test.tsx
+++ b/src/components/UserSearchInput.test.tsx
@@ -178,6 +178,18 @@ describe('UserSearchInput', () => {
     expect(groups[1]).toHaveAccessibleName('@exg_other')
   })
 
+  it('does not block fast account matches behind a slow member lookup', async () => {
+    mockedFetchMemberSuggestions.mockReturnValue(new Promise(() => undefined))
+    mockedFetchAccountSuggestions.mockResolvedValue([
+      suggestion('christineist', '456'),
+    ])
+    const input = renderSearch()
+
+    await userEvent.type(input, 'christine')
+
+    expect(await screen.findByText('@christineist')).toBeInTheDocument()
+  })
+
   it('skips the broader lookup when members fill the suggestion list', async () => {
     mockedFetchMemberSuggestions.mockResolvedValue(
       Array.from({ length: 6 }, (_, index) =>

--- a/src/components/UserSearchInput.test.tsx
+++ b/src/components/UserSearchInput.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom'
 import UserSearchInput from './UserSearchInput'
 import {
-  fetchAccountSuggestions,
+  fetchMemberDirectorySuggestions,
   fetchMemberSuggestions,
 } from '@/lib/queries/fetchUsers'
 import type { UserSuggestion } from '@/lib/searchSuggestions'
@@ -20,12 +20,14 @@ jest.mock('@/utils/supabase', () => ({
 }))
 
 jest.mock('@/lib/queries/fetchUsers', () => ({
-  fetchAccountSuggestions: jest.fn(),
+  fetchMemberDirectorySuggestions: jest.fn(),
   fetchMemberSuggestions: jest.fn(),
 }))
 
-const mockedFetchAccountSuggestions =
-  fetchAccountSuggestions as jest.MockedFunction<typeof fetchAccountSuggestions>
+const mockedFetchMemberDirectorySuggestions =
+  fetchMemberDirectorySuggestions as jest.MockedFunction<
+    typeof fetchMemberDirectorySuggestions
+  >
 const mockedFetchMemberSuggestions =
   fetchMemberSuggestions as jest.MockedFunction<typeof fetchMemberSuggestions>
 
@@ -66,13 +68,13 @@ const renderSearch = () => {
 
 const setDefaultSuggestions = () => {
   mockedFetchMemberSuggestions.mockResolvedValue([memberSuggestion])
-  mockedFetchAccountSuggestions.mockResolvedValue([])
+  mockedFetchMemberDirectorySuggestions.mockResolvedValue([])
 }
 
 describe('UserSearchInput', () => {
   beforeEach(() => {
     mockPush.mockReset()
-    mockedFetchAccountSuggestions.mockReset()
+    mockedFetchMemberDirectorySuggestions.mockReset()
     mockedFetchMemberSuggestions.mockReset()
   })
 
@@ -140,19 +142,19 @@ describe('UserSearchInput', () => {
       target: { value: 'exg', selectionStart: 3 },
     })
     expect(mockedFetchMemberSuggestions).not.toHaveBeenCalled()
-    expect(mockedFetchAccountSuggestions).not.toHaveBeenCalled()
+    expect(mockedFetchMemberDirectorySuggestions).not.toHaveBeenCalled()
 
     await waitFor(() =>
       expect(mockedFetchMemberSuggestions).toHaveBeenCalledTimes(1),
     )
   })
 
-  it('shows member matches before filling open slots from all accounts', async () => {
-    let resolveAccounts!: (users: UserSuggestion[]) => void
+  it('shows gateway members before filling open slots from the member directory', async () => {
+    let resolveDirectory!: (users: UserSuggestion[]) => void
     mockedFetchMemberSuggestions.mockResolvedValue([memberSuggestion])
-    mockedFetchAccountSuggestions.mockReturnValue(
+    mockedFetchMemberDirectorySuggestions.mockReturnValue(
       new Promise((resolve) => {
-        resolveAccounts = resolve
+        resolveDirectory = resolve
       }),
     )
     const input = renderSearch()
@@ -163,14 +165,14 @@ describe('UserSearchInput', () => {
         name: /Ex Genesis @exgenesis Profile/,
       }),
     ).toBeInTheDocument()
-    expect(mockedFetchAccountSuggestions).toHaveBeenCalledWith(
+    expect(mockedFetchMemberDirectorySuggestions).toHaveBeenCalledWith(
       expect.anything(),
       'exg',
       6,
     )
     expect(screen.queryByText('@exg_other')).not.toBeInTheDocument()
 
-    resolveAccounts([suggestion('exg_other', '456')])
+    resolveDirectory([suggestion('exg_other', '456')])
 
     expect(await screen.findByText('@exg_other')).toBeInTheDocument()
     const groups = screen.getAllByRole('group')
@@ -178,9 +180,9 @@ describe('UserSearchInput', () => {
     expect(groups[1]).toHaveAccessibleName('@exg_other')
   })
 
-  it('does not block fast account matches behind a slow member lookup', async () => {
+  it('does not block the member-directory fallback behind a slow gateway', async () => {
     mockedFetchMemberSuggestions.mockReturnValue(new Promise(() => undefined))
-    mockedFetchAccountSuggestions.mockResolvedValue([
+    mockedFetchMemberDirectorySuggestions.mockResolvedValue([
       suggestion('christineist', '456'),
     ])
     const input = renderSearch()
@@ -190,17 +192,17 @@ describe('UserSearchInput', () => {
     expect(await screen.findByText('@christineist')).toBeInTheDocument()
   })
 
-  it('skips the broader lookup when members fill the suggestion list', async () => {
+  it('skips the directory fallback when gateway members fill the list', async () => {
     mockedFetchMemberSuggestions.mockResolvedValue(
       Array.from({ length: 6 }, (_, index) =>
         suggestion(`exg_member_${index}`, String(index + 1)),
       ),
     )
-    mockedFetchAccountSuggestions.mockResolvedValue([])
+    mockedFetchMemberDirectorySuggestions.mockResolvedValue([])
     const input = renderSearch()
 
     await userEvent.type(input, 'exg')
     expect(await screen.findAllByRole('group')).toHaveLength(6)
-    expect(mockedFetchAccountSuggestions).not.toHaveBeenCalled()
+    expect(mockedFetchMemberDirectorySuggestions).not.toHaveBeenCalled()
   })
 })

--- a/src/components/UserSearchInput.test.tsx
+++ b/src/components/UserSearchInput.test.tsx
@@ -1,9 +1,13 @@
 import React, { useState } from 'react'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom'
 import UserSearchInput from './UserSearchInput'
-import { fetchUserSuggestions } from '@/lib/queries/fetchUsers'
+import {
+  fetchAccountSuggestions,
+  fetchMemberSuggestions,
+} from '@/lib/queries/fetchUsers'
+import type { UserSuggestion } from '@/lib/searchSuggestions'
 
 const mockPush = jest.fn()
 
@@ -16,12 +20,28 @@ jest.mock('@/utils/supabase', () => ({
 }))
 
 jest.mock('@/lib/queries/fetchUsers', () => ({
-  fetchUserSuggestions: jest.fn(),
+  fetchAccountSuggestions: jest.fn(),
+  fetchMemberSuggestions: jest.fn(),
 }))
 
-const mockedFetchUserSuggestions = fetchUserSuggestions as jest.MockedFunction<
-  typeof fetchUserSuggestions
->
+const mockedFetchAccountSuggestions =
+  fetchAccountSuggestions as jest.MockedFunction<typeof fetchAccountSuggestions>
+const mockedFetchMemberSuggestions =
+  fetchMemberSuggestions as jest.MockedFunction<typeof fetchMemberSuggestions>
+
+const suggestion = (
+  username: string,
+  accountId: string | null = '123',
+): UserSuggestion => ({
+  account_id: accountId,
+  directory_id: accountId ? `archive:${accountId}` : `optin:${username}`,
+  username,
+  account_display_name: username === 'exgenesis' ? 'Ex Genesis' : username,
+  avatar_media_url: null,
+  num_followers: 100,
+})
+
+const memberSuggestion = suggestion('exgenesis')
 
 function SearchHarness() {
   const [value, setValue] = useState('')
@@ -37,35 +57,32 @@ function SearchHarness() {
   )
 }
 
+const renderSearch = () => {
+  render(<SearchHarness />)
+  return screen.getByRole('combobox', {
+    name: 'Search Community Archive',
+  })
+}
+
+const setDefaultSuggestions = () => {
+  mockedFetchMemberSuggestions.mockResolvedValue([memberSuggestion])
+  mockedFetchAccountSuggestions.mockResolvedValue([])
+}
+
 describe('UserSearchInput', () => {
   beforeEach(() => {
     mockPush.mockReset()
-    mockedFetchUserSuggestions.mockReset()
+    mockedFetchAccountSuggestions.mockReset()
+    mockedFetchMemberSuggestions.mockReset()
   })
 
   it('offers a profile row before a from: filter row', async () => {
-    mockedFetchUserSuggestions.mockResolvedValue([
-      {
-        directory_id: 'archive:123',
-        username: 'exgenesis',
-        account_display_name: 'Ex Genesis',
-        avatar_media_url: null,
-        num_followers: 100,
-      },
-    ])
-
-    render(<SearchHarness />)
-    const input = screen.getByRole('combobox', {
-      name: 'Search Community Archive',
-    })
+    setDefaultSuggestions()
+    const input = renderSearch()
     await userEvent.type(input, 'exg')
 
     const options = await screen.findAllByRole('option')
-    expect(mockedFetchUserSuggestions).toHaveBeenLastCalledWith(
-      expect.anything(),
-      'exg',
-      6,
-    )
+    expect(mockedFetchMemberSuggestions).toHaveBeenLastCalledWith('exg', 6)
     expect(options).toHaveLength(2)
     expect(options[0]).toHaveAccessibleName(/Ex Genesis @exgenesis Profile/)
     expect(options[1]).toHaveAccessibleName(
@@ -80,20 +97,8 @@ describe('UserSearchInput', () => {
   })
 
   it('inserts a from: filter when the filter row is selected', async () => {
-    mockedFetchUserSuggestions.mockResolvedValue([
-      {
-        directory_id: 'archive:123',
-        username: 'exgenesis',
-        account_display_name: 'Ex Genesis',
-        avatar_media_url: null,
-        num_followers: 100,
-      },
-    ])
-
-    render(<SearchHarness />)
-    const input = screen.getByRole('combobox', {
-      name: 'Search Community Archive',
-    })
+    setDefaultSuggestions()
+    const input = renderSearch()
     await userEvent.type(input, 'exg')
 
     const filterOption = await screen.findByRole('option', {
@@ -108,20 +113,8 @@ describe('UserSearchInput', () => {
   })
 
   it('supports arrow-key selection for both actions', async () => {
-    mockedFetchUserSuggestions.mockResolvedValue([
-      {
-        directory_id: 'archive:123',
-        username: 'exgenesis',
-        account_display_name: 'Ex Genesis',
-        avatar_media_url: null,
-        num_followers: 100,
-      },
-    ])
-
-    render(<SearchHarness />)
-    const input = screen.getByRole('combobox', {
-      name: 'Search Community Archive',
-    })
+    setDefaultSuggestions()
+    const input = renderSearch()
     await userEvent.type(input, 'exg')
     await screen.findAllByRole('option')
     await userEvent.keyboard('{ArrowDown}{Enter}')
@@ -129,12 +122,73 @@ describe('UserSearchInput', () => {
     expect(mockPush).toHaveBeenCalledWith('/user/exgenesis')
     expect(input).toHaveValue('exg')
 
-    input.focus()
+    await userEvent.click(input)
     await userEvent.clear(input)
     await userEvent.type(input, 'exg')
     await screen.findAllByRole('option')
     await userEvent.keyboard('{ArrowDown}{ArrowDown}{Enter}')
 
     expect(input).toHaveValue('from:exgenesis')
+  })
+
+  it('debounces typing before starting the member lookup', async () => {
+    setDefaultSuggestions()
+    const input = renderSearch()
+
+    fireEvent.focus(input)
+    fireEvent.change(input, {
+      target: { value: 'exg', selectionStart: 3 },
+    })
+    expect(mockedFetchMemberSuggestions).not.toHaveBeenCalled()
+    expect(mockedFetchAccountSuggestions).not.toHaveBeenCalled()
+
+    await waitFor(() =>
+      expect(mockedFetchMemberSuggestions).toHaveBeenCalledTimes(1),
+    )
+  })
+
+  it('shows member matches before filling open slots from all accounts', async () => {
+    let resolveAccounts!: (users: UserSuggestion[]) => void
+    mockedFetchMemberSuggestions.mockResolvedValue([memberSuggestion])
+    mockedFetchAccountSuggestions.mockReturnValue(
+      new Promise((resolve) => {
+        resolveAccounts = resolve
+      }),
+    )
+    const input = renderSearch()
+
+    await userEvent.type(input, 'exg')
+    expect(
+      await screen.findByRole('option', {
+        name: /Ex Genesis @exgenesis Profile/,
+      }),
+    ).toBeInTheDocument()
+    expect(mockedFetchAccountSuggestions).toHaveBeenCalledWith(
+      expect.anything(),
+      'exg',
+      6,
+    )
+    expect(screen.queryByText('@exg_other')).not.toBeInTheDocument()
+
+    resolveAccounts([suggestion('exg_other', '456')])
+
+    expect(await screen.findByText('@exg_other')).toBeInTheDocument()
+    const groups = screen.getAllByRole('group')
+    expect(groups[0]).toHaveAccessibleName('@exgenesis')
+    expect(groups[1]).toHaveAccessibleName('@exg_other')
+  })
+
+  it('skips the broader lookup when members fill the suggestion list', async () => {
+    mockedFetchMemberSuggestions.mockResolvedValue(
+      Array.from({ length: 6 }, (_, index) =>
+        suggestion(`exg_member_${index}`, String(index + 1)),
+      ),
+    )
+    mockedFetchAccountSuggestions.mockResolvedValue([])
+    const input = renderSearch()
+
+    await userEvent.type(input, 'exg')
+    expect(await screen.findAllByRole('group')).toHaveLength(6)
+    expect(mockedFetchAccountSuggestions).not.toHaveBeenCalled()
   })
 })

--- a/src/components/UserSearchInput.tsx
+++ b/src/components/UserSearchInput.tsx
@@ -28,7 +28,8 @@ interface UserSearchInputProps extends Omit<InputProps, 'onChange' | 'value'> {
 }
 
 const SUGGESTION_LIMIT = 6
-const SUGGESTION_DELAY_MS = 200
+const SUGGESTION_DELAY_MS = 100
+const MEMBER_HEAD_START_MS = 100
 
 export default function UserSearchInput({
   value,
@@ -74,42 +75,66 @@ export default function UserSearchInput({
       requestId === requestIdRef.current &&
       document.activeElement === inputRef.current
 
+    let fallbackTimer: number | undefined
+    let memberSuggestions: UserSuggestion[] = []
+    let accountSuggestions: UserSuggestion[] = []
+    let accountRequest: Promise<void> | null = null
+
+    const renderSuggestions = () => {
+      if (!isCurrentRequest()) return
+      setSuggestions(
+        mergeUserSuggestions(
+          memberSuggestions,
+          accountSuggestions,
+          SUGGESTION_LIMIT,
+        ),
+      )
+    }
+
+    const startAccountLookup = () => {
+      if (accountRequest) return accountRequest
+      accountRequest = fetchAccountSuggestions(
+        supabase,
+        token.fragment,
+        SUGGESTION_LIMIT,
+      )
+        .then((users) => {
+          accountSuggestions = users
+          renderSuggestions()
+        })
+        .catch(() => {
+          // Keep any member suggestions visible if the broader lookup fails.
+        })
+      return accountRequest
+    }
+
     const timer = window.setTimeout(async () => {
-      let memberSuggestions: UserSuggestion[] = []
+      fallbackTimer = window.setTimeout(
+        startAccountLookup,
+        MEMBER_HEAD_START_MS,
+      )
+
       try {
         memberSuggestions = await fetchMemberSuggestions(
           token.fragment,
           SUGGESTION_LIMIT,
         )
         if (!isCurrentRequest()) return
-        setSuggestions(memberSuggestions)
+        renderSuggestions()
       } catch {
         if (!isCurrentRequest()) return
       }
 
-      if (memberSuggestions.length >= SUGGESTION_LIMIT) return
-
-      try {
-        const accountSuggestions = await fetchAccountSuggestions(
-          supabase,
-          token.fragment,
-          SUGGESTION_LIMIT,
-        )
-        if (!isCurrentRequest()) return
-        setSuggestions(
-          mergeUserSuggestions(
-            memberSuggestions,
-            accountSuggestions,
-            SUGGESTION_LIMIT,
-          ),
-        )
-      } catch {
-        // Keep any member suggestions visible if the broader lookup fails.
+      if (fallbackTimer !== undefined) {
+        window.clearTimeout(fallbackTimer)
+        fallbackTimer = undefined
       }
+      if (memberSuggestions.length < SUGGESTION_LIMIT) startAccountLookup()
     }, SUGGESTION_DELAY_MS)
 
     return () => {
       window.clearTimeout(timer)
+      if (fallbackTimer !== undefined) window.clearTimeout(fallbackTimer)
       if (requestIdRef.current === requestId) requestIdRef.current += 1
     }
   }, [supabase, token])

--- a/src/components/UserSearchInput.tsx
+++ b/src/components/UserSearchInput.tsx
@@ -7,7 +7,7 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Input, InputProps } from '@/components/ui/input'
 import { userProfileHref } from '@/lib/navigation'
 import {
-  fetchAccountSuggestions,
+  fetchMemberDirectorySuggestions,
   fetchMemberSuggestions,
 } from '@/lib/queries/fetchUsers'
 import {
@@ -29,7 +29,7 @@ interface UserSearchInputProps extends Omit<InputProps, 'onChange' | 'value'> {
 
 const SUGGESTION_LIMIT = 6
 const SUGGESTION_DELAY_MS = 100
-const MEMBER_HEAD_START_MS = 100
+const MEMBER_DIRECTORY_FALLBACK_MS = 250
 
 export default function UserSearchInput({
   value,
@@ -77,41 +77,41 @@ export default function UserSearchInput({
 
     let fallbackTimer: number | undefined
     let memberSuggestions: UserSuggestion[] = []
-    let accountSuggestions: UserSuggestion[] = []
-    let accountRequest: Promise<void> | null = null
+    let directorySuggestions: UserSuggestion[] = []
+    let directoryRequest: Promise<void> | null = null
 
     const renderSuggestions = () => {
       if (!isCurrentRequest()) return
       setSuggestions(
         mergeUserSuggestions(
           memberSuggestions,
-          accountSuggestions,
+          directorySuggestions,
           SUGGESTION_LIMIT,
         ),
       )
     }
 
-    const startAccountLookup = () => {
-      if (accountRequest) return accountRequest
-      accountRequest = fetchAccountSuggestions(
+    const startDirectoryLookup = () => {
+      if (directoryRequest) return directoryRequest
+      directoryRequest = fetchMemberDirectorySuggestions(
         supabase,
         token.fragment,
         SUGGESTION_LIMIT,
       )
         .then((users) => {
-          accountSuggestions = users
+          directorySuggestions = users
           renderSuggestions()
         })
         .catch(() => {
-          // Keep any member suggestions visible if the broader lookup fails.
+          // Keep any gateway member suggestions visible if the fallback fails.
         })
-      return accountRequest
+      return directoryRequest
     }
 
     const timer = window.setTimeout(async () => {
       fallbackTimer = window.setTimeout(
-        startAccountLookup,
-        MEMBER_HEAD_START_MS,
+        startDirectoryLookup,
+        MEMBER_DIRECTORY_FALLBACK_MS,
       )
 
       try {
@@ -129,7 +129,7 @@ export default function UserSearchInput({
         window.clearTimeout(fallbackTimer)
         fallbackTimer = undefined
       }
-      if (memberSuggestions.length < SUGGESTION_LIMIT) startAccountLookup()
+      if (memberSuggestions.length < SUGGESTION_LIMIT) startDirectoryLookup()
     }, SUGGESTION_DELAY_MS)
 
     return () => {

--- a/src/components/UserSearchInput.tsx
+++ b/src/components/UserSearchInput.tsx
@@ -6,9 +6,13 @@ import { useRouter } from 'next/navigation'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Input, InputProps } from '@/components/ui/input'
 import { userProfileHref } from '@/lib/navigation'
-import { fetchUserSuggestions } from '@/lib/queries/fetchUsers'
+import {
+  fetchAccountSuggestions,
+  fetchMemberSuggestions,
+} from '@/lib/queries/fetchUsers'
 import {
   getUsernameSearchToken,
+  mergeUserSuggestions,
   replaceUsernameTokenWithFromFilter,
 } from '@/lib/searchSuggestions'
 import type {
@@ -66,22 +70,48 @@ export default function UserSearchInput({
     setActiveIndex(-1)
     if (!token) return
 
-    const timer = window.setTimeout(() => {
-      fetchUserSuggestions(supabase, token.fragment, SUGGESTION_LIMIT)
-        .then((users) => {
-          if (
-            requestId === requestIdRef.current &&
-            document.activeElement === inputRef.current
-          ) {
-            setSuggestions(users)
-          }
-        })
-        .catch(() => {
-          if (requestId === requestIdRef.current) setSuggestions([])
-        })
+    const isCurrentRequest = () =>
+      requestId === requestIdRef.current &&
+      document.activeElement === inputRef.current
+
+    const timer = window.setTimeout(async () => {
+      let memberSuggestions: UserSuggestion[] = []
+      try {
+        memberSuggestions = await fetchMemberSuggestions(
+          token.fragment,
+          SUGGESTION_LIMIT,
+        )
+        if (!isCurrentRequest()) return
+        setSuggestions(memberSuggestions)
+      } catch {
+        if (!isCurrentRequest()) return
+      }
+
+      if (memberSuggestions.length >= SUGGESTION_LIMIT) return
+
+      try {
+        const accountSuggestions = await fetchAccountSuggestions(
+          supabase,
+          token.fragment,
+          SUGGESTION_LIMIT,
+        )
+        if (!isCurrentRequest()) return
+        setSuggestions(
+          mergeUserSuggestions(
+            memberSuggestions,
+            accountSuggestions,
+            SUGGESTION_LIMIT,
+          ),
+        )
+      } catch {
+        // Keep any member suggestions visible if the broader lookup fails.
+      }
     }, SUGGESTION_DELAY_MS)
 
-    return () => window.clearTimeout(timer)
+    return () => {
+      window.clearTimeout(timer)
+      if (requestIdRef.current === requestId) requestIdRef.current += 1
+    }
   }, [supabase, token])
 
   useEffect(() => {
@@ -93,7 +123,12 @@ export default function UserSearchInput({
 
   const openProfile = (suggestion: UserSuggestion) => {
     closeSuggestions()
-    router.push(userProfileHref(suggestion.username, suggestion.directory_id))
+    router.push(
+      userProfileHref(
+        suggestion.username,
+        suggestion.account_id || suggestion.directory_id,
+      ),
+    )
   }
 
   const selectFromFilter = (suggestion: UserSuggestion) => {

--- a/src/database-types.ts
+++ b/src/database-types.ts
@@ -2210,6 +2210,18 @@ export type Database = {
         Args: Record<PropertyKey, never>
         Returns: undefined
       }
+      search_user_suggestions: {
+        Args: {
+          search_text: string
+          result_limit?: number
+        }
+        Returns: {
+          account_id: string
+          username: string
+          account_display_name: string
+          num_followers: number | null
+        }[]
+      }
       search_tweets:
         | {
             Args: {

--- a/src/database-types.ts
+++ b/src/database-types.ts
@@ -242,43 +242,6 @@ export type Database = {
           },
         ]
       }
-      conversations: {
-        Row: {
-          conversation_id: string | null
-          tweet_id: string
-        }
-        Insert: {
-          conversation_id?: string | null
-          tweet_id: string
-        }
-        Update: {
-          conversation_id?: string | null
-          tweet_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "conversations_tweet_id_fkey"
-            columns: ["tweet_id"]
-            isOneToOne: true
-            referencedRelation: "enriched_tweets"
-            referencedColumns: ["tweet_id"]
-          },
-          {
-            foreignKeyName: "conversations_tweet_id_fkey"
-            columns: ["tweet_id"]
-            isOneToOne: true
-            referencedRelation: "tweets"
-            referencedColumns: ["tweet_id"]
-          },
-          {
-            foreignKeyName: "conversations_tweet_id_fkey"
-            columns: ["tweet_id"]
-            isOneToOne: true
-            referencedRelation: "tweets_w_conversation_id"
-            referencedColumns: ["tweet_id"]
-          },
-        ]
-      }
       community_projects: {
         Row: {
           archive_use: string
@@ -347,6 +310,43 @@ export type Database = {
           tags?: string[]
         }
         Relationships: []
+      }
+      conversations: {
+        Row: {
+          conversation_id: string | null
+          tweet_id: string
+        }
+        Insert: {
+          conversation_id?: string | null
+          tweet_id: string
+        }
+        Update: {
+          conversation_id?: string | null
+          tweet_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "conversations_tweet_id_fkey"
+            columns: ["tweet_id"]
+            isOneToOne: true
+            referencedRelation: "enriched_tweets"
+            referencedColumns: ["tweet_id"]
+          },
+          {
+            foreignKeyName: "conversations_tweet_id_fkey"
+            columns: ["tweet_id"]
+            isOneToOne: true
+            referencedRelation: "tweets"
+            referencedColumns: ["tweet_id"]
+          },
+          {
+            foreignKeyName: "conversations_tweet_id_fkey"
+            columns: ["tweet_id"]
+            isOneToOne: true
+            referencedRelation: "tweets_w_conversation_id"
+            referencedColumns: ["tweet_id"]
+          },
+        ]
       }
       digest_editions: {
         Row: {
@@ -2210,18 +2210,6 @@ export type Database = {
         Args: Record<PropertyKey, never>
         Returns: undefined
       }
-      search_user_suggestions: {
-        Args: {
-          search_text: string
-          result_limit?: number
-        }
-        Returns: {
-          account_id: string
-          username: string
-          account_display_name: string
-          num_followers: number | null
-        }[]
-      }
       search_tweets:
         | {
             Args: {
@@ -2289,6 +2277,18 @@ export type Database = {
           username: string
           account_display_name: string
           media: Json
+        }[]
+      }
+      search_user_suggestions: {
+        Args: {
+          search_text: string
+          result_limit?: number
+        }
+        Returns: {
+          account_id: string
+          username: string
+          account_display_name: string
+          num_followers: number
         }[]
       }
       set_limit: {
@@ -2444,3 +2444,4 @@ export type CompositeTypes<
   : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
     ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never
+

--- a/src/lib/queries/fetchUsers.test.ts
+++ b/src/lib/queries/fetchUsers.test.ts
@@ -94,12 +94,12 @@ describe('user suggestions', () => {
       { username: 'alexgenesis' },
     ])
     expect(fetchImpl).toHaveBeenCalledWith(
-      '/api/user-directory?limit=30&offset=0&sort_by=num_followers&sort_order=desc&search=exgenesis',
+      '/api/user-directory?limit=30&offset=0&sort_by=username&sort_order=asc&search=exgenesis',
       { cache: 'no-store' },
     )
   })
 
-  it('maps indexed all-account matches into fallback suggestions', async () => {
+  it('uses the ranked account RPC for handle, display-name, and fuzzy matches', async () => {
     const result = {
       data: [
         {
@@ -111,13 +111,8 @@ describe('user suggestions', () => {
       ],
       error: null,
     }
-    const query: Record<string, jest.Mock> = {}
-    query.select = jest.fn(() => query)
-    query.ilike = jest.fn(() => query)
-    query.order = jest.fn(() => query)
-    query.limit = jest.fn().mockResolvedValue(result)
-    const from = jest.fn(() => query)
-    const supabase = { schema: jest.fn(() => ({ from })) }
+    const rpc = jest.fn().mockResolvedValue(result)
+    const supabase = { schema: jest.fn(() => ({ rpc })) }
 
     await expect(
       fetchAccountSuggestions(supabase as any, 'other', 6),
@@ -131,9 +126,50 @@ describe('user suggestions', () => {
         num_followers: 50,
       },
     ])
-    expect(from).toHaveBeenCalledWith('all_account')
-    expect(query.ilike).toHaveBeenCalledWith('username', '%other%')
-    expect(query.limit).toHaveBeenCalledWith(30)
+    expect(rpc).toHaveBeenCalledWith('search_user_suggestions', {
+      search_text: 'other',
+      result_limit: 30,
+    })
+  })
+
+  it('falls back to a prefix query while the ranked RPC is being deployed', async () => {
+    const result = {
+      data: [
+        {
+          account_id: '456',
+          username: 'ChristineNiles1',
+          account_display_name: 'Christine Niles',
+          num_followers: 10_000,
+        },
+        {
+          account_id: '123',
+          username: 'christineist',
+          account_display_name: 'Christine Shiba',
+          num_followers: 10,
+        },
+      ],
+      error: null,
+    }
+    const query: Record<string, jest.Mock> = {}
+    query.select = jest.fn(() => query)
+    query.ilike = jest.fn(() => query)
+    query.order = jest.fn(() => query)
+    query.limit = jest.fn().mockResolvedValue(result)
+    const from = jest.fn(() => query)
+    const rpc = jest.fn().mockResolvedValue({
+      data: null,
+      error: { message: 'function not found' },
+    })
+    const supabase = { schema: jest.fn(() => ({ from, rpc })) }
+
+    const suggestions = await fetchAccountSuggestions(
+      supabase as any,
+      'christine',
+      6,
+    )
+
+    expect(suggestions[0]).toMatchObject({ username: 'christineist' })
+    expect(query.ilike).toHaveBeenCalledWith('username', 'christine%')
   })
 })
 

--- a/src/lib/queries/fetchUsers.test.ts
+++ b/src/lib/queries/fetchUsers.test.ts
@@ -1,6 +1,8 @@
 import { DirectoryUser } from '@/lib/types'
 import {
   buildDirectorySearchFilter,
+  fetchAccountSuggestions,
+  fetchMemberSuggestions,
   fetchUsers,
   getDirectoryProfileHref,
   getUserData,
@@ -58,6 +60,80 @@ describe('fetchUsers', () => {
       '/api/user-directory?limit=15&offset=30&sort_by=joined_at&sort_order=asc&search=alice',
       { cache: 'no-store' },
     )
+  })
+})
+
+describe('user suggestions', () => {
+  it('searches the bounded member-directory endpoint first', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        users: [
+          directoryUser({
+            account_id: '2',
+            directory_id: 'archive:2',
+            username: 'alexgenesis',
+            num_followers: 10_000,
+          }),
+          directoryUser({
+            account_id: '1',
+            directory_id: 'archive:1',
+            username: 'exgenesis',
+            num_followers: 10,
+          }),
+          directoryUser({ username: 'unrelated' }),
+        ],
+        hasMore: false,
+      }),
+    })
+
+    await expect(
+      fetchMemberSuggestions('ExGenesis', 6, fetchImpl as any),
+    ).resolves.toMatchObject([
+      { username: 'exgenesis' },
+      { username: 'alexgenesis' },
+    ])
+    expect(fetchImpl).toHaveBeenCalledWith(
+      '/api/user-directory?limit=30&offset=0&sort_by=num_followers&sort_order=desc&search=exgenesis',
+      { cache: 'no-store' },
+    )
+  })
+
+  it('maps indexed all-account matches into fallback suggestions', async () => {
+    const result = {
+      data: [
+        {
+          account_id: '456',
+          username: 'other_user',
+          account_display_name: 'Other User',
+          num_followers: 50,
+        },
+      ],
+      error: null,
+    }
+    const query: Record<string, jest.Mock> = {}
+    query.select = jest.fn(() => query)
+    query.ilike = jest.fn(() => query)
+    query.order = jest.fn(() => query)
+    query.limit = jest.fn().mockResolvedValue(result)
+    const from = jest.fn(() => query)
+    const supabase = { schema: jest.fn(() => ({ from })) }
+
+    await expect(
+      fetchAccountSuggestions(supabase as any, 'other', 6),
+    ).resolves.toEqual([
+      {
+        account_id: '456',
+        directory_id: 'account:456',
+        username: 'other_user',
+        account_display_name: 'Other User',
+        avatar_media_url: null,
+        num_followers: 50,
+      },
+    ])
+    expect(from).toHaveBeenCalledWith('all_account')
+    expect(query.ilike).toHaveBeenCalledWith('username', '%other%')
+    expect(query.limit).toHaveBeenCalledWith(30)
   })
 })
 

--- a/src/lib/queries/fetchUsers.test.ts
+++ b/src/lib/queries/fetchUsers.test.ts
@@ -2,6 +2,7 @@ import { DirectoryUser } from '@/lib/types'
 import {
   buildDirectorySearchFilter,
   fetchAccountSuggestions,
+  fetchMemberDirectorySuggestions,
   fetchMemberSuggestions,
   fetchUsers,
   getDirectoryProfileHref,
@@ -97,6 +98,36 @@ describe('user suggestions', () => {
       '/api/user-directory?limit=30&offset=0&sort_by=username&sort_order=asc&search=exgenesis',
       { cache: 'no-store' },
     )
+  })
+
+  it('uses only the authoritative member directory as the browser fallback', async () => {
+    const result = {
+      data: [
+        directoryUser({
+          account_id: '123',
+          directory_id: 'archive:123',
+          username: 'christineist',
+          account_display_name: 'Christine Shiba',
+        }),
+      ],
+      error: null,
+    }
+    const query: Record<string, jest.Mock> = {}
+    query.select = jest.fn(() => query)
+    query.or = jest.fn(() => query)
+    query.order = jest.fn(() => query)
+    query.limit = jest.fn().mockResolvedValue(result)
+    const from = jest.fn(() => query)
+    const supabase = { schema: jest.fn(() => ({ from })) }
+
+    await expect(
+      fetchMemberDirectorySuggestions(supabase as any, 'christine', 6),
+    ).resolves.toMatchObject([{ username: 'christineist' }])
+    expect(from).toHaveBeenCalledWith('user_directory')
+    expect(query.or).toHaveBeenCalledWith(
+      'username.ilike."%christine%",account_display_name.ilike."%christine%"',
+    )
+    expect(query.limit).toHaveBeenCalledWith(30)
   })
 
   it('uses the ranked account RPC for handle, display-name, and fuzzy matches', async () => {

--- a/src/lib/queries/fetchUsers.ts
+++ b/src/lib/queries/fetchUsers.ts
@@ -84,6 +84,8 @@ export const fetchMemberSuggestions = async (
   const page = await fetchUsers(
     {
       limit: Math.max(limit * 5, 30),
+      sortBy: 'username',
+      sortOrder: 'asc',
       search: normalizedFragment,
     },
     fetchImpl,
@@ -91,9 +93,14 @@ export const fetchMemberSuggestions = async (
 
   return rankUserSuggestions(
     page.users
-      .filter((user) =>
-        user.username.toLocaleLowerCase().includes(normalizedFragment),
-      )
+      .filter((user) => {
+        const username = user.username.toLocaleLowerCase()
+        const displayName = user.account_display_name.toLocaleLowerCase()
+        return (
+          username.includes(normalizedFragment) ||
+          displayName.includes(normalizedFragment)
+        )
+      })
       .map(
         ({
           account_id,
@@ -124,30 +131,52 @@ export const fetchAccountSuggestions = async (
   const normalizedFragment = normalizeSuggestionFragment(fragment)
   if (!normalizedFragment) return []
 
-  const escapedFragment = normalizedFragment.replace(/[\\%_]/g, '\\$&')
   const { data, error } = await supabase
     .schema('public')
-    .from('all_account')
-    .select('account_id, username, account_display_name, num_followers')
-    .ilike('username', `%${escapedFragment}%`)
-    .order('num_followers', { ascending: false, nullsFirst: false })
-    .limit(Math.max(limit * 5, 30))
+    .rpc('search_user_suggestions', {
+      search_text: normalizedFragment,
+      result_limit: Math.max(limit * 5, 30),
+    })
 
-  if (error) throw error
+  if (error) {
+    // Keep previews usable until the matching migration reaches their DB.
+    const escapedFragment = normalizedFragment.replace(/[\\%_]/g, '\\$&')
+    const fallback = await supabase
+      .schema('public')
+      .from('all_account')
+      .select('account_id, username, account_display_name, num_followers')
+      .ilike('username', `${escapedFragment}%`)
+      .order('username', { ascending: true })
+      .limit(Math.max(limit * 5, 30))
+
+    if (fallback.error) throw error
+    return rankUserSuggestions(
+      (fallback.data || []).map(mapAccountSuggestion),
+      normalizedFragment,
+      limit,
+    )
+  }
 
   return rankUserSuggestions(
-    (data || []).map((user) => ({
-      account_id: user.account_id,
-      directory_id: `account:${user.account_id}`,
-      username: user.username,
-      account_display_name: user.account_display_name,
-      avatar_media_url: null,
-      num_followers: user.num_followers,
-    })),
+    (data || []).map(mapAccountSuggestion),
     normalizedFragment,
     limit,
   )
 }
+
+const mapAccountSuggestion = (user: {
+  account_id: string
+  username: string
+  account_display_name: string
+  num_followers: number | null
+}): UserSuggestion => ({
+  account_id: user.account_id,
+  directory_id: `account:${user.account_id}`,
+  username: user.username,
+  account_display_name: user.account_display_name,
+  avatar_media_url: null,
+  num_followers: user.num_followers,
+})
 
 export const getUserData = async (
   supabase: SupabaseClient,

--- a/src/lib/queries/fetchUsers.ts
+++ b/src/lib/queries/fetchUsers.ts
@@ -62,24 +62,73 @@ export const fetchUsers = async (
   return page
 }
 
-export const fetchUserSuggestions = async (
-  supabase: SupabaseClient,
-  fragment: string,
-  limit = 6,
-): Promise<UserSuggestion[]> => {
+const normalizeSuggestionFragment = (fragment: string) => {
   const normalizedFragment = fragment
     .trim()
     .replace(/^@/, '')
     .toLocaleLowerCase()
-  if (!/^[a-z0-9_]{2,15}$/.test(normalizedFragment)) return []
+
+  return /^[a-z0-9_]{2,15}$/.test(normalizedFragment)
+    ? normalizedFragment
+    : null
+}
+
+export const fetchMemberSuggestions = async (
+  fragment: string,
+  limit = 6,
+  fetchImpl: typeof fetch = fetch,
+): Promise<UserSuggestion[]> => {
+  const normalizedFragment = normalizeSuggestionFragment(fragment)
+  if (!normalizedFragment) return []
+
+  const page = await fetchUsers(
+    {
+      limit: Math.max(limit * 5, 30),
+      search: normalizedFragment,
+    },
+    fetchImpl,
+  )
+
+  return rankUserSuggestions(
+    page.users
+      .filter((user) =>
+        user.username.toLocaleLowerCase().includes(normalizedFragment),
+      )
+      .map(
+        ({
+          account_id,
+          directory_id,
+          username,
+          account_display_name,
+          avatar_media_url,
+          num_followers,
+        }) => ({
+          account_id,
+          directory_id,
+          username,
+          account_display_name,
+          avatar_media_url,
+          num_followers,
+        }),
+      ),
+    normalizedFragment,
+    limit,
+  )
+}
+
+export const fetchAccountSuggestions = async (
+  supabase: SupabaseClient,
+  fragment: string,
+  limit = 6,
+): Promise<UserSuggestion[]> => {
+  const normalizedFragment = normalizeSuggestionFragment(fragment)
+  if (!normalizedFragment) return []
 
   const escapedFragment = normalizedFragment.replace(/[\\%_]/g, '\\$&')
   const { data, error } = await supabase
     .schema('public')
-    .from('user_directory')
-    .select(
-      'directory_id, username, account_display_name, avatar_media_url, num_followers',
-    )
+    .from('all_account')
+    .select('account_id, username, account_display_name, num_followers')
     .ilike('username', `%${escapedFragment}%`)
     .order('num_followers', { ascending: false, nullsFirst: false })
     .limit(Math.max(limit * 5, 30))
@@ -87,7 +136,14 @@ export const fetchUserSuggestions = async (
   if (error) throw error
 
   return rankUserSuggestions(
-    (data as UserSuggestion[]) || [],
+    (data || []).map((user) => ({
+      account_id: user.account_id,
+      directory_id: `account:${user.account_id}`,
+      username: user.username,
+      account_display_name: user.account_display_name,
+      avatar_media_url: null,
+      num_followers: user.num_followers,
+    })),
     normalizedFragment,
     limit,
   )

--- a/src/lib/queries/fetchUsers.ts
+++ b/src/lib/queries/fetchUsers.ts
@@ -123,6 +123,49 @@ export const fetchMemberSuggestions = async (
   )
 }
 
+export const fetchMemberDirectorySuggestions = async (
+  supabase: SupabaseClient,
+  fragment: string,
+  limit = 6,
+): Promise<UserSuggestion[]> => {
+  const normalizedFragment = normalizeSuggestionFragment(fragment)
+  if (!normalizedFragment) return []
+
+  const { data, error } = await supabase
+    .schema('public')
+    .from('user_directory')
+    .select(
+      'account_id, directory_id, username, account_display_name, avatar_media_url, num_followers',
+    )
+    .or(buildDirectorySearchFilter(normalizedFragment))
+    .order('username', { ascending: true })
+    .limit(Math.max(limit * 5, 30))
+
+  if (error) throw error
+
+  return rankUserSuggestions(
+    (data || []).map(
+      ({
+        account_id,
+        directory_id,
+        username,
+        account_display_name,
+        avatar_media_url,
+        num_followers,
+      }) => ({
+        account_id,
+        directory_id,
+        username,
+        account_display_name,
+        avatar_media_url,
+        num_followers,
+      }),
+    ),
+    normalizedFragment,
+    limit,
+  )
+}
+
 export const fetchAccountSuggestions = async (
   supabase: SupabaseClient,
   fragment: string,

--- a/src/lib/searchSuggestions.test.ts
+++ b/src/lib/searchSuggestions.test.ts
@@ -1,5 +1,6 @@
 import {
   getUsernameSearchToken,
+  mergeUserSuggestions,
   rankUserSuggestions,
   replaceUsernameTokenWithFromFilter,
   UserSuggestion,
@@ -9,6 +10,7 @@ const suggestion = (
   username: string,
   numFollowers: number | null = null,
 ): UserSuggestion => ({
+  account_id: username,
   directory_id: `archive:${username}`,
   username,
   account_display_name: username,
@@ -61,5 +63,20 @@ describe('username search suggestions', () => {
         3,
       ).map((user) => user.username),
     ).toEqual(['exgenesis', 'exgenesis_notes', 'alexgenesis'])
+  })
+
+  it('keeps members first while deduplicating broader account matches', () => {
+    const member = suggestion('archive_member', 10)
+
+    expect(
+      mergeUserSuggestions(
+        [member],
+        [
+          { ...member, directory_id: 'account:archive_member' },
+          suggestion('other_account', 10_000),
+        ],
+        6,
+      ).map((user) => user.username),
+    ).toEqual(['archive_member', 'other_account'])
   })
 })

--- a/src/lib/searchSuggestions.test.ts
+++ b/src/lib/searchSuggestions.test.ts
@@ -1,5 +1,6 @@
 import {
   getUsernameSearchToken,
+  getStandaloneUserSearchTerm,
   mergeUserSuggestions,
   rankUserSuggestions,
   replaceUsernameTokenWithFromFilter,
@@ -63,6 +64,42 @@ describe('username search suggestions', () => {
         3,
       ).map((user) => user.username),
     ).toEqual(['exgenesis', 'exgenesis_notes', 'alexgenesis'])
+  })
+
+  it('ranks the closest prefix completion before a more popular long prefix', () => {
+    expect(
+      rankUserSuggestions(
+        [
+          suggestion('ChristineNiles1', 10_000),
+          suggestion('christineist', 10),
+        ],
+        'christine',
+        2,
+      ).map((user) => user.username),
+    ).toEqual(['christineist', 'ChristineNiles1'])
+  })
+
+  it('matches display names and keeps close typo matches behind direct matches', () => {
+    expect(
+      rankUserSuggestions(
+        [
+          {
+            ...suggestion('random_handle', 10_000),
+            account_display_name: 'Christine Shiba',
+          },
+          suggestion('christineist', 10),
+          suggestion('christneist', 100),
+        ],
+        'christine',
+        3,
+      ).map((user) => user.username),
+    ).toEqual(['christineist', 'random_handle', 'christneist'])
+  })
+
+  it('recognizes only standalone username-shaped submitted searches', () => {
+    expect(getStandaloneUserSearchTerm('@ChristineIst')).toBe('christineist')
+    expect(getStandaloneUserSearchTerm('christine ist')).toBeNull()
+    expect(getStandaloneUserSearchTerm('from:christineist')).toBeNull()
   })
 
   it('keeps members first while deduplicating broader account matches', () => {

--- a/src/lib/searchSuggestions.ts
+++ b/src/lib/searchSuggestions.ts
@@ -54,24 +54,46 @@ export function rankUserSuggestions(
   fragment: string,
   limit: number,
 ) {
-  const normalizedFragment = fragment.toLocaleLowerCase()
+  const normalizedFragment = fragment.trim().toLocaleLowerCase()
+
+  const rank = (user: UserSuggestion) => {
+    const username = user.username.toLocaleLowerCase()
+    const displayName = user.account_display_name.toLocaleLowerCase()
+
+    if (username === normalizedFragment) return [0, 1]
+    if (username.startsWith(normalizedFragment)) {
+      return [1, normalizedSimilarity(username, normalizedFragment)]
+    }
+    if (displayName === normalizedFragment) return [2, 1]
+    if (displayName.startsWith(normalizedFragment)) {
+      return [3, normalizedSimilarity(displayName, normalizedFragment)]
+    }
+    if (username.includes(normalizedFragment)) {
+      return [4, normalizedSimilarity(username, normalizedFragment)]
+    }
+    if (displayName.includes(normalizedFragment)) {
+      return [5, normalizedSimilarity(displayName, normalizedFragment)]
+    }
+
+    return [
+      6,
+      Math.max(
+        normalizedSimilarity(username, normalizedFragment),
+        normalizedSimilarity(displayName, normalizedFragment),
+      ),
+    ]
+  }
 
   return [...users]
     .sort((left, right) => {
       const leftUsername = left.username.toLocaleLowerCase()
       const rightUsername = right.username.toLocaleLowerCase()
-      const leftExact = leftUsername === normalizedFragment
-      const rightExact = rightUsername === normalizedFragment
-      if (leftExact !== rightExact) return leftExact ? -1 : 1
-
-      const leftPrefix = leftUsername.startsWith(normalizedFragment)
-      const rightPrefix = rightUsername.startsWith(normalizedFragment)
-      if (leftPrefix !== rightPrefix) return leftPrefix ? -1 : 1
-
-      const positionDifference =
-        leftUsername.indexOf(normalizedFragment) -
-        rightUsername.indexOf(normalizedFragment)
-      if (positionDifference !== 0) return positionDifference
+      const [leftTier, leftSimilarity] = rank(left)
+      const [rightTier, rightSimilarity] = rank(right)
+      if (leftTier !== rightTier) return leftTier - rightTier
+      if (leftSimilarity !== rightSimilarity) {
+        return rightSimilarity - leftSimilarity
+      }
 
       const followerDifference =
         (right.num_followers ?? -1) - (left.num_followers ?? -1)
@@ -80,6 +102,36 @@ export function rankUserSuggestions(
       return leftUsername.localeCompare(rightUsername)
     })
     .slice(0, limit)
+}
+
+function normalizedSimilarity(left: string, right: string) {
+  const longestLength = Math.max(left.length, right.length)
+  if (longestLength === 0) return 1
+  return 1 - levenshteinDistance(left, right) / longestLength
+}
+
+function levenshteinDistance(left: string, right: string) {
+  let previous = Array.from({ length: right.length + 1 }, (_, index) => index)
+
+  for (let leftIndex = 1; leftIndex <= left.length; leftIndex += 1) {
+    const current = [leftIndex]
+    for (let rightIndex = 1; rightIndex <= right.length; rightIndex += 1) {
+      current[rightIndex] = Math.min(
+        current[rightIndex - 1] + 1,
+        previous[rightIndex] + 1,
+        previous[rightIndex - 1] +
+          (left[leftIndex - 1] === right[rightIndex - 1] ? 0 : 1),
+      )
+    }
+    previous = current
+  }
+
+  return previous[right.length]
+}
+
+export function getStandaloneUserSearchTerm(value: string) {
+  const match = value.trim().match(/^@?([a-z0-9_]{2,15})$/i)
+  return match?.[1].toLocaleLowerCase() ?? null
 }
 
 export function mergeUserSuggestions(

--- a/src/lib/searchSuggestions.ts
+++ b/src/lib/searchSuggestions.ts
@@ -8,6 +8,7 @@ export interface UsernameSearchToken {
 
 export type UserSuggestion = Pick<
   DirectoryUser,
+  | 'account_id'
   | 'directory_id'
   | 'username'
   | 'account_display_name'
@@ -79,4 +80,31 @@ export function rankUserSuggestions(
       return leftUsername.localeCompare(rightUsername)
     })
     .slice(0, limit)
+}
+
+export function mergeUserSuggestions(
+  memberSuggestions: UserSuggestion[],
+  accountSuggestions: UserSuggestion[],
+  limit: number,
+) {
+  const merged: UserSuggestion[] = []
+  const seenAccountIds = new Set<string>()
+  const seenUsernames = new Set<string>()
+
+  for (const suggestion of [...memberSuggestions, ...accountSuggestions]) {
+    const username = suggestion.username.toLocaleLowerCase()
+    if (
+      (suggestion.account_id && seenAccountIds.has(suggestion.account_id)) ||
+      seenUsernames.has(username)
+    ) {
+      continue
+    }
+
+    merged.push(suggestion)
+    if (suggestion.account_id) seenAccountIds.add(suggestion.account_id)
+    seenUsernames.add(username)
+    if (merged.length === limit) break
+  }
+
+  return merged
 }

--- a/supabase/migrations/20260828101500_add_ranked_user_suggestions.sql
+++ b/supabase/migrations/20260828101500_add_ranked_user_suggestions.sql
@@ -1,0 +1,71 @@
+-- This index should be prebuilt with CREATE INDEX CONCURRENTLY in production.
+-- The IF NOT EXISTS statement then records the schema contract without a rebuild.
+CREATE INDEX IF NOT EXISTS "idx_all_account_display_name_trgm"
+  ON "public"."all_account" USING "gin"
+  ("account_display_name" "public"."gin_trgm_ops");
+
+CREATE OR REPLACE FUNCTION "public"."search_user_suggestions"(
+  "search_text" text,
+  "result_limit" integer DEFAULT 30
+)
+RETURNS TABLE (
+  "account_id" text,
+  "username" text,
+  "account_display_name" text,
+  "num_followers" integer
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  WITH input AS (
+    SELECT lower(trim(leading '@' FROM trim(search_text))) AS term
+  )
+  SELECT
+    account.account_id,
+    account.username,
+    account.account_display_name,
+    account.num_followers
+  FROM public.all_account AS account
+  CROSS JOIN input
+  WHERE length(input.term) BETWEEN 2 AND 50
+    AND account.is_tombstone IS NOT TRUE
+    AND (
+      (length(input.term) = 2 AND lower(account.username) = input.term)
+      OR (
+        length(input.term) >= 3
+        AND (
+          account.username ILIKE '%' || input.term || '%'
+          OR account.account_display_name ILIKE '%' || input.term || '%'
+          OR account.username OPERATOR(public.%) input.term
+          OR account.account_display_name OPERATOR(public.%) input.term
+        )
+      )
+    )
+  ORDER BY
+    CASE
+      WHEN lower(account.username) = input.term THEN 0
+      WHEN lower(account.username) LIKE input.term || '%' THEN 1
+      WHEN lower(account.account_display_name) = input.term THEN 2
+      WHEN lower(account.account_display_name) LIKE input.term || '%' THEN 3
+      WHEN lower(account.username) LIKE '%' || input.term || '%' THEN 4
+      WHEN lower(account.account_display_name) LIKE '%' || input.term || '%' THEN 5
+      ELSE 6
+    END,
+    greatest(
+      public.similarity(lower(account.username), input.term),
+      public.similarity(lower(account.account_display_name), input.term)
+    ) DESC,
+    account.num_followers DESC NULLS LAST,
+    lower(account.username),
+    account.account_id
+  LIMIT least(greatest(coalesce(result_limit, 30), 1), 60);
+$$;
+
+ALTER FUNCTION "public"."search_user_suggestions"(text, integer)
+  OWNER TO "postgres";
+REVOKE ALL ON FUNCTION "public"."search_user_suggestions"(text, integer)
+  FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION "public"."search_user_suggestions"(text, integer)
+  TO "anon", "authenticated", "readclient", "service_role";

--- a/supabase/schemas/030_indexes.sql
+++ b/supabase/schemas/030_indexes.sql
@@ -105,6 +105,8 @@ CREATE INDEX IF NOT EXISTS "idx_all_account_lower_username"
 -- both exact and wildcard ILIKE lookups.
 CREATE INDEX IF NOT EXISTS "idx_all_account_username_trgm"
   ON "public"."all_account" USING "gin" ("username" "public"."gin_trgm_ops");
+CREATE INDEX IF NOT EXISTS "idx_all_account_display_name_trgm"
+  ON "public"."all_account" USING "gin" ("account_display_name" "public"."gin_trgm_ops");
 
 -- private.tweet_user: every get_streaming_stats_* function filters on created_at.
 CREATE INDEX IF NOT EXISTS "idx_tweet_user_created_at"

--- a/supabase/schemas/070_functions.sql
+++ b/supabase/schemas/070_functions.sql
@@ -3387,3 +3387,68 @@ REVOKE ALL ON FUNCTION "public"."community_archive_monitoring_digest"()
   FROM PUBLIC, "anon", "authenticated", "service_role";
 GRANT EXECUTE ON FUNCTION "public"."community_archive_monitoring_digest"()
   TO "readclient";
+
+CREATE OR REPLACE FUNCTION "public"."search_user_suggestions"(
+  "search_text" text,
+  "result_limit" integer DEFAULT 30
+)
+RETURNS TABLE (
+  "account_id" text,
+  "username" text,
+  "account_display_name" text,
+  "num_followers" integer
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  WITH input AS (
+    SELECT lower(trim(leading '@' FROM trim(search_text))) AS term
+  )
+  SELECT
+    account.account_id,
+    account.username,
+    account.account_display_name,
+    account.num_followers
+  FROM public.all_account AS account
+  CROSS JOIN input
+  WHERE length(input.term) BETWEEN 2 AND 50
+    AND account.is_tombstone IS NOT TRUE
+    AND (
+      (length(input.term) = 2 AND lower(account.username) = input.term)
+      OR (
+        length(input.term) >= 3
+        AND (
+          account.username ILIKE '%' || input.term || '%'
+          OR account.account_display_name ILIKE '%' || input.term || '%'
+          OR account.username OPERATOR(public.%) input.term
+          OR account.account_display_name OPERATOR(public.%) input.term
+        )
+      )
+    )
+  ORDER BY
+    CASE
+      WHEN lower(account.username) = input.term THEN 0
+      WHEN lower(account.username) LIKE input.term || '%' THEN 1
+      WHEN lower(account.account_display_name) = input.term THEN 2
+      WHEN lower(account.account_display_name) LIKE input.term || '%' THEN 3
+      WHEN lower(account.username) LIKE '%' || input.term || '%' THEN 4
+      WHEN lower(account.account_display_name) LIKE '%' || input.term || '%' THEN 5
+      ELSE 6
+    END,
+    greatest(
+      public.similarity(lower(account.username), input.term),
+      public.similarity(lower(account.account_display_name), input.term)
+    ) DESC,
+    account.num_followers DESC NULLS LAST,
+    lower(account.username),
+    account.account_id
+  LIMIT least(greatest(coalesce(result_limit, 30), 1), 60);
+$$;
+ALTER FUNCTION "public"."search_user_suggestions"(text, integer)
+  OWNER TO "postgres";
+REVOKE ALL ON FUNCTION "public"."search_user_suggestions"(text, integer)
+  FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION "public"."search_user_suggestions"(text, integer)
+  TO "anon", "authenticated", "readclient", "service_role";


### PR DESCRIPTION
## Summary
- debounce user suggestions for 100 ms and restrict the dropdown to Community Archive members
- query the gateway member projection first, then hedge through authoritative `public.user_directory` if the gateway is slow or leaves open slots
- keep broader exact-handle, display-name, prefix, and typo-tolerant account matching only on submitted username-like searches
- add a bounded `search_user_suggestions` RPC plus a trigram display-name index for submitted results
- preserve member-first deduplication and profile / `from:` actions

## Validation
- `pnpm type-check`
- focused client/server tests: 4 suites, 29 tests across `UserSearchInput`, `UserMatchResults`, `fetchUsers`, and `searchSuggestions`
- local browser: typing `christine` shows only archive member `@christineist` in the dropdown
- `git diff --check`

## Rollout notes
- Prebuild `idx_all_account_display_name_trgm` with `CREATE INDEX CONCURRENTLY` in production before applying the migration; the migration's `IF NOT EXISTS` then records the schema without rebuilding it.
- The submitted-results RPC caps output at 60 rows. Two-character terms use only an indexed exact-handle lookup; substring, display-name, and fuzzy matching start at three characters.
- The database integration suite requires unavailable `TESTS_SUPABASE_*` credentials. The checked-in database types were regenerated from staging and the rebased branch passes `pnpm type-check`.
- Local ClickHouse member calls remain unavailable without the gateway token; the dropdown's authoritative member-directory hedge is covered by focused component and query tests.