### PR TITLE
Fix profile page crash for non-archived users (function timeout)

### DIFF
--- a/src/app/user/[account_id]/page.tsx
+++ b/src/app/user/[account_id]/page.tsx
@@ -21,6 +21,12 @@ import { resolveProfile } from '@/lib/metaTwitter/profile'
 import type { SectionsByYear } from '@/lib/metaTwitter/chapterSections'
 import { configuredSectionsByYear } from '@/lib/metaTwitter/sectionConfig'
 
+// Uncached profiles wait on the analytics gateway for the header media backfill
+// and the first banger page. When the gateway is slow those can exceed Vercel's
+// 15s default, which aborts the RSC stream mid-render and surfaces client-side
+// as "Connection closed". Match the other ClickHouse-backed pages.
+export const maxDuration = 60
+
 interface PageProps {
   params: { account_id: string }
   searchParams: { chapter?: string; section?: string; username?: string }


### PR DESCRIPTION
## Problem
Profiles for opted-in users without an archive were intermittently rendering as **"Application error: a client-side exception has occurred"** with `Error: Connection closed` in the console.

Sampling 29 cold non-archived profiles on production reproduced it on 12 of them: each returned 504 at ~15.4s, i.e. Vercel's 15s default function limit. When the shell has already streamed, the kill shows up client-side as the RSC stream closing rather than a 504 page. Loaded one at a time the same profiles render in 1–3s, so the trigger is the analytics gateway slowing down under concurrent load.

Non-archived profiles are hit hardest because they usually have no `all_profile` media row, so the header backfills avatar/banner from the ClickHouse gateway on the blocking path *and* then fetch the first banger page from it.

## Fix
Export `maxDuration = 60` from `src/app/user/[account_id]/page.tsx`. Every other ClickHouse-backed page and API route (`/`, `/bangers`, `/trends`, `opengraph-image`, `/api/profile/*`) already does; the profile page was the only one still on the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)