### PR TITLE
Avoid repeated text-search scans

### DIFF
--- a/src/lib/clickhouseSearch.test.ts
+++ b/src/lib/clickhouseSearch.test.ts
@@ -48,6 +48,7 @@ describe('searchTweetsWithClickHouse', () => {
         startDate: '2024-01-01',
         endDate: '2025-01-01',
         sort: 'likes',
+        excludeRetweets: true,
       },
       2,
       20,
@@ -55,7 +56,7 @@ describe('searchTweetsWithClickHouse', () => {
     )
 
     expect(fetchImpl).toHaveBeenCalledWith(
-      '/api/tweet-search?q=Open+source&mode=phrase&limit=20&offset=20&from_user=alice&reply_to_user=bob&since=2024-01-01&until=2025-01-01&sort=likes',
+      '/api/tweet-search?q=Open+source&mode=phrase&limit=20&offset=20&from_user=alice&reply_to_user=bob&since=2024-01-01&until=2025-01-01&sort=likes&exclude_retweets=true',
       { cache: 'no-store' },
     )
     expect(tweets).toEqual([

--- a/src/lib/clickhouseSearch.ts
+++ b/src/lib/clickhouseSearch.ts
@@ -141,7 +141,9 @@ export async function searchTweetsWithClickHouse(
   pageSize: number,
   fetchImpl: typeof fetch = fetch,
 ): Promise<TimelineTweet[]> {
-  return requestClickHouseTweets(criteria, page, pageSize, fetchImpl)
+  return requestClickHouseTweets(criteria, page, pageSize, fetchImpl, {
+    excludeRetweets: criteria.excludeRetweets,
+  })
 }
 
 export function canPreviewTweetSearch(

--- a/src/lib/queries/tweetQueries.test.ts
+++ b/src/lib/queries/tweetQueries.test.ts
@@ -111,7 +111,7 @@ describe('retweet filtering', () => {
     expect(result.tweets.map((tweet) => tweet.tweet_id)).toEqual(['original'])
   })
 
-  it('tops up filtered ClickHouse pages with original tweets', async () => {
+  it('requests one server-filtered ClickHouse page for retweet exclusion', async () => {
     process.env.NEXT_PUBLIC_ENABLE_CLICKHOUSE_SEARCH = 'true'
     const clickHouseTweet = (id: string, fullText: string) => ({
       tweet_id: id,
@@ -127,20 +127,11 @@ describe('retweet filtering', () => {
       },
       media: [],
     })
-    mockClickHouseSearch
-      .mockResolvedValueOnce([
-        ...Array.from({ length: 35 }, (_, index) =>
-          clickHouseTweet(`rt-${index}`, `RT @alice: result ${index}`),
-        ),
-        ...Array.from({ length: 15 }, (_, index) =>
-          clickHouseTweet(`original-${index}`, `Original result ${index}`),
-        ),
-      ])
-      .mockResolvedValueOnce(
-        Array.from({ length: 20 }, (_, index) =>
-          clickHouseTweet(`more-${index}`, `More original ${index}`),
-        ),
-      )
+    mockClickHouseSearch.mockResolvedValueOnce(
+      Array.from({ length: 20 }, (_, index) =>
+        clickHouseTweet(`original-${index}`, `Original result ${index}`),
+      ),
+    )
 
     const result = await fetchTweets(
       buildMockSupabase(),
@@ -153,7 +144,12 @@ describe('retweet filtering', () => {
       20,
     )
 
-    expect(mockClickHouseSearch).toHaveBeenCalledTimes(2)
+    expect(mockClickHouseSearch).toHaveBeenCalledTimes(1)
+    expect(mockClickHouseSearch).toHaveBeenCalledWith(
+      expect.objectContaining({ excludeRetweets: true }),
+      1,
+      20,
+    )
     expect(result.tweets).toHaveLength(20)
     expect(
       result.tweets.every((tweet) => !isRetweetText(tweet.full_text)),

--- a/src/lib/queries/tweetQueries.ts
+++ b/src/lib/queries/tweetQueries.ts
@@ -33,8 +33,6 @@ export interface FilterCriteria {
 export type TweetSearchSort = 'newest' | 'oldest' | 'likes' | 'reposts'
 
 const DEFAULT_PAGE_SIZE = 50
-const CLICKHOUSE_FILTER_PAGE_SIZE = 50
-const MAX_CLICKHOUSE_FILTER_PAGES = 10
 
 export function isRetweetText(text: string): boolean {
   return /^RT @[A-Za-z0-9_]+/.test(text)
@@ -130,33 +128,7 @@ async function searchClickHousePage(
   page: number,
   pageSize: number,
 ): Promise<TimelineTweet[]> {
-  if (!criteria.excludeRetweets) {
-    return searchTweetsWithClickHouse(criteria, page, pageSize)
-  }
-
-  const pageStart = (page - 1) * pageSize
-  const pageEnd = page * pageSize
-  const nonRetweets: TimelineTweet[] = []
-
-  // ClickHouse does not yet expose a retweet predicate, so scan bounded raw
-  // pages from the start to keep filtered pagination deterministic and full.
-  for (
-    let rawPage = 1;
-    rawPage <= MAX_CLICKHOUSE_FILTER_PAGES && nonRetweets.length < pageEnd;
-    rawPage += 1
-  ) {
-    const chunk = await searchTweetsWithClickHouse(
-      criteria,
-      rawPage,
-      CLICKHOUSE_FILTER_PAGE_SIZE,
-    )
-    nonRetweets.push(
-      ...chunk.filter((tweet) => !isRetweetText(tweet.full_text)),
-    )
-    if (chunk.length < CLICKHOUSE_FILTER_PAGE_SIZE) break
-  }
-
-  return nonRetweets.slice(pageStart, pageEnd)
+  return searchTweetsWithClickHouse(criteria, page, pageSize)
 }
 
 /**


### PR DESCRIPTION
## Summary

- send `exclude_retweets=true` to ClickHouse for normal search pages, not just previews
- remove the browser-side loop that repeatedly fetched 50 raw results from page one and filtered retweets locally
- retain the local retweet filter as a deployment-safe response check

## Why

The old first-page path could issue several full searches to accumulate 20 non-retweets. Each gateway request could itself scan multiple yearly partitions, multiplying the slow ClickHouse work. The compatible gateway change is TheExGenesis/community-archive-control-panel#201.

## Validation

- 24 focused tests passed across `clickhouseSearch.test.ts` and `tweetQueries.test.ts`
- full TypeScript check passed
- Prettier and `git diff --check` passed

The repository pre-commit hook's unrelated local Supabase type-generation step could not run in the isolated worktree because its local auth environment is not configured. No database schema or generated type file is changed.

## Rollout

Deploy and verify control-panel PR #201 first. This website retains its Supabase fallback if the gateway request fails, but should not be released before the compatible gateway contract is live. No deployment is included in this PR.
