### PR TITLE
Show gallery like counts on project cards

### DIFF
--- a/src/components/community/CommunityGallery.test.tsx
+++ b/src/components/community/CommunityGallery.test.tsx
@@ -212,6 +212,43 @@ describe('CommunityGallery', () => {
     expect(requestBody.get('projectName')).toBe('Archive Quilt')
   })
 
+  it('likes a project straight from its gallery card', async () => {
+    const user = userEvent.setup()
+    const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ liked: true, count: 3 }),
+    } as Response)
+
+    render(
+      <CommunityGallery
+        isSignedIn
+        publishedProjects={[PUBLISHED_PROJECT]}
+        likedProjectIds={[]}
+      />,
+    )
+
+    await user.type(
+      screen.getByRole('searchbox', { name: 'Search community projects' }),
+      'Archive Quilt',
+    )
+
+    const cardLike = screen.getByRole('button', { name: 'Like Archive Quilt' })
+    expect(cardLike).toHaveTextContent('2')
+
+    await user.click(cardLike)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/api/community/projects/${PUBLISHED_PROJECT.databaseId}/like`,
+      expect.objectContaining({ method: 'POST' }),
+    )
+    expect(
+      await screen.findByRole('button', { name: 'Unlike Archive Quilt' }),
+    ).toHaveTextContent('3')
+    // The card like must not open the project modal.
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
   it('optimistically likes a published project and calls the like API', async () => {
     const user = userEvent.setup()
     const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue({

--- a/src/components/community/CommunityGallery.tsx
+++ b/src/components/community/CommunityGallery.tsx
@@ -388,24 +388,41 @@ function ProjectCover({
 function ProjectCard({
   project,
   onOpen,
+  likeState,
+  onToggleLike,
+  isSignedIn,
 }: {
   project: CommunityProject
   onOpen: () => void
+  likeState?: LikeState
+  onToggleLike: (project: CommunityProject) => void
+  isSignedIn: boolean
 }) {
   return (
-    <div className="min-w-0">
+    <div className="relative min-w-0">
       <button
         type="button"
         onClick={onOpen}
         className="group block w-full min-w-0 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-4 focus-visible:ring-offset-background"
       >
         <ProjectCover project={project} />
-        <span className="mt-3 flex items-baseline justify-between gap-3">
+        {/* Leave room on the right for the like button layered on top. */}
+        <span
+          className={cn(
+            'mt-3 flex items-baseline justify-between gap-3',
+            likeState && 'pr-14',
+          )}
+        >
           <span className="text-[15.5px] font-bold tracking-[-0.005em]">
             {project.name}
           </span>
         </span>
-        <span className="mt-1 block text-[13.5px] text-muted-foreground">
+        <span
+          className={cn(
+            'mt-1 block text-[13.5px] text-muted-foreground',
+            likeState && 'pr-14',
+          )}
+        >
           by{' '}
           <span className="font-semibold text-foreground">
             {project.creator}
@@ -413,6 +430,16 @@ function ProjectCard({
           · Free
         </span>
       </button>
+      {likeState ? (
+        <div className="absolute bottom-0 right-0">
+          <LikeButton
+            project={project}
+            state={likeState}
+            onToggle={onToggleLike}
+            isSignedIn={isSignedIn}
+          />
+        </div>
+      ) : null}
     </div>
   )
 }
@@ -1040,6 +1067,9 @@ export default function CommunityGallery({
                         key={project.slug}
                         project={project}
                         onOpen={() => setSelectedProject(project)}
+                        likeState={likeStateFor(project)}
+                        onToggleLike={toggleLike}
+                        isSignedIn={isSignedIn}
                       />
                     ))}
                   </div>
@@ -1065,6 +1095,9 @@ export default function CommunityGallery({
                   key={project.slug}
                   project={project}
                   onOpen={() => setSelectedProject(project)}
+                  likeState={likeStateFor(project)}
+                  onToggleLike={toggleLike}
+                  isSignedIn={isSignedIn}
                 />
               ))}
             </div>


### PR DESCRIPTION
The like button lived only in the project modal, so a reader scanning the gallery could not see which projects had been liked. This renders the same card-sized button at the bottom right of each card's meta row.

- The button is a **sibling** of the card's click target, not a child, so there is no nested `<button>` and liking never opens the project modal.
- The name and creator lines reserve `pr-14` when a like button is present, so long text wraps clear of it instead of running underneath.
- Cards with no `databaseId` render no heart, matching the modal's existing behavior.

## Testing

- `jest CommunityGallery.test.tsx` - 11/11 pass, including a new test that likes straight from a card and asserts no dialog opens. The three existing modal-like tests pass unchanged (Radix aria-hides the grid behind the dialog, so the duplicate labels do not collide).
- `tsc --noEmit` and prettier clean.
- Verified against the local Supabase stack: clicking a card heart flipped `aria-pressed` to true, the label to "Unlike ...", and the count 0 to 1 from the API response, with no dialog opened.

Generated with [Claude Code](https://claude.com/claude-code)
