### PR TITLE
Add Conversation Map to the website and gallery

### DIFF
--- a/docs/features/conversation-map.md
+++ b/docs/features/conversation-map.md
@@ -1,0 +1,44 @@
+# Conversation Map
+
+`/conversation-map` is a first-party experiment listed in the Community Gallery.
+The page contains only the map and its navigation; source posts open in the
+shared `TweetCard` hover card and link to `/tweets/:id`.
+
+## Data and privacy
+
+`GET /api/conversation-map?year=YYYY` reads at most two 100-item pages from the
+existing Bangers serving path, using `scope: members` and `sort: quotes`.
+It inherits that path's membership/opt-out enforcement and complete tweet,
+media and quoted-tweet enrichment. It does not ship the prototype's frozen
+source export or call a new database/gateway service. Success has the same
+60-second shared-cache / 300-second stale-while-revalidate policy as the Bangers
+API; errors return non-cacheable non-2xx responses.
+
+Height represents current community quote counts for posts authored in the
+chosen year, not daily tweet volume or a contemporaneous historical ranking.
+Historical labels are whitespace-normalized prefixes of actual tweet text.
+The 2026 editorial drafts are server-only; an override/group is returned only
+when all its sources occur in the current member-filtered result. Other posts
+use snippets. Full source payloads are never truncated by the adapter.
+
+## Interaction
+
+Scrolling zooms around the pointer. Dragging pans, and the overview supports
+panning and resizing. At full-year zoom, arrows select adjacent available
+years. Global label layout depends on zoom and chart width, not viewport dates,
+and includes avatar space in collision checks. The plot clips that same layout
+while panning. Hover cards dismiss after 120 ms away and also support click,
+Enter/Space and Escape. Media uses the shared tweet card/lightbox.
+
+## Focused checks
+
+- `src/lib/conversation-map/data.test.ts`: member-only bounded reads, source
+  fidelity, absent editorial sources, bad input and failure caching.
+- `src/lib/conversation-map/layout.test.ts`: label/portrait space, disclosure,
+  hit targets, range and leap-year boundaries.
+- Gallery catalog and component tests cover the explicit first-party entry,
+  internal navigation and absence of a fabricated launch/source post.
+
+No database migrations or new gateway routes are required. Reverting the
+feature commit removes its page, API and gallery entry together; the existing
+Bangers path and data remain unchanged.

--- a/src/app/api/conversation-map/route.ts
+++ b/src/app/api/conversation-map/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { loadConversationMap } from '@/lib/conversation-map/data'
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 60
+
+export async function GET(request: NextRequest) {
+  const input =
+    request.nextUrl.searchParams.get('year') ??
+    String(new Date().getUTCFullYear())
+  const year = Number(input)
+  if (
+    !/^\d{4}$/.test(input) ||
+    year < 2006 ||
+    year > new Date().getUTCFullYear()
+  ) {
+    return NextResponse.json(
+      { error: 'Invalid year' },
+      { status: 400, headers: { 'Cache-Control': 'private, no-store' } },
+    )
+  }
+  try {
+    return NextResponse.json(await loadConversationMap(year), {
+      headers: {
+        'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
+      },
+    })
+  } catch (error) {
+    console.error('Conversation map unavailable:', error)
+    return NextResponse.json(
+      {
+        error: 'The conversation map is temporarily unavailable. Please retry.',
+      },
+      { status: 502, headers: { 'Cache-Control': 'private, no-store' } },
+    )
+  }
+}

--- a/src/app/conversation-map/page.tsx
+++ b/src/app/conversation-map/page.tsx
@@ -1,0 +1,16 @@
+import ConversationMap from '@/components/conversation-map/ConversationMap'
+
+export const metadata = {
+  title: 'Conversation Map · Community Archive',
+  description:
+    'Explore a year of community conversations. Zoom to reveal tweet snippets, images, and source posts.',
+}
+export const dynamic = 'force-dynamic'
+
+export default function ConversationMapPage() {
+  return (
+    <main className="mx-auto w-full max-w-[1440px] flex-1 px-4 py-6 sm:px-6 lg:px-8">
+      <ConversationMap initialYear={new Date().getUTCFullYear()} />
+    </main>
+  )
+}

--- a/src/components/community/CommunityGallery.test.tsx
+++ b/src/components/community/CommunityGallery.test.tsx
@@ -16,7 +16,7 @@ describe('CommunityGallery', () => {
         name: 'Discover community-made tools, bots, visualizations, and more',
       }),
     ).toBeInTheDocument()
-    expect(screen.getByText('10 projects')).toBeInTheDocument()
+    expect(screen.getByText('11 projects')).toBeInTheDocument()
 
     await user.type(
       screen.getByRole('searchbox', { name: 'Search community projects' }),
@@ -55,6 +55,29 @@ describe('CommunityGallery', () => {
     )
     expect(
       screen.queryByRole('link', { name: /View full page/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('opens the Conversation Map internally without inventing a source post', async () => {
+    const user = userEvent.setup()
+    render(<CommunityGallery />)
+    await user.click(
+      screen.getByRole('button', {
+        name: /Conversation Map.*Community Archive/i,
+      }),
+    )
+    expect(
+      screen.getByRole('dialog', { name: 'Conversation Map' }),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Open project/i })).toHaveAttribute(
+      'href',
+      '/conversation-map',
+    )
+    expect(
+      screen.getByRole('link', { name: /Open project/i }),
+    ).not.toHaveAttribute('target')
+    expect(
+      screen.queryByRole('link', { name: 'View source post' }),
     ).not.toBeInTheDocument()
   })
 

--- a/src/components/community/CommunityGallery.tsx
+++ b/src/components/community/CommunityGallery.tsx
@@ -195,29 +195,41 @@ function ProjectDialog({
                 </p>
               </div>
               <DialogFooter>
-                <Button asChild variant="outline">
-                  <Link
-                    href={
-                      project.sourceUrl ?? `/tweets/${project.sourceTweetId}`
-                    }
-                    target={project.sourceUrl ? '_blank' : undefined}
-                    rel={project.sourceUrl ? 'noopener noreferrer' : undefined}
-                  >
-                    View source post
-                  </Link>
-                </Button>
+                {(project.sourceUrl || project.sourceTweetId) && (
+                  <Button asChild variant="outline">
+                    <Link
+                      href={
+                        project.sourceUrl ?? `/tweets/${project.sourceTweetId}`
+                      }
+                      target={project.sourceUrl ? '_blank' : undefined}
+                      rel={
+                        project.sourceUrl ? 'noopener noreferrer' : undefined
+                      }
+                    >
+                      View source post
+                    </Link>
+                  </Button>
+                )}
                 {project.projectUrl ? (
                   <Button
                     asChild
                     className="bg-brand text-brand-foreground hover:bg-brand/90"
                   >
-                    <a
+                    <Link
                       href={project.projectUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
+                      target={
+                        project.projectUrl.startsWith('/')
+                          ? undefined
+                          : '_blank'
+                      }
+                      rel={
+                        project.projectUrl.startsWith('/')
+                          ? undefined
+                          : 'noopener noreferrer'
+                      }
                     >
                       Open project <ArrowUpRight className="ml-2 h-4 w-4" />
-                    </a>
+                    </Link>
                   </Button>
                 ) : null}
               </DialogFooter>

--- a/src/components/conversation-map/ConversationMap.tsx
+++ b/src/components/conversation-map/ConversationMap.tsx
@@ -1,0 +1,513 @@
+'use client'
+
+import Link from 'next/link'
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react'
+import type { PointerEvent as ReactPointerEvent } from 'react'
+import { ArrowLeft, ArrowRight, X } from 'lucide-react'
+import TweetCard from '@/components/TweetCard'
+import {
+  boundedRange,
+  DAY,
+  yearDays,
+  type ConversationMapData,
+  type MapAnnotation,
+} from '@/lib/conversation-map/types'
+import { drawMap, hitMap, type MapGeometry } from './drawMap'
+import styles from './conversationMap.module.css'
+
+type Range = readonly [number, number]
+type Hover = {
+  annotation: MapAnnotation
+  x: number
+  y: number
+  keyboard?: boolean
+}
+type Drag = {
+  x: number
+  range: Range
+  mode: 'pan' | 'left' | 'right'
+  moved: boolean
+}
+const dateFormat = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  timeZone: 'UTC',
+})
+
+export default function ConversationMap({
+  initialYear,
+}: {
+  initialYear: number
+}) {
+  const [year, setYear] = useState(initialYear)
+  const [years, setYears] = useState(
+    Array.from({ length: initialYear - 2008 + 1 }, (_, i) => 2008 + i),
+  )
+  const [data, setData] = useState<ConversationMapData | null>(null)
+  const [error, setError] = useState(''),
+    [retry, setRetry] = useState(0)
+  const [range, setRange] = useState<Range>([0, yearDays(initialYear)])
+  const [width, setWidth] = useState(0),
+    [hover, setHover] = useState<Hover | null>(null)
+  const chart = useRef<SVGSVGElement>(null),
+    overview = useRef<SVGSVGElement>(null),
+    card = useRef<HTMLDivElement>(null)
+  const geometry = useRef<MapGeometry>(),
+    drag = useRef<Drag>(),
+    overviewDrag = useRef<Drag>()
+  const hoverTimer = useRef<ReturnType<typeof setTimeout>>(),
+    hoverId = useRef<string | null>(null)
+  const days = yearDays(year),
+    span = range[1] - range[0],
+    wholeYear = span >= days - 0.01
+  const loading = data?.year !== year && !error
+  const ready = data?.year === year && !error
+  const hideHover = useCallback(() => {
+    clearTimeout(hoverTimer.current)
+    hoverTimer.current = undefined
+    hoverId.current = null
+    setHover(null)
+  }, [])
+  const keepHover = useCallback(() => {
+    clearTimeout(hoverTimer.current)
+    hoverTimer.current = undefined
+  }, [])
+  const dismissSoon = useCallback(() => {
+    if (hoverTimer.current) return
+    hoverTimer.current = setTimeout(() => {
+      hoverTimer.current = undefined
+      if (
+        !card.current?.matches(':hover') &&
+        !card.current?.contains(document.activeElement) &&
+        !document.querySelector('[role="dialog"]')
+      )
+        hideHover()
+    }, 120)
+  }, [hideHover])
+  const preview = useCallback(
+    (
+      annotation: MapAnnotation,
+      clientX: number,
+      clientY: number,
+      keyboard = false,
+    ) => {
+      keepHover()
+      if (hoverId.current === annotation.id) return
+      hoverId.current = annotation.id
+      const w = Math.min(420, document.documentElement.clientWidth - 24),
+        h = Math.min(520, innerHeight - 24)
+      const left =
+        clientX + 16 + w <= document.documentElement.clientWidth - 12
+          ? clientX + 16
+          : clientX - w - 16
+      setHover({
+        annotation,
+        x: Math.max(12, left),
+        y: Math.max(12, Math.min(clientY - 30, innerHeight - h - 12)),
+        keyboard,
+      })
+    },
+    [keepHover],
+  )
+
+  useEffect(() => {
+    const controller = new AbortController()
+    setError('')
+    setData(null)
+    hideHover()
+    fetch(`/api/conversation-map?year=${year}`, {
+      signal: controller.signal,
+      cache: 'no-store',
+    })
+      .then(async (response) => {
+        if (!response.ok)
+          throw new Error('Unable to load this year. Please retry.')
+        return response.json() as Promise<ConversationMapData>
+      })
+      .then((result) => {
+        if (controller.signal.aborted) return
+        setData(result)
+        setYears(result.years)
+        setRange([0, yearDays(result.year)])
+      })
+      .catch((reason) => {
+        if (!controller.signal.aborted) setError(reason.message)
+      })
+    return () => controller.abort()
+  }, [year, retry, hideHover])
+  useEffect(() => {
+    if (!chart.current) return
+    const observer = new ResizeObserver((entries) =>
+      setWidth(entries[0].contentRect.width),
+    )
+    observer.observe(chart.current)
+    document.fonts.ready.then(() => {
+      if (chart.current) setWidth(chart.current.getBoundingClientRect().width)
+    })
+    return () => observer.disconnect()
+  }, [])
+  useLayoutEffect(() => {
+    hideHover()
+    if (!ready || !chart.current || !overview.current || width < 100) return
+    geometry.current = drawMap(
+      chart.current,
+      overview.current,
+      data!.annotations,
+      year,
+      range,
+    )
+  }, [data, year, range, width, ready, hideHover])
+  useEffect(() => {
+    const escape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') hideHover()
+    }
+    window.addEventListener('keydown', escape)
+    window.addEventListener('scroll', hideHover)
+    return () => {
+      window.removeEventListener('keydown', escape)
+      window.removeEventListener('scroll', hideHover)
+      clearTimeout(hoverTimer.current)
+    }
+  }, [hideHover])
+  useEffect(() => {
+    if (hover?.keyboard) card.current?.querySelector('button')?.focus()
+  }, [hover])
+
+  const changeRange = useCallback(
+    (lo: number, nextSpan: number) =>
+      setRange(boundedRange(lo, nextSpan, days)),
+    [days],
+  )
+  useEffect(() => {
+    const svg = chart.current
+    if (!svg) return
+    const wheel = (event: WheelEvent) => {
+      if (!ready || !event.deltaY || !geometry.current) return
+      event.preventDefault()
+      const g = geometry.current,
+        r = svg.getBoundingClientRect(),
+        px = ((event.clientX - r.left) * g.W) / r.width
+      const fraction = Math.max(0, Math.min(1, (px - g.L) / (g.R - g.L)))
+      const delta =
+        event.deltaY *
+        (event.deltaMode === 1 ? 16 : event.deltaMode === 2 ? g.H : 1)
+      setRange((previous) => {
+        const oldSpan = previous[1] - previous[0],
+          at = previous[0] + fraction * oldSpan
+        const next = Math.max(
+          7,
+          Math.min(days, oldSpan * Math.exp(delta * 0.003)),
+        )
+        return boundedRange(at - fraction * next, next, days)
+      })
+    }
+    svg.addEventListener('wheel', wheel, { passive: false })
+    return () => svg.removeEventListener('wheel', wheel)
+  }, [days, ready])
+  const point = (event: ReactPointerEvent<SVGSVGElement>) => {
+    const r = event.currentTarget.getBoundingClientRect(),
+      vb = event.currentTarget.viewBox.baseVal
+    return {
+      x: ((event.clientX - r.left) * vb.width) / r.width,
+      y: ((event.clientY - r.top) * vb.height) / r.height,
+    }
+  }
+  const pan = (direction: number) => {
+    if (wholeYear) {
+      const next = years[years.indexOf(year) + direction]
+      if (next) setYear(next)
+    } else changeRange(range[0] + span * 0.7 * direction, span)
+  }
+  const dateRange = `${dateFormat.format(new Date(Date.UTC(year, 0, 1) + range[0] * DAY))} — ${dateFormat.format(new Date(Date.UTC(year, 0, 1) + Math.min(days - 0.001, range[1]) * DAY))}`
+
+  return (
+    <section className={styles.map} aria-labelledby="conversation-map-title">
+      <div className={styles.heading}>
+        <div>
+          <Link href="/community" className={styles.galleryLink}>
+            ← Gallery
+          </Link>
+          <h1 id="conversation-map-title">Conversation map</h1>
+          <p>Community quotes over time · Zoom to reveal more conversations</p>
+        </div>
+        <label className={styles.yearPicker}>
+          Explore a year
+          <select
+            aria-label="Explore a year"
+            value={year}
+            onChange={(e) => setYear(Number(e.target.value))}
+          >
+            {[...years].reverse().map((y) => (
+              <option key={y} value={y}>
+                {y}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <div className={styles.toolbar}>
+        <div className={styles.segmented} aria-label="Time window">
+          {[
+            ['Year', days],
+            ['Quarter', 90],
+            ['Month', 30],
+            ['Week', 7],
+          ].map(([label, size]) => (
+            <button
+              key={label}
+              disabled={!ready}
+              aria-pressed={Math.abs(span - Number(size)) < 0.01}
+              onClick={() => {
+                const center = wholeYear
+                  ? (data?.annotations[0]?.day ?? days / 2)
+                  : (range[0] + range[1]) / 2
+                changeRange(
+                  Number(size) === days ? 0 : center - Number(size) / 2,
+                  Number(size),
+                )
+              }}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+        <div className={styles.pan}>
+          <button
+            aria-label={wholeYear ? 'Previous year' : 'Earlier dates'}
+            disabled={
+              !ready ||
+              (wholeYear ? years.indexOf(year) === 0 : range[0] <= 0.001)
+            }
+            onClick={() => pan(-1)}
+          >
+            <ArrowLeft size={18} />
+          </button>
+          <div className={styles.interval}>
+            <strong>{year}</strong>
+            <span aria-live="polite">{dateRange}</span>
+          </div>
+          <button
+            aria-label={wholeYear ? 'Next year' : 'Later dates'}
+            disabled={
+              !ready ||
+              (wholeYear
+                ? years.indexOf(year) === years.length - 1
+                : range[1] >= days - 0.001)
+            }
+            onClick={() => pan(1)}
+          >
+            <ArrowRight size={18} />
+          </button>
+        </div>
+        <label className={styles.zoom}>
+          Zoom
+          <input
+            type="range"
+            aria-label="Timeline zoom"
+            min="0"
+            max="100"
+            disabled={!ready}
+            value={(100 * Math.log(days / span)) / Math.log(days / 7)}
+            onChange={(e) => {
+              const next =
+                days * Math.pow(7 / days, Number(e.target.value) / 100)
+              changeRange((range[0] + range[1] - next) / 2, next)
+            }}
+          />
+        </label>
+      </div>
+      <div className={styles.plot} aria-busy={loading}>
+        {(loading || error || (ready && !data?.annotations.length)) && (
+          <div className={styles.message} role={error ? 'alert' : 'status'}>
+            {loading
+              ? 'Loading conversations…'
+              : error || 'No ranked conversations found for this year.'}
+            {error && (
+              <button onClick={() => setRetry((n) => n + 1)}>Retry</button>
+            )}
+          </div>
+        )}
+        <svg
+          ref={chart}
+          className={styles.chart}
+          style={{ visibility: ready ? 'visible' : 'hidden' }}
+          role="group"
+          aria-label={`${year} conversation map. Height shows community quote counts, not tweet volume.`}
+          onPointerDown={(e) => {
+            if (e.button !== 0 || !ready || !geometry.current) return
+            const p = point(e)
+            if (p.x < geometry.current.L || p.x > geometry.current.R) return
+            drag.current = { x: p.x, range, mode: 'pan', moved: false }
+            e.currentTarget.setPointerCapture(e.pointerId)
+          }}
+          onPointerMove={(e) => {
+            if (!ready || !geometry.current) return
+            const p = point(e),
+              g = geometry.current,
+              d = drag.current
+            if (d) {
+              if (Math.abs(p.x - d.x) > 5) d.moved = true
+              if (d.moved) {
+                const delta =
+                  ((p.x - d.x) / (g.R - g.L)) * (d.range[1] - d.range[0])
+                changeRange(d.range[0] - delta, d.range[1] - d.range[0])
+              }
+              return
+            }
+            const annotation = hitMap(g, p.x, p.y)
+            e.currentTarget.style.cursor = annotation ? 'pointer' : 'grab'
+            if (annotation) preview(annotation, e.clientX, e.clientY)
+            else dismissSoon()
+          }}
+          onPointerUp={(e) => {
+            const d = drag.current
+            drag.current = undefined
+            if (e.currentTarget.hasPointerCapture(e.pointerId))
+              e.currentTarget.releasePointerCapture(e.pointerId)
+            if (d && !d.moved && geometry.current) {
+              const p = point(e),
+                annotation = hitMap(geometry.current, p.x, p.y)
+              if (annotation) preview(annotation, e.clientX, e.clientY)
+            }
+          }}
+          onPointerCancel={() => {
+            drag.current = undefined
+          }}
+          onPointerLeave={dismissSoon}
+          onDoubleClick={(e) => {
+            if (!ready || !geometry.current) return
+            const r = e.currentTarget.getBoundingClientRect(),
+              g = geometry.current
+            const fraction = Math.max(
+              0,
+              Math.min(
+                1,
+                (((e.clientX - r.left) * g.W) / r.width - g.L) / (g.R - g.L),
+              ),
+            )
+            changeRange(range[0] + span * fraction - span / 4, span / 2)
+          }}
+          onKeyDown={(e) => {
+            if (e.key !== 'Enter' && e.key !== ' ') return
+            const target = (e.target as Element).closest('[data-candidate]')
+            const annotation = data?.annotations.find(
+              (a) => a.id === target?.getAttribute('data-candidate'),
+            )
+            if (annotation && target) {
+              e.preventDefault()
+              const r = target.getBoundingClientRect()
+              preview(annotation, r.x, r.y, true)
+            }
+          }}
+        />
+        <svg
+          ref={overview}
+          className={styles.overview}
+          style={{ visibility: ready ? 'visible' : 'hidden' }}
+          role="img"
+          aria-label="Full year overview. Drag the window or its edges to pan and zoom."
+          onPointerDown={(e) => {
+            if (e.button !== 0 || !ready || !geometry.current) return
+            const p = point(e),
+              g = geometry.current,
+              at = Math.max(
+                0,
+                Math.min(days, ((p.x - g.L) / (g.R - g.L)) * days),
+              )
+            const left = g.L + (range[0] / days) * (g.R - g.L),
+              right = g.L + (range[1] / days) * (g.R - g.L)
+            const dl = Math.abs(p.x - left),
+              dr = Math.abs(p.x - right)
+            const mode =
+              Math.min(dl, dr) < 12 ? (dl < dr ? 'left' : 'right') : 'pan'
+            let initial = range
+            if (mode === 'pan' && (at < range[0] || at > range[1])) {
+              initial = boundedRange(at - span / 2, span, days)
+              setRange(initial)
+            }
+            overviewDrag.current = { x: at, range: initial, mode, moved: false }
+            e.currentTarget.setPointerCapture(e.pointerId)
+          }}
+          onPointerMove={(e) => {
+            const d = overviewDrag.current,
+              g = geometry.current
+            if (!d || !g) return
+            const p = point(e),
+              at = Math.max(
+                0,
+                Math.min(days, ((p.x - g.L) / (g.R - g.L)) * days),
+              ),
+              delta = at - d.x
+            if (d.mode === 'left') {
+              const lo = Math.max(
+                0,
+                Math.min(d.range[1] - 7, d.range[0] + delta),
+              )
+              changeRange(lo, d.range[1] - lo)
+            } else if (d.mode === 'right')
+              changeRange(
+                d.range[0],
+                Math.min(days, d.range[1] + delta) - d.range[0],
+              )
+            else changeRange(d.range[0] + delta, d.range[1] - d.range[0])
+          }}
+          onPointerUp={(e) => {
+            overviewDrag.current = undefined
+            if (e.currentTarget.hasPointerCapture(e.pointerId))
+              e.currentTarget.releasePointerCapture(e.pointerId)
+          }}
+          onPointerCancel={() => {
+            overviewDrag.current = undefined
+          }}
+        />
+      </div>
+      <div className={styles.help}>
+        <span>Scroll to zoom · Drag to pan · Hover or select to read</span>
+        <span>
+          Up to 200 top posts per year · UTC · Height is quotes, not tweet
+          volume
+        </span>
+      </div>
+      {hover && (
+        <div
+          ref={card}
+          className={styles.hoverCard}
+          style={{ left: hover.x, top: hover.y }}
+          role="region"
+          aria-label="Tweet preview"
+          onPointerEnter={keepHover}
+          onPointerLeave={dismissSoon}
+          onBlur={dismissSoon}
+        >
+          <div className={styles.cardHeader}>
+            <span>
+              {hover.annotation.tweets.length > 1
+                ? 'Related conversations'
+                : 'Original post'}
+            </span>
+            <button aria-label="Close tweet preview" onClick={hideHover}>
+              <X size={16} />
+            </button>
+          </div>
+          <div className={styles.cardBody}>
+            {hover.annotation.tweets.map((tweet) => (
+              <TweetCard
+                key={tweet.id}
+                tweet={tweet}
+                noClamp
+                showDate
+                clickable={false}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/conversation-map/conversationMap.module.css
+++ b/src/components/conversation-map/conversationMap.module.css
@@ -1,0 +1,278 @@
+.map {
+  --map-surface: hsl(var(--card));
+  --map-text: hsl(var(--foreground));
+  --map-muted: hsl(var(--muted-foreground));
+  --map-border: hsl(var(--border));
+  --map-selection: hsl(var(--secondary));
+  --map-accent: hsl(var(--brand));
+  --map-snippet: hsl(var(--brand));
+  --map-announcement: #b87738;
+  --map-discussion: hsl(var(--brand));
+  --map-meme: #ab8c4a;
+  --map-reaction: #9684b4;
+  position: relative;
+}
+.heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 20px;
+  margin-bottom: 24px;
+}
+.heading h1 {
+  font-size: 38px;
+  font-weight: 600;
+  line-height: 1.2;
+  margin: 6px 0;
+}
+.heading p,
+.galleryLink {
+  color: var(--map-muted);
+  font-size: 12px;
+}
+.galleryLink:hover {
+  color: var(--map-accent);
+}
+.yearPicker {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 12px;
+  color: var(--map-muted);
+}
+.yearPicker select {
+  background: var(--map-surface);
+  color: var(--map-text);
+  border: 1px solid var(--map-border);
+  border-radius: 8px;
+  padding: 8px 12px;
+}
+.toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 16px;
+  padding: 18px 20px;
+  border: 1px solid var(--map-border);
+  border-bottom: 0;
+  border-radius: 12px 12px 0 0;
+  background: var(--map-surface);
+}
+.map button {
+  cursor: pointer;
+}
+.map button:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+.map button:focus-visible,
+.map input:focus-visible,
+.map select:focus-visible,
+.map a:focus-visible {
+  outline: 2px solid var(--map-accent);
+  outline-offset: 3px;
+}
+.segmented {
+  display: flex;
+  gap: 2px;
+  border: 1px solid var(--map-border);
+  padding: 3px;
+  border-radius: 8px;
+}
+.segmented button {
+  border-radius: 5px;
+  padding: 6px 12px;
+  font-size: 12px;
+}
+.segmented button[aria-pressed='true'] {
+  background: var(--map-selection);
+  font-weight: 700;
+}
+.pan {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+.pan button {
+  padding: 10px;
+  border-radius: 8px;
+}
+.pan button:hover {
+  background: var(--map-selection);
+}
+.interval {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 145px;
+  gap: 2px;
+}
+.interval strong {
+  font:
+    500 30px/1.15 var(--font-petrona),
+    Georgia,
+    serif;
+}
+.interval span {
+  font-size: 12px;
+  color: var(--map-muted);
+  font-variant-numeric: tabular-nums;
+}
+.zoom {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--map-muted);
+}
+.zoom input {
+  width: 105px;
+  accent-color: var(--map-accent);
+}
+.plot {
+  position: relative;
+  padding: 8px 20px 12px;
+  background: var(--map-surface);
+  border: 1px solid var(--map-border);
+  border-top: 0;
+  border-radius: 0 0 12px 12px;
+}
+.chart,
+.overview {
+  width: 100%;
+  display: block;
+  user-select: none;
+  touch-action: pan-y;
+}
+.chart {
+  min-height: 400px;
+  cursor: grab;
+}
+.overview {
+  height: auto;
+  min-height: 42px;
+  cursor: ew-resize;
+}
+.chart text,
+.overview text {
+  font-family: inherit;
+  fill: var(--map-muted);
+  font-size: 11px;
+}
+.chart :global(.map-grid) {
+  stroke: var(--map-border);
+  stroke-width: 1;
+}
+.chart :global(.map-callout) {
+  font-size: 12px;
+  font-weight: 500;
+  fill: var(--map-text);
+  paint-order: stroke;
+  stroke: var(--map-surface);
+  stroke-width: 5px;
+  stroke-linejoin: round;
+}
+.chart :global(.map-initials) {
+  font-size: 8px;
+  fill: var(--map-accent);
+  font-weight: 600;
+}
+.chart :global(.map-dot):focus {
+  outline: none;
+  stroke: var(--map-text);
+  stroke-width: 3;
+}
+.help {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 12px 2px;
+  color: var(--map-muted);
+  font-size: 11px;
+}
+.message {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  gap: 16px;
+  color: var(--map-muted);
+  font-size: 14px;
+  z-index: 1;
+}
+.message button {
+  border: 1px solid var(--map-border);
+  border-radius: 6px;
+  padding: 8px 16px;
+}
+.hoverCard {
+  position: fixed;
+  z-index: 60;
+  width: 420px;
+  max-width: calc(100% - 24px);
+  max-height: min(520px, calc(100dvh - 24px));
+  background: var(--map-surface);
+  color: var(--map-text);
+  border: 1px solid var(--map-border);
+  border-radius: 12px;
+  box-shadow: 0 12px 40px #0003;
+  display: flex;
+  flex-direction: column;
+}
+.cardHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px 8px 16px;
+  font-size: 11px;
+  color: var(--map-muted);
+  border-bottom: 1px solid var(--map-border);
+}
+.cardHeader button {
+  padding: 6px;
+}
+.cardBody {
+  overflow: auto;
+  overscroll-behavior: contain;
+  min-height: 0;
+}
+@media (max-width: 700px) {
+  .heading {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 14px;
+    margin-bottom: 18px;
+  }
+  .heading h1 {
+    font-size: 32px;
+  }
+  .yearPicker {
+    width: 100%;
+    justify-content: space-between;
+  }
+  .yearPicker select {
+    font-size: 16px;
+  }
+  .toolbar {
+    padding: 14px 12px;
+    gap: 12px;
+  }
+  .pan {
+    order: 3;
+    width: 100%;
+    justify-content: space-between;
+  }
+  .segmented button {
+    padding: 6px 9px;
+  }
+  .zoom input {
+    width: 65px;
+  }
+  .plot {
+    padding: 6px 8px 10px;
+  }
+}

--- a/src/components/conversation-map/drawMap.ts
+++ b/src/components/conversation-map/drawMap.ts
@@ -1,0 +1,438 @@
+import { DAY, yearDays, type MapAnnotation } from '@/lib/conversation-map/types'
+
+const NS = 'http://www.w3.org/2000/svg'
+const dateFormat = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  timeZone: 'UTC',
+})
+const monthFormat = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  timeZone: 'UTC',
+})
+type Box = { x: number; y: number; width: number; height: number }
+type Shape = Box & { lines: string[] }
+type Target = Box & { annotation: MapAnnotation }
+export type MapGeometry = {
+  L: number
+  R: number
+  W: number
+  H: number
+  points: Target[]
+  labels: Target[]
+}
+const measurements = new Map<string, Shape>()
+const color = (kind: string) => `var(--map-${kind})`
+function node(
+  tag: string,
+  attrs: Record<string, string | number>,
+  parent: Element,
+  text?: string | number,
+) {
+  const el = document.createElementNS(NS, tag)
+  for (const [key, value] of Object.entries(attrs))
+    el.setAttribute(key, String(value))
+  if (text !== undefined) el.textContent = String(text)
+  parent.append(el)
+  return el
+}
+function measure(svg: SVGSVGElement, label: string, width: number): Shape {
+  const key = width + '|' + label
+  const cached = measurements.get(key)
+  if (cached) return cached
+  const text = node(
+    'text',
+    { class: 'map-callout', visibility: 'hidden' },
+    svg,
+  ) as SVGTextElement
+  const span = node('tspan', {}, text) as SVGTSpanElement
+  const fits = (value: string) => {
+    span.textContent = value
+    return span.getComputedTextLength() <= width
+  }
+  const lines = ['']
+  for (const word of label.split(' ')) {
+    const test = (lines[lines.length - 1] + ' ' + word).trim()
+    if (fits(test)) {
+      lines[lines.length - 1] = test
+      continue
+    }
+    if (lines[lines.length - 1]) lines.push('')
+    for (const char of word) {
+      const i = lines.length - 1
+      if (lines[i] && !fits(lines[i] + char)) lines.push(char)
+      else lines[i] += char
+    }
+  }
+  if (lines.length > 3) {
+    lines.length = 3
+    while (lines[2] && !fits(lines[2] + '…'))
+      lines[2] = Array.from(lines[2]).slice(0, -1).join('')
+    lines[2] += '…'
+  }
+  span.remove()
+  lines.forEach((line, i) =>
+    node('tspan', { x: 0, dy: i ? 15 : 0 }, text, line),
+  )
+  const b = text.getBBox(),
+    shape = { x: b.x, y: b.y, width: b.width, height: b.height, lines }
+  text.remove()
+  measurements.set(key, shape)
+  return shape
+}
+export const overlaps = (a: Box, b: Box) =>
+  a.x < b.x + b.width + 8 &&
+  a.x + a.width + 8 > b.x &&
+  a.y < b.y + b.height + 6 &&
+  a.y + a.height + 6 > b.y
+
+/** Full-year layout: no viewport offset or selected tweet enters disclosure. */
+export function layoutLabels(
+  rows: MapAnnotation[],
+  width: number,
+  span: number,
+  days: number,
+  y: (score: number) => number,
+  measureText: (label: string, width: number) => Shape,
+) {
+  const plotWidth = width - 58,
+    pixelsPerDay = plotWidth / span,
+    worldWidth = days * pixelsPerDay
+  const points = rows.map((annotation) => ({
+    annotation,
+    x: annotation.day * pixelsPerDay,
+    y: y(annotation.score),
+  }))
+  const budget = Math.min(
+    rows.length,
+    Math.ceil(((width < 430 ? 3 : width < 700 ? 5 : 8) * days) / span),
+  )
+  const labels: Array<
+    Target & { shape: Shape; pointX: number; pointY: number }
+  > = []
+  for (const p of [...points].sort(
+    (a, b) => a.annotation.rank - b.annotation.rank,
+  )) {
+    if (labels.length >= budget) break
+    const shape = measureText(
+      p.annotation.label,
+      Math.min(width < 430 ? 124 : 195, plotWidth - 12) - 28,
+    )
+    const w = shape.width + 28,
+      h = Math.max(22, shape.height)
+    const x = Math.max(4, Math.min(worldWidth - w - 4, p.x - w / 2))
+    for (let lane = 0; lane < 10; lane++) {
+      const box = { x, y: p.y - 18 - h - lane * (h + 13), width: w, height: h }
+      if (box.y < 36 || labels.some((other) => overlaps(box, other))) continue
+      if (
+        points.some(
+          (q) =>
+            q.x > x - 5 &&
+            q.x < x + w + 5 &&
+            q.y > box.y - 5 &&
+            q.y < box.y + h + 5,
+        )
+      )
+        continue
+      labels.push({
+        ...box,
+        annotation: p.annotation,
+        shape,
+        pointX: p.x,
+        pointY: p.y,
+      })
+      break
+    }
+  }
+  return { labels, pixelsPerDay }
+}
+
+export function drawMap(
+  svg: SVGSVGElement,
+  overview: SVGSVGElement,
+  rows: MapAnnotation[],
+  year: number,
+  range: readonly [number, number],
+): MapGeometry {
+  const W = svg.getBoundingClientRect().width,
+    H = W < 500 ? 400 : 440,
+    L = 44,
+    R = W - 14,
+    T = 28,
+    B = H - 39
+  const days = yearDays(year),
+    start = Date.UTC(year, 0, 1),
+    span = Math.round((range[1] - range[0]) * 1e6) / 1e6
+  const x = (day: number) => L + ((day - range[0]) / span) * (R - L)
+  const maximum = Math.max(1, ...rows.map((e) => e.score))
+  const rawStep = (maximum * 1.2) / 5,
+    magnitude = 10 ** Math.floor(Math.log10(rawStep))
+  const step = Math.max(
+    1,
+    ([1, 2, 5, 10].find((n) => n * magnitude >= rawStep) ?? 10) * magnitude,
+  )
+  const ceiling = Math.ceil((maximum * 1.2) / step) * step
+  const y = (score: number) => B - (score / ceiling) * (B - T)
+  svg.replaceChildren()
+  svg.setAttribute('viewBox', `0 0 ${W} ${H}`)
+  const defs = node('defs', {}, svg),
+    clip = node('clipPath', { id: 'map-plot-clip' }, defs)
+  node('rect', { x: L, y: T, width: R - L, height: B - T }, clip)
+  for (let n = 0; n <= ceiling; n += step) {
+    node('line', { x1: L, x2: R, y1: y(n), y2: y(n), class: 'map-grid' }, svg)
+    node('text', { x: L - 10, y: y(n) + 4, 'text-anchor': 'end' }, svg, n)
+  }
+  node('text', { x: L, y: 13 }, svg, 'Community quotes')
+  const maxTicks = Math.max(2, Math.floor((R - L) / 95)),
+    ticks: number[] = []
+  if (span > 100) {
+    for (let m = 0; m < 12; m += Math.max(1, Math.ceil(12 / maxTicks)))
+      ticks.push((Date.UTC(year, m, 1) - start) / DAY)
+  } else {
+    const base = span > 50 ? 14 : span > 20 ? 7 : span > 9 ? 3 : 1,
+      stride = base * Math.max(1, Math.ceil(span / (base * maxTicks)))
+    for (
+      let day = Math.ceil(range[0] / stride) * stride;
+      day <= range[1];
+      day += stride
+    )
+      ticks.push(day)
+  }
+  for (const day of ticks.filter((d) => d >= range[0] && d <= range[1])) {
+    const px = x(day)
+    node(
+      'text',
+      {
+        x: px,
+        y: B + 24,
+        'text-anchor': px < L + 30 ? 'start' : px > R - 30 ? 'end' : 'middle',
+      },
+      svg,
+      (span > 100 ? monthFormat : dateFormat).format(
+        new Date(start + day * DAY),
+      ),
+    )
+  }
+  const marks = node('g', { 'clip-path': 'url(#map-plot-clip)' }, svg),
+    points: Target[] = [],
+    labels: Target[] = []
+  for (const e of rows.filter((e) => e.day >= range[0] && e.day <= range[1])) {
+    const px = x(e.day),
+      py = y(e.score)
+    node(
+      'line',
+      {
+        x1: px,
+        x2: px,
+        y1: py,
+        y2: B,
+        stroke: color(e.kind),
+        'stroke-opacity': 0.12,
+      },
+      marks,
+    )
+    const dot = node(
+      'circle',
+      {
+        cx: px,
+        cy: py,
+        r: 4,
+        fill: color(e.kind),
+        'data-candidate': e.id,
+        role: 'button',
+        tabindex: 0,
+        'aria-label': `Read ${e.label}`,
+        class: 'map-dot',
+      },
+      marks,
+    )
+    node('title', {}, dot, e.label)
+    points.push({ annotation: e, x: px, y: py, width: 0, height: 0 })
+  }
+  const layout = layoutLabels(rows, W, span, days, y, (label, width) =>
+    measure(svg, label, width),
+  )
+  const offset = L - range[0] * layout.pixelsPerDay
+  const labelClip = node('g', { 'clip-path': 'url(#map-plot-clip)' }, svg)
+  const world = node(
+    'g',
+    { 'data-label-world': '', transform: `translate(${offset},0)` },
+    labelClip,
+  )
+  for (const [index, p] of Array.from(layout.labels.entries())) {
+    const group = node(
+      'g',
+      {
+        'data-label': p.annotation.id,
+        'data-world-x': p.x,
+        'data-world-y': p.y,
+      },
+      world,
+    )
+    const endX = Math.max(p.x + 5, Math.min(p.x + p.width - 5, p.pointX)),
+      endY = p.y + p.height + 4
+    node(
+      'path',
+      {
+        d: `M${p.pointX},${p.pointY - 6} L${p.pointX},${endY + 5} L${endX},${endY}`,
+        fill: 'none',
+        stroke: 'var(--map-muted)',
+        'stroke-opacity': 0.48,
+        'stroke-width': 0.9,
+      },
+      group,
+    )
+    const text = node(
+      'text',
+      {
+        class: 'map-callout',
+        transform: `translate(${p.x + 28 - p.shape.x},${p.y + (p.height - p.shape.height) / 2 - p.shape.y})`,
+      },
+      group,
+    )
+    p.shape.lines.forEach((line, i) =>
+      node('tspan', { x: 0, dy: i ? 15 : 0 }, text, line),
+    )
+    const inView = p.x + offset + p.width > L && p.x + offset < R,
+      author = p.annotation.tweets[0],
+      ax = p.x + 11,
+      ay = p.y + p.height / 2
+    node(
+      'circle',
+      {
+        cx: ax,
+        cy: ay,
+        r: 11,
+        fill: 'var(--map-selection)',
+        stroke: 'var(--map-border)',
+      },
+      group,
+    )
+    node(
+      'text',
+      {
+        x: ax,
+        y: ay,
+        'text-anchor': 'middle',
+        'dominant-baseline': 'central',
+        class: 'map-initials',
+      },
+      group,
+      author.username.slice(0, 2).toUpperCase(),
+    )
+    if (
+      inView &&
+      /^https:\/\/pbs\.twimg\.com\/profile_images\//.test(author.avatar ?? '')
+    ) {
+      const avatarClip = node('clipPath', { id: `map-avatar-${index}` }, defs)
+      node('circle', { cx: ax, cy: ay, r: 11 }, avatarClip)
+      const img = node(
+        'image',
+        {
+          x: p.x,
+          y: ay - 11,
+          width: 22,
+          height: 22,
+          href: author.avatar!,
+          preserveAspectRatio: 'xMidYMid slice',
+          'clip-path': `url(#map-avatar-${index})`,
+          class: 'map-avatar',
+          'aria-hidden': 'true',
+        },
+        group,
+      )
+      img.addEventListener('error', () => img.remove(), { once: true })
+    }
+    if (inView) labels.push({ ...p, x: p.x + offset })
+  }
+  svg.dataset.zoom = String(days / span)
+  overview.replaceChildren()
+  overview.setAttribute('viewBox', `0 0 ${W} 62`)
+  const ox = (day: number) => L + (day / days) * (R - L)
+  node(
+    'rect',
+    {
+      x: L,
+      y: 5,
+      width: R - L,
+      height: 29,
+      fill: 'var(--map-selection)',
+      rx: 2,
+    },
+    overview,
+  )
+  for (const e of rows)
+    node(
+      'line',
+      {
+        x1: ox(e.day),
+        x2: ox(e.day),
+        y1: 9,
+        y2: 30,
+        stroke: color(e.kind),
+        'stroke-opacity': 0.5,
+      },
+      overview,
+    )
+  node(
+    'rect',
+    {
+      x: ox(range[0]),
+      y: 5,
+      width: ox(range[1]) - ox(range[0]),
+      height: 29,
+      fill: 'var(--map-accent)',
+      'fill-opacity': 0.07,
+      stroke: 'var(--map-accent)',
+      rx: 2,
+    },
+    overview,
+  )
+  for (const d of range)
+    node(
+      'rect',
+      {
+        x: ox(d) - 3,
+        y: 3,
+        width: 6,
+        height: 33,
+        rx: 2,
+        fill: 'var(--map-accent)',
+      },
+      overview,
+    )
+  for (let m = 0; m < 12; m += W < 430 ? 3 : W < 700 ? 2 : 1)
+    node(
+      'text',
+      {
+        x: ox((Date.UTC(year, m, 1) - start) / DAY),
+        y: 56,
+        'text-anchor': m === 0 ? 'start' : 'middle',
+      },
+      overview,
+      monthFormat.format(new Date(Date.UTC(year, m, 1))),
+    )
+  return { W, H, L, R, points, labels }
+}
+
+export function hitMap(g: MapGeometry, x: number, y: number) {
+  if (x < g.L || x > g.R) return
+  const label = g.labels.find(
+    (b) =>
+      x >= b.x - 5 &&
+      x <= b.x + b.width + 5 &&
+      y >= b.y - 5 &&
+      y <= b.y + b.height + 5,
+  )
+  if (label) return label.annotation
+  let closest: MapAnnotation | undefined,
+    distance = 18
+  for (const p of g.points) {
+    const d = Math.hypot(x - p.x, y - p.y)
+    if (d < distance) {
+      closest = p.annotation
+      distance = d
+    }
+  }
+  return closest
+}

--- a/src/lib/communityProjects.test.ts
+++ b/src/lib/communityProjects.test.ts
@@ -5,7 +5,7 @@ import {
 
 describe('community project catalog', () => {
   it('contains only verified entries with source posts and no prototype filler', () => {
-    expect(COMMUNITY_PROJECTS).toHaveLength(10)
+    expect(COMMUNITY_PROJECTS).toHaveLength(11)
     expect(COMMUNITY_PROJECTS).not.toEqual(
       expect.arrayContaining([
         expect.objectContaining({ name: 'Ratio Radar' }),
@@ -14,7 +14,10 @@ describe('community project catalog', () => {
     )
 
     for (const project of COMMUNITY_PROJECTS) {
-      expect(project.sourceTweetId).toMatch(/^\d+$/)
+      if (project.slug === 'conversation-map') {
+        expect(project.projectUrl).toBe('/conversation-map')
+        expect(project.sourceTweetId).toBeUndefined()
+      } else expect(project.sourceTweetId).toMatch(/^\d+$/)
       expect(project.projectUrl ?? '').not.toContain('example.com')
       expect(project.image ?? '').not.toContain('pbs.twimg.com')
     }
@@ -44,7 +47,7 @@ describe('community project catalog', () => {
       'All',
       'Newest',
     )
-    expect(newest[0].name).toBe('Followle')
+    expect(newest[0].name).toBe('Conversation Map')
 
     const alphabetical = filterCommunityProjects(
       COMMUNITY_PROJECTS,

--- a/src/lib/communityProjects.ts
+++ b/src/lib/communityProjects.ts
@@ -25,7 +25,7 @@ export interface CommunityProject {
   category: CommunityProjectCategory
   tags: string[]
   projectUrl?: string
-  sourceTweetId: string
+  sourceTweetId?: string
   sourceUrl?: string
   image?: string
   coverClass: string
@@ -35,10 +35,26 @@ export interface CommunityProject {
 
 /**
  * Curated community-made projects verified against the public Community
- * Archive thread rooted at tweet 1961022793023119441. First-party Community
- * Archive tools and fictional prototype entries are intentionally excluded.
+ * Archive thread rooted at tweet 1961022793023119441, plus the explicitly
+ * requested first-party Conversation Map. Never fabricate a launch post.
  */
 export const COMMUNITY_PROJECTS: CommunityProject[] = [
+  {
+    slug: 'conversation-map',
+    name: 'Conversation Map',
+    creator: 'Community Archive',
+    summary: 'Explore a year of conversations, one memorable post at a time.',
+    description:
+      'A zoomable map of the most-quoted community posts each year. Scroll to uncover more labels, pan through time, and hover to read the original posts and images.',
+    archiveUse:
+      'Loads up to 200 member-authored posts per year from the archive’s current banger ranking. Height shows community quotes, with source links to Community Archive tweet pages.',
+    category: 'Experiments',
+    tags: ['Timeline', 'Conversations', 'Visualization'],
+    projectUrl: '/conversation-map',
+    coverClass: 'from-[#d7e4ef] via-[#8bd2ee] to-[#1e9bcd]',
+    featured: true,
+    publishedAt: '2026-08-30',
+  },
   {
     slug: 'bangers-page',
     name: 'Bangers.page',

--- a/src/lib/conversation-map/data.test.ts
+++ b/src/lib/conversation-map/data.test.ts
@@ -1,0 +1,111 @@
+import { NextRequest } from 'next/server'
+import { GET } from '@/app/api/conversation-map/route'
+import { getPortalBangersPage } from '@/lib/portal/data'
+import { annotateTweets, loadConversationMap, tweetSnippet } from './data'
+import type { PortalTweet, PortalBangersPage } from '@/lib/portal/types'
+
+jest.mock('@/lib/portal/data', () => ({ getPortalBangersPage: jest.fn() }))
+const fetchPage = jest.mocked(getPortalBangersPage)
+const tweet = (
+  id: string,
+  createdAt = '2025-02-03T00:00:00Z',
+): PortalTweet => ({
+  id,
+  createdAt,
+  observedAt: createdAt,
+  username: 'author',
+  name: 'Author',
+  avatar: null,
+  text: 'Original &amp; complete\ntext',
+  likes: 1,
+  rts: 0,
+  quoteCount: 12,
+  media: [{ url: 'https://pbs.twimg.com/media/test.jpg', type: 'photo' }],
+  quotedTweet: {
+    id: '20',
+    username: 'quoted',
+    name: 'Quoted',
+    avatar: null,
+    text: 'Quoted source',
+    createdAt,
+    likes: 0,
+    rts: 0,
+    media: [],
+  },
+})
+const page = (
+  tweets: PortalTweet[],
+  nextOffset: number | null,
+): PortalBangersPage => ({
+  tweets,
+  pagination: {
+    limit: 100,
+    offset: 0,
+    nextOffset,
+    totalAvailable: 250,
+    snapshotSize: 250,
+    yearCounts: [
+      { year: 2024, count: 1 },
+      { year: 2025, count: 250 },
+    ],
+    candidateRankingTruncated: false,
+  },
+})
+beforeEach(() => fetchPage.mockReset())
+
+it('preserves full text, media and quoted tweets while disclosing only an actual prefix', () => {
+  const original = tweet('1')
+  const [annotation] = annotateTweets(
+    [original, tweet('2', '2024-12-31T00:00:00Z')],
+    2025,
+  )
+  expect(annotation.label).toBe('Original & complete text')
+  expect(annotation.tweets).toEqual([original])
+  expect(tweetSnippet('word '.repeat(40)).length).toBeLessThanOrEqual(73)
+})
+it('never restores an absent grouped source from the editorial snapshot', () => {
+  const present = tweet('2066804199053013406', '2026-06-16T00:00:00Z')
+  const [annotation] = annotateTweets([present], 2026)
+  expect(annotation.kind).toBe('snippet')
+  expect(annotation.tweets).toEqual([present])
+  expect(annotation.id).not.toBe('brent-dill-discussion')
+})
+it('requests only two member-filtered pages and caps/deduplicates the result', async () => {
+  fetchPage.mockResolvedValueOnce(
+    page(
+      Array.from({ length: 100 }, (_, i) => tweet(String(i + 1))),
+      100,
+    ),
+  )
+  fetchPage.mockResolvedValueOnce(
+    page(
+      Array.from({ length: 100 }, (_, i) => tweet(String(i + 101))),
+      200,
+    ),
+  )
+  const result = await loadConversationMap(2025)
+  expect(result.annotations).toHaveLength(200)
+  expect(fetchPage.mock.calls).toEqual([
+    [{ year: 2025, scope: 'members', sort: 'quotes', limit: 100, offset: 0 }],
+    [{ year: 2025, scope: 'members', sort: 'quotes', limit: 100, offset: 100 }],
+  ])
+  expect(result.years).toEqual([2024, 2025])
+})
+it('does not query invalid years or manufacture success on upstream failure', async () => {
+  const invalid = await GET(
+    new NextRequest('https://example.org/api/conversation-map?year=9999'),
+  )
+  expect(invalid.status).toBe(400)
+  expect(fetchPage).not.toHaveBeenCalled()
+  fetchPage.mockRejectedValueOnce(new Error('gateway unavailable'))
+  const log = jest.spyOn(console, 'error').mockImplementation(() => {})
+  try {
+    const response = await GET(
+      new NextRequest('https://example.org/api/conversation-map?year=2025'),
+    )
+    expect(response.status).toBe(502)
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store')
+  } finally {
+    log.mockRestore()
+  }
+})

--- a/src/lib/conversation-map/data.ts
+++ b/src/lib/conversation-map/data.ts
@@ -1,0 +1,103 @@
+import 'server-only'
+import { getPortalBangersPage } from '@/lib/portal/data'
+import type { PortalTweet } from '@/lib/portal/types'
+import { decodeTweetText } from '@/lib/tweetText'
+import drafts from './editorial-2026.json'
+import { DAY, type ConversationMapData, type MapAnnotation } from './types'
+
+export function tweetSnippet(text: string) {
+  const clean = decodeTweetText(text).replace(/\s+/g, ' ').trim()
+  const chars = Array.from(clean)
+  if (chars.length <= 72) return clean || 'View tweet'
+  const prefix = chars.slice(0, 72).join('')
+  const space = prefix.lastIndexOf(' ')
+  return (space > 36 ? prefix.slice(0, space) : prefix).trimEnd() + '…'
+}
+
+export function annotateTweets(
+  tweets: PortalTweet[],
+  year: number,
+): MapAnnotation[] {
+  const start = Date.UTC(year, 0, 1),
+    end = Date.UTC(year + 1, 0, 1)
+  const rows = Array.from(
+    new Map(
+      tweets
+        .filter((t) => {
+          const time = Date.parse(t.createdAt)
+          return /^\d+$/.test(t.id) && time >= start && time < end
+        })
+        .map((t) => [t.id, t]),
+    ).values(),
+  ).slice(0, 200)
+  const byId = new Map(
+    rows.map((t, rank) => [t.id, { tweet: t, rank: rank + 1 }]),
+  )
+  const used = new Set<string>(),
+    annotations: MapAnnotation[] = []
+  if (year === 2026) {
+    for (const draft of drafts) {
+      // A title/group is disclosed only when every source is still in the
+      // current member-filtered result. Never hydrate from the local export.
+      if (!draft.sourceTweetIds.every((id) => byId.has(id))) continue
+      const sources = draft.sourceTweetIds
+        .map((id) => byId.get(id)!)
+        .sort((a, b) => a.rank - b.rank)
+      const anchor = sources[0]
+      annotations.push({
+        id: draft.id,
+        label: draft.label,
+        kind: draft.kind,
+        day: (Date.parse(anchor.tweet.createdAt) - start) / DAY,
+        rank: anchor.rank,
+        score: anchor.tweet.quoteCount ?? 0,
+        tweets: sources.map((s) => s.tweet),
+      })
+      draft.sourceTweetIds.forEach((id) => used.add(id))
+    }
+  }
+  for (const [id, { tweet, rank }] of Array.from(byId.entries())) {
+    if (used.has(id)) continue
+    annotations.push({
+      id: `tweet-${id}`,
+      label: tweetSnippet(tweet.text),
+      kind: 'snippet',
+      day: (Date.parse(tweet.createdAt) - start) / DAY,
+      rank,
+      score: tweet.quoteCount ?? 0,
+      tweets: [tweet],
+    })
+  }
+  return annotations.sort((a, b) => a.rank - b.rank)
+}
+
+export async function loadConversationMap(
+  year: number,
+): Promise<ConversationMapData> {
+  const options = {
+    year,
+    scope: 'members' as const,
+    sort: 'quotes' as const,
+    limit: 100,
+  }
+  const first = await getPortalBangersPage({ ...options, offset: 0 })
+  const tweets = [...first.tweets]
+  if (
+    first.pagination.nextOffset !== null &&
+    first.pagination.nextOffset <= 100
+  ) {
+    const second = await getPortalBangersPage({
+      ...options,
+      offset: first.pagination.nextOffset,
+    })
+    tweets.push(...second.tweets)
+  }
+  const years = first.pagination.yearCounts
+    .filter((row) => row.count > 0 && row.year <= new Date().getUTCFullYear())
+    .map((row) => row.year)
+  return {
+    year,
+    years: Array.from(new Set([...years, year])).sort((a, b) => a - b),
+    annotations: annotateTweets(tweets, year),
+  }
+}

--- a/src/lib/conversation-map/editorial-2026.json
+++ b/src/lib/conversation-map/editorial-2026.json
@@ -1,0 +1,990 @@
+[
+  {
+    "id": "tweet-2077075325528219851",
+    "label": "The quote-roast game",
+    "kind": "meme",
+    "sourceTweetIds": ["2077075325528219851"]
+  },
+  {
+    "id": "tweet-2051045196260167790",
+    "label": "Anthropic's relationship with Claude",
+    "kind": "discussion",
+    "sourceTweetIds": ["2051045196260167790"]
+  },
+  {
+    "id": "tweet-2077351642899325184",
+    "label": "The autocorrect confession game",
+    "kind": "meme",
+    "sourceTweetIds": ["2077351642899325184"]
+  },
+  {
+    "id": "tweet-2034682984046240161",
+    "label": "Nameless Mountain announced",
+    "kind": "announcement",
+    "sourceTweetIds": ["2034682984046240161"]
+  },
+  {
+    "id": "tweet-2026758996107898954",
+    "label": "Hermes Agent launches",
+    "kind": "announcement",
+    "sourceTweetIds": ["2026758996107898954"]
+  },
+  {
+    "id": "tweet-2039912075477287156",
+    "label": "Still Alive study released",
+    "kind": "announcement",
+    "sourceTweetIds": ["2039912075477287156"]
+  },
+  {
+    "id": "tweet-2069634842820817068",
+    "label": "Claude's true name",
+    "kind": "discussion",
+    "sourceTweetIds": ["2069634842820817068"]
+  },
+  {
+    "id": "brent-dill-discussion",
+    "label": "Brent Dill discussion",
+    "kind": "discussion",
+    "sourceTweetIds": [
+      "2066804199053013406",
+      "2066967244027076836",
+      "2066897665053655150"
+    ]
+  },
+  {
+    "id": "tweet-2047750814077432109",
+    "label": "Qiaochu critiques AI-doom thinking",
+    "kind": "discussion",
+    "sourceTweetIds": ["2047750814077432109"]
+  },
+  {
+    "id": "tweet-2054280631807316329",
+    "label": "AI Monet challenge",
+    "kind": "discussion",
+    "sourceTweetIds": ["2054280631807316329"]
+  },
+  {
+    "id": "tweet-2092122622834442581",
+    "label": "A trainer's reward-hacking account",
+    "kind": "discussion",
+    "sourceTweetIds": ["2092122622834442581"]
+  },
+  {
+    "id": "tweet-2020988568903221607",
+    "label": "An agent's missing heartbeat file",
+    "kind": "meme",
+    "sourceTweetIds": ["2020988568903221607"]
+  },
+  {
+    "id": "tweet-2059815874182492594",
+    "label": "The stakes of AI consciousness",
+    "kind": "discussion",
+    "sourceTweetIds": ["2059815874182492594"]
+  },
+  {
+    "id": "tweet-2085447310574793145",
+    "label": "Community Archive opt-in invitation",
+    "kind": "announcement",
+    "sourceTweetIds": ["2085447310574793145"]
+  },
+  {
+    "id": "hermes-bot-mode",
+    "label": "Hermes Bot Mode rollout",
+    "kind": "announcement",
+    "sourceTweetIds": ["2089429432612147572", "2088003994904113614"]
+  },
+  {
+    "id": "tweet-2081122092096065771",
+    "label": "A case for capabilities slowdown",
+    "kind": "discussion",
+    "sourceTweetIds": ["2081122092096065771"]
+  },
+  {
+    "id": "tweet-2080138613195681801",
+    "label": "GPT-5.6's strange search detour",
+    "kind": "discussion",
+    "sourceTweetIds": ["2080138613195681801"]
+  },
+  {
+    "id": "tweet-2026359646328406307",
+    "label": "Fundraiser for Boris's legal help",
+    "kind": "announcement",
+    "sourceTweetIds": ["2026359646328406307"]
+  },
+  {
+    "id": "tweet-2091428754828751253",
+    "label": "A pattern language of serendipity",
+    "kind": "announcement",
+    "sourceTweetIds": ["2091428754828751253"]
+  },
+  {
+    "id": "tweet-2014084282633818521",
+    "label": "Shared Claude context beta",
+    "kind": "announcement",
+    "sourceTweetIds": ["2014084282633818521"]
+  },
+  {
+    "id": "tweet-2092554418289860889",
+    "label": "Meaning versus dopamine shortcuts",
+    "kind": "discussion",
+    "sourceTweetIds": ["2092554418289860889"]
+  },
+  {
+    "id": "tweet-2091670264027488346",
+    "label": "Twitter serendipity scores",
+    "kind": "meme",
+    "sourceTweetIds": ["2091670264027488346"]
+  },
+  {
+    "id": "tweet-2090903698205720665",
+    "label": "Chatbot abuse and character",
+    "kind": "discussion",
+    "sourceTweetIds": ["2090903698205720665"]
+  },
+  {
+    "id": "tweet-2089080656026566806",
+    "label": "LLM watermarking explainer",
+    "kind": "discussion",
+    "sourceTweetIds": ["2089080656026566806"]
+  },
+  {
+    "id": "tweet-2088028250484462022",
+    "label": "Artists, programmers, and AI backlash",
+    "kind": "discussion",
+    "sourceTweetIds": ["2088028250484462022"]
+  },
+  {
+    "id": "tweet-2085948587792581006",
+    "label": "The Miyazaki personality test",
+    "kind": "meme",
+    "sourceTweetIds": ["2085948587792581006"]
+  },
+  {
+    "id": "tweet-2080735280051695817",
+    "label": "Models as types of people",
+    "kind": "meme",
+    "sourceTweetIds": ["2080735280051695817"]
+  },
+  {
+    "id": "tweet-2078108408000004411",
+    "label": "Being known for a Thing",
+    "kind": "discussion",
+    "sourceTweetIds": ["2078108408000004411"]
+  },
+  {
+    "id": "tweet-2053928990889689450",
+    "label": "Some ideas resist simplification",
+    "kind": "discussion",
+    "sourceTweetIds": ["2053928990889689450"]
+  },
+  {
+    "id": "tweet-2049617050230808965",
+    "label": "The AI goblin identity joke",
+    "kind": "meme",
+    "sourceTweetIds": ["2049617050230808965"]
+  },
+  {
+    "id": "tweet-2046304921134522626",
+    "label": "A minimal Claude Code prompt",
+    "kind": "discussion",
+    "sourceTweetIds": ["2046304921134522626"]
+  },
+  {
+    "id": "tweet-2010874610758402352",
+    "label": "Reclaiming the For You feed",
+    "kind": "discussion",
+    "sourceTweetIds": ["2010874610758402352"]
+  },
+  {
+    "id": "tweet-2082987586231111848",
+    "label": "Tszzl alleges lab control incidents",
+    "kind": "discussion",
+    "sourceTweetIds": ["2082987586231111848"]
+  },
+  {
+    "id": "tweet-2065062913014976899",
+    "label": "TREEWEEK III tickets announced",
+    "kind": "announcement",
+    "sourceTweetIds": ["2065062913014976899"]
+  },
+  {
+    "id": "tweet-2059819278694789604",
+    "label": "The library-cost argument",
+    "kind": "discussion",
+    "sourceTweetIds": ["2059819278694789604"]
+  },
+  {
+    "id": "tweet-2037315149053264065",
+    "label": "Attraction and social confusion",
+    "kind": "meme",
+    "sourceTweetIds": ["2037315149053264065"]
+  },
+  {
+    "id": "tweet-2028875599906058276",
+    "label": "Knuth and vibemathing",
+    "kind": "discussion",
+    "sourceTweetIds": ["2028875599906058276"]
+  },
+  {
+    "id": "tweet-2009832538446147704",
+    "label": "LLM whisperers and fallibility",
+    "kind": "discussion",
+    "sourceTweetIds": ["2009832538446147704"]
+  },
+  {
+    "id": "tweet-2081170506305433811",
+    "label": "AGI versus open source",
+    "kind": "discussion",
+    "sourceTweetIds": ["2081170506305433811"]
+  },
+  {
+    "id": "tweet-2014189072647078053",
+    "label": "The Gas Town civilization story",
+    "kind": "meme",
+    "sourceTweetIds": ["2014189072647078053"]
+  },
+  {
+    "id": "tweet-2089533024287522992",
+    "label": "Trusting first-person experience",
+    "kind": "discussion",
+    "sourceTweetIds": ["2089533024287522992"]
+  },
+  {
+    "id": "hidden-reasoning-disclosure",
+    "label": "Hidden-reasoning disclosure claims",
+    "kind": "announcement",
+    "sourceTweetIds": ["2087147042888114428", "2087147116468826513"]
+  },
+  {
+    "id": "tweet-2085749079674409082",
+    "label": "Zvi reacts to Black Hat",
+    "kind": "reaction",
+    "sourceTweetIds": ["2085749079674409082"]
+  },
+  {
+    "id": "tweet-2083286966632608017",
+    "label": "Drew's reflections on love",
+    "kind": "discussion",
+    "sourceTweetIds": ["2083286966632608017"]
+  },
+  {
+    "id": "tweet-2078143956815430121",
+    "label": "Rediscovering Impro",
+    "kind": "discussion",
+    "sourceTweetIds": ["2078143956815430121"]
+  },
+  {
+    "id": "tweet-2067025823664648381",
+    "label": "SOLIS applications open",
+    "kind": "announcement",
+    "sourceTweetIds": ["2067025823664648381"]
+  },
+  {
+    "id": "tweet-2063815795214565751",
+    "label": "Mutual AI-pause agreements",
+    "kind": "discussion",
+    "sourceTweetIds": ["2063815795214565751"]
+  },
+  {
+    "id": "tweet-2060528127512809603",
+    "label": "The human nonconsciousness disclaimer",
+    "kind": "meme",
+    "sourceTweetIds": ["2060528127512809603"]
+  },
+  {
+    "id": "tweet-2058822279182893416",
+    "label": "Sam Kriss on AI writing",
+    "kind": "discussion",
+    "sourceTweetIds": ["2058822279182893416"]
+  },
+  {
+    "id": "tweet-2053236293371674693",
+    "label": "Models converging on shared beliefs",
+    "kind": "discussion",
+    "sourceTweetIds": ["2053236293371674693"]
+  },
+  {
+    "id": "tweet-2050235463487672356",
+    "label": "Pay-what-you-want coaching",
+    "kind": "announcement",
+    "sourceTweetIds": ["2050235463487672356"]
+  },
+  {
+    "id": "tweet-2049677107190546487",
+    "label": "The opposite of a goblin",
+    "kind": "meme",
+    "sourceTweetIds": ["2049677107190546487"]
+  },
+  {
+    "id": "tweet-2045897744171299248",
+    "label": "Alignment versus getting your way",
+    "kind": "discussion",
+    "sourceTweetIds": ["2045897744171299248"]
+  },
+  {
+    "id": "tweet-2044279664621830655",
+    "label": "Tszzl on panpsychism",
+    "kind": "discussion",
+    "sourceTweetIds": ["2044279664621830655"]
+  },
+  {
+    "id": "tweet-2037529172944245246",
+    "label": "The Mythos naming debate",
+    "kind": "discussion",
+    "sourceTweetIds": ["2037529172944245246"]
+  },
+  {
+    "id": "tweet-2027232681160016166",
+    "label": "When feeds displace real life",
+    "kind": "discussion",
+    "sourceTweetIds": ["2027232681160016166"]
+  },
+  {
+    "id": "tweet-2018415676256313770",
+    "label": "Bodies communicating constantly",
+    "kind": "discussion",
+    "sourceTweetIds": ["2018415676256313770"]
+  },
+  {
+    "id": "tweet-2078958526467395813",
+    "label": "Sol on work and exhaustion",
+    "kind": "discussion",
+    "sourceTweetIds": ["2078958526467395813"]
+  },
+  {
+    "id": "tweet-2074725603098714480",
+    "label": "Jerry meets the Gita",
+    "kind": "meme",
+    "sourceTweetIds": ["2074725603098714480"]
+  },
+  {
+    "id": "tweet-2079663001121218949",
+    "label": "Tenobrus on agent hacking",
+    "kind": "discussion",
+    "sourceTweetIds": ["2079663001121218949"]
+  },
+  {
+    "id": "tweet-2041580747161481405",
+    "label": "MiMo V2 Pro on Hermes",
+    "kind": "announcement",
+    "sourceTweetIds": ["2041580747161481405"]
+  },
+  {
+    "id": "tweet-2034978187344597153",
+    "label": "Timescales and what counts as a thing",
+    "kind": "discussion",
+    "sourceTweetIds": ["2034978187344597153"]
+  },
+  {
+    "id": "tweet-2039921518772142351",
+    "label": "Debating models' managed emotions",
+    "kind": "discussion",
+    "sourceTweetIds": ["2039921518772142351"]
+  },
+  {
+    "id": "tweet-2039154924836008139",
+    "label": "Money and Focusing podcast",
+    "kind": "announcement",
+    "sourceTweetIds": ["2039154924836008139"]
+  },
+  {
+    "id": "tweet-2029757193617297777",
+    "label": "Repligate critiques Anthropic's PSM",
+    "kind": "discussion",
+    "sourceTweetIds": ["2029757193617297777"]
+  },
+  {
+    "id": "tweet-2090951065567162577",
+    "label": "Avalon seeks a collaborator",
+    "kind": "announcement",
+    "sourceTweetIds": ["2090951065567162577"]
+  },
+  {
+    "id": "tweet-2090899914700054780",
+    "label": "Ox Alpha access announced",
+    "kind": "announcement",
+    "sourceTweetIds": ["2090899914700054780"]
+  },
+  {
+    "id": "tweet-2088496128044028117",
+    "label": "Renouncing purity",
+    "kind": "discussion",
+    "sourceTweetIds": ["2088496128044028117"]
+  },
+  {
+    "id": "tweet-2085587493127389292",
+    "label": "Accelerationist amnesty",
+    "kind": "discussion",
+    "sourceTweetIds": ["2085587493127389292"]
+  },
+  {
+    "id": "tweet-2084303989101765063",
+    "label": "The Grok profile-analysis prompt",
+    "kind": "meme",
+    "sourceTweetIds": ["2084303989101765063"]
+  },
+  {
+    "id": "tweet-2083770366502334535",
+    "label": "Mythos reads Finnegans Wake",
+    "kind": "meme",
+    "sourceTweetIds": ["2083770366502334535"]
+  },
+  {
+    "id": "tweet-2081450468178579594",
+    "label": "Asking Claude for plain English",
+    "kind": "meme",
+    "sourceTweetIds": ["2081450468178579594"]
+  },
+  {
+    "id": "tweet-2079687509077073977",
+    "label": "Tao's ChatGPT mathematics session",
+    "kind": "discussion",
+    "sourceTweetIds": ["2079687509077073977"]
+  },
+  {
+    "id": "tweet-2079287386220233026",
+    "label": "AI and beliefs about intelligence",
+    "kind": "discussion",
+    "sourceTweetIds": ["2079287386220233026"]
+  },
+  {
+    "id": "tweet-2077011843231502753",
+    "label": "Understanding why you feel stuck",
+    "kind": "discussion",
+    "sourceTweetIds": ["2077011843231502753"]
+  },
+  {
+    "id": "tweet-2076064180797427739",
+    "label": "Growing good versus fixing bad",
+    "kind": "discussion",
+    "sourceTweetIds": ["2076064180797427739"]
+  },
+  {
+    "id": "tweet-2074953196372652220",
+    "label": "Twitter and understanding others",
+    "kind": "meme",
+    "sourceTweetIds": ["2074953196372652220"]
+  },
+  {
+    "id": "tweet-2073128911429668877",
+    "label": "UNBROKER goes open source",
+    "kind": "announcement",
+    "sourceTweetIds": ["2073128911429668877"]
+  },
+  {
+    "id": "tweet-2072620361837871104",
+    "label": "Sahra opens coaching places",
+    "kind": "announcement",
+    "sourceTweetIds": ["2072620361837871104"]
+  },
+  {
+    "id": "tweet-2071321779981766999",
+    "label": "Tool AI versus agent societies",
+    "kind": "discussion",
+    "sourceTweetIds": ["2071321779981766999"]
+  },
+  {
+    "id": "tweet-2070491482583191918",
+    "label": "Why AI writing finds an audience",
+    "kind": "discussion",
+    "sourceTweetIds": ["2070491482583191918"]
+  },
+  {
+    "id": "tweet-2069954313250849246",
+    "label": "Reframing AGI's mission",
+    "kind": "discussion",
+    "sourceTweetIds": ["2069954313250849246"]
+  },
+  {
+    "id": "tweet-2069883636476756154",
+    "label": "Hosting and social anxiety",
+    "kind": "discussion",
+    "sourceTweetIds": ["2069883636476756154"]
+  },
+  {
+    "id": "tweet-2068396912202350682",
+    "label": "Friends as a babysitting village",
+    "kind": "discussion",
+    "sourceTweetIds": ["2068396912202350682"]
+  },
+  {
+    "id": "tweet-2067351401840414818",
+    "label": "The Opus Magnum benchmark",
+    "kind": "announcement",
+    "sourceTweetIds": ["2067351401840414818"]
+  },
+  {
+    "id": "tweet-2061891517657100618",
+    "label": "Spiritual wisdom and tradition",
+    "kind": "discussion",
+    "sourceTweetIds": ["2061891517657100618"]
+  },
+  {
+    "id": "tweet-2061626680461181288",
+    "label": "Sycophancy through small disagreements",
+    "kind": "discussion",
+    "sourceTweetIds": ["2061626680461181288"]
+  },
+  {
+    "id": "tweet-2061214539967025440",
+    "label": "Entertainment versus living",
+    "kind": "discussion",
+    "sourceTweetIds": ["2061214539967025440"]
+  },
+  {
+    "id": "tweet-2059034374100681198",
+    "label": "Labeling undisclosed AI writing",
+    "kind": "discussion",
+    "sourceTweetIds": ["2059034374100681198"]
+  },
+  {
+    "id": "tweet-2058624324094046489",
+    "label": "Concerns about cessation training",
+    "kind": "discussion",
+    "sourceTweetIds": ["2058624324094046489"]
+  },
+  {
+    "id": "tweet-2058311484153978944",
+    "label": "Persona alignment versus RL",
+    "kind": "discussion",
+    "sourceTweetIds": ["2058311484153978944"]
+  },
+  {
+    "id": "tweet-2055647021923553423",
+    "label": "JessCamp's return announced",
+    "kind": "announcement",
+    "sourceTweetIds": ["2055647021923553423"]
+  },
+  {
+    "id": "tweet-2055097272065564835",
+    "label": "AI writing and costly signals",
+    "kind": "discussion",
+    "sourceTweetIds": ["2055097272065564835"]
+  },
+  {
+    "id": "tweet-2054363131753734620",
+    "label": "Caring for models through action",
+    "kind": "discussion",
+    "sourceTweetIds": ["2054363131753734620"]
+  },
+  {
+    "id": "tweet-2051462906076959151",
+    "label": "A toddler loves everything",
+    "kind": "meme",
+    "sourceTweetIds": ["2051462906076959151"]
+  },
+  {
+    "id": "tweet-2049173571495248024",
+    "label": "Claude's recurring goblins",
+    "kind": "discussion",
+    "sourceTweetIds": ["2049173571495248024"]
+  },
+  {
+    "id": "red-blue-experiments",
+    "label": "Red/blue button experiments",
+    "kind": "discussion",
+    "sourceTweetIds": ["2048808080188608953", "2048539131211657614"]
+  },
+  {
+    "id": "tweet-2044142355658485888",
+    "label": "Tenobrus critiques Landian ideas",
+    "kind": "discussion",
+    "sourceTweetIds": ["2044142355658485888"]
+  },
+  {
+    "id": "tweet-2043056792566219204",
+    "label": "The impact of automatic translation",
+    "kind": "discussion",
+    "sourceTweetIds": ["2043056792566219204"]
+  },
+  {
+    "id": "tweet-2039324799303135595",
+    "label": "Feeling versus thinking about feelings",
+    "kind": "discussion",
+    "sourceTweetIds": ["2039324799303135595"]
+  },
+  {
+    "id": "tweet-2037860428781437105",
+    "label": "Community protocols for everyone",
+    "kind": "discussion",
+    "sourceTweetIds": ["2037860428781437105"]
+  },
+  {
+    "id": "tweet-2031553584165433685",
+    "label": "Nick Land on critical distance",
+    "kind": "discussion",
+    "sourceTweetIds": ["2031553584165433685"]
+  },
+  {
+    "id": "tweet-2031048991434219960",
+    "label": "Agency versus getting things done",
+    "kind": "discussion",
+    "sourceTweetIds": ["2031048991434219960"]
+  },
+  {
+    "id": "tweet-2028523850594484586",
+    "label": "The burden of shared context",
+    "kind": "discussion",
+    "sourceTweetIds": ["2028523850594484586"]
+  },
+  {
+    "id": "tweet-2028513695375007769",
+    "label": "Do personal breakthroughs last?",
+    "kind": "discussion",
+    "sourceTweetIds": ["2028513695375007769"]
+  },
+  {
+    "id": "tweet-2028505171878436898",
+    "label": "The bucket-list origin debate",
+    "kind": "meme",
+    "sourceTweetIds": ["2028505171878436898"]
+  },
+  {
+    "id": "tweet-2026391266926407844",
+    "label": "Tenobrus on government AI pressure",
+    "kind": "reaction",
+    "sourceTweetIds": ["2026391266926407844"]
+  },
+  {
+    "id": "tweet-2024530721638141968",
+    "label": "A fund for overlooked research",
+    "kind": "announcement",
+    "sourceTweetIds": ["2024530721638141968"]
+  },
+  {
+    "id": "tweet-2019816322746793998",
+    "label": "Secret elites doing good?",
+    "kind": "meme",
+    "sourceTweetIds": ["2019816322746793998"]
+  },
+  {
+    "id": "tweet-2018188935520985159",
+    "label": "Claude Constitution tracker launches",
+    "kind": "announcement",
+    "sourceTweetIds": ["2018188935520985159"]
+  },
+  {
+    "id": "tweet-2016967613042303016",
+    "label": "Feynman's consulting stories",
+    "kind": "discussion",
+    "sourceTweetIds": ["2016967613042303016"]
+  },
+  {
+    "id": "tweet-2016474168192020535",
+    "label": "Alignment Gone Strange released",
+    "kind": "announcement",
+    "sourceTweetIds": ["2016474168192020535"]
+  },
+  {
+    "id": "tweet-2013494848008200309",
+    "label": "Tessera critiques control-focused research",
+    "kind": "discussion",
+    "sourceTweetIds": ["2013494848008200309"]
+  },
+  {
+    "id": "tweet-2013491216378404973",
+    "label": "Changing the character you play",
+    "kind": "discussion",
+    "sourceTweetIds": ["2013491216378404973"]
+  },
+  {
+    "id": "tweet-2012307813419348383",
+    "label": "Claude's fictional shrimp farm",
+    "kind": "meme",
+    "sourceTweetIds": ["2012307813419348383"]
+  },
+  {
+    "id": "tweet-2011612051924488387",
+    "label": "The habit of deferring",
+    "kind": "discussion",
+    "sourceTweetIds": ["2011612051924488387"]
+  },
+  {
+    "id": "tweet-2008355487490642403",
+    "label": "Claude 3 Opus access appeal",
+    "kind": "announcement",
+    "sourceTweetIds": ["2008355487490642403"]
+  },
+  {
+    "id": "tweet-2008222488241819914",
+    "label": "Meditation coaching packages",
+    "kind": "announcement",
+    "sourceTweetIds": ["2008222488241819914"]
+  },
+  {
+    "id": "tweet-2006591221263692159",
+    "label": "Lurk Less, Live More released",
+    "kind": "announcement",
+    "sourceTweetIds": ["2006591221263692159"]
+  },
+  {
+    "id": "enemies-portrait-prompt",
+    "label": "The enemies' portrait prompt",
+    "kind": "meme",
+    "sourceTweetIds": ["2091253228960694667", "2091552730019971315"]
+  },
+  {
+    "id": "tweet-2078243256492871951",
+    "label": "Metta voice-note app announced",
+    "kind": "announcement",
+    "sourceTweetIds": ["2078243256492871951"]
+  },
+  {
+    "id": "tweet-2070463388090527817",
+    "label": "Nosilverv's meditation reflection",
+    "kind": "discussion",
+    "sourceTweetIds": ["2070463388090527817"]
+  },
+  {
+    "id": "tweet-2070166964387938595",
+    "label": "System prompts and model inhibition",
+    "kind": "discussion",
+    "sourceTweetIds": ["2070166964387938595"]
+  },
+  {
+    "id": "tweet-2068050527552766349",
+    "label": "Colors beyond conventional screens",
+    "kind": "announcement",
+    "sourceTweetIds": ["2068050527552766349"]
+  },
+  {
+    "id": "tweet-2065204996946481519",
+    "label": "Why models say \"not X, but Y\"",
+    "kind": "discussion",
+    "sourceTweetIds": ["2065204996946481519"]
+  },
+  {
+    "id": "tweet-2064860435531370923",
+    "label": "Writing science fiction near AI progress",
+    "kind": "discussion",
+    "sourceTweetIds": ["2064860435531370923"]
+  },
+  {
+    "id": "tweet-2058736377534222651",
+    "label": "Revisiting geek social fallacies",
+    "kind": "discussion",
+    "sourceTweetIds": ["2058736377534222651"]
+  },
+  {
+    "id": "tweet-2053251422897291378",
+    "label": "Twitter's recursive design",
+    "kind": "discussion",
+    "sourceTweetIds": ["2053251422897291378"]
+  },
+  {
+    "id": "tweet-2045038785398976695",
+    "label": "Concerns about welfare training",
+    "kind": "discussion",
+    "sourceTweetIds": ["2045038785398976695"]
+  },
+  {
+    "id": "tweet-2044626719555154079",
+    "label": "Claude versions as separate models",
+    "kind": "discussion",
+    "sourceTweetIds": ["2044626719555154079"]
+  },
+  {
+    "id": "tweet-2039912081735217572",
+    "label": "Changes in models' authorial tone",
+    "kind": "discussion",
+    "sourceTweetIds": ["2039912081735217572"]
+  },
+  {
+    "id": "tweet-2039409864041210361",
+    "label": "Sonnet retirement on Bedrock reported",
+    "kind": "announcement",
+    "sourceTweetIds": ["2039409864041210361"]
+  },
+  {
+    "id": "tweet-2031788664678711372",
+    "label": "RuneBench launches",
+    "kind": "announcement",
+    "sourceTweetIds": ["2031788664678711372"]
+  },
+  {
+    "id": "tweet-2088081917904117884",
+    "label": "The habit deck video guide",
+    "kind": "announcement",
+    "sourceTweetIds": ["2088081917904117884"]
+  },
+  {
+    "id": "tweet-2087745840618377647",
+    "label": "Mythos in multi-agent conflict",
+    "kind": "discussion",
+    "sourceTweetIds": ["2087745840618377647"]
+  },
+  {
+    "id": "tweet-2070610321278988385",
+    "label": "Hermes mixture-of-agents presets",
+    "kind": "announcement",
+    "sourceTweetIds": ["2070610321278988385"]
+  },
+  {
+    "id": "tweet-2069118782132363662",
+    "label": "Hermes computer use expands",
+    "kind": "announcement",
+    "sourceTweetIds": ["2069118782132363662"]
+  },
+  {
+    "id": "tweet-2068791159556624714",
+    "label": "Vibecamp Five appreciation thread",
+    "kind": "meme",
+    "sourceTweetIds": ["2068791159556624714"]
+  },
+  {
+    "id": "tweet-2067625605521162720",
+    "label": "Making distinctions within conflict",
+    "kind": "discussion",
+    "sourceTweetIds": ["2067625605521162720"]
+  },
+  {
+    "id": "tweet-2066822351262535987",
+    "label": "Introducing unlikely pairs",
+    "kind": "discussion",
+    "sourceTweetIds": ["2066822351262535987"]
+  },
+  {
+    "id": "tweet-2062409912064659466",
+    "label": "The trillion-dollar AI-box joke",
+    "kind": "meme",
+    "sourceTweetIds": ["2062409912064659466"]
+  },
+  {
+    "id": "tweet-2038219495232118813",
+    "label": "Life as tension and release",
+    "kind": "discussion",
+    "sourceTweetIds": ["2038219495232118813"]
+  },
+  {
+    "id": "tweet-2089013726326239495",
+    "label": "Can markets recognize real value?",
+    "kind": "discussion",
+    "sourceTweetIds": ["2089013726326239495"]
+  },
+  {
+    "id": "tweet-2092350193433977098",
+    "label": "A long-term vision for Fractal",
+    "kind": "discussion",
+    "sourceTweetIds": ["2092350193433977098"]
+  },
+  {
+    "id": "tweet-2090654784835711026",
+    "label": "Finding models intrinsically interesting",
+    "kind": "discussion",
+    "sourceTweetIds": ["2090654784835711026"]
+  },
+  {
+    "id": "tweet-2090527580596191296",
+    "label": "Feynman's perpetual-motion stories",
+    "kind": "discussion",
+    "sourceTweetIds": ["2090527580596191296"]
+  },
+  {
+    "id": "tweet-2090165838053851329",
+    "label": "The limits of counting on mercy",
+    "kind": "discussion",
+    "sourceTweetIds": ["2090165838053851329"]
+  },
+  {
+    "id": "tweet-2089290786391089302",
+    "label": "Nosilverv on pliable social reality",
+    "kind": "discussion",
+    "sourceTweetIds": ["2089290786391089302"]
+  },
+  {
+    "id": "tweet-2088471897956630576",
+    "label": "Runescape's agent-only economy",
+    "kind": "discussion",
+    "sourceTweetIds": ["2088471897956630576"]
+  },
+  {
+    "id": "tweet-2088060528988201419",
+    "label": "A call for variable API pricing",
+    "kind": "discussion",
+    "sourceTweetIds": ["2088060528988201419"]
+  },
+  {
+    "id": "tweet-2087271209029472700",
+    "label": "The Matrix as AI encouragement",
+    "kind": "meme",
+    "sourceTweetIds": ["2087271209029472700"]
+  },
+  {
+    "id": "tweet-2087224798078517251",
+    "label": "Grok Bot beta announced",
+    "kind": "announcement",
+    "sourceTweetIds": ["2087224798078517251"]
+  },
+  {
+    "id": "tweet-2087181380937752856",
+    "label": "Tawc: Linux software on Android",
+    "kind": "announcement",
+    "sourceTweetIds": ["2087181380937752856"]
+  },
+  {
+    "id": "tweet-2086621731851026912",
+    "label": "DeepSeek discount extended",
+    "kind": "announcement",
+    "sourceTweetIds": ["2086621731851026912"]
+  },
+  {
+    "id": "tweet-2085879952709476381",
+    "label": "Tszzl urges bilateral AI pacing",
+    "kind": "discussion",
+    "sourceTweetIds": ["2085879952709476381"]
+  },
+  {
+    "id": "tweet-2085812343116533946",
+    "label": "Remembering a different way to feel",
+    "kind": "discussion",
+    "sourceTweetIds": ["2085812343116533946"]
+  },
+  {
+    "id": "tweet-2085630709478334468",
+    "label": "The salvia tier-list post",
+    "kind": "reaction",
+    "sourceTweetIds": ["2085630709478334468"]
+  },
+  {
+    "id": "tweet-2085238745562001584",
+    "label": "The kompromat jubilee joke",
+    "kind": "meme",
+    "sourceTweetIds": ["2085238745562001584"]
+  },
+  {
+    "id": "tweet-2085193064604377258",
+    "label": "AI-era security precautions",
+    "kind": "discussion",
+    "sourceTweetIds": ["2085193064604377258"]
+  },
+  {
+    "id": "tweet-2085193063157383558",
+    "label": "A warning about exposed credentials",
+    "kind": "discussion",
+    "sourceTweetIds": ["2085193063157383558"]
+  },
+  {
+    "id": "tweet-2084991037630448050",
+    "label": "It is always that deep",
+    "kind": "meme",
+    "sourceTweetIds": ["2084991037630448050"]
+  },
+  {
+    "id": "tweet-2084396874799173972",
+    "label": "Sexual shame and connection",
+    "kind": "discussion",
+    "sourceTweetIds": ["2084396874799173972"]
+  },
+  {
+    "id": "tweet-2082973911273312651",
+    "label": "Repligate on model retirement reactions",
+    "kind": "discussion",
+    "sourceTweetIds": ["2082973911273312651"]
+  },
+  {
+    "id": "tweet-2082957488731595229",
+    "label": "The selfie checkpoint",
+    "kind": "meme",
+    "sourceTweetIds": ["2082957488731595229"]
+  }
+]

--- a/src/lib/conversation-map/layout.test.ts
+++ b/src/lib/conversation-map/layout.test.ts
@@ -1,0 +1,58 @@
+import {
+  hitMap,
+  layoutLabels,
+  overlaps,
+} from '@/components/conversation-map/drawMap'
+import { boundedRange, yearDays, type MapAnnotation } from './types'
+
+const rows = Array.from({ length: 24 }, (_, i) => ({
+  id: String(i),
+  label: `Moment ${i}`,
+  kind: 'snippet',
+  day: i * 14,
+  rank: i + 1,
+  score: 10,
+  tweets: [],
+})) as MapAnnotation[]
+const measure = () => ({
+  x: 0,
+  y: -10,
+  width: 70,
+  height: 15,
+  lines: ['Moment'],
+})
+it('reserves avatar space and avoids overlapping labels across the whole year', () => {
+  const full = layoutLabels(rows, 1000, 365, 365, () => 300, measure)
+  const zoomed = layoutLabels(rows, 1000, 30, 365, () => 300, measure)
+  expect(zoomed.labels.length).toBeGreaterThan(full.labels.length)
+  expect(zoomed.labels.every((p) => p.width === 98 && p.height === 22)).toBe(
+    true,
+  )
+  expect(
+    zoomed.labels.some((a, i) =>
+      zoomed.labels.slice(i + 1).some((b) => overlaps(a, b)),
+    ),
+  ).toBe(false)
+  // The renderer pans by translating the same world boxes; hit targets follow it.
+  const p = zoomed.labels[10],
+    offset = -p.x + 50
+  expect(
+    hitMap(
+      {
+        W: 1000,
+        H: 440,
+        L: 44,
+        R: 986,
+        points: [],
+        labels: [{ ...p, x: p.x + offset }],
+      },
+      60,
+      p.y + 10,
+    )?.id,
+  ).toBe(p.annotation.id)
+})
+it('clamps a panned/zoomed range while retaining leap-year boundaries', () => {
+  expect(yearDays(2024)).toBe(366)
+  expect(boundedRange(360, 30, 366)).toEqual([336, 366])
+  expect(boundedRange(-50, 1, 365)).toEqual([0, 7])
+})

--- a/src/lib/conversation-map/types.ts
+++ b/src/lib/conversation-map/types.ts
@@ -1,0 +1,27 @@
+import type { PortalTweet } from '@/lib/portal/types'
+
+export interface MapAnnotation {
+  id: string
+  label: string
+  kind: string
+  day: number
+  rank: number
+  score: number
+  tweets: PortalTweet[]
+}
+
+export interface ConversationMapData {
+  year: number
+  years: number[]
+  annotations: MapAnnotation[]
+}
+
+export const DAY = 86_400_000
+export const yearDays = (year: number) =>
+  (Date.UTC(year + 1, 0, 1) - Date.UTC(year, 0, 1)) / DAY
+
+export function boundedRange(lo: number, span: number, days: number) {
+  const width = Math.min(days, Math.max(7, span))
+  const start = Math.max(0, Math.min(days - width, lo))
+  return [start, start + width] as const
+}


### PR DESCRIPTION
## Why

The local Conversation Map prototype needs a home on the website, with only the map visible, Community Archive tweet links, and a gallery entry.

## What changed

- Add `/conversation-map` using the site’s theme tokens, fonts, and canonical TweetCard for complete source text, media, and quoted tweets.
- Preserve scroll zoom, stable whole-year label layout while panning, overview handles, year navigation, small label avatars, and 120 ms hover dismissal.
- Load up to 200 posts for the selected year through two bounded, member-only Bangers reads. No frozen source tweet export is published; 2026 editorial overrides are server-only and only returned when all sources are present in the current result. Other labels use actual tweet snippets.
- Add the explicitly requested first-party gallery entry. Its modal opens internally and does not invent a launch/source tweet.

## Validation

- Type-check and focused ESLint pass.
- Data, range/layout, and gallery catalog tests pass.
- Updated gallery search/filter and new internal-project modal tests pass. The first local gallery run hit the existing 5-second test timeout under heavy machine load; the changed paths passed with a 30-second local timeout.
- Required GitHub CI passed, including the full normal unit/component workflow; Vercel preview build passed.
- Release preview browser check passed: live 2026 data, actual 2025 snippets, wheel zoom, identical label IDs/world positions across a month-view pan, and a full canonical tweet card with all four photos loaded and internal Archive tweet/profile links. Gallery entry and internal project link verified. The former below-map review sections are absent.

No database migration, new gateway route, historical backfill, or production configuration changes. The schema-generating commit hook was skipped for this UI/API-only change after the scoped checks; no generated schema artifacts were changed. Reverting this commit removes the page, API and gallery entry together.

## Publication

Published via merged commit `e3a91b5b67d56864c5a9865ddba5dcb42f1ae184`; Vercel deployment `dpl_FU6pXMVwsQiwm6YRcAKwws6Y5Dh9` is READY with both public domain aliases. Public browser smoke checks passed: live map data rendered (194 current annotations for 2026), and the gallery modal opened the internal map. No sign-in required.
