### PR TITLE
Fix Grafana community membership definition

### DIFF
--- a/src/database-types.ts
+++ b/src/database-types.ts
@@ -418,6 +418,79 @@ export type Database = {
           },
         ]
       }
+      digest_edition_comments: {
+        Row: {
+          content: string
+          created_at: string
+          deleted_at: string | null
+          display_name: string | null
+          edition_id: string
+          id: string
+          updated_at: string
+          user_id: string
+          username: string | null
+        }
+        Insert: {
+          content: string
+          created_at?: string
+          deleted_at?: string | null
+          display_name?: string | null
+          edition_id: string
+          id?: string
+          updated_at?: string
+          user_id: string
+          username?: string | null
+        }
+        Update: {
+          content?: string
+          created_at?: string
+          deleted_at?: string | null
+          display_name?: string | null
+          edition_id?: string
+          id?: string
+          updated_at?: string
+          user_id?: string
+          username?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "digest_edition_comments_edition_id_fkey"
+            columns: ["edition_id"]
+            isOneToOne: false
+            referencedRelation: "digest_editions"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      digest_edition_likes: {
+        Row: {
+          created_at: string
+          edition_id: string
+          id: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          edition_id: string
+          id?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          edition_id?: string
+          id?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "digest_edition_likes_edition_id_fkey"
+            columns: ["edition_id"]
+            isOneToOne: false
+            referencedRelation: "digest_editions"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       digest_editions: {
         Row: {
           content: Json

--- a/src/database-types.ts
+++ b/src/database-types.ts
@@ -418,79 +418,6 @@ export type Database = {
           },
         ]
       }
-      digest_edition_comments: {
-        Row: {
-          content: string
-          created_at: string
-          deleted_at: string | null
-          display_name: string | null
-          edition_id: string
-          id: string
-          updated_at: string
-          user_id: string
-          username: string | null
-        }
-        Insert: {
-          content: string
-          created_at?: string
-          deleted_at?: string | null
-          display_name?: string | null
-          edition_id: string
-          id?: string
-          updated_at?: string
-          user_id: string
-          username?: string | null
-        }
-        Update: {
-          content?: string
-          created_at?: string
-          deleted_at?: string | null
-          display_name?: string | null
-          edition_id?: string
-          id?: string
-          updated_at?: string
-          user_id?: string
-          username?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "digest_edition_comments_edition_id_fkey"
-            columns: ["edition_id"]
-            isOneToOne: false
-            referencedRelation: "digest_editions"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      digest_edition_likes: {
-        Row: {
-          created_at: string
-          edition_id: string
-          id: string
-          user_id: string
-        }
-        Insert: {
-          created_at?: string
-          edition_id: string
-          id?: string
-          user_id: string
-        }
-        Update: {
-          created_at?: string
-          edition_id?: string
-          id?: string
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "digest_edition_likes_edition_id_fkey"
-            columns: ["edition_id"]
-            isOneToOne: false
-            referencedRelation: "digest_editions"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
       digest_editions: {
         Row: {
           content: Json
@@ -2656,4 +2583,3 @@ export type CompositeTypes<
   : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
     ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never
-

--- a/src/database-types.ts
+++ b/src/database-types.ts
@@ -2583,3 +2583,4 @@ export type CompositeTypes<
   : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
     ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never
+

--- a/supabase/migrations/20260902015122_fix_monitoring_membership_definition.sql
+++ b/supabase/migrations/20260902015122_fix_monitoring_membership_definition.sql
@@ -1,0 +1,22 @@
+-- The public directory is the canonical, deduplicated membership projection:
+-- completed archive upload OR explicit opt-in, with explicit opt-out winning.
+-- The previous monitoring bridge counted explicit opt-ins only.
+CREATE OR REPLACE FUNCTION private.community_archive_monitoring_membership()
+RETURNS TABLE (currently_opted_in double precision)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF session_user <> 'archive_metrics_exporter' THEN
+    RAISE EXCEPTION 'monitoring function is restricted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY
+  SELECT COUNT(*)::double precision
+  FROM public.user_directory;
+END;
+$$;
+ALTER FUNCTION private.community_archive_monitoring_membership() OWNER TO postgres;

--- a/supabase/schemas/070_functions.sql
+++ b/supabase/schemas/070_functions.sql
@@ -3471,11 +3471,8 @@ BEGIN
   END IF;
 
   RETURN QUERY
-  SELECT COUNT(*) FILTER (
-    WHERE opted_in IS TRUE
-      AND explicit_optout IS NOT TRUE
-  )::double precision
-  FROM public.optin;
+  SELECT COUNT(*)::double precision
+  FROM public.user_directory;
 END;
 $$;
 ALTER FUNCTION private.community_archive_monitoring_membership() OWNER TO postgres;


### PR DESCRIPTION
## Summary

- count the canonical `public.user_directory` membership projection instead of explicit opt-ins only
- preserve the restricted, aggregate-only monitoring function and empty `search_path`
- add the production migration without applying it

The live authoritative count is 767; the old explicit-opt-in-only count is 600.

## Validation

- verified `public.user_directory` returns 767 and the old predicate returns 600
- confirmed production migration history is current through `20260901230000`; this migration is the sole newer file
- `git diff --check` passes

## Rollout

Requires an explicit production Supabase migration approval. After promotion, wait for the exporter refresh and rename the temporary Grafana panel to `Community members`.
