### PR TITLE
Hide explicitly opted-out profiles

### DIFF
--- a/src/lib/metaTwitter/data.ts
+++ b/src/lib/metaTwitter/data.ts
@@ -4,6 +4,7 @@ import { createClient, SupabaseClient } from '@supabase/supabase-js'
 import { unstable_cache } from 'next/cache'
 import { Database } from '@/database-types'
 import { devLog } from '@/lib/devLog'
+import { isTwitterUsername } from '@/lib/apiInputValidation'
 import { resolveProfileLinks } from '@/lib/profileLinks'
 import type {
   ArchiveMediaItem,
@@ -15,7 +16,9 @@ export type { ArchiveMediaItem, ArchivePerson, ProfileHeaderData }
 
 const DAY = 86_400
 
-const getMetaClient = (): SupabaseClient<Database> => {
+const getMetaClient = (
+  options: { noStore?: boolean } = {},
+): SupabaseClient<Database> => {
   const isDevelopment = process.env.NODE_ENV === 'development'
   const useRemoteDevDb = process.env.NEXT_PUBLIC_USE_REMOTE_DEV_DB === 'true'
   const url =
@@ -28,6 +31,14 @@ const getMetaClient = (): SupabaseClient<Database> => {
       : process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
   return createClient<Database>(url, anonKey, {
     auth: { persistSession: false },
+    ...(options.noStore
+      ? {
+          global: {
+            fetch: (input: RequestInfo | URL, init?: RequestInit) =>
+              fetch(input, { ...init, cache: 'no-store' }),
+          },
+        }
+      : {}),
   })
 }
 
@@ -223,29 +234,51 @@ export const getCachedProfileHeader = unstable_cache(
   { revalidate: 3600 },
 )
 
-export const resolveAccountId = unstable_cache(
-  async (param: string): Promise<string | null> => {
-    let decoded: string
-    try {
-      decoded = decodeURIComponent(param)
-    } catch {
-      return null
-    }
-    decoded = decoded.replace(/^(archive|optin):/, '')
-    if (/^\d+$/.test(decoded)) return decoded
-    const supabase = getMetaClient()
-    const { data, error } = await supabase
-      .from('all_account')
-      .select('account_id')
-      .ilike('username', decoded)
-      .limit(1)
-      .maybeSingle()
-    if (error) throw error
-    return data?.account_id ?? null
-  },
-  ['meta-twitter-resolve-account-v1'],
-  { revalidate: DAY },
-)
+export interface PublicProfileIdentity {
+  accountId: string | null
+  username: string
+}
+
+/**
+ * Resolve only identities that are currently eligible for public serving.
+ * This policy lookup is deliberately uncached so an explicit opt-out hides a
+ * profile on the next request instead of waiting for an application cache.
+ */
+export const resolvePublicProfileIdentity = async (
+  param: string,
+): Promise<PublicProfileIdentity | null> => {
+  let decoded: string
+  try {
+    decoded = decodeURIComponent(param)
+  } catch {
+    return null
+  }
+
+  const isDirectoryIdentifier = /^(archive|optin):/.test(decoded)
+  const isAccountIdentifier = /^\d{1,20}$/.test(decoded)
+  if (
+    !isDirectoryIdentifier &&
+    !isAccountIdentifier &&
+    !isTwitterUsername(decoded)
+  ) {
+    return null
+  }
+
+  const supabase = getMetaClient({ noStore: true })
+  const baseQuery = supabase
+    .from('user_directory')
+    .select('account_id, username')
+
+  const { data, error } = isDirectoryIdentifier
+    ? await baseQuery.eq('directory_id', decoded).limit(1).maybeSingle()
+    : isAccountIdentifier
+      ? await baseQuery.eq('account_id', decoded).limit(1).maybeSingle()
+      : await baseQuery.ilike('username', decoded).limit(1).maybeSingle()
+
+  if (error) throw error
+  if (!data?.username) return null
+  return { accountId: data.account_id ?? null, username: data.username }
+}
 
 export const getCachedArchivedAt = unstable_cache(
   async (accountId: string): Promise<string | null> => {

--- a/src/lib/metaTwitter/profile.test.ts
+++ b/src/lib/metaTwitter/profile.test.ts
@@ -1,4 +1,4 @@
-const resolveAccountIdMock = jest.fn()
+const resolvePublicProfileIdentityMock = jest.fn()
 const getCachedProfileHeaderMock = jest.fn()
 const getClickHouseUserProfileMock = jest.fn()
 
@@ -8,7 +8,8 @@ jest.mock('react', () => ({
 }))
 
 jest.mock('@/lib/metaTwitter/data', () => ({
-  resolveAccountId: (...args: unknown[]) => resolveAccountIdMock(...args),
+  resolvePublicProfileIdentity: (...args: unknown[]) =>
+    resolvePublicProfileIdentityMock(...args),
   getCachedProfileHeader: (...args: unknown[]) =>
     getCachedProfileHeaderMock(...args),
 }))
@@ -44,7 +45,10 @@ beforeEach(() => {
 })
 
 test('prefers the authoritative archived profile', async () => {
-  resolveAccountIdMock.mockResolvedValue('42')
+  resolvePublicProfileIdentityMock.mockResolvedValue({
+    accountId: '42',
+    username: 'alice',
+  })
   getCachedProfileHeaderMock.mockResolvedValue(archivedProfile)
 
   await expect(resolveProfile('alice')).resolves.toEqual({
@@ -55,7 +59,10 @@ test('prefers the authoritative archived profile', async () => {
 })
 
 test('maps the analytical fallback to the shared profile shape', async () => {
-  resolveAccountIdMock.mockResolvedValue(null)
+  resolvePublicProfileIdentityMock.mockResolvedValue({
+    accountId: null,
+    username: 'bob',
+  })
   getClickHouseUserProfileMock.mockResolvedValue({
     user: {
       ...archivedProfile,
@@ -82,15 +89,19 @@ test('maps the analytical fallback to the shared profile shape', async () => {
   })
 })
 
-test('returns null when neither profile source can resolve the user', async () => {
-  resolveAccountIdMock.mockResolvedValue(null)
-  getClickHouseUserProfileMock.mockResolvedValue(null)
+test('does not load profile sources when the public policy identity is hidden', async () => {
+  resolvePublicProfileIdentityMock.mockResolvedValue(null)
 
   await expect(resolveProfile('missing')).resolves.toBeNull()
+  expect(getCachedProfileHeaderMock).not.toHaveBeenCalled()
+  expect(getClickHouseUserProfileMock).not.toHaveBeenCalled()
 })
 
 test('backfills a missing archive avatar from the analytical profile', async () => {
-  resolveAccountIdMock.mockResolvedValue('42')
+  resolvePublicProfileIdentityMock.mockResolvedValue({
+    accountId: '42',
+    username: 'alice',
+  })
   getCachedProfileHeaderMock.mockResolvedValue({
     ...archivedProfile,
     avatar_media_url: null,
@@ -114,7 +125,10 @@ test('backfills a missing archive avatar from the analytical profile', async () 
 })
 
 test('keeps the archived media and skips the analytical lookup when both are present', async () => {
-  resolveAccountIdMock.mockResolvedValue('42')
+  resolvePublicProfileIdentityMock.mockResolvedValue({
+    accountId: '42',
+    username: 'alice',
+  })
   getCachedProfileHeaderMock.mockResolvedValue({
     ...archivedProfile,
     avatar_media_url: 'https://pbs.twimg.com/profile_images/9/archived.jpg',
@@ -130,7 +144,10 @@ test('keeps the archived media and skips the analytical lookup when both are pre
 })
 
 test('leaves media null when neither source has it', async () => {
-  resolveAccountIdMock.mockResolvedValue('42')
+  resolvePublicProfileIdentityMock.mockResolvedValue({
+    accountId: '42',
+    username: 'alice',
+  })
   getCachedProfileHeaderMock.mockResolvedValue({
     ...archivedProfile,
     avatar_media_url: '   ',
@@ -143,8 +160,11 @@ test('leaves media null when neither source has it', async () => {
   })
 })
 
-test('strips the archive prefix before the analytical lookup', async () => {
-  resolveAccountIdMock.mockResolvedValue('42')
+test('uses the policy-approved account ID for the analytical lookup', async () => {
+  resolvePublicProfileIdentityMock.mockResolvedValue({
+    accountId: '42',
+    username: 'alice',
+  })
   getCachedProfileHeaderMock.mockResolvedValue({
     ...archivedProfile,
     avatar_media_url: null,
@@ -152,5 +172,5 @@ test('strips the archive prefix before the analytical lookup', async () => {
   getClickHouseUserProfileMock.mockResolvedValue(null)
 
   await resolveProfile('archive%3Aalice')
-  expect(getClickHouseUserProfileMock).toHaveBeenCalledWith('alice')
+  expect(getClickHouseUserProfileMock).toHaveBeenCalledWith('42')
 })

--- a/src/lib/metaTwitter/profile.ts
+++ b/src/lib/metaTwitter/profile.ts
@@ -4,7 +4,7 @@ import { cache } from 'react'
 import { getClickHouseUserProfile } from '@/lib/clickhouseUserProfile'
 import {
   getCachedProfileHeader,
-  resolveAccountId,
+  resolvePublicProfileIdentity,
 } from '@/lib/metaTwitter/data'
 import type { ProfileHeaderData } from '@/lib/metaTwitter/types'
 
@@ -19,14 +19,6 @@ const normalizeMediaUrl = (value: string | null | undefined): string | null => {
   return trimmed ? trimmed : null
 }
 
-const analyticalLookupKey = (param: string): string => {
-  try {
-    return decodeURIComponent(param).replace(/^(archive|optin):/, '')
-  } catch {
-    return param
-  }
-}
-
 /**
  * Archive uploads frequently omit profile media, so an account can resolve to a
  * complete-looking archived profile that still renders a placeholder avatar.
@@ -36,7 +28,7 @@ const analyticalLookupKey = (param: string): string => {
  */
 async function withBackfilledMedia(
   profile: ProfileHeaderData,
-  param: string,
+  accountId: string,
 ): Promise<ProfileHeaderData> {
   const avatar = normalizeMediaUrl(profile.avatar_media_url)
   const header = normalizeMediaUrl(profile.header_media_url)
@@ -44,7 +36,7 @@ async function withBackfilledMedia(
     return { ...profile, avatar_media_url: avatar, header_media_url: header }
   }
 
-  const fallback = await getClickHouseUserProfile(analyticalLookupKey(param))
+  const fallback = await getClickHouseUserProfile(accountId)
   return {
     ...profile,
     avatar_media_url:
@@ -60,18 +52,22 @@ async function withBackfilledMedia(
  */
 export const resolveProfile = cache(
   async (param: string): Promise<ResolvedProfile | null> => {
-    const archiveAccountId = await resolveAccountId(param)
-    if (archiveAccountId) {
-      const profile = await getCachedProfileHeader(archiveAccountId)
+    const publicIdentity = await resolvePublicProfileIdentity(param)
+    if (!publicIdentity) return null
+
+    if (publicIdentity.accountId) {
+      const profile = await getCachedProfileHeader(publicIdentity.accountId)
       if (profile) {
         return {
-          accountId: archiveAccountId,
-          profile: await withBackfilledMedia(profile, param),
+          accountId: publicIdentity.accountId,
+          profile: await withBackfilledMedia(profile, publicIdentity.accountId),
         }
       }
     }
 
-    const clickHouseProfile = await getClickHouseUserProfile(param)
+    const clickHouseProfile = await getClickHouseUserProfile(
+      publicIdentity.accountId ?? publicIdentity.username,
+    )
     const accountId = clickHouseProfile?.user.account_id
     if (!clickHouseProfile || !accountId) return null
     const user = clickHouseProfile.user

--- a/supabase/migrations/20260828222205_hide_explicit_optouts_from_user_directory.sql
+++ b/supabase/migrations/20260828222205_hide_explicit_optouts_from_user_directory.sql
@@ -1,75 +1,6 @@
--- Views split from prod.sql (no functional changes)
-
--- public.account moved to 032_views_prereq.sql
-
--- public.enriched_tweets
-CREATE OR REPLACE VIEW "public"."enriched_tweets" WITH (security_invoker = true) AS
- SELECT "t"."tweet_id",
-    "t"."account_id",
-    "a"."username",
-    "a"."account_display_name",
-    "t"."created_at",
-    "t"."full_text",
-    "t"."retweet_count",
-    "t"."favorite_count",
-    "t"."reply_to_tweet_id",
-    "t"."reply_to_user_id",
-    "t"."reply_to_username",
-    "qt"."quoted_tweet_id",
-    "c"."conversation_id",
-    "p"."avatar_media_url",
-    "t"."archive_upload_id"
-   FROM (((("public"."tweets" "t"
-     JOIN "public"."all_account" "a" ON (("t"."account_id" = "a"."account_id")))
-     LEFT JOIN "public"."conversations" "c" ON (("t"."tweet_id" = "c"."tweet_id")))
-     LEFT JOIN "public"."quote_tweets" "qt" ON (("t"."tweet_id" = "qt"."tweet_id")))
-     LEFT JOIN LATERAL ( SELECT "all_profile"."avatar_media_url"
-           FROM "public"."all_profile"
-          WHERE ("all_profile"."account_id" = "t"."account_id")
-          ORDER BY "all_profile"."archive_upload_id" DESC
-         LIMIT 1) "p" ON (true));
-ALTER TABLE "public"."enriched_tweets" OWNER TO "postgres";
-
--- public.global_monthly_tweet_counts
-CREATE OR REPLACE VIEW "public"."global_monthly_tweet_counts" AS
- SELECT "monthly_tweet_counts_mv"."month",
-    "sum"("monthly_tweet_counts_mv"."tweet_count") AS "total_tweets",
-    "count"(DISTINCT "monthly_tweet_counts_mv"."account_id") AS "active_accounts",
-    ("avg"("monthly_tweet_counts_mv"."tweet_count"))::numeric(10,2) AS "avg_tweets_per_account"
-   FROM "public"."monthly_tweet_counts_mv"
-  GROUP BY "monthly_tweet_counts_mv"."month"
-  ORDER BY "monthly_tweet_counts_mv"."month" DESC;
-ALTER TABLE "public"."global_monthly_tweet_counts" OWNER TO "postgres";
-
--- public.profile moved to 032_views_prereq.sql
-
--- public.tweet_replies_view
-CREATE OR REPLACE VIEW "public"."tweet_replies_view" WITH (security_invoker = true) AS
- SELECT "tweets"."reply_to_tweet_id",
-    "tweets"."reply_to_user_id"
-   FROM "public"."tweets"
-  WHERE ("tweets"."reply_to_tweet_id" IS NOT NULL);
-ALTER TABLE "public"."tweet_replies_view" OWNER TO "postgres";
-
--- public.tweets_w_conversation_id
-CREATE OR REPLACE VIEW "public"."tweets_w_conversation_id" WITH (security_invoker = true) AS
- SELECT "tweets"."tweet_id",
-    "tweets"."account_id",
-    "tweets"."created_at",
-    "tweets"."full_text",
-    "tweets"."retweet_count",
-    "tweets"."favorite_count",
-    "tweets"."reply_to_tweet_id",
-    "tweets"."reply_to_user_id",
-    "tweets"."reply_to_username",
-    "tweets"."archive_upload_id",
-    "tweets"."fts",
-    "c"."conversation_id"
-   FROM ("public"."tweets"
-     LEFT JOIN "public"."conversations" "c" ON (("tweets"."tweet_id" = "c"."tweet_id")));
-ALTER TABLE "public"."tweets_w_conversation_id" OWNER TO "postgres";
-
--- public.user_directory
+-- An explicit opt-out is a public-serving deny rule. Apply it inside the shared
+-- directory view so listings, suggestions, and profile membership checks all
+-- fail closed before archived profile data can be returned.
 CREATE OR REPLACE VIEW "public"."user_directory" WITH (security_invoker = true) AS
 WITH archived_members AS (
   SELECT
@@ -207,4 +138,5 @@ opted_in_members AS (
 SELECT * FROM archived_members
 UNION ALL
 SELECT * FROM opted_in_members;
-ALTER TABLE "public"."user_directory" OWNER TO "postgres";
+
+GRANT SELECT ON TABLE "public"."user_directory" TO "readclient";


### PR DESCRIPTION
## Summary
- exclude explicit opt-outs from the canonical user directory by account ID or case-insensitive username
- require a fresh public-membership lookup before loading PostgreSQL or ClickHouse profile data
- keep the declarative schema and migration history aligned

## Validation
- focused profile/data resolver tests: 10 passed
- TypeScript compile: passed
- standalone PostgreSQL fixture query: only active archive and active opt-in rows remained; ID, username, and conflicting duplicate opt-outs were excluded
- GitHub PR workflow, Supabase preview, staging sync, and Vercel preview: passed

## Deployment note
The Supabase migration must land before the app change so the new fail-closed profile lookup sees the corrected directory view.