### PR TITLE
Add queue-first archive upload mode

### DIFF
--- a/services/process_archive/README_DOCKER.md
+++ b/services/process_archive/README_DOCKER.md
@@ -76,6 +76,7 @@ ClickHouse paths finish. This lane is inert unless
 
 ```bash
 CANONICAL_ARCHIVE_SHADOW_PUBLISH_ENABLED=false
+CANONICAL_ARCHIVE_QUEUE_FIRST_ENABLED=false
 CANONICAL_ARCHIVE_RETRY_BATCH=5
 CANONICAL_PUBLISH_URL=https://firehose-host/internal/canonical-ingest
 CANONICAL_PUBLISHER_API_KEY=replace-with-dedicated-runtime-secret
@@ -99,6 +100,15 @@ do not carry content or provenance edges. Source-retraction commands and
 user-facing delete actions are not enabled by this publisher.
 Do not enable the flag until the firehose publisher, retained
 stream, and queue-capacity alerting have been deployed and verified.
+
+After every required canonical consumer is caught up and healthy, set
+`CANONICAL_ARCHIVE_QUEUE_FIRST_ENABLED=true`. The worker then loads and
+policy-checks the archive, durably publishes it to the canonical queue, and
+only afterward performs the existing PostgreSQL and optional ClickHouse
+writes. A queue failure restores the upload to `ready_for_commit` for a later
+retry without writing corpus rows. The upload state itself remains
+authoritative in PostgreSQL. Queue-first suppresses the redundant post-write
+shadow copy; compatibility writes remain enabled during migration.
 
 ## Execution Options
 

--- a/services/process_archive/archive_clickhouse.test.ts
+++ b/services/process_archive/archive_clickhouse.test.ts
@@ -347,6 +347,13 @@ test('delivery manifest is content-free and historical uploads are not seeded', 
     ),
     'utf8',
   )
+  const queueFirst = processor.indexOf(
+    'await publishCanonicalArchiveQueueFirst(',
+  )
+  const compatibilityWrite = processor.indexOf(
+    'await processSingleArchive(',
+    queueFirst,
+  )
   const completion = processor.indexOf("SET upload_phase = 'completed'")
   const directSink = processor.indexOf(
     'await attemptClickHouseDelivery(',
@@ -357,7 +364,9 @@ test('delivery manifest is content-free and historical uploads are not seeded', 
     directSink,
   )
   assert.ok(
-    completion >= 0 && directSink > completion && canonicalShadow > directSink,
+    queueFirst >= 0 && compatibilityWrite > queueFirst &&
+      completion > compatibilityWrite && directSink > completion &&
+      canonicalShadow > directSink,
   )
   assert.match(processor, /jsonb_array_elements\(\$\{trx\.json\(candidates as never\)\}::jsonb\)/)
   assert.doesNotMatch(processor, /JSON\.stringify\(candidates\)/)

--- a/services/process_archive/canonical_archive.test.ts
+++ b/services/process_archive/canonical_archive.test.ts
@@ -220,7 +220,9 @@ test('publisher resubmits thin batches for server dedupe on retry', async () => 
 
 test('publisher is inert without its explicit flag', async () => {
   const original = process.env.CANONICAL_ARCHIVE_SHADOW_PUBLISH_ENABLED
+  const originalQueueFirst = process.env.CANONICAL_ARCHIVE_QUEUE_FIRST_ENABLED
   delete process.env.CANONICAL_ARCHIVE_SHADOW_PUBLISH_ENABLED
+  delete process.env.CANONICAL_ARCHIVE_QUEUE_FIRST_ENABLED
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'canonical-archive-'))
   try {
     const result = await publishCanonicalArchiveBatch({
@@ -237,6 +239,51 @@ test('publisher is inert without its explicit flag', async () => {
     } else {
       process.env.CANONICAL_ARCHIVE_SHADOW_PUBLISH_ENABLED = original
     }
+    if (originalQueueFirst === undefined) {
+      delete process.env.CANONICAL_ARCHIVE_QUEUE_FIRST_ENABLED
+    } else {
+      process.env.CANONICAL_ARCHIVE_QUEUE_FIRST_ENABLED = originalQueueFirst
+    }
+    fs.rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+test('queue-first flag enables the canonical publisher without shadow mode', async () => {
+  const originalShadow = process.env.CANONICAL_ARCHIVE_SHADOW_PUBLISH_ENABLED
+  const originalQueueFirst = process.env.CANONICAL_ARCHIVE_QUEUE_FIRST_ENABLED
+  const originalUrl = process.env.CANONICAL_PUBLISH_URL
+  const originalKey = process.env.CANONICAL_PUBLISHER_API_KEY
+  delete process.env.CANONICAL_ARCHIVE_SHADOW_PUBLISH_ENABLED
+  process.env.CANONICAL_ARCHIVE_QUEUE_FIRST_ENABLED = 'true'
+  process.env.CANONICAL_PUBLISH_URL = 'http://127.0.0.1:3000/internal/canonical-ingest'
+  process.env.CANONICAL_PUBLISHER_API_KEY = 'publisher-secret'
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'canonical-archive-'))
+  try {
+    const result = await publishCanonicalArchiveBatch({
+      batch: fixtureBatch(),
+      manifest,
+      policyVersion: 'policy-1',
+      reportDir: directory,
+      fetchImpl: (async (_input, init) => {
+        const body = JSON.parse(String(init?.body))
+        return new Response(JSON.stringify({ accepted: body.batches.map(
+          (submission: { source_batch_id: string }) => ({
+            source_batch_id: submission.source_batch_id,
+            event_id: 'a'.repeat(64), message_id: '1-0', duplicate: false,
+          }),
+        ) }), { status: 202, headers: { 'content-type': 'application/json' } })
+      }) as typeof fetch,
+    })
+    assert.equal(result.status, 'complete')
+  } finally {
+    if (originalShadow === undefined) delete process.env.CANONICAL_ARCHIVE_SHADOW_PUBLISH_ENABLED
+    else process.env.CANONICAL_ARCHIVE_SHADOW_PUBLISH_ENABLED = originalShadow
+    if (originalQueueFirst === undefined) delete process.env.CANONICAL_ARCHIVE_QUEUE_FIRST_ENABLED
+    else process.env.CANONICAL_ARCHIVE_QUEUE_FIRST_ENABLED = originalQueueFirst
+    if (originalUrl === undefined) delete process.env.CANONICAL_PUBLISH_URL
+    else process.env.CANONICAL_PUBLISH_URL = originalUrl
+    if (originalKey === undefined) delete process.env.CANONICAL_PUBLISHER_API_KEY
+    else process.env.CANONICAL_PUBLISHER_API_KEY = originalKey
     fs.rmSync(directory, { recursive: true, force: true })
   }
 })

--- a/services/process_archive/canonical_archive.ts
+++ b/services/process_archive/canonical_archive.ts
@@ -77,6 +77,14 @@ export function canonicalArchiveShadowEnabled(): boolean {
   return process.env.CANONICAL_ARCHIVE_SHADOW_PUBLISH_ENABLED === 'true'
 }
 
+export function canonicalArchiveQueueFirstEnabled(): boolean {
+  return process.env.CANONICAL_ARCHIVE_QUEUE_FIRST_ENABLED === 'true'
+}
+
+export function canonicalArchivePublishingEnabled(): boolean {
+  return canonicalArchiveShadowEnabled() || canonicalArchiveQueueFirstEnabled()
+}
+
 function sha256(value: string): string {
   return createHash('sha256').update(value, 'utf8').digest('hex')
 }
@@ -402,7 +410,7 @@ export async function publishCanonicalArchiveBatch(options: {
   reportDir: string
   fetchImpl?: FetchLike
 }): Promise<CanonicalPublishReport | { status: 'disabled' }> {
-  if (!canonicalArchiveShadowEnabled()) return { status: 'disabled' }
+  if (!canonicalArchivePublishingEnabled()) return { status: 'disabled' }
   const config = publisherConfig()
   const events = buildCanonicalArchiveMutations(options.batch)
   const reportPath = canonicalArchiveReportPath(

--- a/services/process_archive/env.example
+++ b/services/process_archive/env.example
@@ -35,6 +35,7 @@ CLICKHOUSE_PASSWORD=replace-with-runtime-secret
 # Additive canonical queue shadow (disabled until a separately approved rollout)
 # Existing PostgreSQL completion and ClickHouse delivery always run first.
 CANONICAL_ARCHIVE_SHADOW_PUBLISH_ENABLED=false
+CANONICAL_ARCHIVE_QUEUE_FIRST_ENABLED=false
 CANONICAL_ARCHIVE_RETRY_BATCH=5
 CANONICAL_PUBLISH_URL=https://firehose-host/internal/canonical-ingest
 CANONICAL_PUBLISHER_API_KEY=replace-with-dedicated-runtime-secret

--- a/services/process_archive/process_archive_upload.ts
+++ b/services/process_archive/process_archive_upload.ts
@@ -23,9 +23,11 @@ import {
   createArchiveClickHouseManifest,
 } from './archive_clickhouse'
 import {
+  CanonicalArchivePublisherError,
   canonicalArchiveObservedAt,
   canonicalArchivePolicyVersion,
-  canonicalArchiveShadowEnabled,
+  canonicalArchivePublishingEnabled,
+  canonicalArchiveQueueFirstEnabled,
   ensureCanonicalArchivePendingReport,
   pendingCanonicalArchiveReportIds,
   publishCanonicalArchiveBatch,
@@ -926,10 +928,8 @@ function patchArchive(archive: any): any {
 }
 
 // Main processing function
-async function processSingleArchive(sql: Sql, username: string, archiveUploadId: number): Promise<any> {
-  logger.debug(`Loading archive for optimized processing (current memory: ${getMemoryUsageMB()}MB)`)
-  
-  const archive = await loadArchiveData(username)
+async function processSingleArchive(sql: Sql, archive: any, archiveUploadId: number): Promise<any> {
+  logger.debug(`Preparing archive for optimized processing (current memory: ${getMemoryUsageMB()}MB)`)
   
   // Determine processing strategy based on size
   const tweetsCount = archive.tweets?.length || 0
@@ -1015,6 +1015,7 @@ async function buildPolicySafeCanonicalArchiveBatch(
   sql: Sql,
   delivery: ArchiveClickHouseDelivery,
   archive?: any,
+  sourceObservedAt?: unknown,
 ) {
   const manifest = {
     archiveUploadId: String(delivery.archive_upload_id),
@@ -1024,13 +1025,18 @@ async function buildPolicySafeCanonicalArchiveBatch(
   return sql.begin(async (transaction) => {
     const trx = transaction as unknown as Sql
     await trx`SELECT public.lock_policy_account(${manifest.accountId})`
-    const [source] = await trx`
-      SELECT created_at
-      FROM private.archive_clickhouse_delivery
-      WHERE archive_upload_id = ${manifest.archiveUploadId}
-        AND account_id = ${manifest.accountId}
-    `
-    const observedAt = canonicalArchiveObservedAt(source?.created_at)
+    let observedAt: string
+    if (sourceObservedAt !== undefined) {
+      observedAt = canonicalArchiveObservedAt(sourceObservedAt)
+    } else {
+      const [source] = await trx`
+        SELECT created_at
+        FROM private.archive_clickhouse_delivery
+        WHERE archive_upload_id = ${manifest.archiveUploadId}
+          AND account_id = ${manifest.accountId}
+      `
+      observedAt = canonicalArchiveObservedAt(source?.created_at)
+    }
     const [policy] = await trx`
       SELECT public.policy_account_is_blocked(
         ${manifest.accountId},
@@ -1079,12 +1085,40 @@ async function buildPolicySafeCanonicalArchiveBatch(
   })
 }
 
+async function publishCanonicalArchiveQueueFirst(
+  sql: Sql,
+  delivery: ArchiveClickHouseDelivery,
+  archive: any,
+  sourceObservedAt: unknown,
+): Promise<void> {
+  ensureCanonicalArchivePendingReport(
+    String(delivery.archive_upload_id),
+    logsDir,
+  )
+  const prepared = await buildPolicySafeCanonicalArchiveBatch(
+    sql,
+    delivery,
+    archive,
+    sourceObservedAt,
+  )
+  const report = await publishCanonicalArchiveBatch({
+    ...prepared,
+    reportDir: logsDir,
+  })
+  if (report.status !== 'complete') {
+    throw new CanonicalArchivePublisherError('canonical_queue_first_incomplete')
+  }
+  logger.info(
+    `Canonical archive queue-first complete (archive_upload_id=${delivery.archive_upload_id})`,
+  )
+}
+
 async function attemptCanonicalArchiveShadow(
   sql: Sql,
   delivery: ArchiveClickHouseDelivery,
   archive?: any,
 ): Promise<void> {
-  if (!canonicalArchiveShadowEnabled()) return
+  if (!canonicalArchivePublishingEnabled()) return
   try {
     ensureCanonicalArchivePendingReport(
       String(delivery.archive_upload_id),
@@ -1110,7 +1144,7 @@ async function attemptCanonicalArchiveShadow(
 }
 
 async function retryPendingCanonicalArchiveShadows(sql: Sql): Promise<void> {
-  if (!canonicalArchiveShadowEnabled()) return
+  if (!canonicalArchivePublishingEnabled()) return
   const archiveUploadIds = pendingCanonicalArchiveReportIds(logsDir).slice(
     0,
     CONFIG.CANONICAL_ARCHIVE_RETRY_BATCH,
@@ -1317,9 +1351,10 @@ async function main() {
     let archives_processed = 0
 
     for (const row of ready) {
-      const { id: archiveUploadId, account_id, username } = row
+      const { id: archiveUploadId, account_id, username, archive_at } = row
       logger.info(`Processing account ${account_id} with optimized batches (archive_upload_id=${archiveUploadId})`)
 
+      let queueFirstPending = false
       try {
         // Mark as committing
         const updateResult = await sql`
@@ -1334,8 +1369,31 @@ async function main() {
           continue
         }
 
-        // Process archive with optimized batch inserts
-        const archive = await processSingleArchive(sql, username, archiveUploadId)
+        const archive = await loadArchiveData(username)
+        const archiveManifest = createArchiveClickHouseManifest(
+          archive,
+          archiveUploadId,
+        )
+        const delivery = {
+          archive_upload_id: archiveUploadId,
+          account_id,
+          tweet_ids: archiveManifest.tweetIds,
+          username,
+        }
+
+        if (canonicalArchiveQueueFirstEnabled()) {
+          queueFirstPending = true
+          await publishCanonicalArchiveQueueFirst(
+            sql,
+            delivery,
+            archive,
+            archive_at,
+          )
+          queueFirstPending = false
+        }
+
+        // Process archive with optimized compatibility inserts.
+        await processSingleArchive(sql, archive, archiveUploadId)
 
         // Mark as completed
         const completeResult = await sql`
@@ -1356,32 +1414,14 @@ async function main() {
           await attemptClickHouseDelivery(
             sql,
             clickHouseSink,
-            {
-              archive_upload_id: archiveUploadId,
-              account_id,
-              tweet_ids: createArchiveClickHouseManifest(
-                archive,
-                archiveUploadId,
-              ).tweetIds,
-              username,
-            },
+            delivery,
             archive,
           )
         }
 
-        await attemptCanonicalArchiveShadow(
-          sql,
-          {
-            archive_upload_id: archiveUploadId,
-            account_id,
-            tweet_ids: createArchiveClickHouseManifest(
-              archive,
-              archiveUploadId,
-            ).tweetIds,
-            username,
-          },
-          archive,
-        )
+        if (!canonicalArchiveQueueFirstEnabled()) {
+          await attemptCanonicalArchiveShadow(sql, delivery, archive)
+        }
 
         // Force GC between accounts
         if (global.gc) {
@@ -1395,7 +1435,7 @@ async function main() {
         try {
           await sql`
             UPDATE public.archive_upload
-            SET upload_phase = 'failed'
+            SET upload_phase = ${queueFirstPending ? 'ready_for_commit' : 'failed'}
             WHERE id = ${archiveUploadId}
           `
         } catch (statusError) {


### PR DESCRIPTION
Adds a disabled-by-default queue-first mode for archive processing. It loads and policy-checks the archive, durably publishes canonical events, and only then runs the existing PostgreSQL and optional ClickHouse writes. Queue publication failures restore the upload to `ready_for_commit` without corpus writes.

The upload/control state remains authoritative in PostgreSQL, and compatibility sinks stay active.

Validation: archive/canonical focused tests (15 pass). Root TypeScript setup in this isolated worktree lacks two ambient type packages, so the existing full-project typecheck could not start.