### PR TITLE
Add disabled identifier-only admin tombstone batch publication

### DIFF
--- a/docs/admin-delete-worker.md
+++ b/docs/admin-delete-worker.md
@@ -23,6 +23,15 @@ canonical publisher with a dedicated credential. Its failure is isolated from
 the established deletion result, and it is disabled by default. PostgreSQL
 remains the policy authority; this shadow copy is not a transactional outbox.
 
+The shadow submits bounded mutation batches with identifier-only account/tweet
+tombstones. Firehose creates canonical IDs and rechecks the authoritative block;
+producer retries carry the same job ID, batch index and observation version.
+Queue acceptance is not proof of erasure. User-facing delete RPCs are unchanged.
+Before those can use this lane, add a transactional deletion intent/outbox,
+per-sink completion tracking, persistent replay suppression and physical cleanup
+of raw/replay copies. Source/archive retractions are reserved in the contract
+but are rejected until provenance-aware sink execution is implemented.
+
 The manifest contains only its format version, account ID, tweet IDs,
 `content_free: true`, and completion timestamp. It must not contain username,
 tweet text, profile fields, raw archives, opt-out reasons, requester identity, or

--- a/docs/admin-delete-worker.md
+++ b/docs/admin-delete-worker.md
@@ -17,6 +17,12 @@ operational tooling keeps working. The worker no longer exports content.
 5. The legacy retention sweep removes old contentful export folders immediately;
    paths below `tombstones/` are retained.
 
+An optional `CANONICAL_ADMIN_DELETE_SHADOW_PUBLISH_ENABLED=true` step runs only
+after item 4. It sends content-free account and tweet tombstones to the
+canonical publisher with a dedicated credential. Its failure is isolated from
+the established deletion result, and it is disabled by default. PostgreSQL
+remains the policy authority; this shadow copy is not a transactional outbox.
+
 The manifest contains only its format version, account ID, tweet IDs,
 `content_free: true`, and completion timestamp. It must not contain username,
 tweet text, profile fields, raw archives, opt-out reasons, requester identity, or

--- a/services/admin-delete-worker/README.md
+++ b/services/admin-delete-worker/README.md
@@ -26,6 +26,14 @@ Required environment variables are `DATABASE_URL`, `SUPABASE_URL`, and
 `SUPABASE_SERVICE_ROLE`. `POLL_INTERVAL_MS` defaults to 10 seconds. See
 `docker-compose.yml` and `env.example` for runtime wiring.
 
+The worker also has a disabled post-success canonical shadow copy. Set
+`CANONICAL_ADMIN_DELETE_SHADOW_PUBLISH_ENABLED=true` only after the firehose
+canonical stream and external publisher are separately enabled. It publishes
+content-free account and tweet tombstones using the dedicated
+`CANONICAL_PUBLISHER_API_KEY`; failure logs only a bounded error code and never
+changes the completed legacy deletion result. The shadow copy is not a
+transactional outbox and must not be used as the canonical deletion authority.
+
 ## Operational verification
 
 - A policy block must make PostgreSQL rows content-free before the job is

--- a/services/admin-delete-worker/env.example
+++ b/services/admin-delete-worker/env.example
@@ -31,3 +31,12 @@ WORKER_HOST_LABEL=
 # Optional: log level for pino. Default 'info'. Set 'debug' to see every
 # poll cycle, 'warn' to suppress per-job heartbeats.
 LOG_LEVEL=info
+
+# Disabled additive canonical tombstone copy. The existing PostgreSQL policy
+# tombstone, raw-object cleanup, job result, and worker acknowledgement remain
+# authoritative when this is false or publication fails.
+CANONICAL_ADMIN_DELETE_SHADOW_PUBLISH_ENABLED=false
+CANONICAL_PUBLISH_URL=https://firehose-host/internal/canonical-ingest
+CANONICAL_PUBLISHER_API_KEY=replace-with-dedicated-runtime-secret
+CANONICAL_PUBLISH_BATCH_SIZE=100
+CANONICAL_PUBLISH_TIMEOUT_SECONDS=30

--- a/services/admin-delete-worker/package.json
+++ b/services/admin-delete-worker/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "tsx --watch src/index.ts",
     "start": "tsx src/index.ts",
+    "test:canonical": "node --import tsx --test src/canonicalShadow.test.ts",
     "build": "tsc --noEmit",
     "docker:build": "cd ../../ && docker build -f services/admin-delete-worker/Dockerfile -t admin-delete-worker:latest .",
     "docker:up": "docker compose up -d --build",

--- a/services/admin-delete-worker/src/canonicalShadow.test.ts
+++ b/services/admin-delete-worker/src/canonicalShadow.test.ts
@@ -1,0 +1,143 @@
+import assert from 'node:assert/strict'
+import { afterEach, beforeEach, test } from 'node:test'
+import {
+  buildCanonicalAdminDeleteEvents,
+  canonicalAdminDeleteErrorCode,
+  publishCanonicalAdminDeleteShadow,
+} from './canonicalShadow.ts'
+
+const managedEnvironment = [
+  'CANONICAL_ADMIN_DELETE_SHADOW_PUBLISH_ENABLED',
+  'CANONICAL_PUBLISH_URL',
+  'CANONICAL_PUBLISHER_API_KEY',
+  'CANONICAL_PUBLISH_BATCH_SIZE',
+  'CANONICAL_PUBLISH_TIMEOUT_SECONDS',
+] as const
+
+const originalEnvironment = Object.fromEntries(
+  managedEnvironment.map((name) => [name, process.env[name]]),
+)
+
+const input = {
+  jobKey: 'admin-job-17',
+  accountId: '6001',
+  tweetIds: ['5002', '5001', '5001'],
+  observedAt: '2026-08-29T03:00:00.000Z',
+}
+
+beforeEach(() => {
+  for (const name of managedEnvironment) delete process.env[name]
+})
+
+afterEach(() => {
+  for (const name of managedEnvironment) {
+    const value = originalEnvironment[name]
+    if (value === undefined) delete process.env[name]
+    else process.env[name] = value
+  }
+})
+
+test('builds deterministic content-free account and tweet tombstones', () => {
+  const first = buildCanonicalAdminDeleteEvents(
+    input,
+    '2026-08-29T03:10:00.000Z',
+  )
+  const retried = buildCanonicalAdminDeleteEvents(
+    input,
+    '2026-08-29T03:20:00.000Z',
+  )
+
+  assert.equal(first.length, 3)
+  assert.deepEqual(
+    first.map(({ entity_type, entity_key }) => [entity_type, entity_key]),
+    [
+      ['account', '6001'],
+      ['tweet_content', '5001'],
+      ['tweet_content', '5002'],
+    ],
+  )
+  assert.deepEqual(
+    first.map(({ event_id }) => event_id),
+    retried.map(({ event_id }) => event_id),
+  )
+  assert.ok(first.every(({ source }) => source === 'admin_delete'))
+  assert.ok(first.every(({ operation }) => operation === 'tombstone'))
+  assert.doesNotMatch(JSON.stringify(first), /username|reason|requester/)
+  assert.deepEqual(first[1].payload, {
+    tweet_id: '5001',
+    account_id: '6001',
+    full_text: '',
+    is_tombstone: true,
+  })
+})
+
+test('is inert while disabled and does not require publisher configuration', async () => {
+  let called = false
+  const result = await publishCanonicalAdminDeleteShadow(input, async () => {
+    called = true
+    return new Response(null, { status: 500 })
+  })
+
+  assert.deepEqual(result, {
+    eventCount: 0,
+    duplicateCount: 0,
+    skipped: true,
+  })
+  assert.equal(called, false)
+})
+
+test('publishes bounded batches with a dedicated credential', async () => {
+  process.env.CANONICAL_ADMIN_DELETE_SHADOW_PUBLISH_ENABLED = 'true'
+  process.env.CANONICAL_PUBLISH_URL =
+    'http://127.0.0.1:3000/internal/canonical-ingest'
+  process.env.CANONICAL_PUBLISHER_API_KEY = 'publisher-secret'
+  process.env.CANONICAL_PUBLISH_BATCH_SIZE = '2'
+  const batches: unknown[][] = []
+
+  const result = await publishCanonicalAdminDeleteShadow(input, async (
+    _url,
+    init,
+  ) => {
+    assert.equal(
+      (init?.headers as Record<string, string>)['X-API-Key'],
+      'publisher-secret',
+    )
+    const body = JSON.parse(String(init?.body)) as { events: unknown[] }
+    batches.push(body.events)
+    return Response.json(
+      {
+        accepted: body.events.map((event, index) => ({
+          event_id: (event as { event_id: string }).event_id,
+          message_id: `1-${index}`,
+          duplicate: index === 0,
+        })),
+      },
+      { status: 202 },
+    )
+  })
+
+  assert.equal(batches.length, 2)
+  assert.deepEqual(result, {
+    eventCount: 3,
+    duplicateCount: 2,
+    skipped: false,
+  })
+})
+
+test('rejects insecure remote publication and exposes only a bounded code', async () => {
+  process.env.CANONICAL_ADMIN_DELETE_SHADOW_PUBLISH_ENABLED = 'true'
+  process.env.CANONICAL_PUBLISH_URL =
+    'http://firehose.example/internal/canonical-ingest'
+  process.env.CANONICAL_PUBLISHER_API_KEY = 'publisher-secret'
+
+  await assert.rejects(
+    publishCanonicalAdminDeleteShadow(input),
+    /canonical_https_required/,
+  )
+  try {
+    await publishCanonicalAdminDeleteShadow(input)
+  } catch (error) {
+    assert.equal(canonicalAdminDeleteErrorCode(error), 'canonical_https_required')
+    assert.doesNotMatch(canonicalAdminDeleteErrorCode(error), /publisher-secret/)
+  }
+})

--- a/services/admin-delete-worker/src/canonicalShadow.test.ts
+++ b/services/admin-delete-worker/src/canonicalShadow.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import { afterEach, beforeEach, test } from 'node:test'
 import {
-  buildCanonicalAdminDeleteEvents,
+  buildCanonicalAdminDeleteMutations,
   canonicalAdminDeleteErrorCode,
   publishCanonicalAdminDeleteShadow,
 } from './canonicalShadow.ts'
@@ -38,13 +38,11 @@ afterEach(() => {
 })
 
 test('builds deterministic content-free account and tweet tombstones', () => {
-  const first = buildCanonicalAdminDeleteEvents(
+  const first = buildCanonicalAdminDeleteMutations(
     input,
-    '2026-08-29T03:10:00.000Z',
   )
-  const retried = buildCanonicalAdminDeleteEvents(
+  const retried = buildCanonicalAdminDeleteMutations(
     input,
-    '2026-08-29T03:20:00.000Z',
   )
 
   assert.equal(first.length, 3)
@@ -57,16 +55,15 @@ test('builds deterministic content-free account and tweet tombstones', () => {
     ],
   )
   assert.deepEqual(
-    first.map(({ event_id }) => event_id),
-    retried.map(({ event_id }) => event_id),
+    first,
+    retried,
   )
-  assert.ok(first.every(({ source }) => source === 'admin_delete'))
+  assert.ok(first.every((mutation) => !('event_id' in mutation) && !('policy_version' in mutation)))
   assert.ok(first.every(({ operation }) => operation === 'tombstone'))
   assert.doesNotMatch(JSON.stringify(first), /username|reason|requester/)
   assert.deepEqual(first[1].payload, {
     tweet_id: '5001',
     account_id: '6001',
-    full_text: '',
     is_tombstone: true,
   })
 })
@@ -102,12 +99,13 @@ test('publishes bounded batches with a dedicated credential', async () => {
       (init?.headers as Record<string, string>)['X-API-Key'],
       'publisher-secret',
     )
-    const body = JSON.parse(String(init?.body)) as { events: unknown[] }
-    batches.push(body.events)
+    const body = JSON.parse(String(init?.body)) as { batches: unknown[] }
+    batches.push(body.batches)
     return Response.json(
       {
-        accepted: body.events.map((event, index) => ({
-          event_id: (event as { event_id: string }).event_id,
+        accepted: body.batches.map((event, index) => ({
+          source_batch_id: (event as { source_batch_id: string }).source_batch_id,
+          event_id: 'a'.repeat(64),
           message_id: `1-${index}`,
           duplicate: index === 0,
         })),

--- a/services/admin-delete-worker/src/canonicalShadow.ts
+++ b/services/admin-delete-worker/src/canonicalShadow.ts
@@ -1,26 +1,15 @@
-import { createHash } from 'node:crypto'
-
-const SCHEMA_VERSION = 'canonical_ingest_v1'
 const SOURCE = 'admin_delete'
 const MAX_BATCH_SIZE = 100
 
 type CanonicalAdminEntityType = 'account' | 'tweet_content'
 
-export interface CanonicalAdminDeleteEvent {
-  event_id: string
-  schema_version: typeof SCHEMA_VERSION
-  source: typeof SOURCE
-  source_run_id: string
+export interface CanonicalAdminDeleteMutation {
   source_event_id: string
   entity_type: CanonicalAdminEntityType
   entity_key: string
   operation: 'tombstone'
-  observed_at: string
-  emitted_at: string
   version: string
-  policy_version: string
   payload: Record<string, unknown>
-  payload_hash: string
 }
 
 export interface CanonicalAdminDeleteInput {
@@ -50,77 +39,6 @@ export function canonicalAdminDeleteShadowEnabled(): boolean {
   return process.env.CANONICAL_ADMIN_DELETE_SHADOW_PUBLISH_ENABLED === 'true'
 }
 
-function sha256(value: string): string {
-  return createHash('sha256').update(value, 'utf8').digest('hex')
-}
-
-function assertValidUnicode(value: string): void {
-  for (let index = 0; index < value.length; index += 1) {
-    const codeUnit = value.charCodeAt(index)
-    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
-      const next = value.charCodeAt(index + 1)
-      if (!(next >= 0xdc00 && next <= 0xdfff)) {
-        throw new CanonicalAdminDeleteShadowError('invalid_unicode')
-      }
-      index += 1
-    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
-      throw new CanonicalAdminDeleteShadowError('invalid_unicode')
-    }
-  }
-}
-
-function canonicalJson(value: unknown, ancestors = new Set<object>()): string {
-  if (value === null || typeof value === 'boolean') return JSON.stringify(value)
-  if (typeof value === 'string') {
-    assertValidUnicode(value)
-    return JSON.stringify(value)
-  }
-  if (typeof value === 'number') {
-    if (!Number.isFinite(value)) {
-      throw new CanonicalAdminDeleteShadowError('non_finite_number')
-    }
-    return JSON.stringify(value)
-  }
-  if (Array.isArray(value)) {
-    if (ancestors.has(value)) {
-      throw new CanonicalAdminDeleteShadowError('cyclic_json')
-    }
-    ancestors.add(value)
-    try {
-      return `[${value.map((item) => canonicalJson(item, ancestors)).join(',')}]`
-    } finally {
-      ancestors.delete(value)
-    }
-  }
-  if (
-    value === null ||
-    typeof value !== 'object' ||
-    (Object.getPrototypeOf(value) !== Object.prototype &&
-      Object.getPrototypeOf(value) !== null)
-  ) {
-    throw new CanonicalAdminDeleteShadowError('payload_not_plain_json')
-  }
-  if (ancestors.has(value)) {
-    throw new CanonicalAdminDeleteShadowError('cyclic_json')
-  }
-  ancestors.add(value)
-  try {
-    return `{${Object.keys(value)
-      .sort()
-      .map((key) => {
-        assertValidUnicode(key)
-        const child = (value as Record<string, unknown>)[key]
-        if (child === undefined) {
-          throw new CanonicalAdminDeleteShadowError('undefined_json_value')
-        }
-        return `${JSON.stringify(key)}:${canonicalJson(child, ancestors)}`
-      })
-      .join(',')}}`
-  } finally {
-    ancestors.delete(value)
-  }
-}
-
 function versionForObservedAt(observedAt: string): string {
   const milliseconds = Date.parse(observedAt)
   if (!Number.isSafeInteger(milliseconds) || milliseconds < 0) {
@@ -129,97 +47,21 @@ function versionForObservedAt(observedAt: string): string {
   return String(milliseconds)
 }
 
-function createEvent(input: {
-  sourceRunId: string
-  sourceEventId: string
-  entityType: CanonicalAdminEntityType
-  entityKey: string
-  observedAt: string
-  emittedAt: string
-  version: string
-  policyVersion: string
-  payload: Record<string, unknown>
-}): CanonicalAdminDeleteEvent {
-  const payloadHash = sha256(canonicalJson(input.payload))
-  const eventWithoutIdentity: Omit<
-    CanonicalAdminDeleteEvent,
-    'event_id' | 'payload_hash'
-  > = {
-    schema_version: SCHEMA_VERSION,
-    source: SOURCE,
-    source_run_id: input.sourceRunId,
-    source_event_id: input.sourceEventId,
-    entity_type: input.entityType,
-    entity_key: input.entityKey,
-    operation: 'tombstone' as const,
-    observed_at: input.observedAt,
-    emitted_at: input.emittedAt,
-    version: input.version,
-    policy_version: input.policyVersion,
-    payload: input.payload,
-  }
-  return {
-    ...eventWithoutIdentity,
-    payload_hash: payloadHash,
-    event_id: sha256(
-      [
-        eventWithoutIdentity.schema_version,
-        eventWithoutIdentity.source,
-        eventWithoutIdentity.source_run_id,
-        eventWithoutIdentity.source_event_id,
-        eventWithoutIdentity.entity_type,
-        eventWithoutIdentity.entity_key,
-        eventWithoutIdentity.operation,
-        eventWithoutIdentity.version,
-        payloadHash,
-      ].join('\0'),
-    ),
-  }
-}
-
-export function buildCanonicalAdminDeleteEvents(
-  input: CanonicalAdminDeleteInput,
-  emittedAt = new Date().toISOString(),
-): CanonicalAdminDeleteEvent[] {
+export function buildCanonicalAdminDeleteMutations(input: CanonicalAdminDeleteInput): CanonicalAdminDeleteMutation[] {
   const accountId = input.accountId?.trim()
   if (!accountId) return []
+  if (!/^[1-9][0-9]*$/.test(accountId) || input.tweetIds.some((id) => !/^[1-9][0-9]*$/.test(id))) {
+    throw new CanonicalAdminDeleteShadowError('canonical_identifiers_invalid')
+  }
   const version = versionForObservedAt(input.observedAt)
-  const sourceRunId = `admin-delete:${input.jobKey}`
-  const policyVersion = `admin-delete-policy-v1:${sha256(
-    `${accountId}\0${input.observedAt}`,
-  )}`
-  const accountEvent = createEvent({
-    sourceRunId,
-    sourceEventId: `account:${accountId}`,
-    entityType: 'account',
-    entityKey: accountId,
-    observedAt: input.observedAt,
-    emittedAt,
-    version,
-    policyVersion,
-    payload: { account_id: accountId, is_tombstone: true },
-  })
-  const tweetEvents = [...new Set(input.tweetIds.map(String))]
-    .sort()
-    .map((tweetId) =>
-      createEvent({
-        sourceRunId,
-        sourceEventId: `tweet:${tweetId}`,
-        entityType: 'tweet_content',
-        entityKey: tweetId,
-        observedAt: input.observedAt,
-        emittedAt,
-        version,
-        policyVersion,
-        payload: {
-          tweet_id: tweetId,
-          account_id: accountId,
-          full_text: '',
-          is_tombstone: true,
-        },
-      }),
-    )
-  return [accountEvent, ...tweetEvents]
+  return [
+    { source_event_id: `account:${accountId}`, entity_type: 'account', entity_key: accountId,
+      operation: 'tombstone', version, payload: { account_id: accountId, is_tombstone: true } },
+    ...[...new Set(input.tweetIds)].sort().map((tweetId): CanonicalAdminDeleteMutation => ({
+      source_event_id: `tweet:${tweetId}`, entity_type: 'tweet_content', entity_key: tweetId,
+      operation: 'tombstone', version, payload: { account_id: accountId, tweet_id: tweetId, is_tombstone: true },
+    })),
+  ]
 }
 
 function positiveNumber(name: string, fallback: number): number {
@@ -274,9 +116,11 @@ function chunks<T>(values: T[], size: number): T[][] {
 
 async function publishBatch(
   config: PublisherConfig,
-  events: CanonicalAdminDeleteEvent[],
+  submission: { source: string; source_run_id: string; source_batch_id: string; observed_at: string; mutations: CanonicalAdminDeleteMutation[] },
   fetchImpl: FetchLike,
 ): Promise<number> {
+  const requestBody = JSON.stringify({ batches: [submission] })
+  if (Buffer.byteLength(requestBody) > 1_048_576) throw new CanonicalAdminDeleteShadowError('canonical_request_too_large')
   let response: Response
   try {
     response = await fetchImpl(config.endpoint, {
@@ -285,7 +129,7 @@ async function publishBatch(
         'Content-Type': 'application/json',
         'X-API-Key': config.apiKey,
       },
-      body: JSON.stringify({ events }),
+      body: requestBody,
       signal: AbortSignal.timeout(config.timeoutMs),
     })
   } catch {
@@ -309,27 +153,14 @@ async function publishBatch(
   ) {
     throw new CanonicalAdminDeleteShadowError('canonical_receipt_invalid')
   }
-  const receipts = (body as { accepted: unknown[] }).accepted
-  const expected = new Set(events.map(({ event_id }) => event_id))
-  const received = new Set(
-    receipts.map((receipt) =>
-      String((receipt as { event_id?: unknown })?.event_id),
-    ),
-  )
-  if (
-    receipts.length !== events.length ||
-    received.size !== expected.size ||
-    [...expected].some((eventId) => !received.has(eventId)) ||
-    receipts.some(
-      (receipt) =>
-        typeof (receipt as { duplicate?: unknown })?.duplicate !== 'boolean',
-    )
-  ) {
+  const receipts = (body as { accepted: Record<string, unknown>[] }).accepted
+  const receipt = receipts[0]
+  if (receipts.length !== 1 || receipt?.source_batch_id !== submission.source_batch_id ||
+      !/^[a-f0-9]{64}$/.test(String(receipt?.event_id ?? '')) ||
+      !/^\d+-\d+$/.test(String(receipt?.message_id ?? '')) || typeof receipt?.duplicate !== 'boolean') {
     throw new CanonicalAdminDeleteShadowError('canonical_receipt_invalid')
   }
-  return receipts.filter(
-    (receipt) => (receipt as { duplicate: boolean }).duplicate,
-  ).length
+  return receipt.duplicate ? 1 : 0
 }
 
 export async function publishCanonicalAdminDeleteShadow(
@@ -339,14 +170,17 @@ export async function publishCanonicalAdminDeleteShadow(
   if (!canonicalAdminDeleteShadowEnabled()) {
     return { eventCount: 0, duplicateCount: 0, skipped: true }
   }
-  const events = buildCanonicalAdminDeleteEvents(input)
+  const events = buildCanonicalAdminDeleteMutations(input)
   if (events.length === 0) {
     return { eventCount: 0, duplicateCount: 0, skipped: true }
   }
   const config = publisherConfig()
   let duplicateCount = 0
-  for (const batch of chunks(events, config.batchSize)) {
-    duplicateCount += await publishBatch(config, batch, fetchImpl)
+  for (const [index, batch] of chunks(events, config.batchSize).entries()) {
+    duplicateCount += await publishBatch(config, {
+      source: SOURCE, source_run_id: `admin-delete:${input.jobKey}`, source_batch_id: `batch-${index}`,
+      observed_at: input.observedAt, mutations: batch,
+    }, fetchImpl)
   }
   return { eventCount: events.length, duplicateCount, skipped: false }
 }

--- a/services/admin-delete-worker/src/canonicalShadow.ts
+++ b/services/admin-delete-worker/src/canonicalShadow.ts
@@ -1,0 +1,357 @@
+import { createHash } from 'node:crypto'
+
+const SCHEMA_VERSION = 'canonical_ingest_v1'
+const SOURCE = 'admin_delete'
+const MAX_BATCH_SIZE = 100
+
+type CanonicalAdminEntityType = 'account' | 'tweet_content'
+
+export interface CanonicalAdminDeleteEvent {
+  event_id: string
+  schema_version: typeof SCHEMA_VERSION
+  source: typeof SOURCE
+  source_run_id: string
+  source_event_id: string
+  entity_type: CanonicalAdminEntityType
+  entity_key: string
+  operation: 'tombstone'
+  observed_at: string
+  emitted_at: string
+  version: string
+  policy_version: string
+  payload: Record<string, unknown>
+  payload_hash: string
+}
+
+export interface CanonicalAdminDeleteInput {
+  jobKey: string
+  accountId?: string | null
+  tweetIds: string[]
+  observedAt: string
+}
+
+interface PublisherConfig {
+  endpoint: string
+  apiKey: string
+  batchSize: number
+  timeoutMs: number
+}
+
+type FetchLike = typeof fetch
+
+export class CanonicalAdminDeleteShadowError extends Error {
+  constructor(readonly code: string) {
+    super(code)
+    this.name = 'CanonicalAdminDeleteShadowError'
+  }
+}
+
+export function canonicalAdminDeleteShadowEnabled(): boolean {
+  return process.env.CANONICAL_ADMIN_DELETE_SHADOW_PUBLISH_ENABLED === 'true'
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex')
+}
+
+function assertValidUnicode(value: string): void {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index)
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1)
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        throw new CanonicalAdminDeleteShadowError('invalid_unicode')
+      }
+      index += 1
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      throw new CanonicalAdminDeleteShadowError('invalid_unicode')
+    }
+  }
+}
+
+function canonicalJson(value: unknown, ancestors = new Set<object>()): string {
+  if (value === null || typeof value === 'boolean') return JSON.stringify(value)
+  if (typeof value === 'string') {
+    assertValidUnicode(value)
+    return JSON.stringify(value)
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new CanonicalAdminDeleteShadowError('non_finite_number')
+    }
+    return JSON.stringify(value)
+  }
+  if (Array.isArray(value)) {
+    if (ancestors.has(value)) {
+      throw new CanonicalAdminDeleteShadowError('cyclic_json')
+    }
+    ancestors.add(value)
+    try {
+      return `[${value.map((item) => canonicalJson(item, ancestors)).join(',')}]`
+    } finally {
+      ancestors.delete(value)
+    }
+  }
+  if (
+    value === null ||
+    typeof value !== 'object' ||
+    (Object.getPrototypeOf(value) !== Object.prototype &&
+      Object.getPrototypeOf(value) !== null)
+  ) {
+    throw new CanonicalAdminDeleteShadowError('payload_not_plain_json')
+  }
+  if (ancestors.has(value)) {
+    throw new CanonicalAdminDeleteShadowError('cyclic_json')
+  }
+  ancestors.add(value)
+  try {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => {
+        assertValidUnicode(key)
+        const child = (value as Record<string, unknown>)[key]
+        if (child === undefined) {
+          throw new CanonicalAdminDeleteShadowError('undefined_json_value')
+        }
+        return `${JSON.stringify(key)}:${canonicalJson(child, ancestors)}`
+      })
+      .join(',')}}`
+  } finally {
+    ancestors.delete(value)
+  }
+}
+
+function versionForObservedAt(observedAt: string): string {
+  const milliseconds = Date.parse(observedAt)
+  if (!Number.isSafeInteger(milliseconds) || milliseconds < 0) {
+    throw new CanonicalAdminDeleteShadowError('invalid_observed_at')
+  }
+  return String(milliseconds)
+}
+
+function createEvent(input: {
+  sourceRunId: string
+  sourceEventId: string
+  entityType: CanonicalAdminEntityType
+  entityKey: string
+  observedAt: string
+  emittedAt: string
+  version: string
+  policyVersion: string
+  payload: Record<string, unknown>
+}): CanonicalAdminDeleteEvent {
+  const payloadHash = sha256(canonicalJson(input.payload))
+  const eventWithoutIdentity: Omit<
+    CanonicalAdminDeleteEvent,
+    'event_id' | 'payload_hash'
+  > = {
+    schema_version: SCHEMA_VERSION,
+    source: SOURCE,
+    source_run_id: input.sourceRunId,
+    source_event_id: input.sourceEventId,
+    entity_type: input.entityType,
+    entity_key: input.entityKey,
+    operation: 'tombstone' as const,
+    observed_at: input.observedAt,
+    emitted_at: input.emittedAt,
+    version: input.version,
+    policy_version: input.policyVersion,
+    payload: input.payload,
+  }
+  return {
+    ...eventWithoutIdentity,
+    payload_hash: payloadHash,
+    event_id: sha256(
+      [
+        eventWithoutIdentity.schema_version,
+        eventWithoutIdentity.source,
+        eventWithoutIdentity.source_run_id,
+        eventWithoutIdentity.source_event_id,
+        eventWithoutIdentity.entity_type,
+        eventWithoutIdentity.entity_key,
+        eventWithoutIdentity.operation,
+        eventWithoutIdentity.version,
+        payloadHash,
+      ].join('\0'),
+    ),
+  }
+}
+
+export function buildCanonicalAdminDeleteEvents(
+  input: CanonicalAdminDeleteInput,
+  emittedAt = new Date().toISOString(),
+): CanonicalAdminDeleteEvent[] {
+  const accountId = input.accountId?.trim()
+  if (!accountId) return []
+  const version = versionForObservedAt(input.observedAt)
+  const sourceRunId = `admin-delete:${input.jobKey}`
+  const policyVersion = `admin-delete-policy-v1:${sha256(
+    `${accountId}\0${input.observedAt}`,
+  )}`
+  const accountEvent = createEvent({
+    sourceRunId,
+    sourceEventId: `account:${accountId}`,
+    entityType: 'account',
+    entityKey: accountId,
+    observedAt: input.observedAt,
+    emittedAt,
+    version,
+    policyVersion,
+    payload: { account_id: accountId, is_tombstone: true },
+  })
+  const tweetEvents = [...new Set(input.tweetIds.map(String))]
+    .sort()
+    .map((tweetId) =>
+      createEvent({
+        sourceRunId,
+        sourceEventId: `tweet:${tweetId}`,
+        entityType: 'tweet_content',
+        entityKey: tweetId,
+        observedAt: input.observedAt,
+        emittedAt,
+        version,
+        policyVersion,
+        payload: {
+          tweet_id: tweetId,
+          account_id: accountId,
+          full_text: '',
+          is_tombstone: true,
+        },
+      }),
+    )
+  return [accountEvent, ...tweetEvents]
+}
+
+function positiveNumber(name: string, fallback: number): number {
+  const value = Number(process.env[name] ?? fallback)
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new CanonicalAdminDeleteShadowError(`${name.toLowerCase()}_invalid`)
+  }
+  return value
+}
+
+function publisherConfig(): PublisherConfig {
+  const endpoint = process.env.CANONICAL_PUBLISH_URL?.trim() ?? ''
+  const apiKey = process.env.CANONICAL_PUBLISHER_API_KEY?.trim() ?? ''
+  if (!endpoint || !apiKey) {
+    throw new CanonicalAdminDeleteShadowError('canonical_configuration_missing')
+  }
+  let url: URL
+  try {
+    url = new URL(endpoint)
+  } catch {
+    throw new CanonicalAdminDeleteShadowError('canonical_url_invalid')
+  }
+  if (
+    url.protocol !== 'https:' &&
+    !['127.0.0.1', 'localhost', '::1', '[::1]'].includes(url.hostname)
+  ) {
+    throw new CanonicalAdminDeleteShadowError('canonical_https_required')
+  }
+  const batchSize = positiveNumber('CANONICAL_PUBLISH_BATCH_SIZE', 100)
+  const timeoutSeconds = positiveNumber('CANONICAL_PUBLISH_TIMEOUT_SECONDS', 30)
+  if (!Number.isSafeInteger(batchSize) || batchSize > MAX_BATCH_SIZE) {
+    throw new CanonicalAdminDeleteShadowError('canonical_batch_size_invalid')
+  }
+  if (timeoutSeconds > 120) {
+    throw new CanonicalAdminDeleteShadowError('canonical_timeout_invalid')
+  }
+  return {
+    endpoint: url.toString(),
+    apiKey,
+    batchSize,
+    timeoutMs: timeoutSeconds * 1_000,
+  }
+}
+
+function chunks<T>(values: T[], size: number): T[][] {
+  const batches: T[][] = []
+  for (let offset = 0; offset < values.length; offset += size) {
+    batches.push(values.slice(offset, offset + size))
+  }
+  return batches
+}
+
+async function publishBatch(
+  config: PublisherConfig,
+  events: CanonicalAdminDeleteEvent[],
+  fetchImpl: FetchLike,
+): Promise<number> {
+  let response: Response
+  try {
+    response = await fetchImpl(config.endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': config.apiKey,
+      },
+      body: JSON.stringify({ events }),
+      signal: AbortSignal.timeout(config.timeoutMs),
+    })
+  } catch {
+    throw new CanonicalAdminDeleteShadowError('canonical_request_failed')
+  }
+  if (response.status !== 202) {
+    throw new CanonicalAdminDeleteShadowError(
+      `canonical_response_${response.status}`,
+    )
+  }
+  let body: unknown
+  try {
+    body = await response.json()
+  } catch {
+    throw new CanonicalAdminDeleteShadowError('canonical_receipt_invalid')
+  }
+  if (
+    body === null ||
+    typeof body !== 'object' ||
+    !Array.isArray((body as { accepted?: unknown }).accepted)
+  ) {
+    throw new CanonicalAdminDeleteShadowError('canonical_receipt_invalid')
+  }
+  const receipts = (body as { accepted: unknown[] }).accepted
+  const expected = new Set(events.map(({ event_id }) => event_id))
+  const received = new Set(
+    receipts.map((receipt) =>
+      String((receipt as { event_id?: unknown })?.event_id),
+    ),
+  )
+  if (
+    receipts.length !== events.length ||
+    received.size !== expected.size ||
+    [...expected].some((eventId) => !received.has(eventId)) ||
+    receipts.some(
+      (receipt) =>
+        typeof (receipt as { duplicate?: unknown })?.duplicate !== 'boolean',
+    )
+  ) {
+    throw new CanonicalAdminDeleteShadowError('canonical_receipt_invalid')
+  }
+  return receipts.filter(
+    (receipt) => (receipt as { duplicate: boolean }).duplicate,
+  ).length
+}
+
+export async function publishCanonicalAdminDeleteShadow(
+  input: CanonicalAdminDeleteInput,
+  fetchImpl: FetchLike = fetch,
+): Promise<{ eventCount: number; duplicateCount: number; skipped: boolean }> {
+  if (!canonicalAdminDeleteShadowEnabled()) {
+    return { eventCount: 0, duplicateCount: 0, skipped: true }
+  }
+  const events = buildCanonicalAdminDeleteEvents(input)
+  if (events.length === 0) {
+    return { eventCount: 0, duplicateCount: 0, skipped: true }
+  }
+  const config = publisherConfig()
+  let duplicateCount = 0
+  for (const batch of chunks(events, config.batchSize)) {
+    duplicateCount += await publishBatch(config, batch, fetchImpl)
+  }
+  return { eventCount: events.length, duplicateCount, skipped: false }
+}
+
+export function canonicalAdminDeleteErrorCode(error: unknown): string {
+  if (error instanceof CanonicalAdminDeleteShadowError) return error.code
+  return error instanceof Error ? error.name : 'unknown_error'
+}

--- a/services/admin-delete-worker/src/exporter.ts
+++ b/services/admin-delete-worker/src/exporter.ts
@@ -18,6 +18,7 @@ export interface ExportArgs {
 export interface ExportResult {
   export_prefix: string
   archive_files_copied: string[]
+  tweet_ids: string[]
   row_counts: Record<string, number>
   phase_ms: Record<string, number>
 }
@@ -88,6 +89,7 @@ export async function exportAndDelete(
   return {
     export_prefix,
     archive_files_copied: [],
+    tweet_ids: tweetIds.map((row) => row.tweet_id),
     row_counts: {
       all_account: args.accountId ? 1 : 0,
       tweets: tweetIds.length,

--- a/services/admin-delete-worker/src/index.ts
+++ b/services/admin-delete-worker/src/index.ts
@@ -1,6 +1,10 @@
 import 'dotenv/config'
 import { createClient } from '@supabase/supabase-js'
 import postgres from 'postgres'
+import {
+  canonicalAdminDeleteErrorCode,
+  publishCanonicalAdminDeleteShadow,
+} from './canonicalShadow.ts'
 import { logger } from './logger.ts'
 import { exportAndDelete } from './exporter.ts'
 import { makeRunRecorder } from './runRecorder.ts'
@@ -155,13 +159,39 @@ async function drainOnce(
   })
 
   try {
-    const result = await exportAndDelete(storage, sql, {
-      accountId: job.args.account_id,
-      username: job.args.username,
-      reason: job.args.reason ?? 'Admin manual opt-out',
-      requesterUserId: job.args.requested_by_user_id ?? '',
-      enqueuedAt: job.args.enqueued_at,
-    })
+    const { tweet_ids: canonicalTweetIds, ...result } = await exportAndDelete(
+      storage,
+      sql,
+      {
+        accountId: job.args.account_id,
+        username: job.args.username,
+        reason: job.args.reason ?? 'Admin manual opt-out',
+        requesterUserId: job.args.requested_by_user_id ?? '',
+        enqueuedAt: job.args.enqueued_at,
+      },
+    )
+    try {
+      const canonical = await publishCanonicalAdminDeleteShadow({
+        jobKey: job.key,
+        accountId: job.args.account_id,
+        tweetIds: canonicalTweetIds,
+        observedAt: job.args.enqueued_at,
+      })
+      if (!canonical.skipped) {
+        jobLogger.info(
+          {
+            canonical_event_count: canonical.eventCount,
+            canonical_duplicate_count: canonical.duplicateCount,
+          },
+          'canonical admin-delete shadow published',
+        )
+      }
+    } catch (error) {
+      jobLogger.warn(
+        { canonical_error_code: canonicalAdminDeleteErrorCode(error) },
+        'canonical admin-delete shadow failed; legacy deletion remains successful',
+      )
+    }
     await recorder.finish(runId, { status: 'succeeded', result })
     await sql`
       UPDATE private.admin_jobs


### PR DESCRIPTION
## Summary

- additive post-cleanup shadow publication, preserving established admin/opt-out behavior
- thin account/tweet tombstone mutations contain identifiers only
- stable job/batch identity and enqueue-time version; firehose owns canonical metadata
- dedicated publisher credentials, bounded requests and validated server receipts
- no duplicated hashing/JCS implementation
- document later user-delete/outbox, suppression and per-sink completion requirements

## Dependencies and limitations

Stacked on #851 and requires TheExGenesis/community-archive-firehose#22. CANONICAL_ADMIN_DELETE_SHADOW_PUBLISH_ENABLED stays false. This is best-effort shadow publication, NOT a transactional outbox or a complete user-delete implementation. Firehose requires an authoritative policy block for admin tombstones. Ordinary user delete RPCs remain unwired.

## Validation

Four focused admin canonical tests and service TypeScript build passed. Admin-built synthetic batch passed firehose policy/contract/retry/vector-projection checks.

## Safety boundary

Disabled-by-default additive shadow infrastructure only. Existing PostgreSQL/current-ClickHouse writes, acknowledgements, reader endpoints, auth, database schemas and user-facing delete RPCs are unchanged. No deployment, flag enablement, event publication, clone, historical backfill, cutover or legacy shutdown is authorized by this PR. Queue acceptance is not sink completion or erasure.

## All-source compatibility follow-up (2026-08-30)

Merged archive dependency fix 8eed182: stable canonical upload observation time from the existing delivery record rather than retry wall-clock time. The actual admin publisher passed the control-panel local HTTP-intake/vector-writer contract check alongside the four post producer paths. Test queue/SQL transports were simulated; no live admin-delete publication or deployment performed.