### PR TITLE
Add disabled archive mutation-batch shadow publication and retry reports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,3 +67,11 @@ NEXT_PUBLIC_POSTHOG_HOST=<your-posthog-host>
 # value while developing and never expose this key through NEXT_PUBLIC_*).
 OPENROUTER_API_KEY=<your-openrouter-api-key>
 OPENROUTER_API_BASE_URL=https://openrouter.ai/api/v1
+
+# Archive worker canonical queue shadow (disabled by default)
+CANONICAL_ARCHIVE_SHADOW_PUBLISH_ENABLED=false
+CANONICAL_ARCHIVE_RETRY_BATCH=5
+CANONICAL_PUBLISH_URL=
+CANONICAL_PUBLISHER_API_KEY=
+CANONICAL_PUBLISH_BATCH_SIZE=100
+CANONICAL_PUBLISH_TIMEOUT_SECONDS=30

--- a/services/process_archive/README_DOCKER.md
+++ b/services/process_archive/README_DOCKER.md
@@ -87,8 +87,14 @@ The publisher reloads PostgreSQL policy, and the firehose independently
 rechecks policy before accepting each batch. Failures never change an upload's
 completed state or its current ClickHouse delivery. IDs-only retry checkpoints
 are written under `logs/canonical_archive_<upload-id>.json`; the mounted logs
-directory lets later cron runs resume them without storing archive content or
-credentials. Do not enable the flag until the firehose publisher, retained
+directory lets later cron runs retry them without storing archive content or
+credentials. Each request contains one thin submission with at most
+`CANONICAL_PUBLISH_BATCH_SIZE` mutations (default/maximum 100), capped at 1 MiB.
+Firehose owns canonical IDs/hashes/policy stamps; retries resubmit to the server
+instead of trusting local completed-batch markers. Identifier-only tombstones
+do not carry content or provenance edges. Source-retraction commands and
+user-facing delete actions are not enabled by this publisher.
+Do not enable the flag until the firehose publisher, retained
 stream, and queue-capacity alerting have been deployed and verified.
 
 ## Execution Options

--- a/services/process_archive/README_DOCKER.md
+++ b/services/process_archive/README_DOCKER.md
@@ -91,7 +91,10 @@ directory lets later cron runs retry them without storing archive content or
 credentials. Each request contains one thin submission with at most
 `CANONICAL_PUBLISH_BATCH_SIZE` mutations (default/maximum 100), capped at 1 MiB.
 Firehose owns canonical IDs/hashes/policy stamps; retries resubmit to the server
-instead of trusting local completed-batch markers. Identifier-only tombstones
+instead of trusting local completed-batch markers. Canonical observation time
+comes from the existing delivery row's immutable `created_at`, including on
+retry; rebuilding the same archive must not manufacture new event versions.
+Missing source time fails only shadow publication. Identifier-only tombstones
 do not carry content or provenance edges. Source-retraction commands and
 user-facing delete actions are not enabled by this publisher.
 Do not enable the flag until the firehose publisher, retained

--- a/services/process_archive/README_DOCKER.md
+++ b/services/process_archive/README_DOCKER.md
@@ -67,6 +67,30 @@ MAX_MEMORY_MB=1000
 DEV_ARCHIVE_PATH=/path/to/test/archive.json
 ```
 
+### Disabled canonical queue shadow
+
+Newly completed uploads can publish the same policy-safe normalized batch to
+the retained canonical queue after the existing PostgreSQL and optional
+ClickHouse paths finish. This lane is inert unless
+`CANONICAL_ARCHIVE_SHADOW_PUBLISH_ENABLED=true`.
+
+```bash
+CANONICAL_ARCHIVE_SHADOW_PUBLISH_ENABLED=false
+CANONICAL_ARCHIVE_RETRY_BATCH=5
+CANONICAL_PUBLISH_URL=https://firehose-host/internal/canonical-ingest
+CANONICAL_PUBLISHER_API_KEY=replace-with-dedicated-runtime-secret
+CANONICAL_PUBLISH_BATCH_SIZE=100
+CANONICAL_PUBLISH_TIMEOUT_SECONDS=30
+```
+
+The publisher reloads PostgreSQL policy, and the firehose independently
+rechecks policy before accepting each batch. Failures never change an upload's
+completed state or its current ClickHouse delivery. IDs-only retry checkpoints
+are written under `logs/canonical_archive_<upload-id>.json`; the mounted logs
+directory lets later cron runs resume them without storing archive content or
+credentials. Do not enable the flag until the firehose publisher, retained
+stream, and queue-capacity alerting have been deployed and verified.
+
 ## Execution Options
 
 ### Option 1: Docker Compose Run (Recommended)

--- a/services/process_archive/archive_clickhouse.test.ts
+++ b/services/process_archive/archive_clickhouse.test.ts
@@ -352,7 +352,13 @@ test('delivery manifest is content-free and historical uploads are not seeded', 
     'await attemptClickHouseDelivery(',
     completion,
   )
-  assert.ok(completion >= 0 && directSink > completion)
+  const canonicalShadow = processor.indexOf(
+    'await attemptCanonicalArchiveShadow(',
+    directSink,
+  )
+  assert.ok(
+    completion >= 0 && directSink > completion && canonicalShadow > directSink,
+  )
   assert.match(processor, /jsonb_array_elements\(\$\{trx\.json\(candidates as never\)\}::jsonb\)/)
   assert.doesNotMatch(processor, /JSON\.stringify\(candidates\)/)
 })

--- a/services/process_archive/canonical_archive.test.ts
+++ b/services/process_archive/canonical_archive.test.ts
@@ -5,7 +5,7 @@ import path from 'node:path'
 import test from 'node:test'
 import type { ArchiveClickHouseBatch } from './archive_clickhouse'
 import {
-  buildCanonicalArchiveEvents,
+  buildCanonicalArchiveMutations,
   canonicalArchivePolicyVersion,
   ensureCanonicalArchivePendingReport,
   pendingCanonicalArchiveReportIds,
@@ -107,39 +107,9 @@ function withPublisherEnvironment(
   })
 }
 
-test('archive event hashes match the firehose TypeScript contract fixture', () => {
-  const batch = emptyBatch()
-  batch.tweet_content_versions.push({
-    tweet_id: '5001',
-    account_id: '6001',
-    full_text: 'allowed content',
-    is_tombstone: 0,
-    source: 'archive_upload',
-    event_id: 'tweet:5001',
-    observed_at: '2026-08-29T03:00:00.000Z',
-  })
-  const [event] = buildCanonicalArchiveEvents(
-    batch,
-    manifest,
-    'policy-1',
-    '2026-08-29T03:10:00.000Z',
-  )
-
-  assert.equal(
-    event.payload_hash,
-    '21ca72ebb9cb0cc8133efb5a6618b75ae5a33d3c45bc131c34e27eabee8aab81',
-  )
-  assert.equal(
-    event.event_id,
-    '8d2454d7aff296ad3054b42955ace67dd7d1506e8c3df1b262994356ccb34170',
-  )
-})
-
 test('maps policy-safe sink rows and omits the serving projection', () => {
-  const events = buildCanonicalArchiveEvents(
+  const events = buildCanonicalArchiveMutations(
     fixtureBatch(),
-    manifest,
-    'policy-1',
   )
   const byType = new Map(events.map((event) => [event.entity_type, event]))
 
@@ -153,10 +123,8 @@ test('maps policy-safe sink rows and omits the serving projection', () => {
 })
 
 test('converts content-free policy rows to canonical tombstones', () => {
-  const events = buildCanonicalArchiveEvents(
+  const events = buildCanonicalArchiveMutations(
     fixtureBatch(true),
-    manifest,
-    'policy-1',
   )
   const account = events.find((event) => event.entity_type === 'account')
   const tweet = events.find((event) => event.entity_type === 'tweet_content')
@@ -167,9 +135,8 @@ test('converts content-free policy rows to canonical tombstones', () => {
   assert.equal(account?.operation, 'tombstone')
   assert.equal(account?.payload.is_tombstone, true)
   assert.equal(tweet?.operation, 'tombstone')
-  assert.equal(tweet?.payload.full_text, '')
-  assert.equal(provenance?.operation, 'tombstone')
-  assert.equal(provenance?.payload.is_tombstone, true)
+  assert.equal(tweet?.payload.full_text, undefined)
+  assert.equal(provenance, undefined)
 })
 
 test('policy version changes only when a relevant decision changes', () => {
@@ -183,7 +150,7 @@ test('policy version changes only when a relevant decision changes', () => {
   )
 })
 
-test('publisher checkpoints batches and skips them on a retry', async () => {
+test('publisher resubmits thin batches for server dedupe on retry', async () => {
   await withPublisherEnvironment(async () => {
     const directory = fs.mkdtempSync(
       path.join(os.tmpdir(), 'canonical-archive-'),
@@ -192,13 +159,14 @@ test('publisher checkpoints batches and skips them on a retry', async () => {
     const fetchImpl = (async (_input, init) => {
       const body = JSON.parse(String(init?.body))
       calls.push(
-        body.events.map((event: { event_id: string }) => event.event_id),
+        body.batches.map((event: { source_batch_id: string }) => event.source_batch_id),
       )
       return new Response(
         JSON.stringify({
-          accepted: body.events.map(
-            (event: { event_id: string }, index: number) => ({
-              event_id: event.event_id,
+          accepted: body.batches.map(
+            (event: { source_batch_id: string }, index: number) => ({
+              source_batch_id: event.source_batch_id,
+              event_id: 'a'.repeat(64),
               message_id: `1-${index}`,
               duplicate: false,
             }),
@@ -223,7 +191,7 @@ test('publisher checkpoints batches and skips them on a retry', async () => {
       )
       const report = JSON.parse(reportText)
       assert.equal(report.status, 'complete')
-      assert.equal(calls.length, 2)
+      assert.equal(calls.length, 4)
       assert.equal(calls.flat().length, 4)
       assert.equal(reportText.includes('publisher-secret'), false)
       assert.equal(reportText.includes('allowed content'), false)

--- a/services/process_archive/canonical_archive.test.ts
+++ b/services/process_archive/canonical_archive.test.ts
@@ -1,0 +1,303 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import type { ArchiveClickHouseBatch } from './archive_clickhouse'
+import {
+  buildCanonicalArchiveEvents,
+  canonicalArchivePolicyVersion,
+  ensureCanonicalArchivePendingReport,
+  pendingCanonicalArchiveReportIds,
+  publishCanonicalArchiveBatch,
+} from './canonical_archive'
+
+const manifest = {
+  archiveUploadId: '9',
+  accountId: '6001',
+  tweetIds: ['5001'],
+}
+
+function emptyBatch(): ArchiveClickHouseBatch {
+  return {
+    account_observations: [],
+    tweet_content_versions: [],
+    tweet_engagement_observations: [],
+    tweet_analytics_versions: [],
+    tweet_archive_provenance: [],
+    tweet_mentions: [],
+    tweet_relationships: [],
+    tweet_media_versions: [],
+    tweet_url_versions: [],
+  }
+}
+
+function fixtureBatch(tombstone = false): ArchiveClickHouseBatch {
+  const batch = emptyBatch()
+  const observedAt = '2026-08-29T03:00:00.000Z'
+  batch.account_observations.push({
+    account_id: '6001',
+    username: tombstone ? '' : 'alice',
+    account_display_name: tombstone ? '' : 'Alice',
+    is_tombstone: tombstone ? 1 : 0,
+    source: 'archive_upload',
+    event_id: 'account:6001',
+    observed_at: observedAt,
+  })
+  batch.tweet_content_versions.push({
+    tweet_id: '5001',
+    account_id: '6001',
+    full_text: tombstone ? '' : 'allowed content',
+    is_tombstone: tombstone ? 1 : 0,
+    source: 'archive_upload',
+    event_id: 'tweet:5001',
+    observed_at: observedAt,
+  })
+  if (!tombstone) {
+    batch.tweet_engagement_observations.push({
+      tweet_id: '5001',
+      favorite_count: 2,
+      retweet_count: 1,
+      source: 'archive_upload',
+      event_id: 'engagement:5001',
+      observed_at: observedAt,
+    })
+  }
+  batch.tweet_archive_provenance.push({
+    tweet_id: '5001',
+    archive_upload_id: '9',
+    source: 'archive_upload',
+    event_id: 'provenance:5001',
+    observed_at: observedAt,
+  })
+  // The denormalized serving projection is deliberately not canonical input.
+  batch.tweet_analytics_versions.push({
+    tweet_id: '5001',
+    account_id: '6001',
+    full_text: 'projection copy',
+    source: 'archive_upload',
+    event_id: 'analytics:5001',
+    observed_at: observedAt,
+  })
+  return batch
+}
+
+function withPublisherEnvironment(
+  operation: () => Promise<void>,
+): Promise<void> {
+  const names = [
+    'CANONICAL_ARCHIVE_SHADOW_PUBLISH_ENABLED',
+    'CANONICAL_PUBLISH_URL',
+    'CANONICAL_PUBLISHER_API_KEY',
+    'CANONICAL_PUBLISH_BATCH_SIZE',
+  ] as const
+  const original = Object.fromEntries(
+    names.map((name) => [name, process.env[name]]),
+  )
+  process.env.CANONICAL_ARCHIVE_SHADOW_PUBLISH_ENABLED = 'true'
+  process.env.CANONICAL_PUBLISH_URL =
+    'http://127.0.0.1:3000/internal/canonical-ingest'
+  process.env.CANONICAL_PUBLISHER_API_KEY = 'publisher-secret'
+  process.env.CANONICAL_PUBLISH_BATCH_SIZE = '2'
+  return operation().finally(() => {
+    for (const name of names) {
+      if (original[name] === undefined) delete process.env[name]
+      else process.env[name] = original[name]
+    }
+  })
+}
+
+test('archive event hashes match the firehose TypeScript contract fixture', () => {
+  const batch = emptyBatch()
+  batch.tweet_content_versions.push({
+    tweet_id: '5001',
+    account_id: '6001',
+    full_text: 'allowed content',
+    is_tombstone: 0,
+    source: 'archive_upload',
+    event_id: 'tweet:5001',
+    observed_at: '2026-08-29T03:00:00.000Z',
+  })
+  const [event] = buildCanonicalArchiveEvents(
+    batch,
+    manifest,
+    'policy-1',
+    '2026-08-29T03:10:00.000Z',
+  )
+
+  assert.equal(
+    event.payload_hash,
+    '21ca72ebb9cb0cc8133efb5a6618b75ae5a33d3c45bc131c34e27eabee8aab81',
+  )
+  assert.equal(
+    event.event_id,
+    '8d2454d7aff296ad3054b42955ace67dd7d1506e8c3df1b262994356ccb34170',
+  )
+})
+
+test('maps policy-safe sink rows and omits the serving projection', () => {
+  const events = buildCanonicalArchiveEvents(
+    fixtureBatch(),
+    manifest,
+    'policy-1',
+  )
+  const byType = new Map(events.map((event) => [event.entity_type, event]))
+
+  assert.equal(byType.get('tweet_engagement')?.payload.account_id, '6001')
+  assert.equal(byType.get('relationship')?.payload.account_id, '6001')
+  assert.equal(
+    events.some((event) => String(event.entity_type) === 'tweet_analytics'),
+    false,
+  )
+  assert.equal(JSON.stringify(events).includes('projection copy'), false)
+})
+
+test('converts content-free policy rows to canonical tombstones', () => {
+  const events = buildCanonicalArchiveEvents(
+    fixtureBatch(true),
+    manifest,
+    'policy-1',
+  )
+  const account = events.find((event) => event.entity_type === 'account')
+  const tweet = events.find((event) => event.entity_type === 'tweet_content')
+  const provenance = events.find(
+    (event) => event.payload.archive_upload_id === '9',
+  )
+
+  assert.equal(account?.operation, 'tombstone')
+  assert.equal(account?.payload.is_tombstone, true)
+  assert.equal(tweet?.operation, 'tombstone')
+  assert.equal(tweet?.payload.full_text, '')
+  assert.equal(provenance?.operation, 'tombstone')
+  assert.equal(provenance?.payload.is_tombstone, true)
+})
+
+test('policy version changes only when a relevant decision changes', () => {
+  const allowed = new Map([
+    ['candidate', { accountId: '7001', blocked: false }],
+  ])
+  const blocked = new Map([['candidate', { accountId: '7001', blocked: true }]])
+  assert.notEqual(
+    canonicalArchivePolicyVersion(manifest, false, allowed),
+    canonicalArchivePolicyVersion(manifest, false, blocked),
+  )
+})
+
+test('publisher checkpoints batches and skips them on a retry', async () => {
+  await withPublisherEnvironment(async () => {
+    const directory = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'canonical-archive-'),
+    )
+    const calls: string[][] = []
+    const fetchImpl = (async (_input, init) => {
+      const body = JSON.parse(String(init?.body))
+      calls.push(
+        body.events.map((event: { event_id: string }) => event.event_id),
+      )
+      return new Response(
+        JSON.stringify({
+          accepted: body.events.map(
+            (event: { event_id: string }, index: number) => ({
+              event_id: event.event_id,
+              message_id: `1-${index}`,
+              duplicate: false,
+            }),
+          ),
+        }),
+        { status: 202, headers: { 'Content-Type': 'application/json' } },
+      )
+    }) as typeof fetch
+    try {
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        await publishCanonicalArchiveBatch({
+          batch: fixtureBatch(),
+          manifest,
+          policyVersion: 'policy-1',
+          reportDir: directory,
+          fetchImpl,
+        })
+      }
+      const reportText = fs.readFileSync(
+        path.join(directory, 'canonical_archive_9.json'),
+        'utf8',
+      )
+      const report = JSON.parse(reportText)
+      assert.equal(report.status, 'complete')
+      assert.equal(calls.length, 2)
+      assert.equal(calls.flat().length, 4)
+      assert.equal(reportText.includes('publisher-secret'), false)
+      assert.equal(reportText.includes('allowed content'), false)
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true })
+    }
+  })
+})
+
+test('publisher is inert without its explicit flag', async () => {
+  const original = process.env.CANONICAL_ARCHIVE_SHADOW_PUBLISH_ENABLED
+  delete process.env.CANONICAL_ARCHIVE_SHADOW_PUBLISH_ENABLED
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'canonical-archive-'))
+  try {
+    const result = await publishCanonicalArchiveBatch({
+      batch: fixtureBatch(),
+      manifest,
+      policyVersion: 'policy-1',
+      reportDir: directory,
+    })
+    assert.deepEqual(result, { status: 'disabled' })
+    assert.deepEqual(fs.readdirSync(directory), [])
+  } finally {
+    if (original === undefined) {
+      delete process.env.CANONICAL_ARCHIVE_SHADOW_PUBLISH_ENABLED
+    } else {
+      process.env.CANONICAL_ARCHIVE_SHADOW_PUBLISH_ENABLED = original
+    }
+    fs.rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+test('publisher records a safe retry state on HTTP failure', async () => {
+  await withPublisherEnvironment(async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'canonical-archive-'))
+    try {
+      await assert.rejects(
+        publishCanonicalArchiveBatch({
+          batch: fixtureBatch(),
+          manifest,
+          policyVersion: 'policy-1',
+          reportDir: directory,
+          fetchImpl: (async () => new Response('private response body', {
+            status: 503,
+          })) as typeof fetch,
+        }),
+        /canonical_http_503/,
+      )
+      const reportText = fs.readFileSync(
+        path.join(directory, 'canonical_archive_9.json'),
+        'utf8',
+      )
+      const report = JSON.parse(reportText)
+      assert.equal(report.status, 'failed')
+      assert.equal(report.last_error_code, 'canonical_http_503')
+      assert.equal(reportText.includes('private response body'), false)
+      assert.deepEqual(pendingCanonicalArchiveReportIds(directory), ['9'])
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true })
+    }
+  })
+})
+
+test('pending markers are content-free and discoverable after a failed attempt', () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'canonical-archive-'))
+  try {
+    ensureCanonicalArchivePendingReport('9', directory)
+    const report = fs.readFileSync(
+      path.join(directory, 'canonical_archive_9.json'),
+      'utf8',
+    )
+    assert.deepEqual(pendingCanonicalArchiveReportIds(directory), ['9'])
+    assert.equal(report.includes('allowed content'), false)
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true })
+  }
+})

--- a/services/process_archive/canonical_archive.test.ts
+++ b/services/process_archive/canonical_archive.test.ts
@@ -6,11 +6,13 @@ import test from 'node:test'
 import type { ArchiveClickHouseBatch } from './archive_clickhouse'
 import {
   buildCanonicalArchiveMutations,
+  canonicalArchiveObservedAt,
   canonicalArchivePolicyVersion,
   ensureCanonicalArchivePendingReport,
   pendingCanonicalArchiveReportIds,
   publishCanonicalArchiveBatch,
 } from './canonical_archive'
+import { buildArchiveClickHouseBatch, createArchiveClickHouseManifest } from './archive_clickhouse'
 
 const manifest = {
   archiveUploadId: '9',
@@ -120,6 +122,21 @@ test('maps policy-safe sink rows and omits the serving projection', () => {
     false,
   )
   assert.equal(JSON.stringify(events).includes('projection copy'), false)
+})
+
+test('rebuilding an archive on retry preserves source versions and canonical identity input', () => {
+  const sourceTime = '2026-08-30T12:00:00.000Z'
+  const archive = { account: [{ account: { accountId: '6001', username: 'alice', accountDisplayName: 'Alice' } }],
+    tweets: [{ tweet: { id_str: '5001', created_at: sourceTime, full_text: 'allowed content',
+      favorite_count: 2, retweet_count: 1, entities: { urls: [], user_mentions: [], media: [] } } }] }
+  const sourceManifest = createArchiveClickHouseManifest(archive, '9')
+  const rebuild = (value: unknown) => buildCanonicalArchiveMutations(buildArchiveClickHouseBatch(
+    archive, sourceManifest, new Map(), canonicalArchiveObservedAt(value),
+  ))
+  assert.deepEqual(rebuild(sourceTime), rebuild(new Date(sourceTime)))
+  assert(rebuild(sourceTime).every((mutation) => mutation.version === String(Date.parse(sourceTime))))
+  assert.throws(() => canonicalArchiveObservedAt(undefined), /source_time_missing/)
+  assert.throws(() => canonicalArchiveObservedAt('invalid'), /source_time_invalid/)
 })
 
 test('converts content-free policy rows to canonical tombstones', () => {

--- a/services/process_archive/canonical_archive.ts
+++ b/services/process_archive/canonical_archive.ts
@@ -7,7 +7,6 @@ import type {
   ArchivePolicyDecisions,
 } from './archive_clickhouse'
 
-const SCHEMA_VERSION = 'canonical_ingest_v1'
 const SOURCE = 'archive_upload'
 const REPORT_VERSION = 1
 const MAX_BATCH_SIZE = 100
@@ -21,21 +20,13 @@ type CanonicalEntityType =
   | 'mention'
   | 'relationship'
 
-export interface CanonicalIngestEvent {
-  event_id: string
-  schema_version: typeof SCHEMA_VERSION
-  source: typeof SOURCE
-  source_run_id: string
+export interface CanonicalMutation {
   source_event_id: string
   entity_type: CanonicalEntityType
   entity_key: string
   operation: 'upsert' | 'tombstone'
-  observed_at: string
-  emitted_at: string
   version: string
-  policy_version: string
   payload: Record<string, unknown>
-  payload_hash: string
 }
 
 interface CanonicalPublishReport {
@@ -105,77 +96,6 @@ function assertPlainObject(
   }
 }
 
-function assertValidUnicode(value: string): void {
-  for (let index = 0; index < value.length; index += 1) {
-    const codeUnit = value.charCodeAt(index)
-    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
-      const next = value.charCodeAt(index + 1)
-      if (!(next >= 0xdc00 && next <= 0xdfff)) {
-        throw new CanonicalArchivePublisherError('invalid_unicode')
-      }
-      index += 1
-    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
-      throw new CanonicalArchivePublisherError('invalid_unicode')
-    }
-  }
-}
-
-function serializeCanonicalJson(
-  value: unknown,
-  ancestors: Set<object>,
-): string {
-  if (value === null || typeof value === 'boolean') return JSON.stringify(value)
-  if (typeof value === 'string') {
-    assertValidUnicode(value)
-    return JSON.stringify(value)
-  }
-  if (typeof value === 'number') {
-    if (!Number.isFinite(value)) {
-      throw new CanonicalArchivePublisherError('non_finite_number')
-    }
-    return JSON.stringify(value)
-  }
-  if (Array.isArray(value)) {
-    if (ancestors.has(value)) {
-      throw new CanonicalArchivePublisherError('cyclic_json')
-    }
-    ancestors.add(value)
-    try {
-      return `[${value
-        .map((item) => serializeCanonicalJson(item, ancestors))
-        .join(',')}]`
-    } finally {
-      ancestors.delete(value)
-    }
-  }
-  assertPlainObject(value, 'canonical_payload')
-  if (ancestors.has(value)) {
-    throw new CanonicalArchivePublisherError('cyclic_json')
-  }
-  ancestors.add(value)
-  try {
-    return `{${Object.keys(value)
-      .sort()
-      .map((key) => {
-        assertValidUnicode(key)
-        if (value[key] === undefined) {
-          throw new CanonicalArchivePublisherError('undefined_json_value')
-        }
-        return `${JSON.stringify(key)}:${serializeCanonicalJson(
-          value[key],
-          ancestors,
-        )}`
-      })
-      .join(',')}}`
-  } finally {
-    ancestors.delete(value)
-  }
-}
-
-export function canonicalJson(value: unknown): string {
-  return serializeCanonicalJson(value, new Set())
-}
-
 function versionForObservedAt(observedAt: string): string {
   const milliseconds = Date.parse(observedAt)
   if (!Number.isSafeInteger(milliseconds) || milliseconds < 0) {
@@ -217,33 +137,9 @@ function entityKey(
   return `${payload.tweet_id}|${payload.relationship_type}|${payload.related_tweet_id}`
 }
 
-function createEvent(
-  input: Omit<CanonicalIngestEvent, 'event_id' | 'payload_hash'>,
-) {
-  const payloadHash = sha256(canonicalJson(input.payload))
-  const eventId = sha256(
-    [
-      input.schema_version,
-      input.source,
-      input.source_run_id,
-      input.source_event_id,
-      input.entity_type,
-      input.entity_key,
-      input.operation,
-      input.version,
-      payloadHash,
-    ].join('\0'),
-  )
-  return { ...input, event_id: eventId, payload_hash: payloadHash }
-}
-
-export function buildCanonicalArchiveEvents(
+export function buildCanonicalArchiveMutations(
   batch: ArchiveClickHouseBatch,
-  manifest: ArchiveClickHouseManifest,
-  policyVersion: string,
-  emittedAt = new Date().toISOString(),
-): CanonicalIngestEvent[] {
-  const sourceRunId = `archive:${manifest.archiveUploadId}`
+): CanonicalMutation[] {
   const tweetAuthors = new Map(
     batch.tweet_content_versions.map((row) => [
       String(row.tweet_id),
@@ -255,7 +151,7 @@ export function buildCanonicalArchiveEvents(
       .filter((row) => row.is_tombstone === 1)
       .map((row) => String(row.tweet_id)),
   )
-  const byEntity = new Map<string, CanonicalIngestEvent>()
+  const byEntity = new Map<string, CanonicalMutation>()
 
   for (const [table, rows] of Object.entries(batch) as [
     keyof ArchiveClickHouseBatch,
@@ -264,7 +160,7 @@ export function buildCanonicalArchiveEvents(
     const entityType = TABLE_ENTITY_TYPES[table]
     if (!entityType) continue
     for (const row of rows) {
-      const payload = payloadWithoutProjectionMetadata(row)
+      let payload = payloadWithoutProjectionMetadata(row)
       if (payload.account_id === undefined) {
         const author = tweetAuthors.get(String(payload.tweet_id ?? ''))
         if (!author) {
@@ -282,20 +178,21 @@ export function buildCanonicalArchiveEvents(
       }
       const key = entityKey(entityType, payload)
       const observedAt = String(row.observed_at ?? '')
-      const event = createEvent({
-        schema_version: SCHEMA_VERSION,
-        source: SOURCE,
-        source_run_id: sourceRunId,
+      const tombstone = payload.is_tombstone === true
+      if (tombstone) {
+        if (entityType !== 'account' && entityType !== 'tweet_content') continue
+        payload = entityType === 'account'
+          ? { account_id: payload.account_id, is_tombstone: true }
+          : { account_id: payload.account_id, tweet_id: payload.tweet_id, is_tombstone: true }
+      }
+      const event: CanonicalMutation = {
         source_event_id: String(row.event_id ?? ''),
         entity_type: entityType,
         entity_key: key,
         operation: payload.is_tombstone === true ? 'tombstone' : 'upsert',
-        observed_at: observedAt,
-        emitted_at: emittedAt,
         version: versionForObservedAt(observedAt),
-        policy_version: policyVersion,
         payload,
-      })
+      }
       byEntity.set(`${entityType}\0${key}`, event)
     }
   }
@@ -391,34 +288,6 @@ function newReport(
   }
 }
 
-function loadReport(
-  reportPath: string,
-  manifest: ArchiveClickHouseManifest,
-  eventCount: number,
-  policyVersion: string,
-): CanonicalPublishReport {
-  try {
-    const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'))
-    if (
-      report.schema_version === REPORT_VERSION &&
-      report.archive_upload_id === manifest.archiveUploadId &&
-      report.source_run_id === `archive:${manifest.archiveUploadId}` &&
-      report.completed_batches !== null &&
-      typeof report.completed_batches === 'object' &&
-      !Array.isArray(report.completed_batches)
-    ) {
-      return {
-        ...report,
-        status: 'publishing',
-        event_count: eventCount,
-        policy_version: policyVersion,
-        updated_at: new Date().toISOString(),
-      }
-    }
-  } catch {}
-  return newReport(manifest, eventCount, policyVersion)
-}
-
 function writeReport(reportPath: string, report: CanonicalPublishReport): void {
   fs.mkdirSync(path.dirname(reportPath), { recursive: true })
   const temporaryPath = `${reportPath}.${process.pid}.${randomUUID()}.tmp`
@@ -468,15 +337,15 @@ function chunks<T>(values: T[], size: number): T[][] {
   return result
 }
 
-function batchHash(events: CanonicalIngestEvent[]): string {
-  return sha256(events.map((event) => event.event_id).join('\n'))
-}
-
 async function postBatch(
   config: PublisherConfig,
-  events: CanonicalIngestEvent[],
+  submission: { source: string; source_run_id: string; source_batch_id: string; observed_at: string; mutations: CanonicalMutation[] },
   fetchImpl: FetchLike,
 ): Promise<number> {
+  const requestBody = JSON.stringify({ batches: [submission] })
+  if (Buffer.byteLength(requestBody) > 1_048_576) {
+    throw new CanonicalArchivePublisherError('canonical_request_too_large')
+  }
   let response: Response
   try {
     response = await fetchImpl(config.endpoint, {
@@ -485,7 +354,7 @@ async function postBatch(
         'Content-Type': 'application/json',
         'X-API-Key': config.apiKey,
       },
-      body: JSON.stringify({ events }),
+      body: requestBody,
       signal: AbortSignal.timeout(config.timeoutMs),
     })
   } catch {
@@ -503,26 +372,15 @@ async function postBatch(
     throw new CanonicalArchivePublisherError('canonical_response_invalid')
   }
   assertPlainObject(body, 'canonical_response')
-  if (!Array.isArray(body.accepted) || body.accepted.length !== events.length) {
-    throw new CanonicalArchivePublisherError('canonical_receipts_incomplete')
-  }
-  const receipts = body.accepted as Record<string, unknown>[]
-  const expectedIds = new Set(events.map((event) => event.event_id))
-  const receivedIds = new Set(
-    receipts.map((receipt) => String(receipt.event_id)),
-  )
-  if (
-    receivedIds.size !== expectedIds.size ||
-    [...expectedIds].some((eventId) => !receivedIds.has(eventId)) ||
-    receipts.some(
-      (receipt) =>
-        !expectedIds.has(String(receipt.event_id)) ||
-        typeof receipt.duplicate !== 'boolean',
-    )
-  ) {
+  const receipts = body.accepted
+  const receipt = Array.isArray(receipts) ? receipts[0] : null
+  if (!Array.isArray(receipts) || receipts.length !== 1 ||
+      receipt?.source_batch_id !== submission.source_batch_id ||
+      !/^[a-f0-9]{64}$/.test(receipt?.event_id ?? '') ||
+      !/^\d+-\d+$/.test(receipt?.message_id ?? '') || typeof receipt?.duplicate !== 'boolean') {
     throw new CanonicalArchivePublisherError('canonical_receipts_invalid')
   }
-  return receipts.filter((receipt) => receipt.duplicate === true).length
+  return receipt.duplicate ? 1 : 0
 }
 
 export async function publishCanonicalArchiveBatch(options: {
@@ -534,17 +392,12 @@ export async function publishCanonicalArchiveBatch(options: {
 }): Promise<CanonicalPublishReport | { status: 'disabled' }> {
   if (!canonicalArchiveShadowEnabled()) return { status: 'disabled' }
   const config = publisherConfig()
-  const events = buildCanonicalArchiveEvents(
-    options.batch,
-    options.manifest,
-    options.policyVersion,
-  )
+  const events = buildCanonicalArchiveMutations(options.batch)
   const reportPath = canonicalArchiveReportPath(
     options.reportDir,
     options.manifest.archiveUploadId,
   )
-  const report = loadReport(
-    reportPath,
+  const report = newReport(
     options.manifest,
     events.length,
     options.policyVersion,
@@ -552,12 +405,13 @@ export async function publishCanonicalArchiveBatch(options: {
   writeReport(reportPath, report)
 
   try {
-    for (const eventBatch of chunks(events, config.batchSize)) {
-      const hash = batchHash(eventBatch)
-      if (report.completed_batches[hash]) continue
+    for (const [index, eventBatch] of chunks(events, config.batchSize).entries()) {
+      const hash = `batch-${index}`
       const duplicateCount = await postBatch(
         config,
-        eventBatch,
+        { source: SOURCE, source_run_id: `archive:${options.manifest.archiveUploadId}`,
+          source_batch_id: hash, observed_at: new Date(Number(eventBatch[0].version)).toISOString(),
+          mutations: eventBatch },
         options.fetchImpl ?? fetch,
       )
       report.completed_batches[hash] = {

--- a/services/process_archive/canonical_archive.ts
+++ b/services/process_archive/canonical_archive.ts
@@ -1,0 +1,620 @@
+import { createHash, randomUUID } from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
+import type {
+  ArchiveClickHouseBatch,
+  ArchiveClickHouseManifest,
+  ArchivePolicyDecisions,
+} from './archive_clickhouse'
+
+const SCHEMA_VERSION = 'canonical_ingest_v1'
+const SOURCE = 'archive_upload'
+const REPORT_VERSION = 1
+const MAX_BATCH_SIZE = 100
+
+type CanonicalEntityType =
+  | 'account'
+  | 'tweet_content'
+  | 'tweet_engagement'
+  | 'media'
+  | 'url'
+  | 'mention'
+  | 'relationship'
+
+export interface CanonicalIngestEvent {
+  event_id: string
+  schema_version: typeof SCHEMA_VERSION
+  source: typeof SOURCE
+  source_run_id: string
+  source_event_id: string
+  entity_type: CanonicalEntityType
+  entity_key: string
+  operation: 'upsert' | 'tombstone'
+  observed_at: string
+  emitted_at: string
+  version: string
+  policy_version: string
+  payload: Record<string, unknown>
+  payload_hash: string
+}
+
+interface CanonicalPublishReport {
+  schema_version: typeof REPORT_VERSION
+  archive_upload_id: string
+  source_run_id: string
+  status: 'pending' | 'publishing' | 'failed' | 'complete'
+  event_count: number
+  policy_version: string
+  completed_batches: Record<
+    string,
+    { event_count: number; duplicate_count: number; completed_at: string }
+  >
+  updated_at: string
+  last_error_code?: string
+}
+
+interface PublisherConfig {
+  endpoint: string
+  apiKey: string
+  batchSize: number
+  timeoutMs: number
+}
+
+type FetchLike = typeof fetch
+
+const TABLE_ENTITY_TYPES: Partial<
+  Record<keyof ArchiveClickHouseBatch, CanonicalEntityType>
+> = {
+  account_observations: 'account',
+  tweet_content_versions: 'tweet_content',
+  tweet_engagement_observations: 'tweet_engagement',
+  tweet_archive_provenance: 'relationship',
+  tweet_mentions: 'mention',
+  tweet_relationships: 'relationship',
+  tweet_media_versions: 'media',
+  tweet_url_versions: 'url',
+}
+
+export class CanonicalArchivePublisherError extends Error {
+  constructor(readonly code: string) {
+    super(code)
+    this.name = 'CanonicalArchivePublisherError'
+  }
+}
+
+export function canonicalArchiveShadowEnabled(): boolean {
+  return process.env.CANONICAL_ARCHIVE_SHADOW_PUBLISH_ENABLED === 'true'
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex')
+}
+
+function assertPlainObject(
+  value: unknown,
+  description: string,
+): asserts value is Record<string, unknown> {
+  if (
+    value === null ||
+    typeof value !== 'object' ||
+    Array.isArray(value) ||
+    (Object.getPrototypeOf(value) !== Object.prototype &&
+      Object.getPrototypeOf(value) !== null)
+  ) {
+    throw new CanonicalArchivePublisherError(`${description}_not_plain_json`)
+  }
+}
+
+function assertValidUnicode(value: string): void {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index)
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1)
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        throw new CanonicalArchivePublisherError('invalid_unicode')
+      }
+      index += 1
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      throw new CanonicalArchivePublisherError('invalid_unicode')
+    }
+  }
+}
+
+function serializeCanonicalJson(
+  value: unknown,
+  ancestors: Set<object>,
+): string {
+  if (value === null || typeof value === 'boolean') return JSON.stringify(value)
+  if (typeof value === 'string') {
+    assertValidUnicode(value)
+    return JSON.stringify(value)
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new CanonicalArchivePublisherError('non_finite_number')
+    }
+    return JSON.stringify(value)
+  }
+  if (Array.isArray(value)) {
+    if (ancestors.has(value)) {
+      throw new CanonicalArchivePublisherError('cyclic_json')
+    }
+    ancestors.add(value)
+    try {
+      return `[${value
+        .map((item) => serializeCanonicalJson(item, ancestors))
+        .join(',')}]`
+    } finally {
+      ancestors.delete(value)
+    }
+  }
+  assertPlainObject(value, 'canonical_payload')
+  if (ancestors.has(value)) {
+    throw new CanonicalArchivePublisherError('cyclic_json')
+  }
+  ancestors.add(value)
+  try {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => {
+        assertValidUnicode(key)
+        if (value[key] === undefined) {
+          throw new CanonicalArchivePublisherError('undefined_json_value')
+        }
+        return `${JSON.stringify(key)}:${serializeCanonicalJson(
+          value[key],
+          ancestors,
+        )}`
+      })
+      .join(',')}}`
+  } finally {
+    ancestors.delete(value)
+  }
+}
+
+export function canonicalJson(value: unknown): string {
+  return serializeCanonicalJson(value, new Set())
+}
+
+function versionForObservedAt(observedAt: string): string {
+  const milliseconds = Date.parse(observedAt)
+  if (!Number.isSafeInteger(milliseconds) || milliseconds < 0) {
+    throw new CanonicalArchivePublisherError('invalid_observed_at')
+  }
+  return String(milliseconds)
+}
+
+function payloadWithoutProjectionMetadata(
+  row: Record<string, unknown>,
+): Record<string, unknown> {
+  const payload = Object.fromEntries(
+    Object.entries(row).filter(
+      ([key]) => !['event_id', 'source', 'observed_at'].includes(key),
+    ),
+  )
+  if (typeof payload.is_tombstone === 'number') {
+    payload.is_tombstone = payload.is_tombstone === 1
+  }
+  return payload
+}
+
+function entityKey(
+  entityType: CanonicalEntityType,
+  payload: Record<string, unknown>,
+): string {
+  if (entityType === 'account') return String(payload.account_id)
+  if (entityType === 'tweet_content' || entityType === 'tweet_engagement') {
+    return String(payload.tweet_id)
+  }
+  if (entityType === 'mention') {
+    return `${payload.tweet_id}|${payload.mentioned_account_id}`
+  }
+  if (entityType === 'media') return String(payload.media_id)
+  if (entityType === 'url') return `${payload.tweet_id}|${payload.url}`
+  if (payload.archive_upload_id !== undefined) {
+    return `${payload.tweet_id}|archive_provenance|${payload.archive_upload_id}`
+  }
+  return `${payload.tweet_id}|${payload.relationship_type}|${payload.related_tweet_id}`
+}
+
+function createEvent(
+  input: Omit<CanonicalIngestEvent, 'event_id' | 'payload_hash'>,
+) {
+  const payloadHash = sha256(canonicalJson(input.payload))
+  const eventId = sha256(
+    [
+      input.schema_version,
+      input.source,
+      input.source_run_id,
+      input.source_event_id,
+      input.entity_type,
+      input.entity_key,
+      input.operation,
+      input.version,
+      payloadHash,
+    ].join('\0'),
+  )
+  return { ...input, event_id: eventId, payload_hash: payloadHash }
+}
+
+export function buildCanonicalArchiveEvents(
+  batch: ArchiveClickHouseBatch,
+  manifest: ArchiveClickHouseManifest,
+  policyVersion: string,
+  emittedAt = new Date().toISOString(),
+): CanonicalIngestEvent[] {
+  const sourceRunId = `archive:${manifest.archiveUploadId}`
+  const tweetAuthors = new Map(
+    batch.tweet_content_versions.map((row) => [
+      String(row.tweet_id),
+      String(row.account_id),
+    ]),
+  )
+  const tombstonedTweets = new Set(
+    batch.tweet_content_versions
+      .filter((row) => row.is_tombstone === 1)
+      .map((row) => String(row.tweet_id)),
+  )
+  const byEntity = new Map<string, CanonicalIngestEvent>()
+
+  for (const [table, rows] of Object.entries(batch) as [
+    keyof ArchiveClickHouseBatch,
+    Record<string, unknown>[],
+  ][]) {
+    const entityType = TABLE_ENTITY_TYPES[table]
+    if (!entityType) continue
+    for (const row of rows) {
+      const payload = payloadWithoutProjectionMetadata(row)
+      if (payload.account_id === undefined) {
+        const author = tweetAuthors.get(String(payload.tweet_id ?? ''))
+        if (!author) {
+          throw new CanonicalArchivePublisherError('policy_author_missing')
+        }
+        payload.account_id = author
+      } else {
+        payload.account_id = String(payload.account_id)
+      }
+      if (
+        table === 'tweet_archive_provenance' &&
+        tombstonedTweets.has(String(payload.tweet_id))
+      ) {
+        payload.is_tombstone = true
+      }
+      const key = entityKey(entityType, payload)
+      const observedAt = String(row.observed_at ?? '')
+      const event = createEvent({
+        schema_version: SCHEMA_VERSION,
+        source: SOURCE,
+        source_run_id: sourceRunId,
+        source_event_id: String(row.event_id ?? ''),
+        entity_type: entityType,
+        entity_key: key,
+        operation: payload.is_tombstone === true ? 'tombstone' : 'upsert',
+        observed_at: observedAt,
+        emitted_at: emittedAt,
+        version: versionForObservedAt(observedAt),
+        policy_version: policyVersion,
+        payload,
+      })
+      byEntity.set(`${entityType}\0${key}`, event)
+    }
+  }
+
+  return [...byEntity.entries()]
+    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+    .map(([, event]) => event)
+}
+
+export function canonicalArchivePolicyVersion(
+  manifest: ArchiveClickHouseManifest,
+  ownerBlocked: boolean,
+  decisions: ArchivePolicyDecisions,
+): string {
+  const relevantPolicy = [
+    `owner:${manifest.accountId}:${ownerBlocked ? 1 : 0}`,
+    ...[...decisions.entries()]
+      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+      .map(
+        ([key, decision]) =>
+          `${key}:${decision.accountId ?? ''}:${decision.blocked ? 1 : 0}`,
+      ),
+  ].join('\n')
+  return `archive-policy-v1:${sha256(relevantPolicy)}`
+}
+
+function positiveNumber(name: string, fallback: number): number {
+  const value = Number(process.env[name] ?? fallback)
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new CanonicalArchivePublisherError(`${name.toLowerCase()}_invalid`)
+  }
+  return value
+}
+
+function publisherConfig(): PublisherConfig {
+  const endpoint = process.env.CANONICAL_PUBLISH_URL?.trim() ?? ''
+  const apiKey = process.env.CANONICAL_PUBLISHER_API_KEY?.trim() ?? ''
+  if (!endpoint || !apiKey) {
+    throw new CanonicalArchivePublisherError('canonical_configuration_missing')
+  }
+  let url: URL
+  try {
+    url = new URL(endpoint)
+  } catch {
+    throw new CanonicalArchivePublisherError('canonical_url_invalid')
+  }
+  if (
+    url.protocol !== 'https:' &&
+    !['127.0.0.1', 'localhost', '::1', '[::1]'].includes(url.hostname)
+  ) {
+    throw new CanonicalArchivePublisherError('canonical_https_required')
+  }
+  const batchSize = positiveNumber('CANONICAL_PUBLISH_BATCH_SIZE', 100)
+  const timeoutSeconds = positiveNumber('CANONICAL_PUBLISH_TIMEOUT_SECONDS', 30)
+  if (!Number.isSafeInteger(batchSize) || batchSize > MAX_BATCH_SIZE) {
+    throw new CanonicalArchivePublisherError('canonical_batch_size_invalid')
+  }
+  if (timeoutSeconds > 120) {
+    throw new CanonicalArchivePublisherError('canonical_timeout_invalid')
+  }
+  return {
+    endpoint,
+    apiKey,
+    batchSize,
+    timeoutMs: timeoutSeconds * 1_000,
+  }
+}
+
+export function canonicalArchiveReportPath(
+  reportDir: string,
+  archiveUploadId: string,
+): string {
+  if (!/^(0|[1-9][0-9]*)$/.test(archiveUploadId)) {
+    throw new CanonicalArchivePublisherError('archive_upload_id_invalid')
+  }
+  return path.join(reportDir, `canonical_archive_${archiveUploadId}.json`)
+}
+
+function newReport(
+  manifest: ArchiveClickHouseManifest,
+  eventCount: number,
+  policyVersion: string,
+): CanonicalPublishReport {
+  return {
+    schema_version: REPORT_VERSION,
+    archive_upload_id: manifest.archiveUploadId,
+    source_run_id: `archive:${manifest.archiveUploadId}`,
+    status: 'publishing',
+    event_count: eventCount,
+    policy_version: policyVersion,
+    completed_batches: {},
+    updated_at: new Date().toISOString(),
+  }
+}
+
+function loadReport(
+  reportPath: string,
+  manifest: ArchiveClickHouseManifest,
+  eventCount: number,
+  policyVersion: string,
+): CanonicalPublishReport {
+  try {
+    const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'))
+    if (
+      report.schema_version === REPORT_VERSION &&
+      report.archive_upload_id === manifest.archiveUploadId &&
+      report.source_run_id === `archive:${manifest.archiveUploadId}` &&
+      report.completed_batches !== null &&
+      typeof report.completed_batches === 'object' &&
+      !Array.isArray(report.completed_batches)
+    ) {
+      return {
+        ...report,
+        status: 'publishing',
+        event_count: eventCount,
+        policy_version: policyVersion,
+        updated_at: new Date().toISOString(),
+      }
+    }
+  } catch {}
+  return newReport(manifest, eventCount, policyVersion)
+}
+
+function writeReport(reportPath: string, report: CanonicalPublishReport): void {
+  fs.mkdirSync(path.dirname(reportPath), { recursive: true })
+  const temporaryPath = `${reportPath}.${process.pid}.${randomUUID()}.tmp`
+  try {
+    fs.writeFileSync(temporaryPath, `${JSON.stringify(report, null, 2)}\n`, {
+      encoding: 'utf8',
+      mode: 0o600,
+    })
+    const handle = fs.openSync(temporaryPath, 'r')
+    try {
+      fs.fsyncSync(handle)
+    } finally {
+      fs.closeSync(handle)
+    }
+    fs.renameSync(temporaryPath, reportPath)
+  } finally {
+    try {
+      fs.unlinkSync(temporaryPath)
+    } catch {}
+  }
+}
+
+export function ensureCanonicalArchivePendingReport(
+  archiveUploadId: string,
+  reportDir: string,
+): void {
+  const reportPath = canonicalArchiveReportPath(reportDir, archiveUploadId)
+  if (fs.existsSync(reportPath)) return
+  writeReport(reportPath, {
+    schema_version: REPORT_VERSION,
+    archive_upload_id: archiveUploadId,
+    source_run_id: `archive:${archiveUploadId}`,
+    status: 'pending',
+    event_count: 0,
+    policy_version: 'pending',
+    completed_batches: {},
+    updated_at: new Date().toISOString(),
+    last_error_code: 'canonical_archive_pending',
+  })
+}
+
+function chunks<T>(values: T[], size: number): T[][] {
+  const result: T[][] = []
+  for (let offset = 0; offset < values.length; offset += size) {
+    result.push(values.slice(offset, offset + size))
+  }
+  return result
+}
+
+function batchHash(events: CanonicalIngestEvent[]): string {
+  return sha256(events.map((event) => event.event_id).join('\n'))
+}
+
+async function postBatch(
+  config: PublisherConfig,
+  events: CanonicalIngestEvent[],
+  fetchImpl: FetchLike,
+): Promise<number> {
+  let response: Response
+  try {
+    response = await fetchImpl(config.endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': config.apiKey,
+      },
+      body: JSON.stringify({ events }),
+      signal: AbortSignal.timeout(config.timeoutMs),
+    })
+  } catch {
+    throw new CanonicalArchivePublisherError('canonical_request_failed')
+  }
+  if (response.status !== 202) {
+    throw new CanonicalArchivePublisherError(
+      `canonical_http_${response.status}`,
+    )
+  }
+  let body: unknown
+  try {
+    body = await response.json()
+  } catch {
+    throw new CanonicalArchivePublisherError('canonical_response_invalid')
+  }
+  assertPlainObject(body, 'canonical_response')
+  if (!Array.isArray(body.accepted) || body.accepted.length !== events.length) {
+    throw new CanonicalArchivePublisherError('canonical_receipts_incomplete')
+  }
+  const receipts = body.accepted as Record<string, unknown>[]
+  const expectedIds = new Set(events.map((event) => event.event_id))
+  const receivedIds = new Set(
+    receipts.map((receipt) => String(receipt.event_id)),
+  )
+  if (
+    receivedIds.size !== expectedIds.size ||
+    [...expectedIds].some((eventId) => !receivedIds.has(eventId)) ||
+    receipts.some(
+      (receipt) =>
+        !expectedIds.has(String(receipt.event_id)) ||
+        typeof receipt.duplicate !== 'boolean',
+    )
+  ) {
+    throw new CanonicalArchivePublisherError('canonical_receipts_invalid')
+  }
+  return receipts.filter((receipt) => receipt.duplicate === true).length
+}
+
+export async function publishCanonicalArchiveBatch(options: {
+  batch: ArchiveClickHouseBatch
+  manifest: ArchiveClickHouseManifest
+  policyVersion: string
+  reportDir: string
+  fetchImpl?: FetchLike
+}): Promise<CanonicalPublishReport | { status: 'disabled' }> {
+  if (!canonicalArchiveShadowEnabled()) return { status: 'disabled' }
+  const config = publisherConfig()
+  const events = buildCanonicalArchiveEvents(
+    options.batch,
+    options.manifest,
+    options.policyVersion,
+  )
+  const reportPath = canonicalArchiveReportPath(
+    options.reportDir,
+    options.manifest.archiveUploadId,
+  )
+  const report = loadReport(
+    reportPath,
+    options.manifest,
+    events.length,
+    options.policyVersion,
+  )
+  writeReport(reportPath, report)
+
+  try {
+    for (const eventBatch of chunks(events, config.batchSize)) {
+      const hash = batchHash(eventBatch)
+      if (report.completed_batches[hash]) continue
+      const duplicateCount = await postBatch(
+        config,
+        eventBatch,
+        options.fetchImpl ?? fetch,
+      )
+      report.completed_batches[hash] = {
+        event_count: eventBatch.length,
+        duplicate_count: duplicateCount,
+        completed_at: new Date().toISOString(),
+      }
+      report.updated_at = new Date().toISOString()
+      writeReport(reportPath, report)
+    }
+    report.status = 'complete'
+    delete report.last_error_code
+    report.updated_at = new Date().toISOString()
+    writeReport(reportPath, report)
+    return report
+  } catch (error) {
+    report.status = 'failed'
+    report.last_error_code = safeCanonicalArchiveErrorCode(error)
+    report.updated_at = new Date().toISOString()
+    writeReport(reportPath, report)
+    throw error
+  }
+}
+
+export function safeCanonicalArchiveErrorCode(error: unknown): string {
+  return error instanceof CanonicalArchivePublisherError
+    ? error.code
+    : 'canonical_archive_publish_failed'
+}
+
+export function pendingCanonicalArchiveReportIds(reportDir: string): string[] {
+  try {
+    return fs
+      .readdirSync(reportDir)
+      .map((name) => name.match(/^canonical_archive_(\d+)\.json$/)?.[1])
+      .filter((value): value is string => Boolean(value))
+      .filter((archiveUploadId) => {
+        try {
+          const report = JSON.parse(
+            fs.readFileSync(
+              canonicalArchiveReportPath(reportDir, archiveUploadId),
+              'utf8',
+            ),
+          )
+          return report.status !== 'complete'
+        } catch {
+          return true
+        }
+      })
+      .sort((left, right) =>
+        BigInt(left) < BigInt(right)
+          ? -1
+          : BigInt(left) > BigInt(right)
+            ? 1
+            : 0,
+      )
+  } catch {
+    return []
+  }
+}

--- a/services/process_archive/canonical_archive.ts
+++ b/services/process_archive/canonical_archive.ts
@@ -104,6 +104,18 @@ function versionForObservedAt(observedAt: string): string {
   return String(milliseconds)
 }
 
+/** Use the existing delivery's immutable source time, never retry wall-clock time. */
+export function canonicalArchiveObservedAt(value: unknown): string {
+  if (!(value instanceof Date) && typeof value !== 'string') {
+    throw new CanonicalArchivePublisherError('archive_source_time_missing')
+  }
+  const milliseconds = value instanceof Date ? value.getTime() : Date.parse(value)
+  if (!Number.isSafeInteger(milliseconds) || milliseconds < 0) {
+    throw new CanonicalArchivePublisherError('archive_source_time_invalid')
+  }
+  return new Date(milliseconds).toISOString()
+}
+
 function payloadWithoutProjectionMetadata(
   row: Record<string, unknown>,
 ): Record<string, unknown> {

--- a/services/process_archive/env.example
+++ b/services/process_archive/env.example
@@ -32,6 +32,15 @@ CLICKHOUSE_DATABASE=community_archive
 CLICKHOUSE_USER=archive_ingestor
 CLICKHOUSE_PASSWORD=replace-with-runtime-secret
 
+# Additive canonical queue shadow (disabled until a separately approved rollout)
+# Existing PostgreSQL completion and ClickHouse delivery always run first.
+CANONICAL_ARCHIVE_SHADOW_PUBLISH_ENABLED=false
+CANONICAL_ARCHIVE_RETRY_BATCH=5
+CANONICAL_PUBLISH_URL=https://firehose-host/internal/canonical-ingest
+CANONICAL_PUBLISHER_API_KEY=replace-with-dedicated-runtime-secret
+CANONICAL_PUBLISH_BATCH_SIZE=100
+CANONICAL_PUBLISH_TIMEOUT_SECONDS=30
+
 NODE_ENV=production
 
 # Docker-specific Configuration (OPTIONAL)

--- a/services/process_archive/package.json
+++ b/services/process_archive/package.json
@@ -12,7 +12,7 @@
     "start:stream": "set NODE_OPTIONS=--expose-gc && tsx --env-file=.env process_stream.ts",
     "start:copy": "npm run start",
     "smoke:runtime": "node --expose-gc runtime_smoke_test.cjs",
-    "test:archive-clickhouse": "node --import tsx --test archive_clickhouse.test.ts",
+    "test:archive-clickhouse": "node --import tsx --test archive_clickhouse.test.ts canonical_archive.test.ts",
     "run": "set NODE_OPTIONS=--expose-gc && tsx --env-file=.env process.ts",
     "docker:build": "cd ../../ && docker build -f services/process_archive/Dockerfile -t process-archive .",
     "docker:run": "docker compose run --rm process-archive",

--- a/services/process_archive/process_archive_upload.ts
+++ b/services/process_archive/process_archive_upload.ts
@@ -17,8 +17,19 @@ import {
   type ArchivePolicyCandidate,
   type ArchivePolicyDecisions,
   attemptArchiveClickHouseDelivery,
+  buildArchiveClickHouseBatch,
+  buildArchiveTombstoneBatch,
+  collectArchivePolicyCandidates,
   createArchiveClickHouseManifest,
 } from './archive_clickhouse'
+import {
+  canonicalArchivePolicyVersion,
+  canonicalArchiveShadowEnabled,
+  ensureCanonicalArchivePendingReport,
+  pendingCanonicalArchiveReportIds,
+  publishCanonicalArchiveBatch,
+  safeCanonicalArchiveErrorCode,
+} from './canonical_archive'
 
 // Configuration
 const CONFIG = {
@@ -44,6 +55,13 @@ const CONFIG = {
     process.env.CLICKHOUSE_DATABASE || 'community_archive',
   CLICKHOUSE_USER: process.env.CLICKHOUSE_USER,
   CLICKHOUSE_PASSWORD: process.env.CLICKHOUSE_PASSWORD,
+  CANONICAL_ARCHIVE_RETRY_BATCH: Math.max(
+    1,
+    Math.min(
+      50,
+      parseInt(process.env.CANONICAL_ARCHIVE_RETRY_BATCH || '5', 10),
+    ),
+  ),
 } as const
 
 export async function createServerScriptClient() {
@@ -992,6 +1010,136 @@ async function resolveArchivePolicyDecisions(
   )
 }
 
+async function buildPolicySafeCanonicalArchiveBatch(
+  sql: Sql,
+  delivery: ArchiveClickHouseDelivery,
+  archive?: any,
+) {
+  const manifest = {
+    archiveUploadId: String(delivery.archive_upload_id),
+    accountId: String(delivery.account_id),
+    tweetIds: (delivery.tweet_ids ?? []).map(String),
+  }
+  return sql.begin(async (transaction) => {
+    const trx = transaction as unknown as Sql
+    await trx`SELECT public.lock_policy_account(${manifest.accountId})`
+    const [policy] = await trx`
+      SELECT public.policy_account_is_blocked(
+        ${manifest.accountId},
+        ${delivery.username ?? null}
+      ) AS blocked
+    `
+    const ownerBlocked = policy?.blocked === true
+    let decisions: ArchivePolicyDecisions = new Map()
+    let batch
+    if (ownerBlocked) {
+      batch = buildArchiveTombstoneBatch(manifest)
+    } else {
+      const source =
+        archive ??
+        (delivery.username
+          ? patchArchive(await loadArchiveData(delivery.username))
+          : null)
+      if (!source) {
+        throw new ArchiveClickHouseError('archive_source_unavailable')
+      }
+      const sourceManifest = createArchiveClickHouseManifest(
+        source,
+        manifest.archiveUploadId,
+      )
+      if (
+        sourceManifest.accountId !== manifest.accountId ||
+        sourceManifest.tweetIds.join(',') !== manifest.tweetIds.join(',')
+      ) {
+        throw new ArchiveClickHouseError('archive_manifest_mismatch')
+      }
+      decisions = await resolveArchivePolicyDecisions(
+        trx,
+        collectArchivePolicyCandidates(source),
+      )
+      batch = buildArchiveClickHouseBatch(source, manifest, decisions)
+    }
+    return {
+      batch,
+      manifest,
+      policyVersion: canonicalArchivePolicyVersion(
+        manifest,
+        ownerBlocked,
+        decisions,
+      ),
+    }
+  })
+}
+
+async function attemptCanonicalArchiveShadow(
+  sql: Sql,
+  delivery: ArchiveClickHouseDelivery,
+  archive?: any,
+): Promise<void> {
+  if (!canonicalArchiveShadowEnabled()) return
+  try {
+    ensureCanonicalArchivePendingReport(
+      String(delivery.archive_upload_id),
+      logsDir,
+    )
+    const prepared = await buildPolicySafeCanonicalArchiveBatch(
+      sql,
+      delivery,
+      archive,
+    )
+    const report = await publishCanonicalArchiveBatch({
+      ...prepared,
+      reportDir: logsDir,
+    })
+    logger.info(
+      `Canonical archive shadow ${report.status} (archive_upload_id=${delivery.archive_upload_id})`,
+    )
+  } catch (error) {
+    logger.warn(
+      `Canonical archive shadow remains pending (archive_upload_id=${delivery.archive_upload_id}, code=${safeCanonicalArchiveErrorCode(error)})`,
+    )
+  }
+}
+
+async function retryPendingCanonicalArchiveShadows(sql: Sql): Promise<void> {
+  if (!canonicalArchiveShadowEnabled()) return
+  const archiveUploadIds = pendingCanonicalArchiveReportIds(logsDir).slice(
+    0,
+    CONFIG.CANONICAL_ARCHIVE_RETRY_BATCH,
+  )
+  for (const archiveUploadId of archiveUploadIds) {
+    try {
+      const rows = await sql`
+        SELECT
+          upload.id AS archive_upload_id,
+          upload.account_id,
+          upload.username,
+          delivery.tweet_ids
+        FROM public.archive_upload AS upload
+        JOIN private.archive_clickhouse_delivery AS delivery
+          ON delivery.archive_upload_id = upload.id
+        WHERE upload.id = ${archiveUploadId}
+          AND upload.upload_phase = 'completed'
+        LIMIT 1
+      `
+      if (rows.length !== 1) {
+        logger.warn(
+          `Canonical archive retry skipped missing completed upload (archive_upload_id=${archiveUploadId})`,
+        )
+        continue
+      }
+      await attemptCanonicalArchiveShadow(
+        sql,
+        rows[0] as ArchiveClickHouseDelivery,
+      )
+    } catch {
+      logger.warn(
+        `Canonical archive retry failed without affecting archive processing (archive_upload_id=${archiveUploadId})`,
+      )
+    }
+  }
+}
+
 async function attemptClickHouseDelivery(
   sql: Sql,
   sink: ArchiveClickHouseSink,
@@ -1139,6 +1287,8 @@ async function main() {
       }
     }
 
+    await retryPendingCanonicalArchiveShadows(sql)
+
     logger.info('Fetching archive_upload records ready for processing...')
 
     const ready = await sql`
@@ -1210,6 +1360,20 @@ async function main() {
             archive,
           )
         }
+
+        await attemptCanonicalArchiveShadow(
+          sql,
+          {
+            archive_upload_id: archiveUploadId,
+            account_id,
+            tweet_ids: createArchiveClickHouseManifest(
+              archive,
+              archiveUploadId,
+            ).tweetIds,
+            username,
+          },
+          archive,
+        )
 
         // Force GC between accounts
         if (global.gc) {

--- a/services/process_archive/process_archive_upload.ts
+++ b/services/process_archive/process_archive_upload.ts
@@ -23,6 +23,7 @@ import {
   createArchiveClickHouseManifest,
 } from './archive_clickhouse'
 import {
+  canonicalArchiveObservedAt,
   canonicalArchivePolicyVersion,
   canonicalArchiveShadowEnabled,
   ensureCanonicalArchivePendingReport,
@@ -1023,6 +1024,13 @@ async function buildPolicySafeCanonicalArchiveBatch(
   return sql.begin(async (transaction) => {
     const trx = transaction as unknown as Sql
     await trx`SELECT public.lock_policy_account(${manifest.accountId})`
+    const [source] = await trx`
+      SELECT created_at
+      FROM private.archive_clickhouse_delivery
+      WHERE archive_upload_id = ${manifest.archiveUploadId}
+        AND account_id = ${manifest.accountId}
+    `
+    const observedAt = canonicalArchiveObservedAt(source?.created_at)
     const [policy] = await trx`
       SELECT public.policy_account_is_blocked(
         ${manifest.accountId},
@@ -1033,7 +1041,7 @@ async function buildPolicySafeCanonicalArchiveBatch(
     let decisions: ArchivePolicyDecisions = new Map()
     let batch
     if (ownerBlocked) {
-      batch = buildArchiveTombstoneBatch(manifest)
+      batch = buildArchiveTombstoneBatch(manifest, observedAt)
     } else {
       const source =
         archive ??
@@ -1057,7 +1065,7 @@ async function buildPolicySafeCanonicalArchiveBatch(
         trx,
         collectArchivePolicyCandidates(source),
       )
-      batch = buildArchiveClickHouseBatch(source, manifest, decisions)
+      batch = buildArchiveClickHouseBatch(source, manifest, decisions, observedAt)
     }
     return {
       batch,


### PR DESCRIPTION
## Summary

- preserve existing completed-upload and PostgreSQL/current-ClickHouse behavior
- send policy-safe normalized mutation batches after established writes finish
- preserve permitted archive provenance but omit dependent edges for tombstones
- remove repeated producer-side canonical hashing/envelopes; firehose owns identity and policy stamps
- bounded one-batch requests with validated server receipts
- existing content-free pending-report recovery resubmits for server dedupe rather than skipping local batch hashes

## Dependencies and rollout

Requires TheExGenesis/community-archive-firehose#22. CANONICAL_ARCHIVE_SHADOW_PUBLISH_ENABLED remains false. No UI, delete RPC, RLS or database schema changes.

## Validation

Seven focused archive canonical tests passed; targeted TypeScript compile passed using existing Node type definitions from the adjacent admin service. Allowed/blocked archive-built batches, including provenance, passed the real firehose validator and vector projector.

Local commit hook could not load the missing Husky bootstrap; the commit bypassed that broken local hook after focused tests passed.

## Safety boundary

Disabled-by-default additive shadow infrastructure only. Existing PostgreSQL/current-ClickHouse writes, acknowledgements, reader endpoints, auth, database schemas and user-facing delete RPCs are unchanged. No deployment, flag enablement, event publication, clone, historical backfill, cutover or legacy shutdown is authorized by this PR. Queue acceptance is not sink completion or erasure.

## All-source compatibility follow-up (2026-08-30)

Fixed canonical retries rebuilding uploads with retry wall-clock observation time. The archive path now reads the existing delivery row created_at as the stable source timestamp for both normal and blocked batches. Missing timestamp fails only shadow publication. No schema or upload-result changes.

Validation: 14 focused archive tests passed, including rebuilt-source version stability; the archive worker bundles successfully. The real publisher also passed the control-panel five-source local HTTP-intake/vector-writer contract check (in-memory queue and recording SQL transport, not a live deployment test). Included in admin-delete stack #852. Runtime flag remains disabled.