### PR TITLE
Fix directory hydration for Unicode avatar initials

### DIFF
--- a/src/app/user-dir/UserDirectoryClient.test.tsx
+++ b/src/app/user-dir/UserDirectoryClient.test.tsx
@@ -52,6 +52,19 @@ describe('UserDirectoryClient', () => {
     })
   })
 
+  test('keeps a non-BMP display-name initial intact for server hydration', () => {
+    render(
+      <UserDirectoryClient
+        totalCount={1}
+        initialUsers={[{ ...directoryUser(1), account_display_name: '𒐪' }]}
+        initialHasMore={false}
+      />,
+    )
+    // Both the name and avatar fallback must contain the complete code point.
+    // A lone UTF-16 surrogate becomes U+FFFD when the server sends UTF-8 HTML.
+    expect(screen.getAllByText('𒐪')).toHaveLength(2)
+  })
+
   test('records profile opens using aggregate directory context', async () => {
     const initialUsers = [directoryUser(1)]
     render(

--- a/src/app/user-dir/UserDirectoryClient.tsx
+++ b/src/app/user-dir/UserDirectoryClient.tsx
@@ -350,7 +350,9 @@ export default function UserDirectoryClient({
                           alt={`${user.account_display_name}'s avatar`}
                         />
                         <AvatarFallback>
-                          {user.account_display_name.charAt(0).toUpperCase()}
+                          {Array.from(
+                            user.account_display_name,
+                          )[0]?.toUpperCase()}
                         </AvatarFallback>
                       </Avatar>
                       <div className="min-w-0">


### PR DESCRIPTION
The production check after #879 still reported React hydration errors on the directory. Server and browser dates matched, but a display name beginning with `𒐪` exposed another cause: `charAt(0)` splits its UTF-16 surrogate pair. The server's UTF-8 HTML replaces that lone surrogate with U+FFFD, while the browser initially renders the surrogate, causing a text mismatch.

Read the first complete Unicode code point for the avatar fallback. The regression test fails on the old implementation and passes with the fix. This is a small follow-up within the approved website-performance rollout.

Validation: all six directory component tests, TypeScript, scoped lint, formatting, and diff checks passed. The homepage and profile production checks for #879 passed; this follow-up completes the directory fix. No schema or configuration changes. The schema-regeneration commit hook was skipped as in #879; validation ran directly.
