### PR TITLE
Speed up navbar pages with independent loading and smaller bundles

### DIFF
--- a/docs/website-performance.md
+++ b/docs/website-performance.md
@@ -54,8 +54,8 @@ The existing PostHog integration already captures Web Vitals. The additional
 when the start was observed, `elapsed_ms`. It emits after two animation frames;
 this is a readiness proxy, not LCP or a guarantee that images have painted.
 
-Page categories are home, directory, profile, tweet, search, and Bangers. Every
-category has a `navigation_shell` marker. Data markers are homepage stats, digest,
+Page categories include home, directory, profile, tweet, search, and the navbar
+routes listed below. Every category has a `navigation_shell` marker. Data markers are homepage stats, digest,
 stream, profile header/feed, and directory rows. Shell and usable data must be
 analyzed separately. Document time starts at navigation start; client-link time
 starts at click capture; history time starts at `popstate`. Unobserved programmatic
@@ -96,3 +96,33 @@ panels, requires no unopened chapter requests, checks hover/focus prefetch,
 checks viewport/deduplicated previews, and verifies the timezone boundary. Keep
 these behavioral assertions when changing data composition; a `Suspense` wrapper
 alone is not evidence of independent loading.
+
+## Other navbar routes
+
+- Published Digest pages wait only for the edition. Likes, admin controls,
+  calendars, recent editions, and discussion have independent Suspense slots.
+  Metadata and page share a request-local edition read; there is no shared cache
+  of viewer state. Preview/editor props still work without streamed slots.
+- Gallery renders its published catalog before session/liked-project state.
+  Searching and opening cards work immediately; account actions are disabled
+  until the streamed session arrives. The session update preserves filters and
+  local like overrides. The submission form downloads when first opened.
+- Live Stream starts its feed and optional corpus total independently. Its client
+  entry imports the shared polling/pagination hook without the homepage panels.
+- Users renders its first page before the optional corpus count. Searching and
+  pagination retain their current behavior.
+- Trends retains its sign-in gate and loads historical chart series without the
+  twelve weekly queries needed only by homepage panels. The explorer has its own
+  five-minute cache key, keeping full-snapshot consumers unchanged.
+- Graph starts its public snapshot and identity reads together. Its loading
+  boundary downloads the graph engine while the snapshot is in flight.
+- Bangers renders its heading before rankings arrive. Search imports tweet
+  results only when they are needed. Missing route loading boundaries now cover
+  Digest, Gallery, Graph, Trends, and Research, enabling partial route prefetch.
+- Docs and Research already render from static/hourly cached content; there is
+  no reason to introduce another data or caching layer for their landing pages.
+
+The additional readiness categories are Digest, Gallery, Graph, Stream, Trends,
+Research, and Docs. Usable-data markers include `digest_article`,
+`gallery_catalog`, `stream_feed`, and `bangers_results`. A shell marker alone is
+never evidence that a graph or chart is usable.

--- a/docs/website-performance.md
+++ b/docs/website-performance.md
@@ -113,7 +113,7 @@ alone is not evidence of independent loading.
   pagination retain their current behavior.
 - Trends retains its sign-in gate and loads historical chart series without the
   twelve weekly queries needed only by homepage panels. The explorer has its own
-  five-minute cache key, keeping full-snapshot consumers unchanged.
+  daily cache key, keeping full-snapshot consumers unchanged.
 - Graph starts its public snapshot and identity reads together. Its loading
   boundary downloads the graph engine while the snapshot is in flight.
 - Bangers renders its heading before rankings arrive. Search imports tweet

--- a/src/app/bangers/page.tsx
+++ b/src/app/bangers/page.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from 'react'
+import { SectionReady } from '@/components/PagePerformance'
 import Link from 'next/link'
 import { BangersExplorer } from '@/components/portal/BangersExplorer'
 import { MUTED, SERIF } from '@/components/portal/styles'
@@ -16,7 +18,7 @@ function paramValue(value: string | string[] | undefined): string {
   return Array.isArray(value) ? (value[0] ?? '') : (value ?? '')
 }
 
-export default async function BangersPage({
+export default function BangersPage({
   searchParams,
 }: {
   searchParams: BangersSearchParams
@@ -42,7 +44,7 @@ export default async function BangersPage({
   const allTime =
     periodValue === 'all' || (period === undefined && year === undefined)
   const query = paramValue(searchParams.q).trim().slice(0, 120)
-  const initialPage = await getInitialPortalBangersPage({
+  const initialPage = getInitialPortalBangersPage({
     scope,
     sort,
     ...(period ? { period } : { year }),
@@ -66,18 +68,42 @@ export default async function BangersPage({
             Bangers
           </h1>
         </header>
-        <BangersExplorer
+        <Suspense
           key={`${scope}:${sort}:${period ?? year ?? 'all'}:${query}`}
-          initialPage={initialPage}
-          scope={scope}
-          sort={sort}
-          currentYear={currentYear}
-          year={period ? undefined : year}
-          period={period}
-          allTime={allTime}
-          initialQuery={query}
-        />
+          fallback={
+            <p role="status" className="min-h-96 py-8 text-muted-foreground">
+              Loading bangers…
+            </p>
+          }
+        >
+          <LoadedBangers
+            key={`${scope}:${sort}:${period ?? year ?? 'all'}:${query}`}
+            initialPage={initialPage}
+            scope={scope}
+            sort={sort}
+            currentYear={currentYear}
+            year={period ? undefined : year}
+            period={period}
+            allTime={allTime}
+            initialQuery={query}
+          />
+        </Suspense>
       </div>
     </main>
+  )
+}
+
+async function LoadedBangers({
+  initialPage,
+  ...props
+}: Omit<React.ComponentProps<typeof BangersExplorer>, 'initialPage'> & {
+  initialPage: ReturnType<typeof getInitialPortalBangersPage>
+}) {
+  const page = await initialPage
+  return (
+    <>
+      <SectionReady section="bangers_results" />
+      <BangersExplorer {...props} initialPage={page} />
+    </>
   )
 }

--- a/src/app/community/loading.tsx
+++ b/src/app/community/loading.tsx
@@ -1,0 +1,4 @@
+import { PortalPageLoading } from '@/components/portal/PortalPageLoading'
+export default function Loading() {
+  return <PortalPageLoading label="Loading Gallery" />
+}

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -1,5 +1,9 @@
 import type { Metadata } from 'next'
-import CommunityGallery from '@/components/community/CommunityGallery'
+import { Suspense } from 'react'
+import {
+  GallerySession,
+  GallerySessionValue,
+} from '@/components/community/GallerySession'
 import {
   loadCommunityProjectLikesForUser,
   loadPublishedCommunityProjects,
@@ -32,19 +36,26 @@ export const metadata: Metadata = {
   },
 }
 
+async function Viewer({ result }: { result: ReturnType<typeof loadViewer> }) {
+  return <GallerySessionValue session={await result} />
+}
+async function loadViewer() {
+  const user = await getCurrentUser()
+  return {
+    isSignedIn: Boolean(user),
+    likedProjectIds: await loadCommunityProjectLikesForUser(user?.id),
+  }
+}
 export default async function CommunityPage() {
-  const [user, publishedProjects] = await Promise.all([
-    getCurrentUser(),
-    loadPublishedCommunityProjects(),
-  ])
-
-  const likedProjectIds = await loadCommunityProjectLikesForUser(user?.id)
-
+  const viewer = loadViewer()
+  // Attach rejection handling immediately while the independent catalog read runs.
+  void viewer.catch(() => {})
+  const publishedProjects = await loadPublishedCommunityProjects()
   return (
-    <CommunityGallery
-      isSignedIn={Boolean(user)}
-      publishedProjects={publishedProjects}
-      likedProjectIds={likedProjectIds}
-    />
+    <GallerySession projects={publishedProjects}>
+      <Suspense fallback={null}>
+        <Viewer result={viewer} />
+      </Suspense>
+    </GallerySession>
   )
 }

--- a/src/app/digest/[date]/page.tsx
+++ b/src/app/digest/[date]/page.tsx
@@ -1,15 +1,8 @@
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
-import { checkIsAdmin } from '@/app/admin/data'
-import { DigestEditionView } from '@/components/digest/DigestEditionView'
-import {
-  getDigestCommentCount,
-  getDigestLikeState,
-  getPublishedDigest,
-  listPublishedDigestDays,
-} from '@/lib/digest/data'
+import { PublishedDigestView } from '@/components/digest/PublishedDigestView'
+import { getPublishedDigest } from '@/lib/digest/data'
 import { getDigestMetadata } from '@/lib/digest/metadata'
-import { getCurrentUser } from '@/lib/portal/auth'
 
 export const revalidate = 300
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
@@ -35,26 +28,7 @@ export default async function DatedDigestPage({
   params: { date: string }
 }) {
   if (!DATE_PATTERN.test(params.date)) notFound()
-  const [edition, archive, isAdmin] = await Promise.all([
-    getPublishedDigest(params.date),
-    listPublishedDigestDays(),
-    checkIsAdmin(),
-  ])
+  const edition = await getPublishedDigest(params.date)
   if (!edition) notFound()
-  const [likes, user, commentCount] = await Promise.all([
-    getDigestLikeState(edition),
-    getCurrentUser(),
-    getDigestCommentCount(edition),
-  ])
-  return (
-    <DigestEditionView
-      edition={edition}
-      archive={archive}
-      isAdmin={isAdmin}
-      likeCount={likes.count}
-      likedByViewer={likes.likedByViewer}
-      isSignedIn={Boolean(user)}
-      commentCount={commentCount}
-    />
-  )
+  return <PublishedDigestView edition={edition} />
 }

--- a/src/app/digest/loading.tsx
+++ b/src/app/digest/loading.tsx
@@ -1,0 +1,4 @@
+import { PortalPageLoading } from '@/components/portal/PortalPageLoading'
+export default function Loading() {
+  return <PortalPageLoading label="Loading Digest" />
+}

--- a/src/app/digest/page.tsx
+++ b/src/app/digest/page.tsx
@@ -1,15 +1,9 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { checkIsAdmin } from '@/app/admin/data'
-import { DigestEditionView } from '@/components/digest/DigestEditionView'
-import {
-  getDigestCommentCount,
-  getDigestLikeState,
-  getPublishedDigest,
-  listPublishedDigestDays,
-} from '@/lib/digest/data'
+import { PublishedDigestView } from '@/components/digest/PublishedDigestView'
+import { getPublishedDigest } from '@/lib/digest/data'
 import { getDigestMetadata } from '@/lib/digest/metadata'
-import { getCurrentUser } from '@/lib/portal/auth'
 
 export const revalidate = 300
 
@@ -18,30 +12,12 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function DigestPage() {
-  const [edition, archive, isAdmin] = await Promise.all([
-    getPublishedDigest(),
-    listPublishedDigestDays(),
-    checkIsAdmin(),
-  ])
+  const edition = await getPublishedDigest()
   if (edition) {
-    const [likes, user, commentCount] = await Promise.all([
-      getDigestLikeState(edition),
-      getCurrentUser(),
-      getDigestCommentCount(edition),
-    ])
-    return (
-      <DigestEditionView
-        edition={edition}
-        archive={archive}
-        isAdmin={isAdmin}
-        likeCount={likes.count}
-        likedByViewer={likes.likedByViewer}
-        isSignedIn={Boolean(user)}
-        commentCount={commentCount}
-      />
-    )
+    return <PublishedDigestView edition={edition} />
   }
 
+  const isAdmin = await checkIsAdmin()
   return (
     <main className="min-h-[70vh] bg-zinc-100/70 px-4 py-16 dark:bg-background">
       <div className="mx-auto max-w-3xl rounded-lg border border-dashed bg-card p-10 text-center">

--- a/src/app/research/loading.tsx
+++ b/src/app/research/loading.tsx
@@ -1,0 +1,4 @@
+import { PortalPageLoading } from '@/components/portal/PortalPageLoading'
+export default function Loading() {
+  return <PortalPageLoading label="Loading Research" />
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import AdvancedSearchForm from '@/components/AdvancedSearchForm'
-import TweetList from '@/components/TweetList'
+import dynamic from 'next/dynamic'
 import {
   FilterCriteria,
   type TweetSearchSort,
@@ -13,6 +13,10 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { Suspense } from 'react'
 import { capturePostHogEvent } from '@/lib/posthog'
 import UserMatchResults from '@/components/UserMatchResults'
+
+const TweetList = dynamic(() => import('@/components/TweetList'), {
+  loading: () => <p role="status">Loading results…</p>,
+})
 
 const starterSearches = [
   { label: 'Open source', query: 'open source' },

--- a/src/app/social-graph/loading.tsx
+++ b/src/app/social-graph/loading.tsx
@@ -1,0 +1,11 @@
+'use client'
+import { useEffect } from 'react'
+import { PortalPageLoading } from '@/components/portal/PortalPageLoading'
+
+export default function Loading() {
+  // Download the graph engine while the public snapshot is in flight.
+  useEffect(() => {
+    void import('./SocialGraphExplorer').catch(() => {})
+  }, [])
+  return <PortalPageLoading label="Loading Social graph" />
+}

--- a/src/app/social-graph/page.tsx
+++ b/src/app/social-graph/page.tsx
@@ -19,6 +19,10 @@ const SocialGraphExplorer = dynamic(() => import('./SocialGraphExplorer'), {
 export const metadata = { title: 'Social graph · Community Archive' }
 
 export default async function SocialGraphPage() {
+  const snapshotResult = getSocialGraphSnapshot().then(
+    (snapshot) => ({ snapshot, error: null }),
+    (error: unknown) => ({ snapshot: null, error }),
+  )
   const user = await getCurrentUser()
   const isAdmin = Boolean(user && isAdminUser(user))
   const currentMember = user
@@ -30,7 +34,9 @@ export default async function SocialGraphPage() {
 
   let snapshot
   try {
-    snapshot = await getSocialGraphSnapshot()
+    const result = await snapshotResult
+    if (!result.snapshot) throw result.error
+    snapshot = result.snapshot
   } catch (error) {
     console.error('Social graph snapshot request failed:', error)
     return (

--- a/src/app/stream/page.tsx
+++ b/src/app/stream/page.tsx
@@ -1,13 +1,84 @@
-import Portal from '@/components/portal/Portal'
-import { getPortalData } from '@/lib/portal/data'
+import { Suspense } from 'react'
+import Link from 'next/link'
+import { StreamFeed } from '@/components/portal/StreamFeed'
+import { startStreamData } from '@/lib/portal/data'
+import { MUTED, SERIF } from '@/components/portal/styles'
+import ExtensionInstallPrompt from '@/components/ExtensionInstallPrompt'
+import { CHROME_EXTENSION_URL } from '@/lib/browserExtension'
 
 export const metadata = { title: 'Stream · Community Archive' }
-// Keep the stream and homepage on the same request-time analytics snapshots;
-// portal fallbacks must not turn a static-render probe into cached route data.
 export const dynamic = 'force-dynamic'
 export const maxDuration = 60
 
-export default async function StreamPage() {
-  const data = await getPortalData('stream')
-  return <Portal data={data} view="stream" />
+async function Total({
+  result,
+}: {
+  result: ReturnType<typeof startStreamData>['stats']
+}) {
+  const { data, failed } = await result
+  if (failed) return null
+  return (
+    <span
+      className={`inline-flex items-center gap-[7px] text-[12px] ${MUTED}`}
+      title="Archived tweet total from the latest corpus snapshot"
+    >
+      <span className="h-[7px] w-[7px] animate-pulse rounded-full bg-[#2acf80]" />
+      <span className="tabular-nums">
+        {data.totalTweets.toLocaleString('en-US')} tweets
+      </span>
+    </span>
+  )
+}
+async function Feed({
+  result,
+}: {
+  result: ReturnType<typeof startStreamData>['tweets']
+}) {
+  const { data, failed } = await result
+  return <StreamFeed tweets={data} failed={failed} />
+}
+export default function StreamPage() {
+  const data = startStreamData()
+  return (
+    <main className="min-h-screen bg-zinc-100/80 dark:bg-transparent">
+      <div className="mx-auto max-w-[900px] px-4 py-6 sm:px-6">
+        <Link
+          href="/"
+          className={`mb-2 inline-flex items-center text-[12.5px] font-semibold ${MUTED} hover:text-brand`}
+        >
+          ← Dashboard
+        </Link>
+        <div className="mb-1.5 flex items-baseline gap-3">
+          <h1 className="text-[26px] font-semibold" style={SERIF}>
+            Live stream
+          </h1>
+          <Suspense fallback={null}>
+            <Total result={data.stats} />
+          </Suspense>
+        </div>
+        <div className={`mb-3.5 text-[13px] ${MUTED}`}>
+          Tweets arriving from the{' '}
+          <a
+            href={CHROME_EXTENSION_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-semibold text-brand"
+          >
+            browser extension
+          </a>{' '}
+          firehose, as contributors read their timelines.
+        </div>
+        <ExtensionInstallPrompt surface="stream" className="mb-3.5" />
+        <Suspense
+          fallback={
+            <p role="status" className="min-h-96 py-8 text-muted-foreground">
+              Loading live tweets…
+            </p>
+          }
+        >
+          <Feed result={data.tweets} />
+        </Suspense>
+      </div>
+    </main>
+  )
 }

--- a/src/app/trends/loading.tsx
+++ b/src/app/trends/loading.tsx
@@ -1,0 +1,4 @@
+import { PortalPageLoading } from '@/components/portal/PortalPageLoading'
+export default function Loading() {
+  return <PortalPageLoading label="Loading Trends" />
+}

--- a/src/app/user-dir/UserDirectoryClient.tsx
+++ b/src/app/user-dir/UserDirectoryClient.tsx
@@ -2,7 +2,7 @@
 
 import { useReportSectionReady } from '@/components/PagePerformance'
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { ArrowDown, ArrowUp, ArrowUpDown, Loader2, Search } from 'lucide-react'
 
@@ -28,12 +28,14 @@ export const USERS_PER_PAGE = 15
 
 interface UserDirectoryClientProps {
   totalCount: number | null
+  totalCountSlot?: ReactNode
   initialUsers: DirectoryUser[] | null
   initialHasMore: boolean
 }
 
 export default function UserDirectoryClient({
   totalCount,
+  totalCountSlot,
   initialUsers,
   initialHasMore,
 }: UserDirectoryClientProps) {
@@ -219,13 +221,19 @@ export default function UserDirectoryClient({
             Archive.
           </p>
           <p className="mt-2 text-sm font-medium text-muted-foreground">
-            {loading && users.length === 0
-              ? 'Loading users…'
-              : debouncedSearch
-                ? `${users.length}${hasMore ? '+' : ''} matching users`
-                : totalCount === null
-                  ? `${users.length}${hasMore ? '+' : ''} users`
-                  : `${users.length} of ${totalCount.toLocaleString()} users`}
+            {loading && users.length === 0 ? (
+              'Loading users…'
+            ) : debouncedSearch ? (
+              `${users.length}${hasMore ? '+' : ''} matching users`
+            ) : totalCountSlot ? (
+              <>
+                {users.length} of {totalCountSlot} users
+              </>
+            ) : totalCount === null ? (
+              `${users.length}${hasMore ? '+' : ''} users`
+            ) : (
+              `${users.length} of ${totalCount.toLocaleString()} users`
+            )}
           </p>
         </div>
 

--- a/src/app/user-dir/page.tsx
+++ b/src/app/user-dir/page.tsx
@@ -1,26 +1,35 @@
+import { Suspense } from 'react'
 import UserDirectoryClient from './UserDirectoryClient'
 import { getStats } from '@/lib/stats'
 import { getUserDirectoryPage } from '@/lib/userDirectory'
 
 export default async function UserDirectoryPage() {
-  const [totalCount, initialPage] = await Promise.all([
-    getStats()
-      .then((stats) => stats.userCount)
-      .catch((error) => {
-        console.error('Error fetching the directory member count:', error)
-        return null
-      }),
-    getUserDirectoryPage().catch((error) => {
-      console.error('Error fetching the initial user directory page:', error)
+  const totalCount = getStats()
+    .then((stats) => stats.userCount)
+    .catch((error) => {
+      console.error('Error fetching the directory member count:', error)
       return null
-    }),
-  ])
+    })
+  const initialPage = await getUserDirectoryPage().catch((error) => {
+    console.error('Error fetching the initial user directory page:', error)
+    return null
+  })
 
   return (
     <UserDirectoryClient
-      totalCount={totalCount}
+      totalCount={null}
+      totalCountSlot={
+        <Suspense fallback="…">
+          <DirectoryTotal result={totalCount} />
+        </Suspense>
+      }
       initialUsers={initialPage?.users ?? null}
       initialHasMore={initialPage?.hasMore ?? true}
     />
   )
+}
+
+async function DirectoryTotal({ result }: { result: Promise<number | null> }) {
+  const count = await result
+  return <>{count === null ? 'unknown' : count.toLocaleString('en-US')}</>
 }

--- a/src/components/PagePerformance.tsx
+++ b/src/components/PagePerformance.tsx
@@ -34,6 +34,13 @@ export function performancePage(pathname: string) {
   if (pathname.startsWith('/tweets/')) return 'tweet'
   if (pathname === '/search') return 'search'
   if (pathname === '/bangers') return 'bangers'
+  if (pathname === '/digest' || pathname.startsWith('/digest/')) return 'digest'
+  if (pathname === '/community') return 'gallery'
+  if (pathname === '/social-graph') return 'graph'
+  if (pathname === '/stream') return 'stream'
+  if (pathname === '/trends') return 'trends'
+  if (pathname === '/research') return 'research'
+  if (pathname === '/docs') return 'docs'
   return null
 }
 

--- a/src/components/community/CommunityGallery.tsx
+++ b/src/components/community/CommunityGallery.tsx
@@ -1,11 +1,12 @@
 'use client'
 
+import dynamic from 'next/dynamic'
+import { useGallerySessionReady } from './gallerySessionContext'
 import Image from 'next/image'
 import Link from 'next/link'
 import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react'
 import {
   ArrowUpRight,
-  CheckCircle2,
   Heart,
   MessageCircle,
   Plus,
@@ -22,14 +23,6 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
 import { Textarea } from '@/components/ui/textarea'
 import {
   COMMUNITY_PROJECT_CATEGORIES,
@@ -39,6 +32,10 @@ import {
   filterCommunityProjects,
 } from '@/lib/communityProjects'
 import { cn } from '@/utils/tailwind'
+
+const SubmissionDialog = dynamic(() => import('./SubmissionDialog'), {
+  ssr: false,
+})
 
 const SORT_OPTIONS: CommunityProjectSort[] = [
   'Featured',
@@ -62,9 +59,12 @@ function LikeButton({
   size?: 'card' | 'modal'
   isSignedIn?: boolean
 }) {
-  const label = !isSignedIn
-    ? 'Sign in to like'
-    : `${state.liked ? 'Unlike' : 'Like'} ${project.name}`
+  const ready = useGallerySessionReady()
+  const label = !ready
+    ? 'Loading account…'
+    : !isSignedIn
+      ? 'Sign in to like'
+      : `${state.liked ? 'Unlike' : 'Like'} ${project.name}`
   return (
     <button
       type="button"
@@ -72,6 +72,7 @@ function LikeButton({
         event.stopPropagation()
         onToggle(project)
       }}
+      disabled={!ready}
       aria-pressed={state.liked}
       aria-label={label}
       title={label}
@@ -566,252 +567,6 @@ function ProjectDialog({
   )
 }
 
-function SubmissionDialog({
-  open,
-  onOpenChange,
-}: {
-  open: boolean
-  onOpenChange: (open: boolean) => void
-}) {
-  const [complete, setComplete] = useState(false)
-  const [submitting, setSubmitting] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-
-  const handleOpenChange = (nextOpen: boolean) => {
-    onOpenChange(nextOpen)
-    if (!nextOpen) {
-      setComplete(false)
-      setError(null)
-    }
-  }
-
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    setSubmitting(true)
-    setError(null)
-    const formData = new window.FormData(event.currentTarget)
-
-    try {
-      const response = await fetch('/api/community/submissions', {
-        method: 'POST',
-        body: formData,
-      })
-      const result = (await response.json()) as { ok?: boolean; error?: string }
-      if (response.status === 401) {
-        window.location.href = '/login?redirect=/community'
-        return
-      }
-      if (!response.ok || !result.ok) {
-        setError(result.error ?? 'We could not save this submission.')
-        return
-      }
-      setComplete(true)
-    } catch {
-      setError('We could not save this submission. Please try again.')
-    } finally {
-      setSubmitting(false)
-    }
-  }
-
-  return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-h-[92vh] max-w-2xl overflow-y-auto">
-        {complete ? (
-          <div className="py-4 text-center" aria-live="polite">
-            <div className="bg-brand/15 mx-auto flex h-12 w-12 items-center justify-center rounded-full text-brand">
-              <CheckCircle2 className="h-6 w-6" />
-            </div>
-            <DialogHeader className="mt-5 text-center">
-              <DialogTitle className="text-center text-2xl">
-                Your project is in the approval queue
-              </DialogTitle>
-              <DialogDescription className="mx-auto max-w-md leading-6">
-                An admin will review it before it appears in the Gallery.
-              </DialogDescription>
-            </DialogHeader>
-            <div className="mt-7 flex flex-col justify-center gap-3 sm:flex-row">
-              <Button
-                type="button"
-                onClick={() => handleOpenChange(false)}
-                className="bg-brand text-brand-foreground hover:bg-brand/90"
-              >
-                Back to gallery
-              </Button>
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => setComplete(false)}
-              >
-                Submit another
-              </Button>
-            </div>
-          </div>
-        ) : (
-          <>
-            <DialogHeader>
-              <DialogTitle className="text-2xl">Submit a project</DialogTitle>
-              <DialogDescription className="leading-6">
-                Share an independent tool, experiment, research project, or game
-                built with Community Archive data.
-              </DialogDescription>
-            </DialogHeader>
-
-            <form onSubmit={handleSubmit} className="mt-2 space-y-5">
-              <div className="grid gap-5 sm:grid-cols-2">
-                <div className="space-y-2">
-                  <Label htmlFor="project-name">Project name</Label>
-                  <Input
-                    id="project-name"
-                    name="projectName"
-                    autoComplete="off"
-                    placeholder="What did you make?"
-                    required
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="project-url">Project URL</Label>
-                  <Input
-                    id="project-url"
-                    name="projectUrl"
-                    type="url"
-                    inputMode="url"
-                    placeholder="https://"
-                    required
-                  />
-                </div>
-              </div>
-
-              <div className="grid gap-5 sm:grid-cols-2">
-                <div className="space-y-2">
-                  <Label htmlFor="creator-name">Your name</Label>
-                  <Input
-                    id="creator-name"
-                    name="creatorName"
-                    autoComplete="name"
-                    placeholder="Name or studio"
-                    required
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="creator-handle">X handle (optional)</Label>
-                  <Input
-                    id="creator-handle"
-                    name="creatorHandle"
-                    autoComplete="off"
-                    placeholder="@handle"
-                  />
-                </div>
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="project-category">Category</Label>
-                <Select name="category" defaultValue="Tools" required>
-                  <SelectTrigger id="project-category">
-                    <SelectValue placeholder="Choose a category" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {COMMUNITY_PROJECT_CATEGORIES.filter(
-                      (item) => item !== 'All',
-                    ).map((item) => (
-                      <SelectItem key={item} value={item}>
-                        {item}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="project-description">Short description</Label>
-                <Textarea
-                  id="project-description"
-                  name="description"
-                  placeholder="What does the project help people see, do, or understand?"
-                  maxLength={360}
-                  required
-                />
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="archive-use">
-                  How does it use Community Archive data?
-                </Label>
-                <Textarea
-                  id="archive-use"
-                  name="archiveUse"
-                  placeholder="Tell curators which archive data or API the project uses."
-                  maxLength={500}
-                  required
-                />
-              </div>
-
-              <div className="grid gap-5 sm:grid-cols-2">
-                <div className="space-y-2">
-                  <Label htmlFor="source-post">Launch/source post</Label>
-                  <Input
-                    id="source-post"
-                    name="sourcePost"
-                    type="url"
-                    inputMode="url"
-                    placeholder="https://x.com/..."
-                    required
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="project-cover">Cover image (optional)</Label>
-                  <Input
-                    id="project-cover"
-                    name="cover"
-                    type="file"
-                    accept="image/png,image/jpeg,image/webp"
-                    className="cursor-pointer file:mr-3 file:border-0 file:bg-transparent file:text-xs file:font-semibold"
-                  />
-                </div>
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="project-tags">Tags (optional)</Label>
-                <Input
-                  id="project-tags"
-                  name="tags"
-                  placeholder="audio, search, visualization"
-                />
-              </div>
-
-              <p className="rounded-lg border border-border bg-muted/60 p-3 text-xs leading-5 text-muted-foreground">
-                Submissions will be reviewed before appearing in the gallery.
-              </p>
-
-              {error ? (
-                <p role="alert" className="text-sm text-destructive">
-                  {error}
-                </p>
-              ) : null}
-
-              <DialogFooter className="gap-2 sm:gap-0">
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => handleOpenChange(false)}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  type="submit"
-                  disabled={submitting}
-                  className="bg-brand text-brand-foreground hover:bg-brand/90"
-                >
-                  {submitting ? 'Submitting…' : 'Submit for approval'}
-                </Button>
-              </DialogFooter>
-            </form>
-          </>
-        )}
-      </DialogContent>
-    </Dialog>
-  )
-}
-
 export default function CommunityGallery({
   isSignedIn = true,
   publishedProjects = [],
@@ -821,6 +576,7 @@ export default function CommunityGallery({
   publishedProjects?: CommunityProject[]
   likedProjectIds?: string[]
 }) {
+  const viewerReady = useGallerySessionReady()
   const [query, setQuery] = useState('')
   const [category, setCategory] =
     useState<(typeof COMMUNITY_PROJECT_CATEGORIES)[number]>('All')
@@ -828,6 +584,7 @@ export default function CommunityGallery({
   const [selectedProject, setSelectedProject] =
     useState<CommunityProject | null>(null)
   const [submissionOpen, setSubmissionOpen] = useState(false)
+  const [submissionRequested, setSubmissionRequested] = useState(false)
 
   // Server-rendered like counts stay the source of truth; only projects the
   // reader has toggled in this session carry a local override.
@@ -940,6 +697,7 @@ export default function CommunityGallery({
       window.location.href = '/login?redirect=/community'
       return
     }
+    setSubmissionRequested(true)
     setSubmissionOpen(true)
   }
 
@@ -1026,6 +784,7 @@ export default function CommunityGallery({
             <Button
               type="button"
               size="sm"
+              disabled={!viewerReady}
               onClick={openSubmission}
               className="h-9 bg-primary text-primary-foreground"
             >
@@ -1125,7 +884,11 @@ export default function CommunityGallery({
                 >
                   Clear filters
                 </Button>
-                <Button type="button" onClick={openSubmission}>
+                <Button
+                  type="button"
+                  disabled={!viewerReady}
+                  onClick={openSubmission}
+                >
                   Submit a project
                 </Button>
               </div>
@@ -1141,10 +904,12 @@ export default function CommunityGallery({
         onToggleLike={toggleLike}
         isSignedIn={isSignedIn}
       />
-      <SubmissionDialog
-        open={submissionOpen}
-        onOpenChange={setSubmissionOpen}
-      />
+      {submissionRequested && (
+        <SubmissionDialog
+          open={submissionOpen}
+          onOpenChange={setSubmissionOpen}
+        />
+      )}
     </main>
   )
 }

--- a/src/components/community/GallerySession.test.tsx
+++ b/src/components/community/GallerySession.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { GallerySession, GallerySessionValue } from './GallerySession'
+
+test('public filtering works before session hydration and account actions unlock afterwards', async () => {
+  const user = userEvent.setup()
+  const { rerender } = render(
+    <GallerySession projects={[]}>{null}</GallerySession>,
+  )
+  expect(
+    screen.getByRole('button', { name: 'Submit a project' }),
+  ).toBeDisabled()
+  await user.type(
+    screen.getByRole('searchbox', { name: 'Search community projects' }),
+    'radio',
+  )
+  expect(screen.getByText('1 project')).toBeInTheDocument()
+  rerender(
+    <GallerySession projects={[]}>
+      <GallerySessionValue
+        session={{ isSignedIn: true, likedProjectIds: [] }}
+      />
+    </GallerySession>,
+  )
+  expect(screen.getByRole('button', { name: 'Submit a project' })).toBeEnabled()
+  expect(screen.getByRole('searchbox')).toHaveValue('radio')
+})

--- a/src/components/community/GallerySession.tsx
+++ b/src/components/community/GallerySession.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useContext, useEffect, useState, type ReactNode } from 'react'
+import CommunityGallery from './CommunityGallery'
+import type { CommunityProject } from '@/lib/communityProjects'
+import { useReportSectionReady } from '@/components/PagePerformance'
+
+import { SessionContext, type Session } from './gallerySessionContext'
+
+/** Public browsing works while request-scoped viewer state streams in. */
+export function GallerySession({
+  projects,
+  children,
+}: {
+  projects: CommunityProject[]
+  children: ReactNode
+}) {
+  const [session, setSession] = useState<Session | null>(null)
+  useReportSectionReady('gallery_catalog')
+  return (
+    <SessionContext.Provider value={{ ready: session !== null, setSession }}>
+      <CommunityGallery
+        publishedProjects={projects}
+        isSignedIn={session?.isSignedIn ?? false}
+        likedProjectIds={session?.likedProjectIds ?? []}
+      />
+      {children}
+    </SessionContext.Provider>
+  )
+}
+export function GallerySessionValue({ session }: { session: Session }) {
+  const context = useContext(SessionContext)
+  const setSession = context?.setSession
+  useEffect(() => {
+    setSession?.(session)
+  }, [setSession, session])
+  return null
+}

--- a/src/components/community/SubmissionDialog.tsx
+++ b/src/components/community/SubmissionDialog.tsx
@@ -1,0 +1,268 @@
+'use client'
+import { FormEvent, useState } from 'react'
+import { CheckCircle2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
+import { COMMUNITY_PROJECT_CATEGORIES } from '@/lib/communityProjects'
+export default function SubmissionDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const [complete, setComplete] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    onOpenChange(nextOpen)
+    if (!nextOpen) {
+      setComplete(false)
+      setError(null)
+    }
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setSubmitting(true)
+    setError(null)
+    const formData = new window.FormData(event.currentTarget)
+
+    try {
+      const response = await fetch('/api/community/submissions', {
+        method: 'POST',
+        body: formData,
+      })
+      const result = (await response.json()) as { ok?: boolean; error?: string }
+      if (response.status === 401) {
+        window.location.href = '/login?redirect=/community'
+        return
+      }
+      if (!response.ok || !result.ok) {
+        setError(result.error ?? 'We could not save this submission.')
+        return
+      }
+      setComplete(true)
+    } catch {
+      setError('We could not save this submission. Please try again.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-h-[92vh] max-w-2xl overflow-y-auto">
+        {complete ? (
+          <div className="py-4 text-center" aria-live="polite">
+            <div className="bg-brand/15 mx-auto flex h-12 w-12 items-center justify-center rounded-full text-brand">
+              <CheckCircle2 className="h-6 w-6" />
+            </div>
+            <DialogHeader className="mt-5 text-center">
+              <DialogTitle className="text-center text-2xl">
+                Your project is in the approval queue
+              </DialogTitle>
+              <DialogDescription className="mx-auto max-w-md leading-6">
+                An admin will review it before it appears in the Gallery.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="mt-7 flex flex-col justify-center gap-3 sm:flex-row">
+              <Button
+                type="button"
+                onClick={() => handleOpenChange(false)}
+                className="bg-brand text-brand-foreground hover:bg-brand/90"
+              >
+                Back to gallery
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setComplete(false)}
+              >
+                Submit another
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle className="text-2xl">Submit a project</DialogTitle>
+              <DialogDescription className="leading-6">
+                Share an independent tool, experiment, research project, or game
+                built with Community Archive data.
+              </DialogDescription>
+            </DialogHeader>
+
+            <form onSubmit={handleSubmit} className="mt-2 space-y-5">
+              <div className="grid gap-5 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="project-name">Project name</Label>
+                  <Input
+                    id="project-name"
+                    name="projectName"
+                    autoComplete="off"
+                    placeholder="What did you make?"
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="project-url">Project URL</Label>
+                  <Input
+                    id="project-url"
+                    name="projectUrl"
+                    type="url"
+                    inputMode="url"
+                    placeholder="https://"
+                    required
+                  />
+                </div>
+              </div>
+
+              <div className="grid gap-5 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="creator-name">Your name</Label>
+                  <Input
+                    id="creator-name"
+                    name="creatorName"
+                    autoComplete="name"
+                    placeholder="Name or studio"
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="creator-handle">X handle (optional)</Label>
+                  <Input
+                    id="creator-handle"
+                    name="creatorHandle"
+                    autoComplete="off"
+                    placeholder="@handle"
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="project-category">Category</Label>
+                <Select name="category" defaultValue="Tools" required>
+                  <SelectTrigger id="project-category">
+                    <SelectValue placeholder="Choose a category" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {COMMUNITY_PROJECT_CATEGORIES.filter(
+                      (item) => item !== 'All',
+                    ).map((item) => (
+                      <SelectItem key={item} value={item}>
+                        {item}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="project-description">Short description</Label>
+                <Textarea
+                  id="project-description"
+                  name="description"
+                  placeholder="What does the project help people see, do, or understand?"
+                  maxLength={360}
+                  required
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="archive-use">
+                  How does it use Community Archive data?
+                </Label>
+                <Textarea
+                  id="archive-use"
+                  name="archiveUse"
+                  placeholder="Tell curators which archive data or API the project uses."
+                  maxLength={500}
+                  required
+                />
+              </div>
+
+              <div className="grid gap-5 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="source-post">Launch/source post</Label>
+                  <Input
+                    id="source-post"
+                    name="sourcePost"
+                    type="url"
+                    inputMode="url"
+                    placeholder="https://x.com/..."
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="project-cover">Cover image (optional)</Label>
+                  <Input
+                    id="project-cover"
+                    name="cover"
+                    type="file"
+                    accept="image/png,image/jpeg,image/webp"
+                    className="cursor-pointer file:mr-3 file:border-0 file:bg-transparent file:text-xs file:font-semibold"
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="project-tags">Tags (optional)</Label>
+                <Input
+                  id="project-tags"
+                  name="tags"
+                  placeholder="audio, search, visualization"
+                />
+              </div>
+
+              <p className="rounded-lg border border-border bg-muted/60 p-3 text-xs leading-5 text-muted-foreground">
+                Submissions will be reviewed before appearing in the gallery.
+              </p>
+
+              {error ? (
+                <p role="alert" className="text-sm text-destructive">
+                  {error}
+                </p>
+              ) : null}
+
+              <DialogFooter className="gap-2 sm:gap-0">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => handleOpenChange(false)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="submit"
+                  disabled={submitting}
+                  className="bg-brand text-brand-foreground hover:bg-brand/90"
+                >
+                  {submitting ? 'Submitting…' : 'Submit for approval'}
+                </Button>
+              </DialogFooter>
+            </form>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/community/gallerySessionContext.ts
+++ b/src/components/community/gallerySessionContext.ts
@@ -1,0 +1,10 @@
+'use client'
+import { createContext, useContext } from 'react'
+export type Session = { isSignedIn: boolean; likedProjectIds: string[] }
+export const SessionContext = createContext<{
+  ready: boolean
+  setSession: (session: Session) => void
+} | null>(null)
+export function useGallerySessionReady() {
+  return useContext(SessionContext)?.ready ?? true
+}

--- a/src/components/digest/DigestEditionView.tsx
+++ b/src/components/digest/DigestEditionView.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react'
 import Link from 'next/link'
 import TweetCard from '@/components/TweetCard'
 import { DigestDaySelector } from '@/components/digest/DigestDaySelector'
@@ -31,6 +32,7 @@ export function DigestEditionView({
   likedByViewer = false,
   isSignedIn = false,
   commentCount = 0,
+  slots = {},
 }: {
   edition: DigestEdition
   archive: DigestCalendarDay[]
@@ -39,6 +41,9 @@ export function DigestEditionView({
   likedByViewer?: boolean
   isSignedIn?: boolean
   commentCount?: number
+  slots?: Partial<
+    Record<'likes' | 'admin' | 'calendar' | 'recent' | 'comments', ReactNode>
+  >
 }) {
   const content = edition.content
   const returnTo = `/digest/${edition.digestDate}`
@@ -65,23 +70,25 @@ export function DigestEditionView({
               <div className={sectionLabel}>What Happened Yesterday</div>
             </div>
             <div className="flex flex-wrap items-center justify-end gap-3">
-              {edition.isPreview ? null : (
-                <DigestLikeButton
-                  editionId={edition.id}
-                  initialCount={likeCount}
-                  initialLiked={likedByViewer}
-                  isSignedIn={isSignedIn}
-                />
-              )}
+              {slots.likes ??
+                (edition.isPreview ? null : (
+                  <DigestLikeButton
+                    editionId={edition.id}
+                    initialCount={likeCount}
+                    initialLiked={likedByViewer}
+                    isSignedIn={isSignedIn}
+                  />
+                ))}
               <DigestSubscribeButton />
-              {isAdmin ? (
-                <Link
-                  href="/admin/digest"
-                  className="rounded-full bg-zinc-100 px-3 py-1 text-[11px] font-bold uppercase tracking-[0.12em] text-brand transition-colors hover:bg-blue-100 hover:text-blue-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand dark:bg-zinc-800 dark:hover:bg-blue-950 dark:hover:text-blue-100"
-                >
-                  Editorial lab →
-                </Link>
-              ) : null}
+              {slots.admin ??
+                (isAdmin ? (
+                  <Link
+                    href="/admin/digest"
+                    className="rounded-full bg-zinc-100 px-3 py-1 text-[11px] font-bold uppercase tracking-[0.12em] text-brand transition-colors hover:bg-blue-100 hover:text-blue-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand dark:bg-zinc-800 dark:hover:bg-blue-950 dark:hover:text-blue-100"
+                  >
+                    Editorial lab →
+                  </Link>
+                ) : null)}
               <div
                 className={`text-[11.5px] uppercase tracking-[0.18em] ${MUTED}`}
               >
@@ -216,11 +223,13 @@ export function DigestEditionView({
           </div>
 
           <aside className="mt-2 border-zinc-200 pt-10 dark:border-zinc-800 lg:sticky lg:top-24 lg:mt-0 lg:border-l lg:py-0 lg:pl-10">
-            <DigestDaySelector
-              currentDate={edition.digestDate}
-              availableDays={archive}
-              variant="editorial"
-            />
+            {slots.calendar ?? (
+              <DigestDaySelector
+                currentDate={edition.digestDate}
+                availableDays={archive}
+                variant="editorial"
+              />
+            )}
 
             <section className="mt-8 border-t border-zinc-200 pt-7 dark:border-zinc-800">
               <h2 className="text-[19px] font-semibold" style={SERIF}>
@@ -267,32 +276,12 @@ export function DigestEditionView({
               </PostHogLink>
             </section>
 
-            {archive.length > 1 ? (
-              <section className="mt-8 border-t border-zinc-200 pt-7 dark:border-zinc-800">
-                <h2 className="text-[19px] font-semibold" style={SERIF}>
-                  Recent editions
-                </h2>
-                <div className="mt-4 space-y-2">
-                  {archive
-                    .filter((item) => item.digestDate !== edition.digestDate)
-                    .slice(0, 6)
-                    .map((item) => (
-                      <PostHogLink
-                        key={item.digestDate}
-                        href={`/digest/${item.digestDate}`}
-                        eventName="digest_action"
-                        eventProperties={{
-                          action: 'recent_edition_opened',
-                          surface: 'recent_editions',
-                        }}
-                        className="block text-sm text-muted-foreground hover:text-brand"
-                      >
-                        {longDate(item.digestDate)}
-                      </PostHogLink>
-                    ))}
-                </div>
-              </section>
-            ) : null}
+            {slots.recent ?? (
+              <DigestRecentEditions
+                archive={archive}
+                currentDate={edition.digestDate}
+              />
+            )}
           </aside>
         </div>
 
@@ -302,14 +291,54 @@ export function DigestEditionView({
             : 'Curated automatically from the previous 24 hours of archive bangers and reviewed in the editorial lab before publication.'}
         </footer>
 
-        {edition.isPreview ? null : (
-          <DigestComments
-            editionId={edition.id}
-            initialCount={commentCount}
-            isSignedIn={isSignedIn}
-          />
-        )}
+        {slots.comments ??
+          (edition.isPreview ? null : (
+            <DigestComments
+              editionId={edition.id}
+              initialCount={commentCount}
+              isSignedIn={isSignedIn}
+            />
+          ))}
       </article>
     </main>
+  )
+}
+
+export function DigestRecentEditions({
+  archive,
+  currentDate,
+}: {
+  archive: DigestCalendarDay[]
+  currentDate: string
+}) {
+  return (
+    <>
+      {archive.length > 1 ? (
+        <section className="mt-8 border-t border-zinc-200 pt-7 dark:border-zinc-800">
+          <h2 className="text-[19px] font-semibold" style={SERIF}>
+            Recent editions
+          </h2>
+          <div className="mt-4 space-y-2">
+            {archive
+              .filter((item) => item.digestDate !== currentDate)
+              .slice(0, 6)
+              .map((item) => (
+                <PostHogLink
+                  key={item.digestDate}
+                  href={`/digest/${item.digestDate}`}
+                  eventName="digest_action"
+                  eventProperties={{
+                    action: 'recent_edition_opened',
+                    surface: 'recent_editions',
+                  }}
+                  className="block text-sm text-muted-foreground hover:text-brand"
+                >
+                  {longDate(item.digestDate)}
+                </PostHogLink>
+              ))}
+          </div>
+        </section>
+      ) : null}
+    </>
   )
 }

--- a/src/components/digest/PublishedDigestView.tsx
+++ b/src/components/digest/PublishedDigestView.tsx
@@ -1,0 +1,135 @@
+import { Suspense } from 'react'
+import Link from 'next/link'
+import { checkIsAdmin } from '@/app/admin/data'
+import { getCurrentUser } from '@/lib/portal/auth'
+import {
+  getDigestCommentCount,
+  getDigestLikeState,
+  listPublishedDigestDays,
+} from '@/lib/digest/data'
+import type { DigestEdition, DigestCalendarDay } from '@/lib/digest/types'
+import { DigestEditionView, DigestRecentEditions } from './DigestEditionView'
+import { DigestDaySelector } from './DigestDaySelector'
+import { DigestLikeButton } from './DigestLikeButton'
+import { DigestComments } from './DigestComments'
+import { SectionReady } from '@/components/PagePerformance'
+
+async function Likes({ edition }: { edition: DigestEdition }) {
+  const [likes, user] = await Promise.all([
+    getDigestLikeState(edition),
+    getCurrentUser(),
+  ])
+  return (
+    <DigestLikeButton
+      editionId={edition.id}
+      initialCount={likes.count}
+      initialLiked={likes.likedByViewer}
+      isSignedIn={Boolean(user)}
+    />
+  )
+}
+
+async function AdminLink() {
+  if (!(await checkIsAdmin())) return null
+  return (
+    <Link
+      href="/admin/digest"
+      className="rounded-full bg-zinc-100 px-3 py-1 text-[11px] font-bold uppercase tracking-[0.12em] text-brand transition-colors hover:bg-blue-100 hover:text-blue-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand dark:bg-zinc-800 dark:hover:bg-blue-950 dark:hover:text-blue-100"
+    >
+      Editorial lab →
+    </Link>
+  )
+}
+
+async function Calendar({
+  archive,
+  date,
+  recent = false,
+}: {
+  archive: Promise<DigestCalendarDay[]>
+  date: string
+  recent?: boolean
+}) {
+  const days = await archive
+  return recent ? (
+    <DigestRecentEditions archive={days} currentDate={date} />
+  ) : (
+    <DigestDaySelector
+      currentDate={date}
+      availableDays={days}
+      variant="editorial"
+    />
+  )
+}
+
+async function Comments({ edition }: { edition: DigestEdition }) {
+  const [count, user] = await Promise.all([
+    getDigestCommentCount(edition),
+    getCurrentUser(),
+  ])
+  return (
+    <DigestComments
+      editionId={edition.id}
+      initialCount={count}
+      isSignedIn={Boolean(user)}
+    />
+  )
+}
+
+/** Article content never waits for viewer controls, counts, or calendar history. */
+export function PublishedDigestView({ edition }: { edition: DigestEdition }) {
+  const archive = listPublishedDigestDays()
+  return (
+    <>
+      <SectionReady section="digest_article" />
+      <DigestEditionView
+        edition={edition}
+        archive={[]}
+        slots={{
+          likes: edition.isPreview ? (
+            <></>
+          ) : (
+            <Suspense
+              fallback={
+                <span
+                  aria-label="Loading likes"
+                  className="inline-block h-7 w-14 animate-pulse rounded-full bg-muted"
+                />
+              }
+            >
+              <Likes edition={edition} />
+            </Suspense>
+          ),
+          admin: (
+            <Suspense fallback={null}>
+              <AdminLink />
+            </Suspense>
+          ),
+          calendar: (
+            <Suspense
+              fallback={
+                <div role="status" className="h-72 animate-pulse bg-muted">
+                  Loading calendar…
+                </div>
+              }
+            >
+              <Calendar archive={archive} date={edition.digestDate} />
+            </Suspense>
+          ),
+          recent: (
+            <Suspense fallback={null}>
+              <Calendar archive={archive} date={edition.digestDate} recent />
+            </Suspense>
+          ),
+          comments: edition.isPreview ? (
+            <></>
+          ) : (
+            <Suspense fallback={<p role="status">Loading discussion…</p>}>
+              <Comments edition={edition} />
+            </Suspense>
+          ),
+        }}
+      />
+    </>
+  )
+}

--- a/src/components/portal/Portal.tsx
+++ b/src/components/portal/Portal.tsx
@@ -1,7 +1,8 @@
 'use client'
 
+import { usePortalStream } from './usePortalStream'
 import type { ReactNode } from 'react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useMemo, useState } from 'react'
 import Link from 'next/link'
 import { FaDatabase, FaExternalLinkAlt, FaUsers } from 'react-icons/fa'
 import {
@@ -13,11 +14,6 @@ import {
 import { PORTAL_ARTICLES } from './articles'
 import { CARD, MUTED, FAINT, BODY, SERIF } from './styles'
 import TweetCard from '@/components/TweetCard'
-import { PORTAL_STREAM_POLL_INTERVAL_MS } from './live'
-import {
-  comparePortalTweetChronology,
-  selectHomepageStream,
-} from '@/lib/portal/stream'
 import { BANGERS_ALL_TIME_HREF, BANGERS_WEEK_HREF } from '@/lib/portal/bangers'
 import { capturePostHogEvent } from '@/lib/posthog'
 import type { DigestPreview } from '@/lib/digest/types'
@@ -66,34 +62,6 @@ const fmtDelta = (term: TermWeek) => {
   if (term.status === 'new') return 'new'
   if (term.status === 'inactive' || term.deltaPct === null) return '—'
   return `${term.deltaPct >= 0 ? '+' : '−'}${Math.abs(term.deltaPct)}%`
-}
-
-function compareTweetIds(left: string, right: string): number {
-  return left.length - right.length || left.localeCompare(right)
-}
-
-function newestCursor(tweets: PortalTweet[]) {
-  return tweets.reduce<{ observedAt: string; id: string } | null>(
-    (latest, tweet) => {
-      if (!latest) return { observedAt: tweet.observedAt, id: tweet.id }
-      const timeDiff =
-        new Date(tweet.observedAt).getTime() -
-        new Date(latest.observedAt).getTime()
-      if (
-        timeDiff > 0 ||
-        (timeDiff === 0 && compareTweetIds(tweet.id, latest.id) > 0)
-      ) {
-        return { observedAt: tweet.observedAt, id: tweet.id }
-      }
-      return latest
-    },
-    null,
-  )
-}
-
-function oldestPageCursor(tweets: PortalTweet[]) {
-  const oldest = [...tweets].sort(comparePortalTweetChronology).at(-1)
-  return oldest ? { createdAt: oldest.createdAt, id: oldest.id } : null
 }
 
 function PanelHeader({
@@ -725,200 +693,6 @@ export function PortalNotes({
       </div>
     </div>
   )
-}
-
-function usePortalStream(
-  data: Pick<PortalData, 'initialStream'> & {
-    failures: Pick<PortalData['failures'], 'initialStream'>
-  },
-  view: PortalView,
-) {
-  // ---- live stream state -------------------------------------------------
-  const [visible, setVisible] = useState<PortalTweet[]>(data.initialStream)
-  const [streamUnavailable, setStreamUnavailable] = useState(
-    data.failures.initialStream,
-  )
-  const seenIds = useRef<Set<string>>(
-    new Set(data.initialStream.map((t) => t.id)),
-  )
-  const updateCursor = useRef(newestCursor(data.initialStream))
-  const pageCursor = useRef(oldestPageCursor(data.initialStream))
-  const loadingMoreRef = useRef(false)
-  const loadMoreTarget = useRef<HTMLDivElement>(null)
-  const [hasMore, setHasMore] = useState(
-    !data.failures.initialStream && data.initialStream.length >= 30,
-  )
-  const [isLoadingMore, setIsLoadingMore] = useState(false)
-
-  const loadMore = useCallback(async () => {
-    if (
-      view !== 'stream' ||
-      !hasMore ||
-      loadingMoreRef.current ||
-      !pageCursor.current
-    ) {
-      return
-    }
-    loadingMoreRef.current = true
-    setIsLoadingMore(true)
-    try {
-      const params = new URLSearchParams({
-        before: pageCursor.current.createdAt,
-        beforeId: pageCursor.current.id,
-      })
-      const res = await fetch(`/api/portal/stream?${params.toString()}`)
-      if (!res.ok) return
-      const {
-        tweets,
-        nextCursor,
-        hasMore: nextHasMore,
-      } = (await res.json()) as {
-        tweets: PortalTweet[]
-        nextCursor: { createdAt: string; id: string } | null
-        hasMore: boolean
-      }
-      const older = tweets.filter((tweet) => !seenIds.current.has(tweet.id))
-      older.forEach((tweet) => seenIds.current.add(tweet.id))
-      if (older.length > 0) {
-        setVisible((current) =>
-          [...current, ...older].sort(comparePortalTweetChronology),
-        )
-      }
-      pageCursor.current = nextCursor
-      const canLoadMore = nextHasMore && nextCursor !== null
-      setHasMore(canLoadMore)
-      capturePostHogEvent('portal_stream_loaded_more', {
-        loaded_tweet_count: older.length,
-        has_more: canLoadMore,
-      })
-    } catch {
-      // Keep the sentinel active so scrolling can retry after a network hiccup.
-    } finally {
-      loadingMoreRef.current = false
-      setIsLoadingMore(false)
-    }
-  }, [hasMore, view])
-
-  useEffect(() => {
-    const controller = new AbortController()
-    let polling = false
-    const applyHead = (tweets: PortalTweet[], nextHasMore: boolean) => {
-      const head = [...tweets].sort(comparePortalTweetChronology)
-      updateCursor.current = newestCursor(head)
-      pageCursor.current = oldestPageCursor(head)
-      if (view === 'stream') {
-        setHasMore(nextHasMore && pageCursor.current !== null)
-      }
-      setVisible((current) => {
-        const next =
-          view === 'home'
-            ? selectHomepageStream([...head, ...current], 30)
-            : head
-        seenIds.current = new Set(next.map((tweet) => tweet.id))
-        return next
-      })
-    }
-    const fetchHead = async () => {
-      const response = await fetch('/api/portal/stream', {
-        signal: controller.signal,
-        cache: 'no-store',
-      })
-      if (!response.ok) return false
-      const payload = (await response.json()) as {
-        tweets: PortalTweet[]
-        hasMore?: boolean
-      }
-      applyHead(payload.tweets, payload.hasMore ?? false)
-      return true
-    }
-    const poll = async () => {
-      if (polling) return
-      polling = true
-      try {
-        const params = new URLSearchParams()
-        const requestedHead = updateCursor.current === null
-        if (updateCursor.current) {
-          params.set('after', updateCursor.current.observedAt)
-          params.set('afterId', updateCursor.current.id)
-        }
-        const res = await fetch(`/api/portal/stream?${params.toString()}`, {
-          signal: controller.signal,
-          cache: 'no-store',
-        })
-        if (!res.ok) {
-          setStreamUnavailable(true)
-          return
-        }
-        setStreamUnavailable(false)
-        const {
-          tweets,
-          updateCursor: nextUpdateCursor,
-          hasMore: nextHasMore,
-          backlogTruncated,
-        } = (await res.json()) as {
-          tweets: PortalTweet[]
-          updateCursor?: { observedAt: string; id: string } | null
-          hasMore?: boolean
-          backlogTruncated?: boolean
-        }
-        if (requestedHead) {
-          applyHead(tweets, nextHasMore ?? false)
-          return
-        }
-        if (backlogTruncated) {
-          if (!(await fetchHead())) setStreamUnavailable(true)
-          return
-        }
-        const responseCursor = nextUpdateCursor ?? newestCursor(tweets)
-        if (responseCursor) updateCursor.current = responseCursor
-        const fresh = tweets
-          .filter((t) => !seenIds.current.has(t.id))
-          .sort(
-            (a, b) =>
-              new Date(a.observedAt).getTime() -
-                new Date(b.observedAt).getTime() || compareTweetIds(a.id, b.id),
-          )
-        if (fresh.length > 0) {
-          fresh.forEach((t) => seenIds.current.add(t.id))
-          setVisible((current) =>
-            view === 'home'
-              ? selectHomepageStream([...fresh, ...current], 30)
-              : [...fresh, ...current].sort(comparePortalTweetChronology),
-          )
-        }
-      } catch {
-        if (!controller.signal.aborted) setStreamUnavailable(true)
-        // network hiccup; try again next poll
-      } finally {
-        polling = false
-      }
-    }
-    void poll()
-    const interval = window.setInterval(
-      () => void poll(),
-      PORTAL_STREAM_POLL_INTERVAL_MS,
-    )
-    return () => {
-      controller.abort()
-      window.clearInterval(interval)
-    }
-  }, [view])
-
-  useEffect(() => {
-    if (view !== 'stream' || !hasMore) return
-    const target = loadMoreTarget.current
-    if (!target) return
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) void loadMore()
-      },
-      { rootMargin: '600px 0px' },
-    )
-    observer.observe(target)
-    return () => observer.disconnect()
-  }, [hasMore, loadMore, view])
-
-  return { visible, streamUnavailable, loadMoreTarget, isLoadingMore, hasMore }
 }
 
 export function HomePortalLayout({

--- a/src/components/portal/StreamFeed.tsx
+++ b/src/components/portal/StreamFeed.tsx
@@ -1,0 +1,60 @@
+'use client'
+import type { PortalTweet } from '@/lib/portal/types'
+import TweetCard from '@/components/TweetCard'
+import { useReportSectionReady } from '@/components/PagePerformance'
+import { usePortalStream } from './usePortalStream'
+import { CARD, MUTED } from './styles'
+export function StreamFeed({
+  tweets,
+  failed,
+}: {
+  tweets: PortalTweet[]
+  failed: boolean
+}) {
+  const { visible, streamUnavailable, loadMoreTarget, isLoadingMore, hasMore } =
+    usePortalStream(
+      { initialStream: tweets, failures: { initialStream: failed } },
+      'stream',
+    )
+  useReportSectionReady('stream_feed', !streamUnavailable)
+  return (
+    <>
+      {' '}
+      <div className={`${CARD} overflow-hidden`}>
+        {visible.map((t, i) => (
+          <TweetCard
+            key={t.id}
+            tweet={t}
+            animate={i === 0}
+            showArchivedBadge
+            origin="stream"
+            returnTo="/stream"
+          />
+        ))}
+        {visible.length === 0 && streamUnavailable && (
+          <p role="status" className="p-8 text-center">
+            Live stream is temporarily unavailable.
+          </p>
+        )}
+        {visible.length === 0 && !streamUnavailable && (
+          <div className={`px-4 py-8 text-center text-[13px] ${MUTED}`}>
+            Waiting for the firehose…
+          </div>
+        )}
+      </div>
+      <div
+        ref={loadMoreTarget}
+        aria-live="polite"
+        className={`py-5 text-center text-[12.5px] ${MUTED}`}
+      >
+        {isLoadingMore
+          ? 'Loading older tweets…'
+          : hasMore
+            ? 'Scroll for older tweets'
+            : visible.length > 0
+              ? 'You’ve reached the end.'
+              : ''}
+      </div>
+    </>
+  )
+}

--- a/src/components/portal/usePortalStream.ts
+++ b/src/components/portal/usePortalStream.ts
@@ -1,0 +1,231 @@
+'use client'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { PortalData, PortalTweet } from '@/lib/portal/types'
+import {
+  comparePortalTweetChronology,
+  selectHomepageStream,
+} from '@/lib/portal/stream'
+import { PORTAL_STREAM_POLL_INTERVAL_MS } from './live'
+import { capturePostHogEvent } from '@/lib/posthog'
+type PortalView = 'home' | 'stream'
+function compareTweetIds(left: string, right: string): number {
+  return left.length - right.length || left.localeCompare(right)
+}
+
+function newestCursor(tweets: PortalTweet[]) {
+  return tweets.reduce<{ observedAt: string; id: string } | null>(
+    (latest, tweet) => {
+      if (!latest) return { observedAt: tweet.observedAt, id: tweet.id }
+      const timeDiff =
+        new Date(tweet.observedAt).getTime() -
+        new Date(latest.observedAt).getTime()
+      if (
+        timeDiff > 0 ||
+        (timeDiff === 0 && compareTweetIds(tweet.id, latest.id) > 0)
+      ) {
+        return { observedAt: tweet.observedAt, id: tweet.id }
+      }
+      return latest
+    },
+    null,
+  )
+}
+
+function oldestPageCursor(tweets: PortalTweet[]) {
+  const oldest = [...tweets].sort(comparePortalTweetChronology).at(-1)
+  return oldest ? { createdAt: oldest.createdAt, id: oldest.id } : null
+}
+
+export function usePortalStream(
+  data: Pick<PortalData, 'initialStream'> & {
+    failures: Pick<PortalData['failures'], 'initialStream'>
+  },
+  view: PortalView,
+) {
+  // ---- live stream state -------------------------------------------------
+  const [visible, setVisible] = useState<PortalTweet[]>(data.initialStream)
+  const [streamUnavailable, setStreamUnavailable] = useState(
+    data.failures.initialStream,
+  )
+  const seenIds = useRef<Set<string>>(
+    new Set(data.initialStream.map((t) => t.id)),
+  )
+  const updateCursor = useRef(newestCursor(data.initialStream))
+  const pageCursor = useRef(oldestPageCursor(data.initialStream))
+  const loadingMoreRef = useRef(false)
+  const loadMoreTarget = useRef<HTMLDivElement>(null)
+  const [hasMore, setHasMore] = useState(
+    !data.failures.initialStream && data.initialStream.length >= 30,
+  )
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+
+  const loadMore = useCallback(async () => {
+    if (
+      view !== 'stream' ||
+      !hasMore ||
+      loadingMoreRef.current ||
+      !pageCursor.current
+    ) {
+      return
+    }
+    loadingMoreRef.current = true
+    setIsLoadingMore(true)
+    try {
+      const params = new URLSearchParams({
+        before: pageCursor.current.createdAt,
+        beforeId: pageCursor.current.id,
+      })
+      const res = await fetch(`/api/portal/stream?${params.toString()}`)
+      if (!res.ok) return
+      const {
+        tweets,
+        nextCursor,
+        hasMore: nextHasMore,
+      } = (await res.json()) as {
+        tweets: PortalTweet[]
+        nextCursor: { createdAt: string; id: string } | null
+        hasMore: boolean
+      }
+      const older = tweets.filter((tweet) => !seenIds.current.has(tweet.id))
+      older.forEach((tweet) => seenIds.current.add(tweet.id))
+      if (older.length > 0) {
+        setVisible((current) =>
+          [...current, ...older].sort(comparePortalTweetChronology),
+        )
+      }
+      pageCursor.current = nextCursor
+      const canLoadMore = nextHasMore && nextCursor !== null
+      setHasMore(canLoadMore)
+      capturePostHogEvent('portal_stream_loaded_more', {
+        loaded_tweet_count: older.length,
+        has_more: canLoadMore,
+      })
+    } catch {
+      // Keep the sentinel active so scrolling can retry after a network hiccup.
+    } finally {
+      loadingMoreRef.current = false
+      setIsLoadingMore(false)
+    }
+  }, [hasMore, view])
+
+  useEffect(() => {
+    const controller = new AbortController()
+    let polling = false
+    const applyHead = (tweets: PortalTweet[], nextHasMore: boolean) => {
+      const head = [...tweets].sort(comparePortalTweetChronology)
+      updateCursor.current = newestCursor(head)
+      pageCursor.current = oldestPageCursor(head)
+      if (view === 'stream') {
+        setHasMore(nextHasMore && pageCursor.current !== null)
+      }
+      setVisible((current) => {
+        const next =
+          view === 'home'
+            ? selectHomepageStream([...head, ...current], 30)
+            : head
+        seenIds.current = new Set(next.map((tweet) => tweet.id))
+        return next
+      })
+    }
+    const fetchHead = async () => {
+      const response = await fetch('/api/portal/stream', {
+        signal: controller.signal,
+        cache: 'no-store',
+      })
+      if (!response.ok) return false
+      const payload = (await response.json()) as {
+        tweets: PortalTweet[]
+        hasMore?: boolean
+      }
+      applyHead(payload.tweets, payload.hasMore ?? false)
+      return true
+    }
+    const poll = async () => {
+      if (polling) return
+      polling = true
+      try {
+        const params = new URLSearchParams()
+        const requestedHead = updateCursor.current === null
+        if (updateCursor.current) {
+          params.set('after', updateCursor.current.observedAt)
+          params.set('afterId', updateCursor.current.id)
+        }
+        const res = await fetch(`/api/portal/stream?${params.toString()}`, {
+          signal: controller.signal,
+          cache: 'no-store',
+        })
+        if (!res.ok) {
+          setStreamUnavailable(true)
+          return
+        }
+        setStreamUnavailable(false)
+        const {
+          tweets,
+          updateCursor: nextUpdateCursor,
+          hasMore: nextHasMore,
+          backlogTruncated,
+        } = (await res.json()) as {
+          tweets: PortalTweet[]
+          updateCursor?: { observedAt: string; id: string } | null
+          hasMore?: boolean
+          backlogTruncated?: boolean
+        }
+        if (requestedHead) {
+          applyHead(tweets, nextHasMore ?? false)
+          return
+        }
+        if (backlogTruncated) {
+          if (!(await fetchHead())) setStreamUnavailable(true)
+          return
+        }
+        const responseCursor = nextUpdateCursor ?? newestCursor(tweets)
+        if (responseCursor) updateCursor.current = responseCursor
+        const fresh = tweets
+          .filter((t) => !seenIds.current.has(t.id))
+          .sort(
+            (a, b) =>
+              new Date(a.observedAt).getTime() -
+                new Date(b.observedAt).getTime() || compareTweetIds(a.id, b.id),
+          )
+        if (fresh.length > 0) {
+          fresh.forEach((t) => seenIds.current.add(t.id))
+          setVisible((current) =>
+            view === 'home'
+              ? selectHomepageStream([...fresh, ...current], 30)
+              : [...fresh, ...current].sort(comparePortalTweetChronology),
+          )
+        }
+      } catch {
+        if (!controller.signal.aborted) setStreamUnavailable(true)
+        // network hiccup; try again next poll
+      } finally {
+        polling = false
+      }
+    }
+    void poll()
+    const interval = window.setInterval(
+      () => void poll(),
+      PORTAL_STREAM_POLL_INTERVAL_MS,
+    )
+    return () => {
+      controller.abort()
+      window.clearInterval(interval)
+    }
+  }, [view])
+
+  useEffect(() => {
+    if (view !== 'stream' || !hasMore) return
+    const target = loadMoreTarget.current
+    if (!target) return
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) void loadMore()
+      },
+      { rootMargin: '600px 0px' },
+    )
+    observer.observe(target)
+    return () => observer.disconnect()
+  }, [hasMore, loadMore, view])
+
+  return { visible, streamUnavailable, loadMoreTarget, isLoadingMore, hasMore }
+}

--- a/src/lib/digest/data.ts
+++ b/src/lib/digest/data.ts
@@ -1,3 +1,4 @@
+import { cache } from 'react'
 import { cookies } from 'next/headers'
 import type { Json } from '@/database-types'
 import {
@@ -172,7 +173,7 @@ export async function loadDigestLabState(runId?: string) {
   }
 }
 
-export async function getPublishedDigest(
+async function readPublishedDigest(
   digestDate?: string,
 ): Promise<DigestEdition | null> {
   const preview = getPreviewDigestEdition(digestDate)
@@ -192,6 +193,10 @@ export async function getPublishedDigest(
   }
   return data ? mapDigestEdition(data) : getPreviewDigestEdition(digestDate)
 }
+
+// Next supplies request-local cache in RSC; plain React 18 test runtimes do not.
+const requestCache = cache ?? ((loader: typeof readPublishedDigest) => loader)
+export const getPublishedDigest = requestCache(readPublishedDigest)
 
 export interface DigestLikeState {
   count: number

--- a/src/lib/navbarPageLoading.test.tsx
+++ b/src/lib/navbarPageLoading.test.tsx
@@ -1,0 +1,111 @@
+import {
+  Children,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+} from 'react'
+import DigestPage from '@/app/digest/page'
+import CommunityPage from '@/app/community/page'
+import StreamPage from '@/app/stream/page'
+import TrendsPage from '@/app/trends/page'
+import { PublishedDigestView } from '@/components/digest/PublishedDigestView'
+import { DigestEditionView } from '@/components/digest/DigestEditionView'
+import { GallerySession } from '@/components/community/GallerySession'
+import { StreamFeed } from '@/components/portal/StreamFeed'
+import {
+  getPublishedDigest,
+  listPublishedDigestDays,
+  getDigestLikeState,
+} from '@/lib/digest/data'
+import { getCurrentUser, getIsMember } from '@/lib/portal/auth'
+import { loadPublishedCommunityProjects } from '@/lib/communityProjectDatabase'
+import { getPortalTrendSnapshot, startStreamData } from '@/lib/portal/data'
+import { AUGUST_11_MOCK_DIGEST } from '@/lib/digest/mock'
+
+jest.mock('@/lib/digest/data', () => ({
+  getPublishedDigest: jest.fn(),
+  listPublishedDigestDays: jest.fn(),
+  getDigestLikeState: jest.fn(),
+  getDigestCommentCount: jest.fn(),
+}))
+jest.mock('@/lib/portal/auth', () => ({
+  getCurrentUser: jest.fn(),
+  getIsMember: jest.fn(),
+}))
+jest.mock('@/app/admin/data', () => ({ checkIsAdmin: jest.fn() }))
+jest.mock('@/lib/communityProjectDatabase', () => ({
+  loadPublishedCommunityProjects: jest.fn(),
+  loadCommunityProjectLikesForUser: jest.fn(),
+}))
+jest.mock('@/lib/portal/data', () => ({
+  startStreamData: jest.fn(),
+  getPortalTrendSnapshot: jest.fn(),
+  loadPortalComponentData: jest.fn(),
+}))
+jest.mock('next/navigation', () => ({
+  redirect: () => {
+    throw new Error('redirect')
+  },
+}))
+
+jest.mock('@/components/digest/DigestMarkdown', () => ({
+  DigestMarkdown: () => null,
+}))
+
+const pending = new Promise<never>(() => {})
+function find(
+  node: ReactNode,
+  predicate: (element: ReactElement) => boolean,
+): ReactElement | undefined {
+  if (!isValidElement<{ children?: ReactNode }>(node)) return undefined
+  if (predicate(node)) return node
+  for (const child of Children.toArray(node.props.children)) {
+    const result = find(child, predicate)
+    if (result) return result
+  }
+}
+beforeEach(() => jest.clearAllMocks())
+
+test('published article is available while calendar and viewer reads remain pending', async () => {
+  jest.mocked(getPublishedDigest).mockResolvedValue(AUGUST_11_MOCK_DIGEST)
+  jest.mocked(listPublishedDigestDays).mockReturnValue(pending)
+  jest.mocked(getCurrentUser).mockReturnValue(pending)
+  const page = await DigestPage()
+  expect(page.type).toBe(PublishedDigestView)
+  const view = PublishedDigestView(page.props)
+  const article = find(view, (node) => node.type === DigestEditionView)!
+  expect(article.props.edition.content).toBe(AUGUST_11_MOCK_DIGEST.content)
+  expect(getDigestLikeState).not.toHaveBeenCalled()
+  expect(getCurrentUser).not.toHaveBeenCalled()
+})
+
+test('gallery catalog does not wait for viewer authentication', async () => {
+  jest.mocked(getCurrentUser).mockReturnValue(pending)
+  jest.mocked(loadPublishedCommunityProjects).mockResolvedValue([])
+  const page = await CommunityPage()
+  expect(page.type).toBe(GallerySession)
+  expect(page.props.projects).toEqual([])
+})
+
+test('live tweets resolve while optional corpus totals remain pending', async () => {
+  jest.mocked(startStreamData).mockReturnValue({
+    tweets: Promise.resolve({ data: [], failed: false }),
+    stats: pending,
+  })
+  const page = StreamPage()
+  const feed = find(
+    page,
+    (node) =>
+      node.props.result ===
+      jest.mocked(startStreamData).mock.results[0].value.tweets,
+  )!
+  const result = await (feed.type as Function)(feed.props)
+  expect(result.type).toBe(StreamFeed)
+  expect(result.props.failed).toBe(false)
+})
+
+test('signed-out Trends still redirects before requesting analytical data', async () => {
+  jest.mocked(getIsMember).mockResolvedValue(false)
+  await expect(TrendsPage({})).rejects.toThrow('redirect')
+  expect(getPortalTrendSnapshot).not.toHaveBeenCalled()
+})

--- a/src/lib/portal/analytics.test.ts
+++ b/src/lib/portal/analytics.test.ts
@@ -557,3 +557,18 @@ test('homepage weekly snapshot makes no historical corpus requests', async () =>
     expect(call[1].get('bucket')).toBe('day')
   }
 })
+
+test('explorer snapshot requests historical charts without twelve unused weekly queries', async () => {
+  const fetcher = jest.fn(async () => ({ data: [] }))
+  const result = await fetchPortalTrends(
+    new Date('2026-09-06T00:00:00Z'),
+    fetcher as unknown as AnalyticsFetcher,
+    true,
+    false,
+  )
+  expect(result.series.length).toBeGreaterThan(0)
+  expect(result.weekly).toEqual([])
+  expect(fetcher).toHaveBeenCalledTimes(result.series.length)
+  for (const call of (fetcher as jest.Mock).mock.calls)
+    expect(call[1].get('bucket')).toBe('year')
+})

--- a/src/lib/portal/analytics.ts
+++ b/src/lib/portal/analytics.ts
@@ -783,6 +783,7 @@ export async function fetchPortalTrends(
   now = new Date(),
   fetcher: AnalyticsFetcher = fetchAnalyticsGatewayJson,
   includeHistory = true,
+  includeWeekly = true,
 ): Promise<PortalTrends> {
   const currentYear = now.getUTCFullYear()
   const years = Array.from(
@@ -799,13 +800,14 @@ export async function fetchPortalTrends(
   const weeklyTo = daysBefore(today, -1)
 
   const chartTerms = includeHistory ? CHART_TERMS : []
+  const weeklyTerms = includeWeekly ? WATCHLIST : []
   const jobs: Array<() => Promise<ClickHouseTrendResponse>> = [
     ...chartTerms.map(
       ({ term }) =>
         () =>
           fetchTrend(term, 'year', yearlyFrom, yearlyTo, fetcher),
     ),
-    ...WATCHLIST.map(
+    ...weeklyTerms.map(
       (term) => () =>
         fetchTrend(
           term,
@@ -843,7 +845,7 @@ export async function fetchPortalTrends(
     }
   })
 
-  const weekly: TermWeek[] = WATCHLIST.map((term, index) => {
+  const weekly: TermWeek[] = weeklyTerms.map((term, index) => {
     let last7 = 0
     let prev7 = 0
     for (const row of weeklyResponses[index].data) {

--- a/src/lib/portal/data.ts
+++ b/src/lib/portal/data.ts
@@ -732,7 +732,9 @@ const getCachedExplorerTrends = unstable_cache(
   async (_sourceKey: string) =>
     fetchPortalTrends(new Date(), undefined, true, false),
   ['portal-explorer-trends-v1'],
-  { revalidate: 300 },
+  // Preserve the historical seed's daily refresh; query pruning must not
+  // increase how often corpus-wide analytical queries run.
+  { revalidate: 86_400 },
 )
 
 const getCachedTrendsSnapshot = unstable_cache(

--- a/src/lib/portal/data.ts
+++ b/src/lib/portal/data.ts
@@ -728,6 +728,13 @@ async function fetchPortalJoinedThisWeek(): Promise<number> {
 
 // Arguments participate in the cache key, keeping staging/prod sources and
 // deployment environments isolated even when the Data Cache survives deploys.
+const getCachedExplorerTrends = unstable_cache(
+  async (_sourceKey: string) =>
+    fetchPortalTrends(new Date(), undefined, true, false),
+  ['portal-explorer-trends-v1'],
+  { revalidate: 300 },
+)
+
 const getCachedTrendsSnapshot = unstable_cache(
   async (_sourceKey: string) => fetchPortalTrends(),
   ['portal-trends-snapshot-v1'],
@@ -955,7 +962,7 @@ export async function getInitialPortalBangersPage(
 
 /** Cached corpus-wide seed series for the authenticated trends explorer. */
 export async function getPortalTrendSnapshot(): Promise<PortalTrends> {
-  return getCachedTrendsSnapshot(portalDataSourceKey())
+  return getCachedExplorerTrends(portalDataSourceKey())
 }
 
 export async function getPortalData(
@@ -1179,3 +1186,19 @@ export function startHomepageData() {
 }
 
 export type HomepageData = ReturnType<typeof startHomepageData>
+
+/** Public feed and optional total have independent failure/streaming boundaries. */
+export function startStreamData() {
+  return {
+    tweets: loadPortalComponentData(
+      'initial-stream',
+      () => getPortalStreamPage(30),
+      [],
+    ),
+    stats: loadPortalComponentData(
+      'global-stats',
+      () => getCachedGlobalStats(portalDataSourceKey()),
+      { totalTweets: 0, memberCount: 0, generatedAt: new Date().toISOString() },
+    ),
+  }
+}

--- a/src/lib/portalStreamPage.test.tsx
+++ b/src/lib/portalStreamPage.test.tsx
@@ -1,30 +1,25 @@
 import StreamPage, { dynamic as streamRenderingMode } from '@/app/stream/page'
-import { getPortalData } from '@/lib/portal/data'
-import type { PortalData } from '@/lib/portal/types'
+import { startStreamData } from '@/lib/portal/data'
+import { getIsMember, getCurrentUser } from '@/lib/portal/auth'
 
-jest.mock('@/lib/portal/data', () => ({
-  getPortalData: jest.fn(),
+jest.mock('@/lib/portal/data', () => ({ startStreamData: jest.fn() }))
+jest.mock('@/lib/portal/auth', () => ({
+  getIsMember: jest.fn(),
+  getCurrentUser: jest.fn(),
 }))
-
-jest.mock('@/components/portal/Portal', () => ({
-  __esModule: true,
-  default: ({ view }: { view: string }) => <div>Portal view: {view}</div>,
-}))
-
-const getPortalDataMock = getPortalData as jest.MockedFunction<
-  typeof getPortalData
->
 
 test('renders at request time so portal fallback data is not frozen at build time', () => {
   expect(streamRenderingMode).toBe('force-dynamic')
 })
 
-test('renders the public stream without a membership check', async () => {
-  const data = {} as PortalData
-  getPortalDataMock.mockResolvedValue(data)
-
-  const page = await StreamPage()
-
-  expect(getPortalDataMock).toHaveBeenCalledWith('stream')
-  expect(page.props).toMatchObject({ data, view: 'stream' })
+test('renders the public stream without a membership check', () => {
+  const pending = new Promise<never>(() => {})
+  jest
+    .mocked(startStreamData)
+    .mockReturnValue({ tweets: pending, stats: pending })
+  const page = StreamPage()
+  expect(page.type).toBe('main')
+  expect(startStreamData).toHaveBeenCalledTimes(1)
+  expect(getIsMember).not.toHaveBeenCalled()
+  expect(getCurrentUser).not.toHaveBeenCalled()
 })


### PR DESCRIPTION
Digest, Gallery, Users, and Live Stream currently wait for optional viewer state, calendars, or corpus totals before returning useful content. This change gives those sections independent loading boundaries while preserving authentication checks and existing interactions.

- Digest shares its edition read between metadata and page, then streams likes/admin/calendar/discussion separately. Gallery streams viewer state after the public catalog and disables account actions until ready.
- Stream has a dedicated client entry using the unchanged polling/pagination hook. Directory rows no longer wait for the optional total.
- Trends omits twelve unused weekly queries; its historical seed has a separate cache. Graph overlaps identity and snapshot reads and warms its engine during loading.
- Gallery's submission form and Search's tweet results load on demand. Bangers streams its heading; missing navbar loading boundaries enable partial route prefetch. Docs and Research already have fast static/cached landing content.

Validation: 75 focused tests passed across the affected data, streaming, gallery, directory, graph, digest, and polling paths; TypeScript, focused lint, and production build passed. Added pending-promise regressions ensure optional reads cannot rejoin the main content gate, plus coverage for gallery session hydration and Trends authorization/query pruning.

Local production-build browser verification: with calendar/count responses deliberately delayed 3.5 seconds, Digest article content appeared at 658 ms and the document completed at 3,844 ms, without page/hydration errors. Gallery filtering, directory rows, blank Search, and Stream also passed. Local analytics-script and fixture/external image errors are unrelated to application execution. Authenticated controls are covered by tests; no production write or member session was used.

Build comparison (sum of route-entry JavaScript files, uncompressed; not network transfer or Web Vitals): Search −99,731 bytes, Gallery −39,244 bytes, Stream −26,769 bytes. Digest adds ~2.5 KB for streamed-section readiness/controls. Production speed gains still require post-rollout measurements.

Single signed-out production samples before changes, document completion: Docs 137 ms, Bangers 440 ms, Digest 15,441 ms, Gallery 5,021 ms, Graph 3,129 ms, Stream 948 ms, Research 369 ms, Search 332 ms. These are directional samples, not percentile benchmarks or directly comparable to local fixture timings.

Final head `09ff22e`: GitHub CI passed all 167 suites / 720 tests, ESLint, and TypeScript. Vercel preview build passed. The old Stream-page mock was updated to exercise the independent loader and verify that no membership or user lookup is required. Merged as `734884ed3688846dba674d4de46fe99255d6642e`; production deployment `dpl_9DBm2zKfLNhvK392AARd2ZqEjSX6` is READY and serves www.community-archive.org.

Production rollout smoke check: Digest, Gallery, Stream, and Users all returned 200 on the new deployment with no page/hydration errors. Gallery filtering worked and Users rendered 15 rows. A short deployment-scoped scan found no error/fatal logs. Single document-completion samples: Digest 1,818 ms, Gallery 2,594 ms, Stream 1,562 ms, Users 339 ms; these are health observations, not percentile benchmarks. Previous healthy production deployment `dpl_AsqiswLTBk2bG1uTdN466QTV9vrm` remains the rollback reference.
