### PR TITLE
Fix database gallery cover delivery

### DIFF
--- a/src/components/community/CommunityGallery.test.tsx
+++ b/src/components/community/CommunityGallery.test.tsx
@@ -23,6 +23,9 @@ const PUBLISHED_PROJECT: CommunityProject = {
   commentCount: 1,
 }
 
+const DATABASE_COVER_URL =
+  '/api/community/projects/8c21b2b5-3530-4ec8-9729-07635b28b692/cover?v=cover.png'
+
 async function openPublishedProject(user: ReturnType<typeof userEvent.setup>) {
   await user.type(
     screen.getByRole('searchbox', { name: 'Search community projects' }),
@@ -87,6 +90,23 @@ describe('CommunityGallery', () => {
     expect(
       screen.queryByRole('link', { name: /View full page/i }),
     ).not.toBeInTheDocument()
+  })
+
+  it('loads database-backed covers directly instead of through the image optimizer', async () => {
+    render(
+      <CommunityGallery
+        publishedProjects={[
+          { ...PUBLISHED_PROJECT, image: DATABASE_COVER_URL },
+        ]}
+      />,
+    )
+
+    const covers = screen.getAllByRole('img', {
+      name: 'Preview of Archive Quilt',
+    })
+    expect(covers).toHaveLength(1)
+    expect(covers[0]).toHaveAttribute('src', DATABASE_COVER_URL)
+    expect(covers[0]).not.toHaveAttribute('srcset')
   })
 
   it('opens the Conversation Map internally without inventing a source post', async () => {

--- a/src/components/community/CommunityGallery.tsx
+++ b/src/components/community/CommunityGallery.tsx
@@ -351,6 +351,7 @@ function ProjectCover({
             alt={`Preview of ${project.name}`}
             fill
             sizes={modal ? '620px' : '(max-width: 940px) 100vw, 33vw'}
+            unoptimized={project.image.startsWith('/api/community/projects/')}
             className="object-cover"
           />
           {modal ? (


### PR DESCRIPTION
## Summary
- load database-backed gallery covers directly in the browser
- bypass the server-side image optimizer that production middleware rejects
- add a regression test for the direct cover URL

## Validation
- `npm test -- --runInBand src/components/community/CommunityGallery.test.tsx` (12/12 passed)
- `npx prettier --check src/components/community/CommunityGallery.tsx src/components/community/CommunityGallery.test.tsx`
- `git diff --check`

The repository pre-commit hook could not generate local Supabase types because the isolated worktree does not have the local Twitter/Supabase environment. No database or generated-type files changed.