### PR TITLE
Track canonical projection receipts

### DIFF
--- a/supabase/migrations/20260902061550_canonical_ingest_projection_receipts.sql
+++ b/supabase/migrations/20260902061550_canonical_ingest_projection_receipts.sql
@@ -1,0 +1,9 @@
+ALTER TABLE private.canonical_ingest_receipts
+  ADD COLUMN projected_payload_hash text NOT NULL,
+  ADD CONSTRAINT canonical_ingest_receipts_projected_hash_check
+    CHECK (projected_payload_hash ~ '^[0-9a-f]{64}$');
+
+ALTER TABLE private.canonical_ingest_entity_versions
+  ADD COLUMN operation_rank smallint DEFAULT 1 NOT NULL,
+  ADD CONSTRAINT canonical_ingest_entity_versions_operation_rank_check
+    CHECK (operation_rank IN (1, 2));

--- a/supabase/schemas/020_tables.sql
+++ b/supabase/schemas/020_tables.sql
@@ -115,6 +115,7 @@ CREATE TABLE IF NOT EXISTS "private"."canonical_ingest_receipts" (
     "source" "text" NOT NULL,
     "source_batch_id_hash" "text" NOT NULL,
     "payload_hash" "text" NOT NULL,
+    "projected_payload_hash" "text" NOT NULL,
     "mutation_count" integer NOT NULL,
     "committed_at" timestamp with time zone DEFAULT "now"() NOT NULL,
     CONSTRAINT "canonical_ingest_receipts_event_id_check" CHECK (("event_id" ~ '^[0-9a-f]{64}$'::"text")),
@@ -122,6 +123,7 @@ CREATE TABLE IF NOT EXISTS "private"."canonical_ingest_receipts" (
     CONSTRAINT "canonical_ingest_receipts_source_check" CHECK (("source" = ANY (ARRAY['extension'::"text", 'autorefresh'::"text", 'archive_upload'::"text", 'manual'::"text", 'backfill'::"text", 'admin_delete'::"text", 'user_delete'::"text"]))),
     CONSTRAINT "canonical_ingest_receipts_source_batch_hash_check" CHECK (("source_batch_id_hash" ~ '^[0-9a-f]{64}$'::"text")),
     CONSTRAINT "canonical_ingest_receipts_payload_hash_check" CHECK (("payload_hash" ~ '^[0-9a-f]{64}$'::"text")),
+    CONSTRAINT "canonical_ingest_receipts_projected_hash_check" CHECK (("projected_payload_hash" ~ '^[0-9a-f]{64}$'::"text")),
     CONSTRAINT "canonical_ingest_receipts_mutation_count_check" CHECK ((("mutation_count" > 0) AND ("mutation_count" <= 500)))
 );
 ALTER TABLE "private"."canonical_ingest_receipts" OWNER TO "postgres";
@@ -134,12 +136,14 @@ CREATE TABLE IF NOT EXISTS "private"."canonical_ingest_entity_versions" (
     "entity_key_hash" "text" NOT NULL,
     "version" numeric(40, 0) NOT NULL,
     "event_id" "text" NOT NULL,
+    "operation_rank" smallint DEFAULT 1 NOT NULL,
     "applied_at" timestamp with time zone DEFAULT "now"() NOT NULL,
     CONSTRAINT "canonical_ingest_entity_versions_pkey" PRIMARY KEY ("entity_type", "entity_key_hash"),
     CONSTRAINT "canonical_ingest_entity_versions_type_check" CHECK (("entity_type" = ANY (ARRAY['account'::"text", 'tweet_content'::"text", 'tweet_engagement'::"text", 'media'::"text", 'url'::"text", 'mention'::"text", 'relationship'::"text", 'archive_upload'::"text"]))),
     CONSTRAINT "canonical_ingest_entity_versions_key_hash_check" CHECK (("entity_key_hash" ~ '^[0-9a-f]{64}$'::"text")),
     CONSTRAINT "canonical_ingest_entity_versions_version_check" CHECK (("version" >= (0)::numeric)),
-    CONSTRAINT "canonical_ingest_entity_versions_event_id_check" CHECK (("event_id" ~ '^[0-9a-f]{64}$'::"text"))
+    CONSTRAINT "canonical_ingest_entity_versions_event_id_check" CHECK (("event_id" ~ '^[0-9a-f]{64}$'::"text")),
+    CONSTRAINT "canonical_ingest_entity_versions_operation_rank_check" CHECK (("operation_rank" = ANY (ARRAY[(1)::smallint, (2)::smallint])))
 );
 ALTER TABLE "private"."canonical_ingest_entity_versions" OWNER TO "postgres";
 ALTER TABLE "private"."canonical_ingest_entity_versions" ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
Adds the projected hash and operation precedence needed for policy-safe retries. The tables are empty and no consumer is live yet.