### PR TITLE
Keep digest subscribe input in place when its caption appears

### DIFF
--- a/src/components/digest/DigestSubscribeButton.tsx
+++ b/src/components/digest/DigestSubscribeButton.tsx
@@ -82,7 +82,7 @@ function SubscribeControl() {
   }
 
   return (
-    <div className="flex flex-col items-end gap-1">
+    <div className="relative">
       <form
         className="flex items-center gap-1 rounded-full border border-zinc-300 bg-white py-0.5 pl-3 pr-0.5 focus-within:ring-2 focus-within:ring-brand dark:border-zinc-700 dark:bg-zinc-900"
         onSubmit={(event) => {
@@ -112,7 +112,7 @@ function SubscribeControl() {
           {phase === 'submitting' ? 'Sending…' : 'Subscribe'}
         </button>
       </form>
-      <span className="pr-2 text-[11px] text-zinc-500 dark:text-zinc-400">
+      <span className="absolute right-0 top-full mt-1 whitespace-nowrap pr-2 text-[11px] text-zinc-500 dark:text-zinc-400">
         {error ?? 'Daily digest in your inbox. Unsubscribe anytime.'}
       </span>
     </div>


### PR DESCRIPTION
## Problem

Clicking **Subscribe** in the digest header made the email input jump upward before you could type in it.

The expanded control stacked the form and its helper caption in a `flex flex-col`. The surrounding header row is `items-center`, so the extra caption line made the block taller and the row re-centered it — dragging the input up by roughly half the caption's height at the exact moment it received focus.

## Fix

Take the caption out of flow: the wrapper becomes `relative` and the caption is `absolute right-0 top-full`. The wrapper now measures only the form's height, so the input lands precisely where the pill was, and the caption hangs below it. Added `whitespace-nowrap` since the caption is no longer width-constrained by the flex column.

## Verification

Measured in the running app (`/digest`, expanded state):

- vertical drift of the form's center vs. the original button's center: **-0.5px** (was ~half the caption height)
- right edge unchanged: `873.8125` before and after, so no horizontal shift either
- caption top (`217`) sits below form bottom (`213`) — no overlap

Client jest suite passes (188/188).

🤖 Generated with [Claude Code](https://claude.com/claude-code)