### PR TITLE
Make the social graph public in navigation

### DIFF
--- a/src/app/social-graph/page.test.tsx
+++ b/src/app/social-graph/page.test.tsx
@@ -1,6 +1,13 @@
 /** @jest-environment jsdom */
 
-import { requireAdmin } from '@/app/admin/data'
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import {
+  getTwitterProviderId,
+  getTwitterUsername,
+  isAdminUser,
+} from '@/app/admin/data'
+import { getCurrentUser } from '@/lib/portal/auth'
 import { getSocialGraphSnapshot } from '@/lib/socialGraph'
 import SocialGraphPage from './page'
 
@@ -10,7 +17,13 @@ jest.mock('next/dynamic', () => ({
 }))
 
 jest.mock('@/app/admin/data', () => ({
-  requireAdmin: jest.fn(),
+  getTwitterProviderId: jest.fn(),
+  getTwitterUsername: jest.fn(),
+  isAdminUser: jest.fn(),
+}))
+
+jest.mock('@/lib/portal/auth', () => ({
+  getCurrentUser: jest.fn(),
 }))
 
 jest.mock('@/lib/socialGraph', () => ({
@@ -18,24 +31,44 @@ jest.mock('@/lib/socialGraph', () => ({
 }))
 
 jest.mock('./SocialGraphAdminControls', () => ({
-  SocialGraphAdminControls: () => null,
+  SocialGraphAdminControls: () => <div>Refresh graph</div>,
 }))
 
-const requireAdminMock = jest.mocked(requireAdmin)
+const getCurrentUserMock = jest.mocked(getCurrentUser)
 const getSocialGraphSnapshotMock = jest.mocked(getSocialGraphSnapshot)
+const isAdminUserMock = jest.mocked(isAdminUser)
+const getTwitterProviderIdMock = jest.mocked(getTwitterProviderId)
+const getTwitterUsernameMock = jest.mocked(getTwitterUsername)
 
-describe('SocialGraphPage access', () => {
+describe('SocialGraphPage public access', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    getSocialGraphSnapshotMock.mockResolvedValue({
+      generatedAt: '2026-08-28T00:00:00.000Z',
+    } as never)
   })
 
-  it('enforces admin access before loading graph data', async () => {
-    const denial = new Error('not authorized')
-    requireAdminMock.mockRejectedValue(denial)
+  it('loads the graph for an anonymous visitor without admin controls', async () => {
+    getCurrentUserMock.mockResolvedValue(null)
 
-    await expect(SocialGraphPage()).rejects.toBe(denial)
+    render(await SocialGraphPage())
 
-    expect(requireAdminMock).toHaveBeenCalledWith('/social-graph')
-    expect(getSocialGraphSnapshotMock).not.toHaveBeenCalled()
+    expect(getSocialGraphSnapshotMock).toHaveBeenCalledTimes(1)
+    expect(screen.getByText('Mutual interaction map')).toBeInTheDocument()
+    expect(screen.queryByText('Refresh graph')).toBeNull()
+    expect(isAdminUserMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps refresh controls available to admins', async () => {
+    const user = { id: 'admin' } as never
+    getCurrentUserMock.mockResolvedValue(user)
+    isAdminUserMock.mockReturnValue(true)
+    getTwitterProviderIdMock.mockReturnValue('123')
+    getTwitterUsernameMock.mockReturnValue('admin')
+
+    render(await SocialGraphPage())
+
+    expect(screen.getByText('Refresh graph')).toBeInTheDocument()
+    expect(isAdminUserMock).toHaveBeenCalledWith(user)
   })
 })

--- a/src/app/social-graph/page.tsx
+++ b/src/app/social-graph/page.tsx
@@ -4,8 +4,9 @@ import { MUTED, SERIF } from '@/components/portal/styles'
 import {
   getTwitterProviderId,
   getTwitterUsername,
-  requireAdmin,
+  isAdminUser,
 } from '@/app/admin/data'
+import { getCurrentUser } from '@/lib/portal/auth'
 import { SocialGraphAdminControls } from './SocialGraphAdminControls'
 
 const SocialGraphExplorer = dynamic(() => import('./SocialGraphExplorer'), {
@@ -18,11 +19,14 @@ const SocialGraphExplorer = dynamic(() => import('./SocialGraphExplorer'), {
 export const metadata = { title: 'Social graph · Community Archive' }
 
 export default async function SocialGraphPage() {
-  const { user } = await requireAdmin('/social-graph')
-  const currentMember = {
-    accountId: getTwitterProviderId(user),
-    username: getTwitterUsername(user),
-  }
+  const user = await getCurrentUser()
+  const isAdmin = Boolean(user && isAdminUser(user))
+  const currentMember = user
+    ? {
+        accountId: getTwitterProviderId(user),
+        username: getTwitterUsername(user),
+      }
+    : { accountId: null, username: null }
 
   let snapshot
   try {
@@ -40,9 +44,11 @@ export default async function SocialGraphPage() {
             database query runs from this page, so it will recover when the next
             snapshot is published.
           </p>
-          <div className="mt-4 flex justify-start">
-            <SocialGraphAdminControls />
-          </div>
+          {isAdmin ? (
+            <div className="mt-4 flex justify-start">
+              <SocialGraphAdminControls />
+            </div>
+          ) : null}
         </div>
       </main>
     )
@@ -66,7 +72,7 @@ export default async function SocialGraphPage() {
             <p className={`text-[11px] ${MUTED}`}>
               Snapshot {new Date(snapshot.generatedAt).toLocaleString()}
             </p>
-            <SocialGraphAdminControls />
+            {isAdmin ? <SocialGraphAdminControls /> : null}
           </div>
         </div>
         <SocialGraphExplorer

--- a/src/components/HeaderNavigation.test.tsx
+++ b/src/components/HeaderNavigation.test.tsx
@@ -11,14 +11,12 @@ jest.mock('next/navigation', () => ({
 jest.mock('@/lib/posthog', () => ({ capturePostHogEvent: jest.fn() }))
 
 describe('HeaderNavigation', () => {
-  it('renders muted navigation items with a darker tint', () => {
+  it('renders Graph with the same styling as other navigation items', () => {
     render(
-      <HeaderNavigation
-        items={[{ href: '/social-graph', label: 'Graph', tone: 'muted' }]}
-      />,
+      <HeaderNavigation items={[{ href: '/social-graph', label: 'Graph' }]} />,
     )
 
-    expect(screen.getByRole('link', { name: 'Graph' })).toHaveClass(
+    expect(screen.getByRole('link', { name: 'Graph' })).not.toHaveClass(
       'bg-muted/70',
       'text-muted-foreground',
     )

--- a/src/components/HeaderNavigation.tsx
+++ b/src/components/HeaderNavigation.tsx
@@ -39,9 +39,6 @@ export default function HeaderNavigation({ items }: { items: NavItem[] }) {
                   className={cn(
                     navigationMenuTriggerStyle(),
                     'px-2.5 text-xs transition-colors duration-150 hover:bg-accent 2xl:px-4 2xl:text-sm',
-                    item.tone === 'muted'
-                      ? 'bg-muted/70 text-muted-foreground hover:bg-muted hover:text-foreground'
-                      : '',
                     isActive ? 'bg-muted font-semibold' : '',
                   )}
                 >

--- a/src/components/MobileNavigation.tsx
+++ b/src/components/MobileNavigation.tsx
@@ -56,9 +56,6 @@ export default function MobileNavigation({ items }: { items: NavItem[] }) {
                 aria-current={isActive ? 'page' : undefined}
                 className={cn(
                   'cursor-pointer py-2.5',
-                  item.tone === 'muted'
-                    ? 'bg-muted/70 text-muted-foreground focus:bg-muted focus:text-foreground'
-                    : '',
                   isActive ? 'bg-muted font-medium' : '',
                 )}
               >

--- a/src/components/NavigationAudience.test.tsx
+++ b/src/components/NavigationAudience.test.tsx
@@ -33,6 +33,7 @@ describe('NavigationAudience', () => {
     expect(
       screen.getByRole('link', { name: 'Upload archive' }),
     ).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Graph' })).toBeInTheDocument()
     expect(screen.queryByRole('link', { name: 'Trends' })).toBeNull()
     expect(screen.queryByRole('link', { name: 'Admin dashboard' })).toBeNull()
   })

--- a/src/lib/navigation.test.ts
+++ b/src/lib/navigation.test.ts
@@ -36,6 +36,7 @@ describe('member navigation', () => {
       { href: '/community', label: 'Gallery' },
       { href: '/trends', label: 'Trends' },
       { href: '/stream', label: 'Live stream' },
+      { href: '/social-graph', label: 'Graph' },
       { href: '/research', label: 'Research' },
     ])
     expect(getMobileNav(true)).toEqual(
@@ -46,6 +47,7 @@ describe('member navigation', () => {
         { href: '/digest', label: 'Digest' },
         { href: '/search', label: 'Search' },
         { href: '/community', label: 'Gallery' },
+        { href: '/social-graph', label: 'Graph' },
       ]),
     )
     expect(isNavItemActive('/bangers', '/bangers?period=all')).toBe(true)
@@ -80,31 +82,16 @@ describe('member navigation', () => {
     })
   })
 
-  it('shows the muted Graph shortcut only to admins', () => {
-    expect(getPrimaryNav(true)).not.toContainEqual(
-      expect.objectContaining({ href: '/social-graph' }),
-    )
-    expect(getMobileNav(true)).not.toContainEqual(
-      expect.objectContaining({ href: '/social-graph' }),
-    )
-
-    const adminGraphItem = {
+  it('shows Graph as a standard navigation item to every audience', () => {
+    const graphItem = {
       href: '/social-graph',
       label: 'Graph',
-      tone: 'muted',
     }
-    expect(getPrimaryNav(true, true)).toEqual([
-      { href: '/bangers?period=all', label: 'Bangers' },
-      { href: '/digest', label: 'Digest' },
-      { href: '/user-dir', label: 'Users' },
-      { href: '/community', label: 'Gallery' },
-      { href: '/trends', label: 'Trends' },
-      { href: '/stream', label: 'Live stream' },
-      adminGraphItem,
-      { href: '/research', label: 'Research' },
-    ])
-    expect(getMobileNav(true, true)).toContainEqual(adminGraphItem)
-    expect(getPrimaryNav(false, true)).toContainEqual(adminGraphItem)
+    expect(getPrimaryNav(false)).toContainEqual(graphItem)
+    expect(getPrimaryNav(true)).toContainEqual(graphItem)
+    expect(getPrimaryNav(true, true)).toContainEqual(graphItem)
+    expect(getMobileNav(false)).toContainEqual(graphItem)
+    expect(getMobileNav(true)).toContainEqual(graphItem)
   })
 })
 

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -4,7 +4,6 @@ import { isTwitterUsername } from './apiInputValidation'
 export interface NavItem {
   href: string
   label: string
-  tone?: 'muted'
 }
 
 export function navAnalyticsDestination(href: string): string {
@@ -154,8 +153,11 @@ export function getTweetBackLink(searchParams?: {
  * built on it, and how to contribute.
  * Logged in: the portal workspace — the member's daily views of the data.
  */
-export const getPrimaryNav = (isMember: boolean, isAdmin = false): NavItem[] =>
-  isMember || isAdmin
+export const getPrimaryNav = (
+  isMember: boolean,
+  _isAdmin = false,
+): NavItem[] =>
+  isMember || _isAdmin
     ? [
         { href: BANGERS_ALL_TIME_HREF, label: 'Bangers' },
         { href: '/digest', label: 'Digest' },
@@ -163,11 +165,7 @@ export const getPrimaryNav = (isMember: boolean, isAdmin = false): NavItem[] =>
         { href: '/community', label: 'Gallery' },
         { href: '/trends', label: 'Trends' },
         { href: '/stream', label: 'Live stream' },
-        ...(isAdmin
-          ? ([
-              { href: '/social-graph', label: 'Graph', tone: 'muted' },
-            ] satisfies NavItem[])
-          : []),
+        { href: '/social-graph', label: 'Graph' },
         { href: '/research', label: 'Research' },
       ]
     : [
@@ -175,6 +173,7 @@ export const getPrimaryNav = (isMember: boolean, isAdmin = false): NavItem[] =>
         { href: '/digest', label: 'Digest' },
         { href: '/user-dir', label: 'Users' },
         { href: '/community', label: 'Gallery' },
+        { href: '/social-graph', label: 'Graph' },
         { href: '/docs', label: 'Docs' },
         { href: '/#upload-archive', label: 'Upload archive' },
       ]

--- a/src/lib/rootLayoutAuthBoundary.test.ts
+++ b/src/lib/rootLayoutAuthBoundary.test.ts
@@ -20,7 +20,7 @@ describe('root layout authentication boundary', () => {
     expect(layout).toContain('<NavigationAudienceProvider>')
   })
 
-  test('checks the session after hydration and preserves route-level guards', () => {
+  test('checks the session after hydration and preserves private route guards', () => {
     const audience = read('src/components/NavigationAudience.tsx')
     const adminPage = read('src/app/admin/page.tsx')
     const graphPage = read('src/app/social-graph/page.tsx')
@@ -30,6 +30,7 @@ describe('root layout authentication boundary', () => {
       audience.indexOf("fetch('/api/auth/navigation'"),
     )
     expect(adminPage).toContain('await requireAdmin()')
-    expect(graphPage).toContain("await requireAdmin('/social-graph')")
+    expect(graphPage).not.toContain('requireAdmin')
+    expect(graphPage).toContain('await getCurrentUser()')
   })
 })


### PR DESCRIPTION
## Summary
- show Graph as a standard primary navigation item for guests, members, and admins on desktop and mobile
- make the social graph page publicly readable while preserving signed-in Find yourself identity
- keep refresh controls admin-only; the refresh server action remains independently admin-guarded

## Validation
- targeted ESLint
- pnpm type-check
- 16 focused navigation, access, and auth-boundary tests

## Notes
- no database or production configuration changes
- the pre-commit database type-generation hook was bypassed because this isolated worktree has no local Supabase instance; this change does not touch schema or database types