### PR TITLE
Show tweet fallback on sparse profiles

### DIFF
--- a/src/app/user/[account_id]/page.tsx
+++ b/src/app/user/[account_id]/page.tsx
@@ -75,6 +75,7 @@ async function SparseProfileTweets({
   return (
     <ProfileTweetFallback
       avatarUrl={avatarUrl}
+      className="order-2 min-w-0 xl:col-start-1 xl:row-start-2"
       displayName={displayName}
       engagedTweets={withoutBangers(engaged.tweets)}
       recentTweets={withoutBangers(recent.tweets)}
@@ -144,27 +145,29 @@ async function ProfileArchiveContent({
   const navChapters: NavChapter[] = initialPage.yearCounts
 
   return (
-    <>
-      <ProfileArchive
-        accountId={accountId}
-        avatarUrl={avatarUrl}
-        basePath={basePath}
-        chapters={navChapters}
-        displayName={displayName}
-        initialYear={year}
-        initialPage={initialPage}
-      />
-      <Suspense fallback={null}>
-        <SparseProfileTweets
-          accountId={accountId}
-          avatarUrl={avatarUrl}
-          basePath={basePath}
-          displayName={displayName}
-          initialPage={initialPage}
-          initialYear={year}
-        />
-      </Suspense>
-    </>
+    <ProfileArchive
+      accountId={accountId}
+      avatarUrl={avatarUrl}
+      basePath={basePath}
+      chapters={navChapters}
+      displayName={displayName}
+      initialYear={year}
+      initialPage={initialPage}
+      supplementalTweets={
+        needsProfileTweetFallback(initialPage, year) ? (
+          <Suspense fallback={null}>
+            <SparseProfileTweets
+              accountId={accountId}
+              avatarUrl={avatarUrl}
+              basePath={basePath}
+              displayName={displayName}
+              initialPage={initialPage}
+              initialYear={year}
+            />
+          </Suspense>
+        ) : null
+      }
+    />
   )
 }
 

--- a/src/app/user/[account_id]/page.tsx
+++ b/src/app/user/[account_id]/page.tsx
@@ -4,6 +4,7 @@ import { notFound, redirect } from 'next/navigation'
 import { ProfileHeader } from '@/components/metaTwitter/ProfileHeader'
 import type { NavChapter } from '@/components/metaTwitter/ArchiveNav'
 import { ProfileArchive } from '@/components/metaTwitter/ProfileArchive'
+import { ProfileTweetFallback } from '@/components/metaTwitter/ProfileTweetFallback'
 import { ProfileArchiveSkeleton } from '@/components/metaTwitter/ProfilePageSkeleton'
 import { ProfileEditingProvider } from '@/components/metaTwitter/ProfileEditingContext'
 import { userProfileHref } from '@/lib/navigation'
@@ -14,14 +15,72 @@ import {
 import { getAuthenticatedAccountId } from '@/lib/authenticatedAccount'
 import {
   PROFILE_BANGERS_INITIAL_LIMIT,
+  needsProfileTweetFallback,
   resolveProfileChapterYear,
+  type ProfileBangersPageState,
 } from '@/lib/metaTwitter/profilePagination'
 import { getCachedArchivedAt } from '@/lib/metaTwitter/data'
 import { resolveProfile } from '@/lib/metaTwitter/profile'
+import { getProfileTweets } from '@/lib/metaTwitter/profileTweets'
+import type { ProfileTweet } from '@/lib/metaTwitter/types'
 
 interface PageProps {
   params: { account_id: string }
   searchParams: { chapter?: string; username?: string }
+}
+
+async function SparseProfileTweets({
+  accountId,
+  avatarUrl,
+  basePath,
+  displayName,
+  initialPage,
+  initialYear,
+}: {
+  accountId: string
+  avatarUrl: string | null
+  basePath: string
+  displayName: string
+  initialPage: ProfileBangersPageState
+  initialYear: number | null
+}) {
+  let sparseOverallPage = initialPage
+  const mayNeedFallback = needsProfileTweetFallback(initialPage, initialYear)
+
+  if (mayNeedFallback && initialYear !== null) {
+    sparseOverallPage = await getCuratedProfileBangersPage(accountId, {
+      limit: PROFILE_BANGERS_INITIAL_LIMIT,
+    })
+  }
+
+  if (
+    !sparseOverallPage.available ||
+    sparseOverallPage.total >= PROFILE_BANGERS_INITIAL_LIMIT
+  ) {
+    return null
+  }
+
+  const [engaged, recent] = await Promise.all([
+    getProfileTweets(accountId, 'engagement'),
+    getProfileTweets(accountId, 'recent'),
+  ])
+  if (!engaged.available && !recent.available) return null
+
+  const bangerIds = new Set(
+    sparseOverallPage.tweets.map((tweet) => tweet.tweet_id),
+  )
+  const withoutBangers = (tweets: ProfileTweet[]) =>
+    tweets.filter((tweet) => !bangerIds.has(tweet.tweet_id))
+
+  return (
+    <ProfileTweetFallback
+      avatarUrl={avatarUrl}
+      displayName={displayName}
+      engagedTweets={withoutBangers(engaged.tweets)}
+      recentTweets={withoutBangers(recent.tweets)}
+      returnTo={basePath}
+    />
+  )
 }
 
 export async function generateMetadata({
@@ -85,15 +144,27 @@ async function ProfileArchiveContent({
   const navChapters: NavChapter[] = initialPage.yearCounts
 
   return (
-    <ProfileArchive
-      accountId={accountId}
-      avatarUrl={avatarUrl}
-      basePath={basePath}
-      chapters={navChapters}
-      displayName={displayName}
-      initialYear={year}
-      initialPage={initialPage}
-    />
+    <>
+      <ProfileArchive
+        accountId={accountId}
+        avatarUrl={avatarUrl}
+        basePath={basePath}
+        chapters={navChapters}
+        displayName={displayName}
+        initialYear={year}
+        initialPage={initialPage}
+      />
+      <Suspense fallback={null}>
+        <SparseProfileTweets
+          accountId={accountId}
+          avatarUrl={avatarUrl}
+          basePath={basePath}
+          displayName={displayName}
+          initialPage={initialPage}
+          initialYear={year}
+        />
+      </Suspense>
+    </>
   )
 }
 

--- a/src/components/metaTwitter/ProfileArchive.tsx
+++ b/src/components/metaTwitter/ProfileArchive.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
 import { ArchiveNav, archiveChapterHref, type NavChapter } from './ArchiveNav'
 import { Workspace } from './Workspace'
 import {
@@ -78,6 +78,7 @@ export function ProfileArchive({
   initialYear,
   initialPage,
   initialSidebar,
+  supplementalTweets,
 }: {
   accountId: string
   avatarUrl: string | null
@@ -87,6 +88,7 @@ export function ProfileArchive({
   initialYear: number | null
   initialPage: ProfileBangersPageState
   initialSidebar?: SidebarData
+  supplementalTweets?: ReactNode
 }) {
   const initialFeedKey = feedKey(initialYear, 'quotes')
   const initialScopeKey = scopeKey(initialYear)
@@ -840,6 +842,7 @@ export function ProfileArchive({
         onLoadMore={() => void loadMore()}
         loadMoreRef={loadMoreRef}
         returnTo={returnTo}
+        supplementalTweets={supplementalTweets}
         editing={editing && activeYear === null}
         editSaving={editSaving}
         editError={editError}

--- a/src/components/metaTwitter/ProfileTweetFallback.test.tsx
+++ b/src/components/metaTwitter/ProfileTweetFallback.test.tsx
@@ -36,6 +36,7 @@ test('starts with most engaged tweets and can switch to recent tweets', async ()
   render(
     <ProfileTweetFallback
       avatarUrl={null}
+      className="order-2"
       displayName="Alice"
       engagedTweets={[tweet('101', 'Most engaged tweet')]}
       recentTweets={[tweet('102', 'Newest tweet')]}
@@ -44,6 +45,12 @@ test('starts with most engaged tweets and can switch to recent tweets', async ()
   )
 
   expect(screen.getByRole('heading', { name: 'More from Alice' })).toBeVisible()
+  expect(
+    screen.getByRole('heading', { name: 'More from Alice' }).closest('section'),
+  ).toHaveClass('order-2', 'pt-5')
+  expect(
+    screen.getByRole('heading', { name: 'More from Alice' }).closest('section'),
+  ).not.toHaveClass('mt-12')
   expect(screen.getByText('Most engaged tweet')).toBeVisible()
   expect(screen.queryByText('Newest tweet')).not.toBeInTheDocument()
 

--- a/src/components/metaTwitter/ProfileTweetFallback.test.tsx
+++ b/src/components/metaTwitter/ProfileTweetFallback.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ProfileTweet } from '@/lib/metaTwitter/types'
+import { ProfileTweetFallback } from './ProfileTweetFallback'
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}))
+jest.mock('@/components/TweetAvatarImage', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+jest.mock('@/components/ImageLightbox', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+
+const tweet = (id: string, text: string): ProfileTweet => ({
+  tweet_id: id,
+  account_id: '42',
+  created_at: '2026-08-14T09:00:00.000Z',
+  full_text: text,
+  favorite_count: 30,
+  retweet_count: 4,
+  reply_to_username: null,
+  username: 'alice',
+  account_display_name: 'Alice',
+  avatar_media_url: null,
+  media: [],
+  quote_tweet_id: null,
+  quoted_tweet: null,
+})
+
+test('starts with most engaged tweets and can switch to recent tweets', async () => {
+  const user = userEvent.setup()
+  render(
+    <ProfileTweetFallback
+      avatarUrl={null}
+      displayName="Alice"
+      engagedTweets={[tweet('101', 'Most engaged tweet')]}
+      recentTweets={[tweet('102', 'Newest tweet')]}
+      returnTo="/user/alice"
+    />,
+  )
+
+  expect(screen.getByRole('heading', { name: 'More from Alice' })).toBeVisible()
+  expect(screen.getByText('Most engaged tweet')).toBeVisible()
+  expect(screen.queryByText('Newest tweet')).not.toBeInTheDocument()
+
+  await user.click(screen.getByRole('tab', { name: 'Recent tweets' }))
+
+  expect(screen.getByText('Newest tweet')).toBeVisible()
+  expect(screen.queryByText('Most engaged tweet')).not.toBeInTheDocument()
+})

--- a/src/components/metaTwitter/ProfileTweetFallback.tsx
+++ b/src/components/metaTwitter/ProfileTweetFallback.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import TweetCard from '@/components/TweetCard'
+import { profilePortalTweet } from '@/lib/metaTwitter/bangerPortalTweet'
+import type { ProfileTweet } from '@/lib/metaTwitter/types'
+
+function TweetCards({
+  avatarUrl,
+  returnTo,
+  tweets,
+}: {
+  avatarUrl: string | null
+  returnTo: string
+  tweets: ProfileTweet[]
+}) {
+  if (tweets.length === 0) {
+    return (
+      <p className="rounded-lg border border-dashed border-border p-7 text-center text-sm text-muted-foreground">
+        No tweets are available in this view yet.
+      </p>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {tweets.map((tweet) => (
+        <div key={tweet.tweet_id}>
+          <TweetCard
+            tweet={profilePortalTweet(tweet, avatarUrl)}
+            clickable={false}
+            showDate
+            showExternalLink
+            origin="profile"
+            returnTo={returnTo}
+          />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function ProfileTweetFallback({
+  avatarUrl,
+  displayName,
+  engagedTweets,
+  recentTweets,
+  returnTo,
+}: {
+  avatarUrl: string | null
+  displayName: string
+  engagedTweets: ProfileTweet[]
+  recentTweets: ProfileTweet[]
+  returnTo: string
+}) {
+  if (engagedTweets.length === 0 && recentTweets.length === 0) return null
+
+  return (
+    <section
+      aria-labelledby="profile-more-tweets-heading"
+      className="mx-4 mb-8 mt-12 border-t border-border pt-8 sm:mx-6"
+    >
+      <div className="mx-auto max-w-3xl">
+        <h2 id="profile-more-tweets-heading" className="text-xl font-extrabold">
+          More from {displayName}
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          See their tweets with the most likes and reposts, or switch to what
+          they posted recently.
+        </p>
+
+        <Tabs
+          defaultValue={engagedTweets.length > 0 ? 'engagement' : 'recent'}
+          className="mt-4"
+        >
+          <TabsList aria-label="Profile tweet view">
+            <TabsTrigger value="engagement">Most engaged</TabsTrigger>
+            <TabsTrigger value="recent">Recent tweets</TabsTrigger>
+          </TabsList>
+          <TabsContent value="engagement" className="mt-4">
+            <TweetCards
+              avatarUrl={avatarUrl}
+              returnTo={returnTo}
+              tweets={engagedTweets}
+            />
+          </TabsContent>
+          <TabsContent value="recent" className="mt-4">
+            <TweetCards
+              avatarUrl={avatarUrl}
+              returnTo={returnTo}
+              tweets={recentTweets}
+            />
+          </TabsContent>
+        </Tabs>
+      </div>
+    </section>
+  )
+}

--- a/src/components/metaTwitter/ProfileTweetFallback.tsx
+++ b/src/components/metaTwitter/ProfileTweetFallback.tsx
@@ -2,6 +2,7 @@
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import TweetCard from '@/components/TweetCard'
+import { cn } from '@/lib/utils'
 import { profilePortalTweet } from '@/lib/metaTwitter/bangerPortalTweet'
 import type { ProfileTweet } from '@/lib/metaTwitter/types'
 
@@ -42,12 +43,14 @@ function TweetCards({
 
 export function ProfileTweetFallback({
   avatarUrl,
+  className,
   displayName,
   engagedTweets,
   recentTweets,
   returnTo,
 }: {
   avatarUrl: string | null
+  className?: string
   displayName: string
   engagedTweets: ProfileTweet[]
   recentTweets: ProfileTweet[]
@@ -58,9 +61,9 @@ export function ProfileTweetFallback({
   return (
     <section
       aria-labelledby="profile-more-tweets-heading"
-      className="mx-4 mb-8 mt-12 border-t border-border pt-8 sm:mx-6"
+      className={cn('border-t border-border pt-5', className)}
     >
-      <div className="mx-auto max-w-3xl">
+      <div className="w-full">
         <h2 id="profile-more-tweets-heading" className="text-xl font-extrabold">
           More from {displayName}
         </h2>
@@ -71,20 +74,20 @@ export function ProfileTweetFallback({
 
         <Tabs
           defaultValue={engagedTweets.length > 0 ? 'engagement' : 'recent'}
-          className="mt-4"
+          className="mt-3"
         >
           <TabsList aria-label="Profile tweet view">
             <TabsTrigger value="engagement">Most engaged</TabsTrigger>
             <TabsTrigger value="recent">Recent tweets</TabsTrigger>
           </TabsList>
-          <TabsContent value="engagement" className="mt-4">
+          <TabsContent value="engagement" className="mt-3">
             <TweetCards
               avatarUrl={avatarUrl}
               returnTo={returnTo}
               tweets={engagedTweets}
             />
           </TabsContent>
-          <TabsContent value="recent" className="mt-4">
+          <TabsContent value="recent" className="mt-3">
             <TweetCards
               avatarUrl={avatarUrl}
               returnTo={returnTo}

--- a/src/components/metaTwitter/Workspace.test.tsx
+++ b/src/components/metaTwitter/Workspace.test.tsx
@@ -95,6 +95,9 @@ test('shows the initial canonical banger cards with media and profile return lin
       onLoadMore={onLoadMore}
       loadMoreRef={createRef<HTMLDivElement>()}
       returnTo="/user/alice?chapter=2025"
+      supplementalTweets={
+        <section data-testid="supplemental-tweets">More tweets</section>
+      }
     />,
   )
 
@@ -107,6 +110,17 @@ test('shows the initial canonical banger cards with media and profile return lin
   expect(
     screen.queryByRole('heading', { name: 'Bangers' }),
   ).not.toBeInTheDocument()
+  const supplementalTweets = screen.getByTestId('supplemental-tweets')
+  const mediaHeading = screen.getByRole('heading', { name: 'Media' })
+  expect(
+    supplementalTweets.compareDocumentPosition(mediaHeading) &
+      Node.DOCUMENT_POSITION_FOLLOWING,
+  ).toBeTruthy()
+  expect(mediaHeading.closest('aside')).toHaveClass(
+    'order-3',
+    'xl:col-start-2',
+    'xl:row-start-1',
+  )
   expect(
     screen.queryByText(
       '167 bangers · 2+ Community Archive member quote posts · self-quotes excluded',

--- a/src/components/metaTwitter/Workspace.tsx
+++ b/src/components/metaTwitter/Workspace.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, type FormEvent, type RefObject } from 'react'
+import { useState, type FormEvent, type ReactNode, type RefObject } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import {
@@ -65,6 +65,7 @@ export function Workspace({
   onLoadMore,
   loadMoreRef,
   returnTo,
+  supplementalTweets,
   editing = false,
   editSaving = false,
   editError = null,
@@ -98,6 +99,7 @@ export function Workspace({
   onLoadMore: () => void
   loadMoreRef: RefObject<HTMLDivElement>
   returnTo: string
+  supplementalTweets?: ReactNode
   editing?: boolean
   editSaving?: boolean
   editError?: string | null
@@ -251,7 +253,7 @@ export function Workspace({
       <div className="grid grid-cols-1 items-start gap-4 xl:grid-cols-[1fr_280px]">
         <section
           aria-labelledby="profile-bangers-heading"
-          className="flex flex-col gap-3"
+          className="order-1 flex flex-col gap-3 xl:col-start-1 xl:row-start-1"
         >
           {!bangersAvailable && (
             <div className="rounded-lg border border-dashed border-border p-7 text-center text-sm text-muted-foreground">
@@ -368,7 +370,9 @@ export function Workspace({
           )}
         </section>
 
-        <aside className="flex flex-col gap-5">
+        {supplementalTweets}
+
+        <aside className="order-3 flex flex-col gap-5 xl:col-start-2 xl:row-span-2 xl:row-start-1">
           <section aria-labelledby="profile-media-heading">
             <h3
               id="profile-media-heading"

--- a/src/lib/clickhouseGateway.test.ts
+++ b/src/lib/clickhouseGateway.test.ts
@@ -220,6 +220,24 @@ describe('ClickHouse analytics gateway requests', () => {
     ).toThrow('Unsupported ClickHouse analytics endpoint')
   })
 
+  test('allows only profile tweet sort and limit parameters', () => {
+    const target = analyticsGatewayRequestUrl(
+      ['user', '42', 'tweets'],
+      new URLSearchParams('limit=6&sort=recent&raw_sql=DROP'),
+      'https://stream.example/analytics',
+    )
+    expect(target.toString()).toBe(
+      'https://stream.example/analytics/user/42/tweets?limit=6&sort=recent',
+    )
+    expect(() =>
+      analyticsGatewayRequestUrl(
+        ['user', 'not-an-id', 'tweets'],
+        new URLSearchParams(),
+        'https://stream.example/analytics',
+      ),
+    ).toThrow('Unsupported ClickHouse analytics endpoint')
+  })
+
   test('allows a core user read to omit interactions', () => {
     const target = analyticsGatewayRequestUrl(
       ['user', 'alice'],

--- a/src/lib/clickhouseGateway.ts
+++ b/src/lib/clickhouseGateway.ts
@@ -102,6 +102,13 @@ export function analyticsGatewayRequestUrl(
     cleanPath.length === 3 &&
     cleanPath[0] === 'user' &&
     /^\d{1,20}$/.test(cleanPath[1]) &&
+    cleanPath[2] === 'tweets'
+  ) {
+    allowedParams = new Set(['limit', 'sort'])
+  } else if (
+    cleanPath.length === 3 &&
+    cleanPath[0] === 'user' &&
+    /^\d{1,20}$/.test(cleanPath[1]) &&
     cleanPath[2] === 'sidebar'
   ) {
     allowedParams = new Set(['year', 'media_limit', 'people_limit'])

--- a/src/lib/metaTwitter/bangerPortalTweet.ts
+++ b/src/lib/metaTwitter/bangerPortalTweet.ts
@@ -1,4 +1,4 @@
-import type { ArchiveTweet, BangerTweet } from './types'
+import type { ArchiveTweet, BangerTweet, ProfileTweet } from './types'
 import type {
   PortalMedia,
   PortalQuotedTweet,
@@ -20,7 +20,7 @@ function portalMedia(tweet: ArchiveTweet): PortalMedia[] {
   })
 }
 
-function portalQuotedTweet(tweet: BangerTweet): PortalQuotedTweet | undefined {
+function portalQuotedTweet(tweet: ProfileTweet): PortalQuotedTweet | undefined {
   if (tweet.quoted_tweet) {
     const quoted = tweet.quoted_tweet
     return {
@@ -56,8 +56,8 @@ function portalQuotedTweet(tweet: BangerTweet): PortalQuotedTweet | undefined {
  * Keep this adapter client-safe: Workspace sorts and progressively reveals the
  * cards in the browser.
  */
-export function bangerPortalTweet(
-  tweet: BangerTweet,
+export function profilePortalTweet(
+  tweet: ProfileTweet,
   fallbackAvatarUrl?: string | null,
 ): PortalTweet {
   return {
@@ -73,6 +73,15 @@ export function bangerPortalTweet(
     rts: tweet.retweet_count ?? 0,
     media: portalMedia(tweet),
     quotedTweet: portalQuotedTweet(tweet),
+  }
+}
+
+export function bangerPortalTweet(
+  tweet: BangerTweet,
+  fallbackAvatarUrl?: string | null,
+): PortalTweet {
+  return {
+    ...profilePortalTweet(tweet, fallbackAvatarUrl),
     quoteCount: tweet.quote_count,
   }
 }

--- a/src/lib/metaTwitter/profilePagination.test.ts
+++ b/src/lib/metaTwitter/profilePagination.test.ts
@@ -1,4 +1,7 @@
-import { resolveProfileChapterYear } from './profilePagination'
+import {
+  needsProfileTweetFallback,
+  resolveProfileChapterYear,
+} from './profilePagination'
 
 test('preserves a requested chapter when its scoped request is unavailable', () => {
   expect(
@@ -13,4 +16,32 @@ test('rejects an unknown chapter only after a successful scoped request', () => 
       yearCounts: [{ year: 2024, count: 3 }],
     }),
   ).toBeNull()
+})
+
+test('supplements only profiles with fewer than two overall bangers', () => {
+  expect(
+    needsProfileTweetFallback(
+      { available: true, total: 1, yearCounts: [{ year: 2025, count: 1 }] },
+      null,
+    ),
+  ).toBe(true)
+  expect(
+    needsProfileTweetFallback(
+      {
+        available: true,
+        total: 1,
+        yearCounts: [
+          { year: 2025, count: 1 },
+          { year: 2024, count: 1 },
+        ],
+      },
+      2025,
+    ),
+  ).toBe(false)
+  expect(
+    needsProfileTweetFallback(
+      { available: false, total: 0, yearCounts: [] },
+      null,
+    ),
+  ).toBe(false)
 })

--- a/src/lib/metaTwitter/profilePagination.ts
+++ b/src/lib/metaTwitter/profilePagination.ts
@@ -24,3 +24,15 @@ export const resolveProfileChapterYear = (
     ? candidateYear
     : null
 }
+
+export const needsProfileTweetFallback = (
+  page: Pick<ProfileBangersPageState, 'available' | 'total' | 'yearCounts'>,
+  activeYear: number | null,
+): boolean => {
+  if (!page.available) return false
+  const overallCount =
+    activeYear === null
+      ? page.total
+      : page.yearCounts.reduce((total, chapter) => total + chapter.count, 0)
+  return overallCount < PROFILE_BANGERS_INITIAL_LIMIT
+}

--- a/src/lib/metaTwitter/profileTweets.test.ts
+++ b/src/lib/metaTwitter/profileTweets.test.ts
@@ -1,0 +1,87 @@
+import type { AnalyticsGatewayFetcher } from '@/lib/clickhouseGateway'
+import { fetchProfileTweets } from './profileTweets'
+
+test('maps a complete engagement-ranked profile tweet package', async () => {
+  const fetcher = jest.fn(async () => ({
+    data: {
+      tweets: [
+        {
+          tweetId: '101',
+          accountId: '42',
+          createdAt: '2026-08-14 09:00:00.000',
+          fullText: 'A popular tweet',
+          replyToUsername: null,
+          favoriteCount: '30',
+          retweetCount: '4',
+          username: 'alice',
+          accountDisplayName: 'Alice',
+          avatarMediaUrl: 'https://example.com/alice.jpg',
+          media: [
+            {
+              mediaUrl: 'https://example.com/photo.jpg',
+              mediaType: 'photo',
+              width: 1200,
+              height: 800,
+            },
+          ],
+          quoteTweetId: '202',
+          quotedTweet: {
+            tweetId: '202',
+            accountId: '77',
+            createdAt: '2026-08-13 09:00:00.000',
+            fullText: 'Quoted context',
+            replyToUsername: null,
+            favoriteCount: '8',
+            retweetCount: '1',
+            username: 'bob',
+            accountDisplayName: 'Bob',
+            avatarMediaUrl: null,
+            media: [],
+          },
+        },
+      ],
+    },
+    query: { accountId: '42', limit: 6, sort: 'engagement' },
+  })) as unknown as AnalyticsGatewayFetcher
+
+  await expect(
+    fetchProfileTweets('42', 'engagement', 6, fetcher),
+  ).resolves.toEqual([
+    expect.objectContaining({
+      tweet_id: '101',
+      account_id: '42',
+      created_at: '2026-08-14T09:00:00.000Z',
+      favorite_count: 30,
+      media: [
+        {
+          media_url: 'https://example.com/photo.jpg',
+          media_type: 'photo',
+          width: 1200,
+          height: 800,
+        },
+      ],
+      quote_tweet_id: '202',
+      quoted_tweet: expect.objectContaining({
+        tweet_id: '202',
+        username: 'bob',
+        full_text: 'Quoted context',
+      }),
+    }),
+  ])
+  expect(fetcher).toHaveBeenCalledWith(
+    ['user', '42', 'tweets'],
+    new URLSearchParams({ limit: '6', sort: 'engagement' }),
+    { revalidate: 300, timeoutMs: 15_000 },
+  )
+})
+
+test('rejects a response scoped to a different author', async () => {
+  const fetcher = jest.fn(async () => ({
+    data: { tweets: [] },
+    query: { accountId: '77', limit: 6, sort: 'recent' },
+  })) as unknown as AnalyticsGatewayFetcher
+
+  await expect(fetchProfileTweets('42', 'recent', 6, fetcher)).rejects.toThrow(
+    'mismatched profile tweets',
+  )
+})

--- a/src/lib/metaTwitter/profileTweets.ts
+++ b/src/lib/metaTwitter/profileTweets.ts
@@ -1,0 +1,196 @@
+import 'server-only'
+
+import {
+  fetchAnalyticsGatewayJson,
+  type AnalyticsGatewayFetcher,
+} from '@/lib/clickhouseGateway'
+import { devLog } from '@/lib/devLog'
+import type { ArchiveTweet, ProfileTweet } from './types'
+
+export type ProfileTweetSort = 'engagement' | 'recent'
+
+interface GatewayMedia {
+  mediaUrl?: unknown
+  mediaType?: unknown
+  width?: unknown
+  height?: unknown
+}
+
+interface GatewayTweet {
+  tweetId?: unknown
+  accountId?: unknown
+  createdAt?: unknown
+  fullText?: unknown
+  replyToUsername?: unknown
+  favoriteCount?: unknown
+  retweetCount?: unknown
+  username?: unknown
+  accountDisplayName?: unknown
+  avatarMediaUrl?: unknown
+  media?: unknown
+  quoteTweetId?: unknown
+  quotedTweet?: unknown
+}
+
+interface GatewayResponse {
+  data?: { tweets?: unknown }
+  query?: {
+    accountId?: unknown
+    limit?: unknown
+    sort?: unknown
+  }
+}
+
+export interface ProfileTweetsState {
+  tweets: ProfileTweet[]
+  available: boolean
+}
+
+const ID_PATTERN = /^\d{1,20}$/
+
+function count(value: unknown, label: string): number {
+  const parsed = Number(value)
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new Error(`ClickHouse returned an invalid ${label}`)
+  }
+  return parsed
+}
+
+function timestamp(value: unknown): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error('ClickHouse returned an invalid profile tweet timestamp')
+  }
+  const normalized = value.includes('T') ? value : `${value.replace(' ', 'T')}Z`
+  const parsed = new Date(normalized)
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error('ClickHouse returned an invalid profile tweet timestamp')
+  }
+  return parsed.toISOString()
+}
+
+function media(value: unknown): ArchiveTweet['media'][number] {
+  const item = value as GatewayMedia
+  if (
+    typeof item.mediaUrl !== 'string' ||
+    !item.mediaUrl.trim() ||
+    typeof item.mediaType !== 'string' ||
+    !item.mediaType.trim()
+  ) {
+    throw new Error('ClickHouse returned invalid profile tweet media')
+  }
+  return {
+    media_url: item.mediaUrl,
+    media_type: item.mediaType,
+    width: count(item.width ?? 0, 'profile tweet media width'),
+    height: count(item.height ?? 0, 'profile tweet media height'),
+  }
+}
+
+function archiveTweet(value: unknown): ArchiveTweet {
+  const tweet = value as GatewayTweet
+  if (
+    typeof tweet.tweetId !== 'string' ||
+    !ID_PATTERN.test(tweet.tweetId) ||
+    typeof tweet.accountId !== 'string' ||
+    !ID_PATTERN.test(tweet.accountId) ||
+    typeof tweet.username !== 'string' ||
+    !tweet.username ||
+    typeof tweet.fullText !== 'string'
+  ) {
+    throw new Error('ClickHouse returned an invalid profile tweet')
+  }
+  return {
+    tweet_id: tweet.tweetId,
+    account_id: tweet.accountId,
+    created_at: timestamp(tweet.createdAt),
+    full_text: tweet.fullText,
+    favorite_count: count(tweet.favoriteCount, 'profile tweet favorite count'),
+    retweet_count: count(tweet.retweetCount, 'profile tweet repost count'),
+    reply_to_username:
+      typeof tweet.replyToUsername === 'string' && tweet.replyToUsername
+        ? tweet.replyToUsername
+        : null,
+    username: tweet.username,
+    account_display_name:
+      typeof tweet.accountDisplayName === 'string' && tweet.accountDisplayName
+        ? tweet.accountDisplayName
+        : tweet.username,
+    avatar_media_url:
+      typeof tweet.avatarMediaUrl === 'string' && tweet.avatarMediaUrl.trim()
+        ? tweet.avatarMediaUrl
+        : null,
+    media: Array.isArray(tweet.media) ? tweet.media.map(media) : [],
+  }
+}
+
+function profileTweet(value: unknown, accountId: string): ProfileTweet {
+  const row = value as GatewayTweet
+  const tweet = archiveTweet(row)
+  if (tweet.account_id !== accountId) {
+    throw new Error('ClickHouse returned a mismatched profile tweet author')
+  }
+  const quoteTweetId =
+    row.quoteTweetId === null || row.quoteTweetId === undefined
+      ? null
+      : typeof row.quoteTweetId === 'string' &&
+          ID_PATTERN.test(row.quoteTweetId)
+        ? row.quoteTweetId
+        : (() => {
+            throw new Error('ClickHouse returned an invalid quoted tweet ID')
+          })()
+  const quotedTweet =
+    row.quotedTweet === null || row.quotedTweet === undefined
+      ? null
+      : archiveTweet(row.quotedTweet)
+  if (quotedTweet && quotedTweet.tweet_id !== quoteTweetId) {
+    throw new Error('ClickHouse returned mismatched quoted tweet content')
+  }
+  return { ...tweet, quote_tweet_id: quoteTweetId, quoted_tweet: quotedTweet }
+}
+
+export async function fetchProfileTweets(
+  accountId: string,
+  sort: ProfileTweetSort,
+  limit = 6,
+  fetcher: AnalyticsGatewayFetcher = fetchAnalyticsGatewayJson,
+): Promise<ProfileTweet[]> {
+  if (!ID_PATTERN.test(accountId)) {
+    throw new Error('Profile tweets require a numeric account ID')
+  }
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 20) {
+    throw new Error('Invalid profile tweet limit')
+  }
+
+  const params = new URLSearchParams({ limit: String(limit), sort })
+  const response = await fetcher<GatewayResponse>(
+    ['user', accountId, 'tweets'],
+    params,
+    { revalidate: 300, timeoutMs: 15_000 },
+  )
+  const tweets = response.data?.tweets
+  if (
+    !Array.isArray(tweets) ||
+    response.query?.accountId !== accountId ||
+    Number(response.query?.limit) !== limit ||
+    response.query?.sort !== sort
+  ) {
+    throw new Error('ClickHouse returned mismatched profile tweets')
+  }
+  return tweets.map((tweet) => profileTweet(tweet, accountId))
+}
+
+export async function getProfileTweets(
+  accountId: string,
+  sort: ProfileTweetSort,
+  limit = 6,
+): Promise<ProfileTweetsState> {
+  try {
+    return {
+      tweets: await fetchProfileTweets(accountId, sort, limit),
+      available: true,
+    }
+  } catch (error) {
+    devLog('profile tweets unavailable', { accountId, sort, error })
+    return { tweets: [], available: false }
+  }
+}

--- a/src/lib/metaTwitter/types.ts
+++ b/src/lib/metaTwitter/types.ts
@@ -19,11 +19,14 @@ export interface ArchiveTweet {
   }[]
 }
 
-export interface BangerTweet extends ArchiveTweet {
-  quote_count: number
-  quoting_accounts: number
+export interface ProfileTweet extends ArchiveTweet {
   quote_tweet_id?: string | null
   quoted_tweet?: ArchiveTweet | null
+}
+
+export interface BangerTweet extends ProfileTweet {
+  quote_count: number
+  quoting_accounts: number
   curation?: {
     is_featured: boolean
     position: number | null


### PR DESCRIPTION
## Summary
- when an overall profile has fewer than two bangers, stream in a separate tweet section below the archive workspace
- default to the author’s most-liked/reposted tweets and offer a Recent tweets tab
- omit any existing banger from both supplemental views
- keep canonical TweetCard rendering with attached media and quoted-tweet context
- leave profiles with two or more bangers unchanged

## Dependency
- Requires TheExGenesis/community-archive-control-panel#197 to land and be deployed first.

## Validation
- `pnpm test -- --runInBand src/lib/clickhouseGateway.test.ts src/lib/metaTwitter/profileTweets.test.ts src/lib/metaTwitter/profilePagination.test.ts src/components/metaTwitter/ProfileTweetFallback.test.tsx` (25 tests)
- `pnpm type-check`