### PR TITLE
Add searchable Settings deletion controls

### DIFF
--- a/src/app/profile/ProfileContent.test.tsx
+++ b/src/app/profile/ProfileContent.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import ProfileContent from './ProfileContent'
 
@@ -8,6 +8,28 @@ const originalFetch = global.fetch
 const mockLogInsert = jest.fn().mockResolvedValue({ error: null })
 const mockRpc = jest.fn()
 const mockUpdateDownloadArchiveVisibility = jest.fn()
+const mockTweetRange = jest.fn()
+const mockTweetTextSearch = jest.fn()
+const mockTweetQuery: Record<string, jest.Mock> = {}
+
+mockTweetQuery.select = jest.fn(() => mockTweetQuery)
+mockTweetQuery.eq = jest.fn(() => mockTweetQuery)
+mockTweetQuery.order = jest.fn(() => mockTweetQuery)
+mockTweetQuery.textSearch = mockTweetTextSearch.mockImplementation(
+  () => mockTweetQuery,
+)
+mockTweetQuery.range = mockTweetRange
+
+class IntersectionObserverMock {
+  static instances: IntersectionObserverMock[] = []
+
+  observe = jest.fn()
+  disconnect = jest.fn()
+
+  constructor(readonly callback: IntersectionObserverCallback) {
+    IntersectionObserverMock.instances.push(this)
+  }
+}
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ refresh: jest.fn() }),
@@ -21,7 +43,8 @@ jest.mock('@/hooks/useAuthAndArchive', () => ({
 
 jest.mock('@/utils/supabase', () => ({
   createBrowserClient: () => ({
-    from: () => ({ insert: mockLogInsert }),
+    from: (table: string) =>
+      table === 'tweets' ? mockTweetQuery : { insert: mockLogInsert },
     rpc: mockRpc,
     storage: { from: jest.fn() },
   }),
@@ -53,8 +76,12 @@ const user = {
 describe('ProfileContent opt-in preference', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    IntersectionObserverMock.instances = []
+    global.IntersectionObserver =
+      IntersectionObserverMock as unknown as typeof IntersectionObserver
     global.fetch = mockFetch
     mockUpdateDownloadArchiveVisibility.mockResolvedValue({ ok: true })
+    mockTweetRange.mockResolvedValue({ data: [], error: null })
   })
 
   afterAll(() => {
@@ -180,5 +207,133 @@ describe('ProfileContent opt-in preference', () => {
     )
     expect(await screen.findByText('Tweet deleted permanently')).toBeVisible()
     expect(screen.queryByText('A tweet I can remove')).not.toBeInTheDocument()
+  })
+
+  it('deletes only the owner like associations', async () => {
+    const interaction = userEvent.setup()
+    jest.spyOn(window, 'confirm').mockReturnValue(true)
+    mockRpc.mockResolvedValue({ data: 12, error: null })
+
+    render(
+      <ProfileContent
+        user={user}
+        accountId="twitter-123"
+        initialOptInData={null}
+        archives={[]}
+      />,
+    )
+
+    await interaction.click(screen.getByRole('tab', { name: 'My Tweets' }))
+    await interaction.click(
+      screen.getByRole('button', { name: 'Delete all likes' }),
+    )
+
+    await waitFor(() =>
+      expect(mockRpc).toHaveBeenCalledWith('delete_own_likes'),
+    )
+    expect(
+      await screen.findByText('12 likes were removed from your account'),
+    ).toBeVisible()
+  })
+
+  it('uses full-text search and replaces the visible tweet page', async () => {
+    const interaction = userEvent.setup()
+    mockTweetRange.mockResolvedValue({
+      data: [
+        {
+          tweet_id: 'search-result',
+          created_at: '2026-08-14T00:00:00.000Z',
+          full_text: 'The matching archival tweet',
+          favorite_count: 1,
+          retweet_count: 0,
+        },
+      ],
+      error: null,
+    })
+
+    render(
+      <ProfileContent
+        user={user}
+        accountId="twitter-123"
+        initialOptInData={null}
+        archives={[]}
+        initialTweets={[
+          {
+            tweet_id: 'initial',
+            created_at: '2026-08-15T00:00:00.000Z',
+            full_text: 'Initial recent tweet',
+            favorite_count: 0,
+            retweet_count: 0,
+          },
+        ]}
+      />,
+    )
+
+    await interaction.click(screen.getByRole('tab', { name: 'My Tweets' }))
+    await interaction.type(
+      screen.getByRole('searchbox', { name: 'Search your tweets' }),
+      'matching archival',
+    )
+
+    await waitFor(() =>
+      expect(mockTweetTextSearch).toHaveBeenCalledWith(
+        'fts',
+        'matching archival',
+        { config: 'english', type: 'websearch' },
+      ),
+    )
+    expect(mockTweetRange).toHaveBeenCalledWith(0, 10)
+    expect(await screen.findByText('The matching archival tweet')).toBeVisible()
+    expect(screen.queryByText('Initial recent tweet')).not.toBeInTheDocument()
+  })
+
+  it('loads the next ten tweets when the scroll sentinel intersects', async () => {
+    const interaction = userEvent.setup()
+    const initialTweets = Array.from({ length: 10 }, (_, index) => ({
+      tweet_id: `initial-${index}`,
+      created_at: `2026-08-${String(20 - index).padStart(2, '0')}T00:00:00.000Z`,
+      full_text: `Initial tweet ${index}`,
+      favorite_count: 0,
+      retweet_count: 0,
+    }))
+    mockTweetRange.mockResolvedValue({
+      data: [
+        {
+          tweet_id: 'next-page',
+          created_at: '2026-08-01T00:00:00.000Z',
+          full_text: 'Tweet from the next page',
+          favorite_count: 0,
+          retweet_count: 0,
+        },
+      ],
+      error: null,
+    })
+
+    render(
+      <ProfileContent
+        user={user}
+        accountId="twitter-123"
+        initialOptInData={null}
+        archives={[]}
+        initialTweets={initialTweets}
+        initialTweetsHaveMore
+      />,
+    )
+
+    await interaction.click(screen.getByRole('tab', { name: 'My Tweets' }))
+    await waitFor(() =>
+      expect(IntersectionObserverMock.instances).toHaveLength(1),
+    )
+
+    const observer = IntersectionObserverMock.instances[0]
+    await act(async () => {
+      observer.callback(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        observer as unknown as IntersectionObserver,
+      )
+    })
+
+    await waitFor(() => expect(mockTweetRange).toHaveBeenCalledWith(10, 20))
+    expect(await screen.findByText('Tweet from the next page')).toBeVisible()
   })
 })

--- a/src/app/profile/ProfileContent.tsx
+++ b/src/app/profile/ProfileContent.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { User } from '@supabase/supabase-js'
 import { Button } from '@/components/ui/button'
 import {
@@ -13,6 +13,7 @@ import {
 import { Switch } from '@/components/ui/switch'
 import { Label } from '@/components/ui/label'
 import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Input } from '@/components/ui/input'
 import {
   Dialog,
   DialogContent,
@@ -21,7 +22,16 @@ import {
   DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog'
-import { AlertCircle, Archive, Trash2, UserX, CheckCircle } from 'lucide-react'
+import {
+  AlertCircle,
+  Archive,
+  CheckCircle,
+  HeartOff,
+  Loader2,
+  Search,
+  Trash2,
+  UserX,
+} from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { createBrowserClient } from '@/utils/supabase'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -33,6 +43,7 @@ import { ArchiveUploadButton } from '@/components/ArchiveUploadButton'
 import { capturePostHogEvent } from '@/lib/posthog'
 import { updateOptIn } from '@/lib/optInApi'
 import { updateDownloadArchiveVisibility } from '@/app/user/[account_id]/actions'
+import { OWN_TWEETS_PAGE_SIZE, type OwnTweet } from '@/lib/ownTweetDeletion'
 
 interface ProfileContentProps {
   user: User
@@ -40,13 +51,8 @@ interface ProfileContentProps {
   initialDownloadArchiveVisible?: boolean
   initialOptInData: any
   archives: any[]
-  initialTweets?: Array<{
-    tweet_id: string
-    created_at: string
-    full_text: string
-    favorite_count: number | null
-    retweet_count: number | null
-  }>
+  initialTweets?: OwnTweet[]
+  initialTweetsHaveMore?: boolean
 }
 
 export default function ProfileContent({
@@ -56,6 +62,7 @@ export default function ProfileContent({
   initialOptInData,
   archives,
   initialTweets = [],
+  initialTweetsHaveMore = false,
 }: ProfileContentProps) {
   const router = useRouter()
   const { userMetadata } = useAuthAndArchive()
@@ -74,10 +81,23 @@ export default function ProfileContent({
   const [success, setSuccess] = useState<string | null>(null)
   const [deletingArchive, setDeletingArchive] = useState<string | null>(null)
   const [deletingTweetId, setDeletingTweetId] = useState<string | null>(null)
+  const [deletingLikes, setDeletingLikes] = useState(false)
   const [ownTweets, setOwnTweets] = useState(initialTweets)
+  const [tweetSearch, setTweetSearch] = useState('')
+  const [debouncedTweetSearch, setDebouncedTweetSearch] = useState('')
+  const [loadingTweets, setLoadingTweets] = useState(false)
+  const [loadingMoreTweets, setLoadingMoreTweets] = useState(false)
+  const [hasMoreTweets, setHasMoreTweets] = useState(initialTweetsHaveMore)
+  const [nextTweetOffset, setNextTweetOffset] = useState(initialTweets.length)
+  const [activeTab, setActiveTab] = useState('privacy')
   const [showDeleteAllDialog, setShowDeleteAllDialog] = useState(false)
   const [showOptOutDialog, setShowOptOutDialog] = useState(false)
-  const supabase = createBrowserClient()
+  const [supabase] = useState(createBrowserClient)
+  const [loadMoreTweetsTarget, setLoadMoreTweetsTarget] =
+    useState<HTMLDivElement | null>(null)
+  const tweetLoadMoreInFlightRef = useRef(false)
+  const tweetRequestVersionRef = useRef(0)
+  const skipInitialTweetLoadRef = useRef(true)
 
   const twitterUsername =
     userMetadata?.user_name ||
@@ -375,6 +395,194 @@ export default function ProfileContent({
     }
   }
 
+  const fetchOwnTweets = useCallback(
+    async (search: string, offset: number) => {
+      if (!accountId) return { tweets: [] as OwnTweet[], hasMore: false }
+
+      let query = supabase
+        .from('tweets')
+        .select(
+          'tweet_id, created_at, full_text, favorite_count, retweet_count',
+        )
+        .eq('account_id', accountId)
+        .order('created_at', { ascending: false })
+        .order('tweet_id', { ascending: false })
+
+      const normalizedSearch = search.trim()
+      if (normalizedSearch) {
+        query = query.textSearch('fts', normalizedSearch, {
+          config: 'english',
+          type: 'websearch',
+        })
+      }
+
+      const { data, error: tweetsError } = await query.range(
+        offset,
+        offset + OWN_TWEETS_PAGE_SIZE,
+      )
+      if (tweetsError) throw tweetsError
+
+      const rows = data || []
+      return {
+        tweets: rows.slice(0, OWN_TWEETS_PAGE_SIZE),
+        hasMore: rows.length > OWN_TWEETS_PAGE_SIZE,
+      }
+    },
+    [accountId, supabase],
+  )
+
+  useEffect(() => {
+    const timer = window.setTimeout(
+      () => setDebouncedTweetSearch(tweetSearch),
+      300,
+    )
+    return () => window.clearTimeout(timer)
+  }, [tweetSearch])
+
+  useEffect(() => {
+    if (skipInitialTweetLoadRef.current) {
+      skipInitialTweetLoadRef.current = false
+      return
+    }
+
+    let isCurrentRequest = true
+    const requestVersion = ++tweetRequestVersionRef.current
+
+    const reloadTweets = async () => {
+      setLoadingTweets(true)
+      setError(null)
+      try {
+        const page = await fetchOwnTweets(debouncedTweetSearch, 0)
+        if (
+          !isCurrentRequest ||
+          requestVersion !== tweetRequestVersionRef.current
+        ) {
+          return
+        }
+        setOwnTweets(page.tweets)
+        setHasMoreTweets(page.hasMore)
+        setNextTweetOffset(page.tweets.length)
+      } catch (err: any) {
+        if (!isCurrentRequest) return
+        setError(err.message || 'Failed to search your tweets')
+      } finally {
+        if (isCurrentRequest) setLoadingTweets(false)
+      }
+    }
+
+    void reloadTweets()
+    return () => {
+      isCurrentRequest = false
+    }
+  }, [debouncedTweetSearch, fetchOwnTweets])
+
+  const loadMoreTweets = useCallback(async () => {
+    if (
+      loadingTweets ||
+      loadingMoreTweets ||
+      !hasMoreTweets ||
+      tweetLoadMoreInFlightRef.current
+    ) {
+      return
+    }
+
+    const requestVersion = tweetRequestVersionRef.current
+    const offset = nextTweetOffset
+    tweetLoadMoreInFlightRef.current = true
+    setLoadingMoreTweets(true)
+    setError(null)
+
+    try {
+      const page = await fetchOwnTweets(debouncedTweetSearch, offset)
+      if (requestVersion !== tweetRequestVersionRef.current) return
+
+      setOwnTweets((currentTweets) => {
+        const existingIds = new Set(
+          currentTweets.map((tweet) => tweet.tweet_id),
+        )
+        return [
+          ...currentTweets,
+          ...page.tweets.filter((tweet) => !existingIds.has(tweet.tweet_id)),
+        ]
+      })
+      setHasMoreTweets(page.hasMore)
+      setNextTweetOffset(offset + page.tweets.length)
+    } catch (err: any) {
+      setError(err.message || 'Failed to load more tweets')
+    } finally {
+      tweetLoadMoreInFlightRef.current = false
+      setLoadingMoreTweets(false)
+    }
+  }, [
+    debouncedTweetSearch,
+    fetchOwnTweets,
+    hasMoreTweets,
+    loadingMoreTweets,
+    loadingTweets,
+    nextTweetOffset,
+  ])
+
+  useEffect(() => {
+    if (
+      activeTab !== 'tweets' ||
+      !loadMoreTweetsTarget ||
+      !hasMoreTweets ||
+      loadingTweets ||
+      loadingMoreTweets
+    ) {
+      return
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) void loadMoreTweets()
+      },
+      { rootMargin: '300px 0px' },
+    )
+    observer.observe(loadMoreTweetsTarget)
+    return () => observer.disconnect()
+  }, [
+    activeTab,
+    hasMoreTweets,
+    loadMoreTweetsTarget,
+    loadMoreTweets,
+    loadingMoreTweets,
+    loadingTweets,
+  ])
+
+  const handleDeleteLikes = async () => {
+    if (
+      !confirm(
+        'Delete all records that link your account to tweets you liked? The archived tweet text will remain. This cannot be undone.',
+      )
+    ) {
+      return
+    }
+
+    setDeletingLikes(true)
+    setError(null)
+    setSuccess(null)
+
+    try {
+      const { data, error: deleteError } =
+        await supabase.rpc('delete_own_likes')
+      if (deleteError) throw deleteError
+
+      const deletedLikes = data || 0
+      setSuccess(
+        `${deletedLikes} ${deletedLikes === 1 ? 'like was' : 'likes were'} removed from your account`,
+      )
+      capturePostHogEvent('own_likes_deleted', {
+        deleted_like_count: deletedLikes,
+      })
+      await logUserAction('delete_likes', { deleted_likes: deletedLikes })
+    } catch (err: any) {
+      setError(err.message || 'Failed to delete likes')
+    } finally {
+      setDeletingLikes(false)
+    }
+  }
+
   const handleDeleteTweet = async (tweetId: string) => {
     if (
       !confirm(
@@ -401,6 +609,7 @@ export default function ProfileContent({
       setOwnTweets((tweets) =>
         tweets.filter((tweet) => tweet.tweet_id !== tweetId),
       )
+      setNextTweetOffset((offset) => Math.max(0, offset - 1))
       setSuccess('Tweet deleted permanently')
       capturePostHogEvent('own_tweet_deleted')
       await logUserAction('delete_tweet', { tweet_id: tweetId })
@@ -433,11 +642,12 @@ export default function ProfileContent({
       </Card>
 
       <Tabs
-        defaultValue="privacy"
+        value={activeTab}
         className="w-full"
-        onValueChange={(tab) =>
+        onValueChange={(tab) => {
+          setActiveTab(tab)
           capturePostHogEvent('settings_tab_selected', { tab })
-        }
+        }}
       >
         <TabsList className="grid w-full grid-cols-3">
           <TabsTrigger value="privacy">Privacy Settings</TabsTrigger>
@@ -646,50 +856,115 @@ export default function ProfileContent({
         <TabsContent value="tweets" className="space-y-4">
           <Card>
             <CardHeader>
-              <CardTitle>Your Tweets</CardTitle>
+              <CardTitle>Delete Tweets and Likes</CardTitle>
               <CardDescription>
-                Permanently remove individual tweets from your archive. The most
-                recent 100 tweets are shown.
+                Permanently remove individual tweets or unlink your likes from
+                your account.
               </CardDescription>
             </CardHeader>
-            <CardContent>
-              {ownTweets.length === 0 ? (
+            <CardContent className="space-y-6">
+              <div className="flex flex-col justify-between gap-4 rounded-lg border p-4 sm:flex-row sm:items-center">
+                <div className="space-y-1">
+                  <p className="font-medium">Delete your likes</p>
+                  <p className="text-sm text-muted-foreground">
+                    Removes only the links between your account and tweets you
+                    liked. Archived tweet text remains available.
+                  </p>
+                </div>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  className="flex-shrink-0"
+                  onClick={handleDeleteLikes}
+                  disabled={deletingLikes || !accountId}
+                >
+                  <HeartOff className="mr-2 h-4 w-4" />
+                  {deletingLikes ? 'Deleting...' : 'Delete all likes'}
+                </Button>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="tweet-deletion-search">
+                  Search your tweets
+                </Label>
+                <div className="relative">
+                  <Search
+                    aria-hidden="true"
+                    className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+                  />
+                  <Input
+                    id="tweet-deletion-search"
+                    type="search"
+                    value={tweetSearch}
+                    onChange={(event) => setTweetSearch(event.target.value)}
+                    placeholder="Search the full text of your tweets"
+                    className="pl-9"
+                  />
+                </div>
+              </div>
+
+              {loadingTweets ? (
+                <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Searching tweets...
+                </div>
+              ) : ownTweets.length === 0 ? (
                 <div className="py-8 text-center text-muted-foreground">
-                  No archived tweets found.
+                  {debouncedTweetSearch
+                    ? 'No tweets match your search.'
+                    : 'No archived tweets found.'}
                 </div>
               ) : (
-                <div className="divide-y rounded-lg border">
-                  {ownTweets.map((tweet) => (
-                    <div
-                      key={tweet.tweet_id}
-                      className="flex items-start justify-between gap-4 p-4"
-                    >
-                      <div className="min-w-0 space-y-2">
-                        <p className="whitespace-pre-wrap break-words text-sm">
-                          {tweet.full_text}
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          {new Date(tweet.created_at).toLocaleDateString()} ·{' '}
-                          {tweet.favorite_count || 0} likes ·{' '}
-                          {tweet.retweet_count || 0} reposts
-                        </p>
-                      </div>
-                      <Button
-                        variant="destructive"
-                        size="sm"
-                        className="flex-shrink-0"
-                        onClick={() => handleDeleteTweet(tweet.tweet_id)}
-                        disabled={deletingTweetId !== null}
-                        aria-label={`Delete tweet ${tweet.tweet_id}`}
+                <>
+                  <div className="divide-y rounded-lg border">
+                    {ownTweets.map((tweet) => (
+                      <div
+                        key={tweet.tweet_id}
+                        className="flex items-start justify-between gap-4 p-4"
                       >
-                        <Trash2 className="mr-2 h-4 w-4" />
-                        {deletingTweetId === tweet.tweet_id
-                          ? 'Deleting...'
-                          : 'Delete'}
-                      </Button>
+                        <div className="min-w-0 space-y-2">
+                          <p className="whitespace-pre-wrap break-words text-sm">
+                            {tweet.full_text}
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            {new Date(tweet.created_at).toLocaleDateString()} ·{' '}
+                            {tweet.favorite_count || 0} likes ·{' '}
+                            {tweet.retweet_count || 0} reposts
+                          </p>
+                        </div>
+                        <Button
+                          variant="destructive"
+                          size="sm"
+                          className="flex-shrink-0"
+                          onClick={() => handleDeleteTweet(tweet.tweet_id)}
+                          disabled={deletingTweetId !== null}
+                          aria-label={`Delete tweet ${tweet.tweet_id}`}
+                        >
+                          <Trash2 className="mr-2 h-4 w-4" />
+                          {deletingTweetId === tweet.tweet_id
+                            ? 'Deleting...'
+                            : 'Delete'}
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                  {hasMoreTweets ? (
+                    <div
+                      ref={setLoadMoreTweetsTarget}
+                      className="min-h-12 flex items-center justify-center gap-2 text-sm text-muted-foreground"
+                      aria-live="polite"
+                    >
+                      {loadingMoreTweets ? (
+                        <>
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                          Loading more tweets...
+                        </>
+                      ) : (
+                        'Scroll to load more'
+                      )}
                     </div>
-                  ))}
-                </div>
+                  ) : null}
+                </>
               )}
             </CardContent>
           </Card>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -6,6 +6,7 @@ import { createServerAdminClient, createServerClient } from '@/utils/supabase'
 import { cookies } from 'next/headers'
 import ProfileContent from '../profile/ProfileContent'
 import { CommunitySubmissionQueue } from './CommunitySubmissionQueue'
+import { OWN_TWEETS_PAGE_SIZE } from '@/lib/ownTweetDeletion'
 
 const getTwitterUsername = (
   user: Awaited<ReturnType<typeof requireAuth>>['user'],
@@ -80,7 +81,8 @@ export default async function SettingsPage() {
           )
           .eq('account_id', twitterAccountId)
           .order('created_at', { ascending: false })
-          .limit(100)
+          .order('tweet_id', { ascending: false })
+          .limit(OWN_TWEETS_PAGE_SIZE + 1)
       : Promise.resolve({ data: [], error: null }),
     twitterAccountId
       ? getPublicProfileSettings(twitterAccountId)
@@ -106,7 +108,13 @@ export default async function SettingsPage() {
           initialDownloadArchiveVisible={settings.downloadArchiveVisible}
           initialOptInData={optInResponse.data}
           archives={archivesResponse.data || []}
-          initialTweets={tweetsResponse.data || []}
+          initialTweets={(tweetsResponse.data || []).slice(
+            0,
+            OWN_TWEETS_PAGE_SIZE,
+          )}
+          initialTweetsHaveMore={
+            (tweetsResponse.data?.length || 0) > OWN_TWEETS_PAGE_SIZE
+          }
         />
       </div>
     </main>

--- a/src/database-types.ts
+++ b/src/database-types.ts
@@ -242,43 +242,6 @@ export type Database = {
           },
         ]
       }
-      conversations: {
-        Row: {
-          conversation_id: string | null
-          tweet_id: string
-        }
-        Insert: {
-          conversation_id?: string | null
-          tweet_id: string
-        }
-        Update: {
-          conversation_id?: string | null
-          tweet_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "conversations_tweet_id_fkey"
-            columns: ["tweet_id"]
-            isOneToOne: true
-            referencedRelation: "enriched_tweets"
-            referencedColumns: ["tweet_id"]
-          },
-          {
-            foreignKeyName: "conversations_tweet_id_fkey"
-            columns: ["tweet_id"]
-            isOneToOne: true
-            referencedRelation: "tweets"
-            referencedColumns: ["tweet_id"]
-          },
-          {
-            foreignKeyName: "conversations_tweet_id_fkey"
-            columns: ["tweet_id"]
-            isOneToOne: true
-            referencedRelation: "tweets_w_conversation_id"
-            referencedColumns: ["tweet_id"]
-          },
-        ]
-      }
       community_projects: {
         Row: {
           archive_use: string
@@ -347,6 +310,43 @@ export type Database = {
           tags?: string[]
         }
         Relationships: []
+      }
+      conversations: {
+        Row: {
+          conversation_id: string | null
+          tweet_id: string
+        }
+        Insert: {
+          conversation_id?: string | null
+          tweet_id: string
+        }
+        Update: {
+          conversation_id?: string | null
+          tweet_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "conversations_tweet_id_fkey"
+            columns: ["tweet_id"]
+            isOneToOne: true
+            referencedRelation: "enriched_tweets"
+            referencedColumns: ["tweet_id"]
+          },
+          {
+            foreignKeyName: "conversations_tweet_id_fkey"
+            columns: ["tweet_id"]
+            isOneToOne: true
+            referencedRelation: "tweets"
+            referencedColumns: ["tweet_id"]
+          },
+          {
+            foreignKeyName: "conversations_tweet_id_fkey"
+            columns: ["tweet_id"]
+            isOneToOne: true
+            referencedRelation: "tweets_w_conversation_id"
+            referencedColumns: ["tweet_id"]
+          },
+        ]
       }
       digest_editions: {
         Row: {
@@ -2436,3 +2436,4 @@ export type CompositeTypes<
   : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
     ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never
+

--- a/src/database-types.ts
+++ b/src/database-types.ts
@@ -1658,6 +1658,10 @@ export type Database = {
           deleted_private_tweet_user: number
         }[]
       }
+      delete_own_likes: {
+        Args: Record<PropertyKey, never>
+        Returns: number
+      }
       delete_own_tweets: {
         Args: {
           p_tweet_ids: string[]

--- a/src/lib/ownTweetDeletion.ts
+++ b/src/lib/ownTweetDeletion.ts
@@ -1,0 +1,9 @@
+export const OWN_TWEETS_PAGE_SIZE = 10
+
+export interface OwnTweet {
+  tweet_id: string
+  created_at: string
+  full_text: string
+  favorite_count: number | null
+  retweet_count: number | null
+}

--- a/supabase/migrations/20260828170444_delete_own_likes.sql
+++ b/supabase/migrations/20260828170444_delete_own_likes.sql
@@ -1,0 +1,42 @@
+-- Let an authenticated member remove only the associations between their X
+-- account and liked tweets. The shared liked_tweets content table is
+-- intentionally left untouched.
+
+CREATE OR REPLACE FUNCTION public.delete_own_likes()
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET statement_timeout = '30s'
+SET search_path = ''
+AS $$
+DECLARE
+  v_provider_id text;
+  v_deleted_likes bigint;
+BEGIN
+  v_provider_id := nullif(auth.jwt()->'app_metadata'->>'provider_id', '');
+
+  IF auth.uid() IS NULL OR v_provider_id IS NULL THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '42501',
+      MESSAGE = 'A linked Twitter account is required';
+  END IF;
+
+  WITH deleted AS (
+    DELETE FROM public.likes
+    WHERE account_id = v_provider_id
+    RETURNING 1
+  )
+  SELECT count(*) INTO v_deleted_likes FROM deleted;
+
+  RETURN v_deleted_likes;
+END;
+$$;
+
+ALTER FUNCTION public.delete_own_likes() OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.delete_own_likes() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.delete_own_likes() FROM anon;
+GRANT EXECUTE ON FUNCTION public.delete_own_likes() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.delete_own_likes() TO service_role;
+
+COMMENT ON FUNCTION public.delete_own_likes() IS
+  'Deletes likes owned by the authenticated Twitter account without deleting shared liked_tweets content.';

--- a/supabase/schemas/070_functions.sql
+++ b/supabase/schemas/070_functions.sql
@@ -1348,6 +1348,43 @@ GRANT EXECUTE ON FUNCTION "public"."delete_own_tweets"("p_tweet_ids" "text"[]) T
 COMMENT ON FUNCTION "public"."delete_own_tweets"("p_tweet_ids" "text"[]) IS 'Deletes up to 100 tweets only when every ID belongs to the authenticated Twitter account in app_metadata.provider_id.';
 
 
+CREATE OR REPLACE FUNCTION "public"."delete_own_likes"() RETURNS bigint
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "statement_timeout" TO '30s'
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+  v_provider_id text;
+  v_deleted_likes bigint;
+BEGIN
+  v_provider_id := nullif(auth.jwt()->'app_metadata'->>'provider_id', '');
+
+  IF auth.uid() IS NULL OR v_provider_id IS NULL THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '42501',
+      MESSAGE = 'A linked Twitter account is required';
+  END IF;
+
+  WITH deleted AS (
+    DELETE FROM public.likes
+    WHERE account_id = v_provider_id
+    RETURNING 1
+  )
+  SELECT count(*) INTO v_deleted_likes FROM deleted;
+
+  RETURN v_deleted_likes;
+END;
+$$;
+
+ALTER FUNCTION "public"."delete_own_likes"() OWNER TO "postgres";
+REVOKE ALL ON FUNCTION "public"."delete_own_likes"() FROM PUBLIC;
+REVOKE ALL ON FUNCTION "public"."delete_own_likes"() FROM "anon";
+GRANT EXECUTE ON FUNCTION "public"."delete_own_likes"() TO "authenticated";
+GRANT EXECUTE ON FUNCTION "public"."delete_own_likes"() TO "service_role";
+
+COMMENT ON FUNCTION "public"."delete_own_likes"() IS 'Deletes likes owned by the authenticated Twitter account without deleting shared liked_tweets content.';
+
+
 CREATE OR REPLACE FUNCTION "public"."delete_user_archive"("p_account_id" "text") RETURNS "void"
     LANGUAGE "plpgsql" SECURITY DEFINER
     SET "statement_timeout" TO '20min'


### PR DESCRIPTION
## Summary
- add an owner-scoped action to remove rows from public.likes without deleting public.liked_tweets content
- load the Settings tweet deletion list in pages of 10 with infinite scroll
- add indexed full-text search across the owner tweet list
- cover like deletion, search, and scroll pagination in the focused component tests

## Validation
- pnpm type-check
- pnpm exec jest --selectProjects client --runTestsByPath src/app/profile/ProfileContent.test.tsx --runInBand
- static SQL contract check confirms the function targets public.likes and never deletes from public.liked_tweets

## Migration
This PR adds a Supabase migration. The staging sync workflow should apply it and regenerate database types after push. Production migration is still required before merge/deploy; run the documented migrations:check flow.