### PR TITLE
Fix website QA findings in banners, pagination, search, and profiles

### DIFF
--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -152,7 +152,6 @@ export default function DocsPage() {
                 while current PostgreSQL policy permits it.
               </p>
               <p className="mt-4 break-all font-mono text-xs leading-5 text-muted-foreground">
-                {API_URL}
                 https://www.community-archive.org/api/archive/&lt;username&gt;
               </p>
             </article>

--- a/src/app/login/LoginContent.test.tsx
+++ b/src/app/login/LoginContent.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react'
+import LoginContent from './LoginContent'
+
+jest.mock('@/components/SignIn', () => ({
+  __esModule: true,
+  default: () => <button>Sign in with Twitter</button>,
+}))
+
+it.each(['/search?q=100%', '/search?q=%E0%A4%A', '/search?q=%26'])(
+  'keeps sign-in available for the already-parsed redirect %s',
+  (redirectUrl) => {
+    render(<LoginContent redirectUrl={redirectUrl} />)
+
+    expect(
+      screen.getByRole('button', { name: 'Sign in with Twitter' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(`You'll be redirected to: ${redirectUrl}`),
+    ).toBeInTheDocument()
+  },
+)

--- a/src/app/login/LoginContent.tsx
+++ b/src/app/login/LoginContent.tsx
@@ -21,7 +21,7 @@ export default function LoginContent({ redirectUrl }: LoginContentProps) {
             </p>
             {redirectUrl && (
               <p className="mt-2 text-sm text-brand">
-                You&apos;ll be redirected to: {decodeURIComponent(redirectUrl)}
+                You&apos;ll be redirected to: {redirectUrl}
               </p>
             )}
           </div>

--- a/src/app/profile/ProfileContent.tsx
+++ b/src/app/profile/ProfileContent.tsx
@@ -448,9 +448,9 @@ export default function ProfileContent({
         <TabsContent value="privacy" className="space-y-4">
           <Card>
             <CardHeader className="space-y-1.5">
-              <CardTitle>Public Profile</CardTitle>
+              <CardTitle>Profile controls</CardTitle>
               <CardDescription>
-                Choose which owner actions appear to visitors
+                Choose which controls you see on your profile
               </CardDescription>
             </CardHeader>
             <CardContent>
@@ -460,8 +460,8 @@ export default function ProfileContent({
                     Show Download Archive
                   </Label>
                   <div className="text-sm text-muted-foreground">
-                    Visible by default. Turn this off to hide the button from
-                    your public profile.
+                    Only you can see and use this button. Turn it off to hide it
+                    when viewing your own profile.
                   </div>
                 </div>
                 <Switch

--- a/src/app/stream-monitor/page.test.tsx
+++ b/src/app/stream-monitor/page.test.tsx
@@ -1,0 +1,143 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import StreamMonitor from './page'
+import getLatestTweets from '@/lib/queries/getLatestTweets'
+
+jest.mock('@/utils/supabase', () => ({ createBrowserClient: () => ({}) }))
+jest.mock('@/lib/queries/getLatestTweets', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+jest.mock('@/components/ExtensionInstallPrompt', () => () => null)
+jest.mock(
+  '@/components/UnifiedTweetList',
+  () =>
+    function TweetListMock({
+      tweets,
+    }: {
+      tweets: { tweet_id: string; full_text: string }[]
+    }) {
+      return (
+        <ul>
+          {tweets.map((tweet) => (
+            <li key={tweet.tweet_id}>{tweet.full_text}</li>
+          ))}
+        </ul>
+      )
+    },
+)
+jest.mock('@/components/ui/chart', () => ({
+  ChartContainer: () => null,
+  ChartTooltip: () => null,
+  ChartTooltipContent: () => null,
+}))
+
+const latest = jest.mocked(getLatestTweets)
+const tweets = (start: number, count: number) =>
+  Array.from({ length: count }, (_, i) => ({
+    tweet_id: String(start + i),
+    full_text: `Tweet ${start + i}`,
+  })) as Awaited<ReturnType<typeof getLatestTweets>>
+
+const clients: QueryClient[] = []
+function setup() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  clients.push(client)
+  render(
+    <QueryClientProvider client={client}>
+      <StreamMonitor />
+    </QueryClientProvider>,
+  )
+  return client
+}
+
+beforeEach(() => {
+  latest.mockReset()
+  jest.spyOn(global, 'fetch').mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      data: [],
+      summary: { totalTweets: 0, avgTweetsPerPeriod: 0, sourceMessages: 0 },
+      count: 0,
+    }),
+  } as Response)
+})
+afterEach(() => {
+  clients.splice(0).forEach((client) => client.clear())
+  jest.restoreAllMocks()
+})
+
+test('keeps loaded tweets while loading more, deduplicates overlapping pages, and stops at the end', async () => {
+  latest.mockResolvedValueOnce(tweets(0, 20))
+  let resolvePage!: (value: Awaited<ReturnType<typeof getLatestTweets>>) => void
+  latest.mockImplementationOnce(
+    () =>
+      new Promise((resolve) => {
+        resolvePage = resolve
+      }),
+  )
+  setup()
+  fireEvent.click(await screen.findByRole('button', { name: 'Load More' }))
+  expect(screen.getByText('Tweet 0')).toBeInTheDocument()
+  await act(async () => resolvePage(tweets(19, 2)))
+  expect(await screen.findByText('Tweet 20')).toBeInTheDocument()
+  expect(screen.getAllByText('Tweet 19')).toHaveLength(1)
+  expect(
+    screen.queryByRole('button', { name: 'Load More' }),
+  ).not.toBeInTheDocument()
+})
+
+test('refetching a later page does not duplicate it, and Refresh requests page zero', async () => {
+  latest
+    .mockResolvedValueOnce(tweets(0, 20))
+    .mockResolvedValueOnce(tweets(20, 20))
+  const client = setup()
+  fireEvent.click(await screen.findByRole('button', { name: 'Load More' }))
+  await screen.findByText('Tweet 39')
+  latest.mockResolvedValueOnce(tweets(21, 20))
+  await act(async () => {
+    await client.refetchQueries({ queryKey: ['streamMonitorTweets', 20] })
+  })
+  expect(await screen.findByText('Tweet 40')).toBeInTheDocument()
+  expect(screen.getAllByText('Tweet 21')).toHaveLength(1)
+  latest.mockResolvedValueOnce(tweets(100, 3))
+  fireEvent.click(screen.getByRole('button', { name: 'Refresh' }))
+  expect(await screen.findByText('Tweet 100')).toBeInTheDocument()
+  expect(latest).toHaveBeenLastCalledWith(expect.anything(), 20, undefined, 0, {
+    includeEnrichments: false,
+  })
+  expect(screen.queryByText('Tweet 39')).not.toBeInTheDocument()
+})
+
+test('a failed later page preserves existing tweets and retries the same offset', async () => {
+  latest
+    .mockResolvedValueOnce(tweets(0, 20))
+    .mockRejectedValueOnce(new Error('offline'))
+    .mockResolvedValueOnce(tweets(20, 1))
+  setup()
+  fireEvent.click(await screen.findByRole('button', { name: 'Load More' }))
+  const retry = await screen.findByRole('button', {
+    name: 'Retry loading tweets',
+  })
+  expect(screen.getByText('Tweet 0')).toBeInTheDocument()
+  fireEvent.click(retry)
+  expect(await screen.findByText('Tweet 20')).toBeInTheDocument()
+  expect(latest.mock.calls.map((call) => call[3])).toEqual([0, 20, 20])
+})
+
+test('failed statistics show unavailable rather than zero activity', async () => {
+  jest
+    .mocked(fetch)
+    .mockResolvedValue({ ok: false, json: async () => ({}) } as Response)
+  latest.mockResolvedValue([])
+  setup()
+  await waitFor(() =>
+    expect(screen.getAllByText('Unavailable')).toHaveLength(4),
+  )
+  expect(screen.queryByText('0')).not.toBeInTheDocument()
+  expect(
+    screen.getByRole('button', { name: 'Next time period' }),
+  ).toBeDisabled()
+})

--- a/src/app/stream-monitor/page.tsx
+++ b/src/app/stream-monitor/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React, { useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { createBrowserClient } from '@/utils/supabase'
 import {
   ChartContainer,
@@ -93,6 +93,7 @@ function getStatsRange(viewMode: ViewMode, timeOffset: number) {
 }
 
 const StreamMonitor = () => {
+  const queryClient = useQueryClient()
   const [viewMode, setViewMode] = useState<ViewMode>('7d')
   const [timeOffset, setTimeOffset] = useState(0)
   const [showStreamedOnly, setShowStreamedOnly] = useState(true)
@@ -165,14 +166,20 @@ const StreamMonitor = () => {
   const chartLoading = statsLoading
   const chartError = statsError
   const sourceMetric = showStreamedOnly
-    ? scrapingStats?.summary?.sourceMessages || 0
-    : scrapingStats?.summary?.sourceCount || 0
-  const sourceMetricLoading = statsLoading
+    ? scrapingStats?.summary?.sourceMessages
+    : scrapingStats?.summary?.sourceCount
+  const formatMetric = (value: number | undefined) =>
+    statsLoading
+      ? '...'
+      : statsError || value == null
+        ? 'Unavailable'
+        : value.toLocaleString()
 
   // Query for latest tweets with pagination
   const {
     data: tweetsData,
     isLoading: tweetsLoading,
+    isFetching: tweetsFetching,
     error: tweetsError,
     refetch: refetchTweets,
   } = useQuery({
@@ -198,8 +205,14 @@ const StreamMonitor = () => {
         // Fresh load or refresh - replace all tweets
         setLoadedTweets(tweetsData)
       } else {
-        // Load more - append to existing tweets
-        setLoadedTweets((prev) => [...prev, ...tweetsData])
+        // Pages can overlap as new tweets arrive or the current page refetches.
+        setLoadedTweets((prev) =>
+          Array.from(
+            new Map(
+              [...prev, ...tweetsData].map((tweet) => [tweet.tweet_id, tweet]),
+            ).values(),
+          ),
+        )
       }
     }
   }, [tweetsData, tweetOffset])
@@ -263,14 +276,6 @@ const StreamMonitor = () => {
     }
   }
 
-  const getTotalTweets = () => {
-    return scrapingStats?.summary?.totalTweets || 0
-  }
-
-  const getAverageTweetsPerPeriod = () => {
-    return scrapingStats?.summary?.avgTweetsPerPeriod || 0
-  }
-
   const averageUnit =
     viewMode === '24h' ? 'hour' : viewMode === '7d' ? 'day' : 'week'
 
@@ -279,14 +284,24 @@ const StreamMonitor = () => {
   }
 
   const refreshLatestTweets = async () => {
-    setTweetOffset(0)
-    await refetchTweets()
+    if (tweetOffset === 0) {
+      await refetchTweets()
+    } else {
+      // Mark the first page stale before switching back to it. Refetching here
+      // would use the old offset and request another later page instead.
+      await queryClient.invalidateQueries({
+        queryKey: ['streamMonitorTweets', 0],
+        exact: true,
+        refetchType: 'none',
+      })
+      setTweetOffset(0)
+    }
   }
 
   return (
     <div className="mx-auto w-full max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
       <div className="mb-8">
-        <div className="mb-4 flex items-center justify-between">
+        <div className="mb-4 flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
           <div>
             <h1 className="mb-2 text-3xl font-bold text-foreground">
               Stream Monitor
@@ -327,7 +342,7 @@ const StreamMonitor = () => {
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold text-brand">
-              {getTotalTweets().toLocaleString()}
+              {formatMetric(scrapingStats?.summary?.totalTweets)}
             </div>
           </CardContent>
         </Card>
@@ -343,7 +358,7 @@ const StreamMonitor = () => {
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold text-green-600 dark:text-green-400">
-              {getAverageTweetsPerPeriod().toLocaleString()}
+              {formatMetric(scrapingStats?.summary?.avgTweetsPerPeriod)}
             </div>
           </CardContent>
         </Card>
@@ -379,7 +394,7 @@ const StreamMonitor = () => {
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold text-purple-600 dark:text-purple-400">
-              {sourceMetricLoading ? '...' : sourceMetric}
+              {formatMetric(sourceMetric)}
             </div>
           </CardContent>
         </Card>
@@ -387,7 +402,7 @@ const StreamMonitor = () => {
 
       <Card className="mb-8">
         <CardHeader>
-          <div className="mb-4 flex items-center justify-between">
+          <div className="mb-4 flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
             <div>
               <CardTitle>
                 {showStreamedOnly
@@ -397,13 +412,19 @@ const StreamMonitor = () => {
               <CardDescription>{getTimeRangeLabel()}</CardDescription>
             </div>
             <div className="flex items-center gap-2">
-              <Button variant="outline" size="sm" onClick={handlePrevious}>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handlePrevious}
+                aria-label="Previous time period"
+              >
                 <ChevronLeft className="h-4 w-4" />
               </Button>
               <Button
                 variant="outline"
                 size="sm"
                 onClick={handleNext}
+                aria-label="Next time period"
                 disabled={timeOffset === 0}
               >
                 <ChevronRight className="h-4 w-4" />
@@ -413,7 +434,7 @@ const StreamMonitor = () => {
           <Tabs
             value={viewMode}
             onValueChange={(v) => {
-              setViewMode(v as any)
+              setViewMode(v as ViewMode)
               setTimeOffset(0)
             }}
           >
@@ -470,9 +491,11 @@ const StreamMonitor = () => {
               onClick={refreshLatestTweets}
               variant="outline"
               size="sm"
-              disabled={tweetsLoading}
+              disabled={tweetsFetching}
             >
-              {tweetsLoading ? 'Refreshing...' : 'Refresh'}
+              {tweetsFetching && tweetOffset === 0
+                ? 'Refreshing...'
+                : 'Refresh'}
             </Button>
           </CardTitle>
           <CardDescription>
@@ -481,32 +504,46 @@ const StreamMonitor = () => {
           </CardDescription>
         </CardHeader>
         <CardContent>
-          {tweetsLoading ? (
+          {tweetsLoading && loadedTweets.length === 0 ? (
             <div className="flex items-center justify-center py-8">
               <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-brand"></div>
             </div>
-          ) : tweetsError ? (
-            <div className="flex items-center justify-center py-8 text-red-600 dark:text-red-400">
-              Error loading tweets
-            </div>
           ) : (
             <>
-              <UnifiedTweetList
-                tweets={loadedTweets}
-                isLoading={false}
-                emptyMessage="No tweets available"
-                showCsvExport={true}
-                csvFilename="stream_monitor_tweets.csv"
-              />
+              {(!tweetsError || loadedTweets.length > 0) && (
+                <UnifiedTweetList
+                  tweets={loadedTweets}
+                  isLoading={false}
+                  emptyMessage="No tweets available"
+                  showCsvExport={true}
+                  csvFilename="stream_monitor_tweets.csv"
+                />
+              )}
 
-              {loadedTweets.length > 0 && (
+              {tweetsError && (
+                <p
+                  role="alert"
+                  className="pt-4 text-center text-red-600 dark:text-red-400"
+                >
+                  Could not load tweets. Please try again.
+                </p>
+              )}
+              {(tweetsError ||
+                tweetsLoading ||
+                tweetsData?.length === tweetsPerPage) && (
                 <div className="flex justify-center pt-4">
                   <Button
-                    onClick={loadMoreTweets}
+                    onClick={
+                      tweetsError ? () => void refetchTweets() : loadMoreTweets
+                    }
                     variant="outline"
-                    disabled={tweetsLoading}
+                    disabled={tweetsFetching}
                   >
-                    {tweetsLoading ? 'Loading...' : 'Load More'}
+                    {tweetsFetching
+                      ? 'Loading...'
+                      : tweetsError
+                        ? 'Retry loading tweets'
+                        : 'Load More'}
                   </Button>
                 </div>
               )}

--- a/src/app/user-dir/UserDirectoryClient.test.tsx
+++ b/src/app/user-dir/UserDirectoryClient.test.tsx
@@ -181,4 +181,41 @@ describe('UserDirectoryClient', () => {
       expect.objectContaining({ limit: 15, offset: 0 }),
     )
   })
+  test('retries a failed search from the first page without showing unrelated users', async () => {
+    const log = jest.spyOn(console, 'error').mockImplementation(() => {})
+    mockFetchUsers.mockRejectedValueOnce(new Error('offline'))
+    mockFetchUsers.mockResolvedValueOnce({
+      users: [directoryUser(2)],
+      hasMore: false,
+    })
+    render(
+      <UserDirectoryClient
+        totalCount={20}
+        initialUsers={[directoryUser(1)]}
+        initialHasMore
+      />,
+    )
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search users' }), {
+      target: { value: 'member_2' },
+    })
+    const retry = await screen.findByRole('button', {
+      name: 'Retry loading users',
+    })
+    expect(
+      screen.queryByRole('link', { name: /Member 1/ }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Load more users' }),
+    ).not.toBeInTheDocument()
+    fireEvent.click(retry)
+
+    expect(
+      await screen.findByRole('link', { name: /Member 2/ }),
+    ).toBeInTheDocument()
+    expect(mockFetchUsers).toHaveBeenLastCalledWith(
+      expect.objectContaining({ offset: 0, search: 'member_2' }),
+    )
+    log.mockRestore()
+  })
 })

--- a/src/app/user-dir/UserDirectoryClient.tsx
+++ b/src/app/user-dir/UserDirectoryClient.tsx
@@ -41,6 +41,7 @@ export default function UserDirectoryClient({
   const [loading, setLoading] = useState(initialUsers === null)
   const [loadingMore, setLoadingMore] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [retryCount, setRetryCount] = useState(0)
   useReportSectionReady('directory_rows', !loading && !error)
   const [sortKey, setSortKey] = useState<SortKey>('num_followers')
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
@@ -99,6 +100,8 @@ export default function UserDirectoryClient({
         }
       } catch (err) {
         if (!isCurrentRequest) return
+        setUsers([])
+        setHasMore(false)
         setError('We could not load users. Please try again.')
         console.error('Error fetching users:', err)
       } finally {
@@ -110,7 +113,7 @@ export default function UserDirectoryClient({
     return () => {
       isCurrentRequest = false
     }
-  }, [debouncedSearch, sortKey, sortOrder])
+  }, [debouncedSearch, retryCount, sortKey, sortOrder])
 
   const loadMore = useCallback(async () => {
     if (loading || loadingMore || !hasMore || loadMoreInFlightRef.current) {
@@ -328,7 +331,14 @@ export default function UserDirectoryClient({
                     colSpan={4}
                     className="h-40 text-center text-sm text-red-600 dark:text-red-400"
                   >
-                    {error}
+                    <p role="alert">{error}</p>
+                    <Button
+                      variant="outline"
+                      className="mt-3"
+                      onClick={() => setRetryCount((count) => count + 1)}
+                    >
+                      Retry loading users
+                    </Button>
                   </TableCell>
                 </TableRow>
               ) : users.length === 0 ? (
@@ -432,6 +442,8 @@ export default function UserDirectoryClient({
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                   Loading…
                 </>
+              ) : error ? (
+                'Retry loading more users'
               ) : (
                 'Load more users'
               )}

--- a/src/components/ExtensionInstallPrompt.styles.test.ts
+++ b/src/components/ExtensionInstallPrompt.styles.test.ts
@@ -1,0 +1,26 @@
+/** @jest-environment node */
+import fs from 'fs'
+import path from 'path'
+import postcss from 'postcss'
+import tailwindcss from 'tailwindcss'
+
+const config = require('../../tailwind.config')
+
+test('compiles a dark background for the extension reminder', async () => {
+  const source = fs.readFileSync(
+    path.join(__dirname, 'ExtensionInstallPrompt.tsx'),
+    'utf8',
+  )
+  const result = await postcss([
+    tailwindcss({ ...config, content: [{ raw: source, extension: 'tsx' }] }),
+  ]).process('@tailwind utilities;', { from: undefined })
+  const darkBackgrounds: string[] = []
+  result.root.walkRules((rule) => {
+    if (rule.selector.includes('.dark') && rule.selector.includes('bg-')) {
+      rule.walkDecls('background-color', (declaration) => {
+        darkBackgrounds.push(declaration.value)
+      })
+    }
+  })
+  expect(darkBackgrounds).toContain('rgb(18 18 20 / 0.85)')
+})

--- a/src/components/UserMatchResults.test.tsx
+++ b/src/components/UserMatchResults.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import UserMatchResults from './UserMatchResults'
 import {
@@ -50,5 +50,20 @@ describe('UserMatchResults', () => {
 
     expect(fetchAccountSuggestions).not.toHaveBeenCalled()
     expect(fetchMemberSuggestions).not.toHaveBeenCalled()
+  })
+  it('clears old people while a different query is loading or fails', async () => {
+    const { rerender } = render(<UserMatchResults query="christine" />)
+    await screen.findByRole('link', { name: /Christine Shiba/ })
+    jest.mocked(fetchAccountSuggestions).mockRejectedValue(new Error('offline'))
+    jest.mocked(fetchMemberSuggestions).mockRejectedValue(new Error('offline'))
+
+    await act(async () => rerender(<UserMatchResults query="exgenesis" />))
+
+    expect(
+      screen.queryByRole('link', { name: /Christine Shiba/ }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('heading', { name: /People matching/ }),
+    ).not.toBeInTheDocument()
   })
 })

--- a/src/components/UserMatchResults.tsx
+++ b/src/components/UserMatchResults.tsx
@@ -27,9 +27,9 @@ export default function UserMatchResults({ query }: { query?: string }) {
     let active = true
     let memberMatches: UserSuggestion[] = []
     let accountMatches: UserSuggestion[] = []
+    setMatches([])
 
     if (!searchTerm) {
-      setMatches([])
       return () => {
         active = false
       }

--- a/src/components/metaTwitter/ProfileHeader.test.tsx
+++ b/src/components/metaTwitter/ProfileHeader.test.tsx
@@ -212,3 +212,16 @@ test('shows resolved, clickable profile bio and website links', () => {
   expect(screen.queryByText('https://t.co/bio')).not.toBeInTheDocument()
   expect(screen.queryByText('https://t.co/site')).not.toBeInTheDocument()
 })
+
+test('links to all available tweets from this user sorted newest first', () => {
+  render(
+    <ProfileHeader
+      profile={profile({ has_archive: false, is_opted_in: true })}
+      archivedAt={null}
+    />,
+  )
+  expect(screen.getByRole('link', { name: 'Latest tweets →' })).toHaveAttribute(
+    'href',
+    '/search?fromUser=alice&sort=newest',
+  )
+})

--- a/src/components/metaTwitter/ProfileHeader.tsx
+++ b/src/components/metaTwitter/ProfileHeader.tsx
@@ -200,6 +200,12 @@ export function ProfileHeader({
               <Stat value={profile.num_following} label="Following" />
               <Stat value={profile.num_likes} label="Likes" />
             </div>
+            <Link
+              href={`/search?${new URLSearchParams({ fromUser: profile.username, sort: 'newest' })}`}
+              className="self-start text-sm font-medium text-brand underline-offset-4 hover:underline lg:self-end"
+            >
+              Latest tweets →
+            </Link>
           </div>
         </div>
       </div>

--- a/src/components/ui/chart.test.tsx
+++ b/src/components/ui/chart.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react'
+import { ChartContainer, ChartTooltipContent } from './chart'
+
+jest.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) =>
+    children,
+  Tooltip: () => null,
+}))
+
+test('renders a zero count in the same numeric column as nonzero chart values', () => {
+  render(
+    <ChartContainer config={{ tweets: { label: 'Tweets' } }}>
+      <ChartTooltipContent
+        active
+        payload={[{ name: 'tweets', dataKey: 'tweets', value: 0, payload: {} }]}
+      />
+    </ChartContainer>,
+  )
+  expect(screen.getByText('0')).toHaveClass('tabular-nums')
+})

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -238,7 +238,7 @@ const ChartTooltipContent = React.forwardRef<
                           {itemConfig?.label || item.name}
                         </span>
                       </div>
-                      {item.value && (
+                      {item.value !== undefined && item.value !== null && (
                         <span className="font-mono font-medium tabular-nums text-foreground">
                           {item.value.toLocaleString()}
                         </span>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,6 +10,14 @@ module.exports = {
       screens: { '2xl': '1400px' },
     },
     extend: {
+      // Intermediate alpha values used by banners and interaction states.
+      opacity: {
+        15: '0.15',
+        35: '0.35',
+        45: '0.45',
+        55: '0.55',
+        85: '0.85',
+      },
       colors: {
         border: 'hsl(var(--border))',
         input: 'hsl(var(--input))',


### PR DESCRIPTION
## What changes

Fixes several website QA findings affecting browsing and recovery from failed requests:

- Dark-mode extension reminders regain their dark background. Tailwind now generates the intermediate opacity values already used by banners, digest states, and other controls (#877).
- Stream Monitor keeps loaded tweets visible, deduplicates overlapping/refetched pages, retries the failed page, stops at the end, and refreshes the newest page correctly. Failed statistics show “Unavailable”; chart controls have accessible labels and fit narrow screens. Zero tooltip counts retain their numeric styling.
- Directory errors clear unrelated previous results and offer retry; people suggestions clear when a new search starts. Profiles gain a newest-first author-search shortcut (#874), and settings accurately describe the owner-only archive download control.
- Login redirect text no longer crashes on percent signs or malformed escapes, and the docs archive URL example loses a stray URL prefix.

## Validation

Baseline client tests: 61 suites / 199 tests passed. Changed paths: 7 suites / 28 tests passed, including 9 new cases; the earlier login fix adds 3 percent-encoding regression cases. Type checking and changed-file lint pass.

Real-browser QA covered desktop/mobile search and profile navigation, signed-in settings/upload picker entry, Stream Monitor paging and refresh, newest-user search → tweet → return, gallery, digest stories, Bangers date/member/text filters and 60 unique paged tweets, Trends scale, graph account selection, and the reported image/thread examples. Dark banner computed background changes from white at 80% to the intended dark at 85%. No account-data submissions, deployment, or destructive actions were performed.

The historical bulk-export link still points to a missing bucket (#873/#882); no unverified replacement is introduced. Older reports #784, #795, #796, #831, #847, and #875 did not reproduce in the checked flows. Upload processing, email delivery, OAuth round trips, and corpus-wide integrity are outside this pass.
