### PR TITLE
Add infinite scroll and chronological sorting to Trends

### DIFF
--- a/src/app/api/portal/trends/route.ts
+++ b/src/app/api/portal/trends/route.ts
@@ -55,6 +55,12 @@ function optionalDate(value: string | null, label: string): string | undefined {
   return value
 }
 
+function boundedOffset(value: string | null): number {
+  if (value === null) return 0
+  if (!/^\d+$/.test(value)) throw new Error('Choose a valid page offset')
+  return Math.min(5_000, Number(value))
+}
+
 export async function GET(request: NextRequest) {
   if (!(await getIsMember())) {
     return privateJson({ error: 'Sign in to explore trends' }, 401)
@@ -88,17 +94,21 @@ export async function GET(request: NextRequest) {
       }
       const since = optionalDate(params.get('since'), 'start')
       const until = optionalDate(params.get('until'), 'end')
+      const offset = boundedOffset(params.get('offset'))
+      const sort = params.get('sort') === 'oldest' ? 'oldest' : 'newest'
       if (since && until && since >= until) {
         throw new Error('Choose an end date after the start date')
       }
+      const page = await fetchPortalTrendEvidence(includeTerms, {
+        limit: 30,
+        offset,
+        since,
+        sort,
+        until,
+      })
       return privateJson({
-        tweets: await enrichPortalTweets(
-          await fetchPortalTrendEvidence(includeTerms, {
-            limit: 30,
-            since,
-            until,
-          }),
-        ),
+        tweets: await enrichPortalTweets(page.tweets),
+        nextOffset: page.nextOffset,
       })
     }
 

--- a/src/components/portal/TrendsExplorer.tsx
+++ b/src/components/portal/TrendsExplorer.tsx
@@ -10,10 +10,12 @@ import {
   hasCompleteTrendEvidence,
   storeTrendEvidence,
   trendEvidenceCacheKey,
+  trendEvidenceNextOffset,
 } from '@/lib/portal/trendEvidenceCache'
 import type {
   TrendEvidenceCacheEntry,
   TrendEvidenceRange,
+  TrendEvidenceSort,
 } from '@/lib/portal/trendEvidenceCache'
 import {
   clampTrendRange,
@@ -39,6 +41,7 @@ type FeedFilter = 'include' | 'off'
 
 interface FeedResponse {
   tweets: PortalTweet[]
+  nextOffset: number | null
   error?: string
 }
 
@@ -79,6 +82,7 @@ type TrendsExplorerAction =
   | 'chart_series_toggled'
   | 'evidence_filter_toggled'
   | 'evidence_refreshed'
+  | 'evidence_sort_changed'
   | 'granularity_changed'
   | 'retry_defaults'
   | 'scale_changed'
@@ -115,9 +119,16 @@ async function requestTrendSeries(
 async function requestTrendEvidence(
   term: string,
   range: TrendEvidenceRange | null,
+  sort: TrendEvidenceSort,
+  offset: number,
   signal: AbortSignal,
-): Promise<PortalTweet[]> {
-  const params = new URLSearchParams({ view: 'feed', include: term })
+): Promise<FeedResponse> {
+  const params = new URLSearchParams({
+    view: 'feed',
+    include: term,
+    offset: String(offset),
+    sort,
+  })
   if (range) {
     params.set('since', range.since)
     params.set('until', range.until)
@@ -129,10 +140,16 @@ async function requestTrendEvidence(
   if (!response.ok) {
     throw new Error(body?.error || `Could not load tweets for ${term}`)
   }
-  if (!body || !Array.isArray(body.tweets)) {
+  if (
+    !body ||
+    !Array.isArray(body.tweets) ||
+    (body.nextOffset !== undefined &&
+      body.nextOffset !== null &&
+      !Number.isSafeInteger(body.nextOffset))
+  ) {
     throw new Error('The tweet feed returned an invalid response')
   }
-  return body.tweets
+  return { tweets: body.tweets, nextOffset: body.nextOffset ?? null }
 }
 
 function sameEvidenceRange(
@@ -307,6 +324,8 @@ export default function TrendsExplorer({
     initialLoadFailed ? 'The default trends could not be loaded.' : null,
   )
   const [isLoadingEvidence, setIsLoadingEvidence] = useState(true)
+  const [isLoadingMoreEvidence, setIsLoadingMoreEvidence] = useState(false)
+  const [evidenceSort, setEvidenceSort] = useState<TrendEvidenceSort>('newest')
   const [feedError, setFeedError] = useState<string | null>(null)
   const [refreshKey, setRefreshKey] = useState(0)
   const [selectedRange, setSelectedRange] = useState<TrendRange | null>(
@@ -321,6 +340,8 @@ export default function TrendsExplorer({
   const [, setEvidenceCacheVersion] = useState(0)
   const [dragStartBucket, setDragStartBucket] = useState<string | null>(null)
   const chartRef = useRef<SVGSVGElement>(null)
+  const evidenceScrollRef = useRef<HTMLDivElement>(null)
+  const evidenceSentinelRef = useRef<HTMLDivElement>(null)
   const seriesRequestIdRef = useRef(0)
   const evidenceCacheRef = useRef<Map<string, TrendEvidenceCacheEntry>>(
     new Map(),
@@ -328,7 +349,7 @@ export default function TrendsExplorer({
   const evidenceRequestsRef = useRef(
     new Map<
       string,
-      { controller: AbortController; promise: Promise<PortalTweet[]> }
+      { controller: AbortController; promise: Promise<FeedResponse> }
     >(),
   )
   const evidenceRequestSignatureRef = useRef('')
@@ -373,6 +394,7 @@ export default function TrendsExplorer({
     evidenceCacheRef.current,
     includeTerms,
     selectedEvidenceRange,
+    evidenceSort,
   )
   const captureExplorerAction = (
     action: TrendsExplorerAction,
@@ -465,6 +487,7 @@ export default function TrendsExplorer({
       includeTerms,
       requestedRange,
       refreshKey,
+      evidenceSort,
     })
     evidenceRequestSignatureRef.current = signature
     if (includeTerms.length === 0) {
@@ -483,6 +506,7 @@ export default function TrendsExplorer({
           term,
           requestedRange,
           EVIDENCE_PAGE_SIZE,
+          evidenceSort,
         ),
     )
     if (termsToLoad.length === 0) {
@@ -494,34 +518,45 @@ export default function TrendsExplorer({
     const loadEvidence = async () => {
       setIsLoadingEvidence(true)
       setFeedError(null)
-      const results: PromiseSettledResult<PortalTweet[]>[] = []
+      const results: PromiseSettledResult<FeedResponse>[] = []
       for (const term of termsToLoad) {
-        const key = trendEvidenceCacheKey(term, requestedRange)
-        let request = evidenceRequestsRef.current.get(key)
+        const cacheKey = trendEvidenceCacheKey(
+          term,
+          requestedRange,
+          evidenceSort,
+        )
+        const requestKey = `${cacheKey}\u0000initial`
+        let request = evidenceRequestsRef.current.get(requestKey)
         if (!request) {
           const controller = new AbortController()
-          let promise: Promise<PortalTweet[]>
+          let promise: Promise<FeedResponse>
           promise = requestTrendEvidence(
             term,
             requestedRange,
+            evidenceSort,
+            0,
             controller.signal,
           )
-            .then((tweets) => {
+            .then((page) => {
               storeTrendEvidence(evidenceCacheRef.current, {
                 term,
                 range: requestedRange,
-                tweets,
+                sort: evidenceSort,
+                tweets: page.tweets,
+                nextOffset: page.nextOffset,
               })
               setEvidenceCacheVersion((version) => version + 1)
-              return tweets
+              return page
             })
             .finally(() => {
-              if (evidenceRequestsRef.current.get(key)?.promise === promise) {
-                evidenceRequestsRef.current.delete(key)
+              if (
+                evidenceRequestsRef.current.get(requestKey)?.promise === promise
+              ) {
+                evidenceRequestsRef.current.delete(requestKey)
               }
             })
           request = { controller, promise }
-          evidenceRequestsRef.current.set(key, request)
+          evidenceRequestsRef.current.set(requestKey, request)
         }
         try {
           results.push({ status: 'fulfilled', value: await request.promise })
@@ -541,17 +576,137 @@ export default function TrendsExplorer({
             : 'Could not load matching tweets',
         )
       }
-      setIsLoadingEvidence(
-        includeTerms.some((term) =>
-          evidenceRequestsRef.current.has(
-            trendEvidenceCacheKey(term, requestedRange),
-          ),
-        ),
-      )
+      setIsLoadingEvidence(false)
     }
 
     void loadEvidence()
-  }, [includeTerms, refreshKey, requestedRange])
+  }, [evidenceSort, includeTerms, refreshKey, requestedRange])
+
+  const hasMoreEvidence = includeTerms.some(
+    (term) =>
+      typeof trendEvidenceNextOffset(
+        evidenceCacheRef.current,
+        term,
+        requestedRange,
+        evidenceSort,
+      ) === 'number',
+  )
+
+  const loadMoreEvidence = useCallback(async () => {
+    if (
+      isLoadingEvidence ||
+      isLoadingMoreEvidence ||
+      !sameEvidenceRange(selectedEvidenceRange, requestedRange)
+    ) {
+      return
+    }
+    const pages = includeTerms.flatMap((term) => {
+      const offset = trendEvidenceNextOffset(
+        evidenceCacheRef.current,
+        term,
+        requestedRange,
+        evidenceSort,
+      )
+      return typeof offset === 'number' ? [{ term, offset }] : []
+    })
+    if (pages.length === 0) return
+
+    setIsLoadingMoreEvidence(true)
+    setFeedError(null)
+    const signature = evidenceRequestSignatureRef.current
+    const failures: unknown[] = []
+    for (const { term, offset } of pages) {
+      const cacheKey = trendEvidenceCacheKey(term, requestedRange, evidenceSort)
+      const requestKey = `${cacheKey}\u0000${offset}`
+      let request = evidenceRequestsRef.current.get(requestKey)
+      if (!request) {
+        const controller = new AbortController()
+        let promise: Promise<FeedResponse>
+        promise = requestTrendEvidence(
+          term,
+          requestedRange,
+          evidenceSort,
+          offset,
+          controller.signal,
+        )
+          .then((page) => {
+            storeTrendEvidence(
+              evidenceCacheRef.current,
+              {
+                term,
+                range: requestedRange,
+                sort: evidenceSort,
+                tweets: page.tweets,
+                nextOffset: page.nextOffset,
+              },
+              { append: true },
+            )
+            setEvidenceCacheVersion((version) => version + 1)
+            return page
+          })
+          .finally(() => {
+            if (
+              evidenceRequestsRef.current.get(requestKey)?.promise === promise
+            ) {
+              evidenceRequestsRef.current.delete(requestKey)
+            }
+          })
+        request = { controller, promise }
+        evidenceRequestsRef.current.set(requestKey, request)
+      }
+      try {
+        await request.promise
+      } catch (error) {
+        failures.push(error)
+      }
+    }
+    if (
+      failures.length > 0 &&
+      evidenceRequestSignatureRef.current === signature
+    ) {
+      const failure = failures[0]
+      setFeedError(
+        failure instanceof Error
+          ? failure.message
+          : 'Could not load more matching tweets',
+      )
+    }
+    setIsLoadingMoreEvidence(false)
+  }, [
+    evidenceSort,
+    includeTerms,
+    isLoadingEvidence,
+    isLoadingMoreEvidence,
+    requestedRange,
+    selectedEvidenceRange,
+  ])
+
+  useEffect(() => {
+    const root = evidenceScrollRef.current
+    const target = evidenceSentinelRef.current
+    if (
+      !root ||
+      !target ||
+      !hasMoreEvidence ||
+      typeof IntersectionObserver === 'undefined'
+    ) {
+      return
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          void loadMoreEvidence()
+        }
+      },
+      { root, rootMargin: '160px 0px' },
+    )
+    observer.observe(target)
+    return () => observer.disconnect()
+  }, [hasMoreEvidence, loadMoreEvidence])
+
+  useEffect(() => {
+    if (evidenceScrollRef.current) evidenceScrollRef.current.scrollTop = 0
+  }, [evidenceSort, selectedEvidenceRange])
 
   const removeTerm = (term: string) => {
     captureExplorerAction('term_removed', {
@@ -796,6 +951,7 @@ export default function TrendsExplorer({
               term,
               selectedEvidenceRange,
               EVIDENCE_PAGE_SIZE,
+              evidenceSort,
             ),
         )))
 
@@ -1372,21 +1528,54 @@ export default function TrendsExplorer({
                 <p className={`mt-0.5 text-[11.5px] ${MUTED}`}>
                   {selectedRange
                     ? `Posts from ${bucketLabel(selectedRange.start, granularity)}–${bucketLabel(selectedRange.end, granularity)} matching any included trend.`
-                    : 'Latest posts matching any included trend.'}
+                    : evidenceSort === 'newest'
+                      ? 'Latest posts matching any included trend.'
+                      : 'First posts matching any included trend.'}
                 </p>
               </div>
-              <button
-                type="button"
-                onClick={() => {
-                  captureExplorerAction('evidence_refreshed')
-                  setRequestedRange(selectedEvidenceRange)
-                  setRefreshKey((key) => key + 1)
-                }}
-                disabled={isLoadingEvidence || includeTerms.length === 0}
-                className={`text-[11.5px] font-semibold ${MUTED} hover:text-brand disabled:opacity-40`}
-              >
-                Refresh
-              </button>
+              <div className="flex items-center gap-2">
+                <div
+                  className="inline-flex rounded-[4px] border border-zinc-300 p-0.5 dark:border-[#34343a]"
+                  aria-label="Tweet order"
+                >
+                  {(['newest', 'oldest'] as const).map((option) => (
+                    <button
+                      key={option}
+                      type="button"
+                      aria-pressed={evidenceSort === option}
+                      onClick={() => {
+                        if (evidenceSort === option) return
+                        captureExplorerAction('evidence_sort_changed')
+                        setFeedError(null)
+                        setEvidenceSort(option)
+                      }}
+                      className={`rounded-[3px] px-2 py-1 text-[10.5px] font-semibold transition-colors ${
+                        evidenceSort === option
+                          ? 'bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900'
+                          : `${MUTED} hover:text-foreground`
+                      }`}
+                    >
+                      {option === 'newest' ? 'Newest first' : 'Oldest first'}
+                    </button>
+                  ))}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => {
+                    captureExplorerAction('evidence_refreshed')
+                    setRequestedRange(selectedEvidenceRange)
+                    setRefreshKey((key) => key + 1)
+                  }}
+                  disabled={
+                    isLoadingEvidence ||
+                    isLoadingMoreEvidence ||
+                    includeTerms.length === 0
+                  }
+                  className={`text-[11.5px] font-semibold ${MUTED} hover:text-brand disabled:opacity-40`}
+                >
+                  Refresh
+                </button>
+              </div>
             </div>
 
             <div className={`${CARD} mb-3 p-3`}>
@@ -1440,8 +1629,21 @@ export default function TrendsExplorer({
             </div>
 
             <div
+              ref={evidenceScrollRef}
               className={`${CARD} max-h-[760px] overflow-y-auto`}
+              aria-label="Matching tweets"
               aria-live="polite"
+              onScroll={(event) => {
+                const element = event.currentTarget
+                if (
+                  element.scrollHeight -
+                    element.scrollTop -
+                    element.clientHeight <
+                  160
+                ) {
+                  void loadMoreEvidence()
+                }
+              }}
             >
               {isUpdatingEvidence && evidence.length === 0 && (
                 <div className={`px-4 py-12 text-center text-[13px] ${MUTED}`}>
@@ -1485,6 +1687,23 @@ export default function TrendsExplorer({
                   returnTo={returnTo}
                 />
               ))}
+              <div ref={evidenceSentinelRef} className="h-px" />
+              {isLoadingMoreEvidence && (
+                <div className={`px-4 py-3 text-center text-[11.5px] ${MUTED}`}>
+                  Loading more tweets…
+                </div>
+              )}
+              {!isLoadingEvidence &&
+                !isLoadingMoreEvidence &&
+                !feedError &&
+                evidence.length > 0 &&
+                !hasMoreEvidence && (
+                  <div
+                    className={`border-t border-zinc-100 px-4 py-3 text-center text-[10.5px] dark:border-[#202023] ${MUTED}`}
+                  >
+                    End of matching tweets.
+                  </div>
+                )}
             </div>
           </aside>
         </div>

--- a/src/lib/portal/TrendsExplorerResilience.test.tsx
+++ b/src/lib/portal/TrendsExplorerResilience.test.tsx
@@ -348,7 +348,7 @@ describe('TrendsExplorer request isolation', () => {
     expect(screen.getByRole('button', { name: 'Clear range' })).toBeVisible()
   })
 
-  test('skips a range top-up when a broader cache has a full page', async () => {
+  test('loads an exact range page even when broader cached evidence is visible', async () => {
     jest.useFakeTimers()
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
     const tweets = Array.from({ length: 30 }, (_, index) =>
@@ -368,9 +368,75 @@ describe('TrendsExplorer request isolation', () => {
     expect(screen.getByText('tweet-2026-0')).toBeVisible()
     expect(
       screen.queryByText('Updating this period in the background…'),
-    ).not.toBeInTheDocument()
+    ).toBeInTheDocument()
     act(() => jest.advanceTimersByTime(1_200))
-    expect(fetchMock).toHaveBeenCalledTimes(1)
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+  })
+
+  test('loads the next evidence page when the sidebar nears its end', async () => {
+    const firstPage = Array.from({ length: 30 }, (_, index) =>
+      feedTweet(String(index), 2026),
+    )
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tweets: firstPage, nextOffset: 30 }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          tweets: [feedTweet('older', 2025)],
+          nextOffset: null,
+        }),
+      } as Response)
+
+    render(<TrendsExplorer initialTrends={successfulTrends} />)
+
+    expect(await screen.findByText('tweet-2026-0')).toBeVisible()
+    const sidebar = screen.getByLabelText('Matching tweets')
+    Object.defineProperties(sidebar, {
+      clientHeight: { configurable: true, value: 760 },
+      scrollHeight: { configurable: true, value: 1_000 },
+      scrollTop: { configurable: true, value: 200, writable: true },
+    })
+    fireEvent.scroll(sidebar)
+
+    expect(await screen.findByText('tweet-2025-older')).toBeVisible()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(String(fetchMock.mock.calls[1][0])).toContain('offset=30')
+    expect(String(fetchMock.mock.calls[1][0])).toContain('sort=newest')
+    expect(screen.getByText('End of matching tweets.')).toBeVisible()
+  })
+
+  test('sorts evidence oldest first within the active period', async () => {
+    const user = userEvent.setup()
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockImplementation(async (url) => {
+        const requestUrl = new URL(String(url), 'https://example.com')
+        const oldest = requestUrl.searchParams.get('sort') === 'oldest'
+        return {
+          ok: true,
+          json: async () => ({
+            tweets: [
+              feedTweet(oldest ? 'first' : 'latest', oldest ? 2025 : 2026),
+            ],
+            nextOffset: null,
+          }),
+        } as Response
+      })
+
+    render(<TrendsExplorer initialTrends={successfulTrends} />)
+
+    expect(await screen.findByText('tweet-2026-latest')).toBeVisible()
+    await user.click(screen.getByRole('button', { name: 'Oldest first' }))
+
+    expect(await screen.findByText('tweet-2025-first')).toBeVisible()
+    expect(screen.queryByText('tweet-2026-latest')).not.toBeInTheDocument()
+    expect(
+      fetchMock.mock.calls.some(([url]) => String(url).includes('sort=oldest')),
+    ).toBe(true)
   })
 
   test('does not query during a pointer drag and debounces after release', async () => {

--- a/src/lib/portal/analytics.test.ts
+++ b/src/lib/portal/analytics.test.ts
@@ -224,7 +224,7 @@ describe('ClickHouse-backed portal analytics', () => {
     expect(maxActive).toBe(2)
   })
 
-  test('merges included evidence and forwards a selected date range', async () => {
+  test('merges included evidence and forwards range, page, and order', async () => {
     const tweet = (tweetId: string, fullText: string, createdAt: string) => ({
       tweetId,
       accountId: '42',
@@ -276,17 +276,27 @@ describe('ClickHouse-backed portal analytics', () => {
 
     const result = await fetchPortalTrendEvidence(
       ['alpha', 'beta'],
-      { limit: 30, since: '2024-01-01', until: '2026-01-01' },
+      {
+        limit: 30,
+        offset: 60,
+        since: '2024-01-01',
+        sort: 'oldest',
+        until: '2026-01-01',
+      },
       fetcher,
     )
 
     expect(fetcher).toHaveBeenCalledTimes(2)
     expect(fetcherMock.mock.calls[0]?.[0]).toEqual(['trend-evidence'])
-    expect(result.map(({ id }) => id)).toEqual(['102', '101', '100'])
+    expect(result.tweets.map(({ id }) => id)).toEqual(['100', '101', '102'])
+    expect(result.nextOffset).toBeNull()
     expect(fetcherMock.mock.calls[0]?.[1]?.toString()).toContain(
       'since=2024-01-01&until=2026-01-01',
     )
-    expect(result[0]).toMatchObject({
+    expect(fetcherMock.mock.calls[0]?.[1]?.toString()).toContain(
+      'offset=60&sort=oldest',
+    )
+    expect(result.tweets[2]).toMatchObject({
       username: 'alice',
       createdAt: '2026-08-07T12:00:00.000Z',
       likes: 3,

--- a/src/lib/portal/analytics.ts
+++ b/src/lib/portal/analytics.ts
@@ -336,17 +336,31 @@ export async function fetchPortalTrendSeries(
 
 interface PortalTrendEvidenceOptions {
   limit?: number
+  offset?: number
   since?: string
+  sort?: 'newest' | 'oldest'
   until?: string
 }
 
-/** Latest posts counted by at least one included trend in an optional period. */
+export interface PortalTrendEvidencePage {
+  tweets: PortalTweet[]
+  nextOffset: number | null
+}
+
+/** Chronological page of posts counted by an included trend in a period. */
 export async function fetchPortalTrendEvidence(
   includeTerms: string[],
-  { limit = 30, since, until }: PortalTrendEvidenceOptions = {},
+  {
+    limit = 30,
+    offset = 0,
+    since,
+    sort = 'newest',
+    until,
+  }: PortalTrendEvidenceOptions = {},
   fetcher: AnalyticsFetcher = fetchAnalyticsGatewayJson,
-): Promise<PortalTweet[]> {
+): Promise<PortalTrendEvidencePage> {
   const safeLimit = Math.max(1, Math.min(50, Math.trunc(limit)))
+  const safeOffset = Math.max(0, Math.min(5_000, Math.trunc(offset)))
   const candidateLimit = Math.min(50, Math.max(safeLimit * 2, 30))
   const responses = await runBatched(
     includeTerms.map(
@@ -358,6 +372,8 @@ export async function fetchPortalTrendEvidence(
               q: term,
               mode: 'all',
               limit: String(candidateLimit),
+              offset: String(safeOffset),
+              sort,
             })
             if (since) params.set('since', since)
             if (until) params.set('until', until)
@@ -372,10 +388,19 @@ export async function fetchPortalTrendEvidence(
   )
 
   const unique = new Map<string, PortalTweet>()
+  let hasMore = false
   for (const response of responses) {
     if (!Array.isArray(response.data?.tweets)) {
       throw new Error('ClickHouse search returned an invalid response')
     }
+    if (
+      response.data.nextOffset !== null &&
+      (!Number.isSafeInteger(response.data.nextOffset) ||
+        response.data.nextOffset <= safeOffset)
+    ) {
+      throw new Error('ClickHouse search returned an invalid next offset')
+    }
+    hasMore ||= response.data.nextOffset !== null
     for (const row of response.data.tweets) {
       if (
         !/^\d{1,32}$/.test(row.tweetId) ||
@@ -418,13 +443,24 @@ export async function fetchPortalTrendEvidence(
     }
   }
 
-  return Array.from(unique.values())
+  const direction = sort === 'oldest' ? 1 : -1
+  const tweets = Array.from(unique.values())
     .sort(
       (left, right) =>
-        new Date(right.createdAt).getTime() -
-          new Date(left.createdAt).getTime() || right.id.localeCompare(left.id),
+        direction *
+        (new Date(left.createdAt).getTime() -
+          new Date(right.createdAt).getTime() ||
+          left.id.localeCompare(right.id)),
     )
     .slice(0, safeLimit)
+  return {
+    tweets,
+    nextOffset:
+      (hasMore || unique.size > safeLimit) &&
+      safeOffset + tweets.length <= 5_000
+        ? safeOffset + tweets.length
+        : null,
+  }
 }
 
 export async function fetchPortalLiveAnalytics(
@@ -551,7 +587,9 @@ export async function fetchPortalDailyInteractions(
     { timeoutMs: 30_000, revalidate: 300 },
   )
   if (!Array.isArray(response.data)) {
-    throw new Error('ClickHouse daily-interactions returned an invalid response')
+    throw new Error(
+      'ClickHouse daily-interactions returned an invalid response',
+    )
   }
 
   return response.data.map((row) => {

--- a/src/lib/portal/trendEvidenceCache.test.ts
+++ b/src/lib/portal/trendEvidenceCache.test.ts
@@ -3,6 +3,7 @@ import {
   cachedTrendEvidence,
   hasCompleteTrendEvidence,
   storeTrendEvidence,
+  trendEvidenceNextOffset,
 } from './trendEvidenceCache'
 import type { PortalTweet } from './types'
 
@@ -70,7 +71,7 @@ describe('trend evidence cache', () => {
     expect(Array.from(cache.values())[0].term).toBe('term-1')
   })
 
-  test('uses a full page from a broader range without an exact-range top-up', () => {
+  test('requires an exact range page so selected periods remain pageable', () => {
     const cache = new Map()
     storeTrendEvidence(cache, {
       term: 'tpot',
@@ -88,7 +89,7 @@ describe('trend evidence cache', () => {
         since: '2026-01-01',
         until: '2027-01-01',
       }),
-    ).toBe(true)
+    ).toBe(false)
     expect(
       hasCompleteTrendEvidence(cache, 'tpot', {
         since: '2025-01-01',
@@ -96,5 +97,33 @@ describe('trend evidence cache', () => {
       }),
     ).toBe(false)
     expect(hasCompleteTrendEvidence(cache, 'tpot', null)).toBe(true)
+  })
+
+  test('appends pages and keeps oldest-first evidence separate', () => {
+    const cache = new Map()
+    storeTrendEvidence(cache, {
+      term: 'tpot',
+      range: null,
+      sort: 'oldest',
+      tweets: [tweet('1', '2024-01-01T00:00:00.000Z')],
+      nextOffset: 1,
+    })
+    storeTrendEvidence(
+      cache,
+      {
+        term: 'tpot',
+        range: null,
+        sort: 'oldest',
+        tweets: [tweet('2', '2025-01-01T00:00:00.000Z')],
+        nextOffset: null,
+      },
+      { append: true },
+    )
+
+    expect(
+      cachedTrendEvidence(cache, ['tpot'], null, 'oldest').map(({ id }) => id),
+    ).toEqual(['1', '2'])
+    expect(cachedTrendEvidence(cache, ['tpot'], null, 'newest')).toEqual([])
+    expect(trendEvidenceNextOffset(cache, 'tpot', null, 'oldest')).toBeNull()
   })
 })

--- a/src/lib/portal/trendEvidenceCache.ts
+++ b/src/lib/portal/trendEvidenceCache.ts
@@ -1,5 +1,7 @@
 import type { PortalTweet } from './types'
 
+export type TrendEvidenceSort = 'newest' | 'oldest'
+
 export interface TrendEvidenceRange {
   /** Inclusive UTC date in YYYY-MM-DD form. */
   since: string
@@ -10,7 +12,9 @@ export interface TrendEvidenceRange {
 export interface TrendEvidenceCacheEntry {
   term: string
   range: TrendEvidenceRange | null
+  sort?: TrendEvidenceSort
   tweets: PortalTweet[]
+  nextOffset?: number | null
 }
 
 export const MAX_TREND_EVIDENCE_CACHE_ENTRIES = 96
@@ -30,17 +34,29 @@ function tweetFallsWithinRange(
 export function trendEvidenceCacheKey(
   term: string,
   range: TrendEvidenceRange | null,
+  sort: TrendEvidenceSort = 'newest',
 ): string {
-  return `${term}\u0000${range ? `${range.since}-${range.until}` : 'any'}`
+  return `${term}\u0000${range ? `${range.since}-${range.until}` : 'any'}\u0000${sort}`
 }
 
 export function storeTrendEvidence(
   cache: Map<string, TrendEvidenceCacheEntry>,
   entry: TrendEvidenceCacheEntry,
+  { append = false }: { append?: boolean } = {},
 ): void {
-  const key = trendEvidenceCacheKey(entry.term, entry.range)
+  const sort = entry.sort ?? 'newest'
+  const key = trendEvidenceCacheKey(entry.term, entry.range, sort)
+  const existing = append ? cache.get(key) : undefined
+  const tweets = new Map<string, PortalTweet>()
+  existing?.tweets.forEach((tweet) => tweets.set(tweet.id, tweet))
+  entry.tweets.forEach((tweet) => tweets.set(tweet.id, tweet))
   cache.delete(key)
-  cache.set(key, entry)
+  cache.set(key, {
+    ...entry,
+    sort,
+    tweets: Array.from(tweets.values()),
+    nextOffset: entry.nextOffset ?? null,
+  })
   while (cache.size > MAX_TREND_EVIDENCE_CACHE_ENTRIES) {
     const oldestKey = cache.keys().next().value
     if (oldestKey === undefined) return
@@ -57,37 +73,33 @@ export function hasCompleteTrendEvidence(
   cache: ReadonlyMap<string, TrendEvidenceCacheEntry>,
   term: string,
   range: TrendEvidenceRange | null,
-  limit = 30,
+  _limit = 30,
+  sort: TrendEvidenceSort = 'newest',
 ): boolean {
-  if (cache.has(trendEvidenceCacheKey(term, range))) return true
-  if (!range) return false
+  return cache.has(trendEvidenceCacheKey(term, range, sort))
+}
 
-  return Array.from(cache.values()).some((entry) => {
-    if (entry.term !== term) return false
-    if (
-      entry.range &&
-      (entry.range.since > range.since || entry.range.until < range.until)
-    ) {
-      return false
-    }
-    return (
-      entry.tweets.filter((tweet) => tweetFallsWithinRange(tweet, range))
-        .length >= limit
-    )
-  })
+export function trendEvidenceNextOffset(
+  cache: ReadonlyMap<string, TrendEvidenceCacheEntry>,
+  term: string,
+  range: TrendEvidenceRange | null,
+  sort: TrendEvidenceSort = 'newest',
+): number | null | undefined {
+  return cache.get(trendEvidenceCacheKey(term, range, sort))?.nextOffset
 }
 
 export function cachedTrendEvidence(
   cache: ReadonlyMap<string, TrendEvidenceCacheEntry>,
   includedTerms: string[],
   range: TrendEvidenceRange | null,
-  limit = 30,
+  sort: TrendEvidenceSort = 'newest',
 ): PortalTweet[] {
   const included = new Set(includedTerms)
   const unique = new Map<string, PortalTweet>()
 
   cache.forEach((entry) => {
     if (!included.has(entry.term)) return
+    if ((entry.sort ?? 'newest') !== sort) return
     for (const tweet of entry.tweets) {
       const createdAt = new Date(tweet.createdAt).getTime()
       if (!Number.isFinite(createdAt)) continue
@@ -96,11 +108,11 @@ export function cachedTrendEvidence(
     }
   })
 
-  return Array.from(unique.values())
-    .sort(
-      (left, right) =>
-        new Date(right.createdAt).getTime() -
-          new Date(left.createdAt).getTime() || right.id.localeCompare(left.id),
-    )
-    .slice(0, Math.max(1, limit))
+  const direction = sort === 'oldest' ? 1 : -1
+  return Array.from(unique.values()).sort(
+    (left, right) =>
+      direction *
+      (new Date(left.createdAt).getTime() -
+        new Date(right.createdAt).getTime() || left.id.localeCompare(right.id)),
+  )
 }

--- a/src/lib/portalTrendsRoute.test.ts
+++ b/src/lib/portalTrendsRoute.test.ts
@@ -101,11 +101,14 @@ describe('portal trends route', () => {
   })
 
   test('forwards included terms and a selected date range to evidence search', async () => {
-    fetchPortalTrendEvidenceMock.mockResolvedValue([])
+    fetchPortalTrendEvidenceMock.mockResolvedValue({
+      tweets: [],
+      nextOffset: null,
+    })
 
     const response = await GET(
       new NextRequest(
-        'https://community-archive.org/api/portal/trends?view=feed&include=Alpha&include=Beta&since=2022-01-01&until=2025-01-01',
+        'https://community-archive.org/api/portal/trends?view=feed&include=Alpha&include=Beta&since=2022-01-01&until=2025-01-01&offset=60&sort=oldest',
       ),
     )
 
@@ -114,7 +117,9 @@ describe('portal trends route', () => {
       ['alpha', 'beta'],
       {
         limit: 30,
+        offset: 60,
         since: '2022-01-01',
+        sort: 'oldest',
         until: '2025-01-01',
       },
     )


### PR DESCRIPTION
## Summary

- add automatic infinite loading to the Trends tweet sidebar
- add Newest first and Oldest first controls
- keep pagination, caching, and ordering scoped to each included term and selected chart period
- show the first matching posts within a selected period when oldest-first is active

## Dependency

Requires the backward-compatible gateway contract in https://github.com/TheExGenesis/community-archive-control-panel/pull/203 to be deployed first.

## Verification

- 35 focused route, analytics, cache, and component tests pass
- `pnpm type-check`
- Prettier check on all eight changed files

## Local hook note

The repository pre-commit hook could not generate local Supabase types because the local OAuth environment and Supabase instance are unavailable. This change does not touch database artifacts; the focused tests and type-check were run directly before committing with the hook skipped.