### PR TITLE
Show search results sooner and cancel obsolete requests

### DIFF
--- a/docs/website-performance.md
+++ b/docs/website-performance.md
@@ -126,3 +126,31 @@ The additional readiness categories are Digest, Gallery, Graph, Stream, Trends,
 Research, and Docs. Usable-data markers include `digest_article`,
 `gallery_catalog`, `stream_feed`, and `bangers_results`. A shell marker alone is
 never evidence that a graph or chart is usable.
+
+## Search request path
+
+Search gives its five-result preview at most 250 ms before starting the canonical
+page. A fast, definitively empty preview still avoids the second query. A slow
+preview can overlap one canonical request; canonical results take precedence and
+cancel any remaining preview. This bounds the preview's added latency without
+changing query terms, phrase matching, filters, ordering, or page size.
+
+Canonical tweet text, authors, media, and engagement render before optional
+quoted-tweet bodies finish. Quotes are attached afterward; CSV export waits for
+the complete enrichment. Load-more retains the established page ordering.
+Equivalent parent rerenders do not restart searches. Changing filters, retrying,
+or unmounting cancels obsolete browser requests and prevents their late results
+or enrichment callbacks from replacing the active search. Cancellation also
+reaches Supabase reads and the Vercel proxy's upstream fetch; database-side query
+termination remains the gateway's responsibility.
+
+When ClickHouse text search is enabled, its failures return an actionable error
+and retry control instead of starting another corpus scan against PostgreSQL.
+The existing PostgreSQL path remains available for unsupported/filter-only reads
+and environments with ClickHouse search disabled. Search responses remain
+private and uncached, and this change introduces no database or policy changes.
+
+`search_results_received` measures from the start of each list request to its
+preview/canonical response, with only `phase`, `result_count`, `elapsed_ms`, and
+`page`. It measures data availability, not paint or navigation time, and includes
+no query text, account names, filters, or URLs.

--- a/src/app/api/tweet-search/route.ts
+++ b/src/app/api/tweet-search/route.ts
@@ -34,11 +34,16 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: message }, { status: 400 })
   }
 
+  const controller = new AbortController()
+  const cancel = () => controller.abort(request.signal.reason)
+  const timeout = setTimeout(() => controller.abort(), 25_000)
+  if (request.signal.aborted) cancel()
+  request.signal.addEventListener('abort', cancel, { once: true })
   try {
     const response = await fetch(target, {
       headers: { Authorization: `Bearer ${token}` },
       cache: 'no-store',
-      signal: AbortSignal.timeout(25_000),
+      signal: controller.signal,
     })
     const body = await response.text()
     return new NextResponse(body, {
@@ -50,10 +55,14 @@ export async function GET(request: NextRequest) {
       },
     })
   } catch (error) {
+    if (request.signal.aborted) return new NextResponse(null, { status: 499 })
     console.error('ClickHouse tweet search request failed:', error)
     return NextResponse.json(
       { error: 'Tweet search is temporarily unavailable' },
       { status: 502 },
     )
+  } finally {
+    clearTimeout(timeout)
+    request.signal.removeEventListener('abort', cancel)
   }
 }

--- a/src/components/TweetList.test.tsx
+++ b/src/components/TweetList.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { act, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import TweetList from './TweetList'
 import { fetchTweets } from '@/lib/queries/tweetQueries'
@@ -208,4 +208,174 @@ describe('TweetList progressive search', () => {
       screen.queryByText('Loading the remaining results…'),
     ).not.toBeInTheDocument()
   })
+})
+
+describe('search request scheduling and cancellation', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    ;(canPreviewTweetSearch as jest.Mock).mockReturnValue(false)
+  })
+  afterEach(() => jest.useRealTimers())
+
+  it('starts the canonical query despite an unresolved preview and ignores a late preview', async () => {
+    jest.useFakeTimers()
+    const preview = deferred<{
+      tweets: typeof previewTweets
+      definitiveEmpty: boolean
+    }>()
+    ;(canPreviewTweetSearch as jest.Mock).mockReturnValue(true)
+    ;(searchTweetPreviewsWithClickHouse as jest.Mock).mockReturnValue(
+      preview.promise,
+    )
+    ;(fetchTweets as jest.Mock).mockResolvedValue({
+      tweets: [{ ...previewTweet, tweet_id: 'canonical' }],
+      totalCount: null,
+      error: null,
+    })
+    render(<TweetList filterCriteria={{ rawSearchQuery: 'archive' }} />)
+    await act(async () => {
+      jest.advanceTimersByTime(250)
+    })
+    expect(fetchTweets).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('tweet-ids')).toHaveTextContent('canonical')
+    await act(async () => {
+      preview.resolve({ tweets: previewTweets, definitiveEmpty: false })
+    })
+    expect(screen.getByTestId('tweet-ids')).toHaveTextContent('canonical')
+    expect(
+      (searchTweetPreviewsWithClickHouse as jest.Mock).mock.calls[0][2].aborted,
+    ).toBe(true)
+  })
+
+  it('shows the canonical page while quote bodies are still loading', async () => {
+    const enriched = deferred<any>()
+    ;(fetchTweets as jest.Mock).mockImplementation(
+      (_client, _criteria, _page, _size, options) => {
+        options.onBaseTweets([{ ...previewTweet, tweet_id: 'canonical' }])
+        return enriched.promise
+      },
+    )
+    render(
+      <TweetList
+        filterCriteria={{ rawSearchQuery: 'archive', includeQuoteTweets: true }}
+      />,
+    )
+    expect(await screen.findByTestId('tweet-ids')).toHaveTextContent(
+      'canonical',
+    )
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Loading quoted tweets…',
+    )
+    await act(async () => {
+      enriched.resolve({
+        tweets: [{ ...previewTweet, tweet_id: 'canonical' }],
+        totalCount: null,
+        error: null,
+      })
+    })
+    expect(screen.queryByText('Loading quoted tweets…')).not.toBeInTheDocument()
+  })
+
+  it('aborts obsolete searches and rejects late results and quote updates', async () => {
+    const old = deferred<any>()
+    const current = deferred<any>()
+    ;(fetchTweets as jest.Mock)
+      .mockReturnValueOnce(old.promise)
+      .mockReturnValueOnce(current.promise)
+    const { rerender, unmount } = render(
+      <TweetList filterCriteria={{ rawSearchQuery: 'old' }} />,
+    )
+    const oldOptions = (fetchTweets as jest.Mock).mock.calls[0][4]
+    rerender(<TweetList filterCriteria={{ rawSearchQuery: 'new' }} />)
+    expect(oldOptions.signal.aborted).toBe(true)
+    await act(async () => {
+      current.resolve({
+        tweets: [{ ...previewTweet, tweet_id: 'current' }],
+        totalCount: null,
+        error: null,
+      })
+    })
+    await act(async () => {
+      oldOptions.onBaseTweets(previewTweets)
+      old.resolve({ tweets: previewTweets, totalCount: null, error: null })
+    })
+    expect(screen.getByTestId('tweet-ids')).toHaveTextContent('current')
+    const currentSignal = (fetchTweets as jest.Mock).mock.calls[1][4].signal
+    unmount()
+    expect(currentSignal.aborted).toBe(true)
+  })
+
+  it('does not repeat an equivalent search after a parent rerender', async () => {
+    ;(fetchTweets as jest.Mock).mockResolvedValue({
+      tweets: previewTweets,
+      totalCount: null,
+      error: null,
+    })
+    const { rerender } = render(
+      <TweetList filterCriteria={{ rawSearchQuery: 'archive' }} />,
+    )
+    await screen.findByTestId('tweet-ids')
+    rerender(<TweetList filterCriteria={{ rawSearchQuery: 'archive' }} />)
+    expect(fetchTweets).toHaveBeenCalledTimes(1)
+  })
+})
+
+test('retries a failed search explicitly without changing its filters', async () => {
+  jest.resetAllMocks()
+  const errorLog = jest.spyOn(console, 'error').mockImplementation(() => {})
+  ;(canPreviewTweetSearch as jest.Mock).mockReturnValue(false)
+  ;(fetchTweets as jest.Mock)
+    .mockResolvedValueOnce({
+      tweets: [],
+      totalCount: null,
+      error: new Error('Temporarily unavailable'),
+    })
+    .mockResolvedValueOnce({
+      tweets: previewTweets,
+      totalCount: null,
+      error: null,
+    })
+  render(
+    <TweetList
+      filterCriteria={{ rawSearchQuery: 'archive', fromUsername: 'alice' }}
+    />,
+  )
+  fireEvent.click(await screen.findByRole('button', { name: 'Retry search' }))
+  expect(await screen.findByTestId('tweet-ids')).toHaveTextContent('preview-1')
+  expect((fetchTweets as jest.Mock).mock.calls[1][1]).toEqual({
+    rawSearchQuery: 'archive',
+    fromUsername: 'alice',
+  })
+  errorLog.mockRestore()
+})
+
+test('a cancelled late preview cannot replace a completed search error', async () => {
+  jest.resetAllMocks()
+  jest.useFakeTimers()
+  const errorLog = jest.spyOn(console, 'error').mockImplementation(() => {})
+  const preview = deferred<{
+    tweets: typeof previewTweets
+    definitiveEmpty: boolean
+  }>()
+  ;(canPreviewTweetSearch as jest.Mock).mockReturnValue(true)
+  ;(searchTweetPreviewsWithClickHouse as jest.Mock).mockReturnValue(
+    preview.promise,
+  )
+  ;(fetchTweets as jest.Mock).mockResolvedValue({
+    tweets: [],
+    totalCount: null,
+    error: new Error('Search unavailable'),
+  })
+  render(<TweetList filterCriteria={{ rawSearchQuery: 'archive' }} />)
+  await act(async () => {
+    jest.advanceTimersByTime(250)
+  })
+  expect(screen.getByText('Search could not be completed')).toBeVisible()
+  await act(async () => {
+    preview.resolve({ tweets: previewTweets, definitiveEmpty: false })
+  })
+  expect(screen.queryByTestId('tweet-ids')).not.toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'Retry search' })).toBeVisible()
+  errorLog.mockRestore()
+  jest.useRealTimers()
 })

--- a/src/components/TweetList.tsx
+++ b/src/components/TweetList.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import UnifiedTweetList from '@/components/UnifiedTweetList'
 import { Button } from '@/components/ui/button'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
@@ -18,6 +18,7 @@ import {
   searchTweetPreviewsWithClickHouse,
 } from '@/lib/clickhouseSearch'
 import { AlertCircle, Loader2 } from 'lucide-react'
+import { capturePostHogEvent } from '@/lib/posthog'
 import type { TweetOrigin } from '@/lib/navigation'
 
 interface TweetListProps {
@@ -53,7 +54,18 @@ export default function TweetList({
   const [isLoading, setIsLoading] = useState(true)
   const [isLoadingMore, setIsLoadingMore] = useState(false)
   const [isCompletingPreview, setIsCompletingPreview] = useState(false)
+  const [isLoadingQuotes, setIsLoadingQuotes] = useState(false)
+  const activeRequest = useRef<{
+    controller: AbortController
+    previewController: AbortController
+  } | null>(null)
+  const criteriaKey = JSON.stringify(filterCriteria)
+  const stableCriteria = useMemo<FilterCriteria>(
+    () => JSON.parse(criteriaKey),
+    [criteriaKey],
+  )
   const [error, setError] = useState<string | null>(null)
+  const [failedPage, setFailedPage] = useState(1)
   const [currentPage, setCurrentPage] = useState(1)
   const [totalCount, setTotalCount] = useState<number | null>(null)
   const [supabase, setSupabase] = useState<SupabaseClient | null>(null)
@@ -66,11 +78,35 @@ export default function TweetList({
   const loadTweets = useCallback(
     async (pageToLoad: number, criteria: FilterCriteria) => {
       if (!supabase) return
+      activeRequest.current?.controller.abort()
+      activeRequest.current?.previewController.abort()
+      const request = {
+        controller: new AbortController(),
+        previewController: new AbortController(),
+      }
+      activeRequest.current = request
+      const signal = request.controller.signal
+      const isCurrent = () =>
+        activeRequest.current === request && !signal.aborted
+      const startedAt = performance.now()
+      const reportReceived = (phase: 'preview' | 'canonical', count: number) =>
+        capturePostHogEvent('search_results_received', {
+          phase,
+          result_count: count,
+          elapsed_ms: Math.round(performance.now() - startedAt),
+          page: pageToLoad,
+        })
+      let canonicalReady = false
+      let definitiveEmpty = false
 
       if (pageToLoad === 1) {
         setIsLoading(true)
         setIsCompletingPreview(false)
+        setIsLoadingQuotes(false)
         setTweets([])
+        setTotalCount(null)
+        setLastFetchCount(0)
+        setCurrentPage(1)
       } else {
         setIsLoadingMore(true)
       }
@@ -78,55 +114,106 @@ export default function TweetList({
 
       try {
         if (pageToLoad === 1 && canPreviewTweetSearch(criteria)) {
-          try {
-            const preview = await searchTweetPreviewsWithClickHouse(criteria)
-            if (preview.definitiveEmpty) {
-              setTweets([])
-              setIsLoading(false)
-              setLastFetchCount(0)
-              setTotalCount(0)
-              setCurrentPage(1)
-              return
-            }
-            if (preview.tweets.length > 0) {
-              setTweets(preview.tweets)
-              setIsLoading(false)
-              setIsCompletingPreview(true)
-            }
-          } catch (previewError) {
-            console.warn(
-              'Could not load the progressive tweet preview:',
-              previewError,
-            )
-          }
+          const preview = searchTweetPreviewsWithClickHouse(
+            criteria,
+            undefined,
+            request.previewController.signal,
+          )
+            .then((result) => {
+              if (
+                !isCurrent() ||
+                canonicalReady ||
+                request.previewController.signal.aborted
+              )
+                return
+              if (result.definitiveEmpty) {
+                definitiveEmpty = true
+                setTweets([])
+                setIsLoading(false)
+                setIsCompletingPreview(false)
+                setLastFetchCount(0)
+                setTotalCount(0)
+                request.controller.abort()
+              } else if (result.tweets.length > 0) {
+                reportReceived('preview', result.tweets.length)
+                setTweets(result.tweets)
+                setIsLoading(false)
+                setIsCompletingPreview(true)
+              }
+            })
+            .catch((error) => {
+              if (isCurrent() && !request.previewController.signal.aborted) {
+                console.warn(
+                  'Could not load the progressive tweet preview:',
+                  error,
+                )
+              }
+            })
+          // Let fast/definitively empty previews avoid another query, but never
+          // let a slow preview hold the canonical page behind it indefinitely.
+          let release!: () => void
+          let timer: ReturnType<typeof setTimeout> | undefined
+          const headStart = new Promise<void>((resolve) => {
+            release = resolve
+            timer = setTimeout(resolve, 250)
+            signal.addEventListener('abort', release, { once: true })
+          })
+          await Promise.race([preview, headStart])
+          clearTimeout(timer)
+          signal.removeEventListener('abort', release)
+          if (!isCurrent() || definitiveEmpty) return
         }
 
-        const {
-          tweets: fetchedTweets,
-          error: fetchError,
-          totalCount: fetchedTotalCount,
-        } = await fetchTweets(supabase, criteria, pageToLoad, itemsPerPage)
-
-        if (fetchError) {
-          throw fetchError
-        }
-
-        setTweets((prevTweets) =>
-          pageToLoad === 1 ? fetchedTweets : [...prevTweets, ...fetchedTweets],
+        const result = await fetchTweets(
+          supabase,
+          criteria,
+          pageToLoad,
+          itemsPerPage,
+          {
+            signal,
+            onBaseTweets:
+              pageToLoad === 1
+                ? (baseTweets) => {
+                    if (!isCurrent()) return
+                    reportReceived('canonical', baseTweets.length)
+                    canonicalReady = true
+                    request.previewController.abort()
+                    setTweets(baseTweets)
+                    setIsLoading(false)
+                    setIsCompletingPreview(false)
+                    setIsLoadingQuotes(true)
+                  }
+                : undefined,
+          },
         )
-        setLastFetchCount(fetchedTweets.length)
-        if (fetchedTotalCount !== null) {
-          setTotalCount(fetchedTotalCount)
-        }
+        if (!isCurrent()) return
+        if (result.error) throw result.error
+        if (!canonicalReady) reportReceived('canonical', result.tweets.length)
+        canonicalReady = true
+        setTweets((previous) =>
+          pageToLoad === 1 ? result.tweets : [...previous, ...result.tweets],
+        )
+        setLastFetchCount(result.tweets.length)
+        if (result.totalCount !== null) setTotalCount(result.totalCount)
         setCurrentPage(pageToLoad)
-      } catch (e: any) {
-        console.error('Failed to load tweets for list:', e)
-        setError(e.message || 'Failed to load tweets.')
+      } catch (error) {
+        if (!isCurrent()) return
+        setFailedPage(pageToLoad)
+        console.error('Failed to load tweets for list:', error)
+        setError(
+          error &&
+            typeof error === 'object' &&
+            'message' in error &&
+            typeof error.message === 'string'
+            ? error.message
+            : 'Failed to load tweets.',
+        )
       } finally {
-        if (pageToLoad === 1) {
+        request.previewController.abort()
+        if (isCurrent()) {
           setIsLoading(false)
           setIsCompletingPreview(false)
-        } else {
+          setIsLoadingQuotes(false)
           setIsLoadingMore(false)
         }
       }
@@ -135,17 +222,21 @@ export default function TweetList({
   )
 
   useEffect(() => {
-    if (supabase) {
-      setCurrentPage(1)
-      setTotalCount(null)
-      setLastFetchCount(0)
-      loadTweets(1, filterCriteria)
+    if (supabase) void loadTweets(1, stableCriteria)
+    return () => {
+      activeRequest.current?.controller.abort()
+      activeRequest.current?.previewController.abort()
     }
-  }, [supabase, filterCriteria, loadTweets])
+  }, [supabase, stableCriteria, loadTweets])
 
   const handleLoadMore = () => {
-    if (!isLoadingMore && hasMoreTweets) {
-      loadTweets(currentPage + 1, filterCriteria)
+    if (
+      !isLoadingMore &&
+      !isCompletingPreview &&
+      !isLoadingQuotes &&
+      hasMoreTweets
+    ) {
+      void loadTweets(currentPage + 1, stableCriteria)
     }
   }
 
@@ -189,6 +280,14 @@ export default function TweetList({
         <AlertCircle className="h-4 w-4" />
         <AlertTitle>Search could not be completed</AlertTitle>
         <AlertDescription>{error}</AlertDescription>
+        <Button
+          variant="outline"
+          size="sm"
+          className="mt-3"
+          onClick={() => void loadTweets(failedPage, stableCriteria)}
+        >
+          Retry search
+        </Button>
       </Alert>
     )
   }
@@ -230,7 +329,9 @@ export default function TweetList({
         isLoading={isLoading}
         emptyMessage="No tweets to display for the current filters."
         className="space-y-4"
-        showCsvExport={showCsvExportButton && !isCompletingPreview}
+        showCsvExport={
+          showCsvExportButton && !isCompletingPreview && !isLoadingQuotes
+        }
         csvFilename={csvExportFilename}
         headerTitle={
           resultsHeading
@@ -248,14 +349,16 @@ export default function TweetList({
         onSearchSortChange={onSearchSortChange}
       />
 
-      {isCompletingPreview && (
+      {(isCompletingPreview || isLoadingQuotes) && (
         <div
           className="flex items-center justify-center gap-2 text-sm text-muted-foreground"
           role="status"
           aria-live="polite"
         >
           <Loader2 className="h-4 w-4 animate-spin" />
-          Loading the remaining results…
+          {isLoadingQuotes
+            ? 'Loading quoted tweets…'
+            : 'Loading the remaining results…'}
         </div>
       )}
 
@@ -263,13 +366,21 @@ export default function TweetList({
         <Alert variant="destructive">
           <AlertTitle>More results could not be loaded</AlertTitle>
           <AlertDescription>{error}</AlertDescription>
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-3"
+            onClick={() => void loadTweets(failedPage, stableCriteria)}
+          >
+            Retry search
+          </Button>
         </Alert>
       )}
       {hasMoreTweets && (
         <div className="mt-8 flex justify-center">
           <Button
             onClick={handleLoadMore}
-            disabled={isLoadingMore}
+            disabled={isLoadingMore || isCompletingPreview || isLoadingQuotes}
             variant="outline"
             className="min-w-36"
           >

--- a/src/lib/clickhouseSearch.ts
+++ b/src/lib/clickhouseSearch.ts
@@ -35,6 +35,7 @@ interface MappedClickHouseSearchResponse {
 
 interface ClickHouseSearchRequestOptions {
   preview?: boolean
+  signal?: AbortSignal
   excludeRetweets?: boolean
 }
 
@@ -98,6 +99,7 @@ async function requestClickHouseSearch(
 
   const response = await fetchImpl(`/api/tweet-search?${params.toString()}`, {
     cache: 'no-store',
+    ...(options.signal ? { signal: options.signal } : {}),
   })
   const body = await response.text()
   if (!response.ok) {
@@ -140,9 +142,11 @@ export async function searchTweetsWithClickHouse(
   page: number,
   pageSize: number,
   fetchImpl: typeof fetch = fetch,
+  signal?: AbortSignal,
 ): Promise<TimelineTweet[]> {
   return requestClickHouseTweets(criteria, page, pageSize, fetchImpl, {
     excludeRetweets: criteria.excludeRetweets,
+    signal,
   })
 }
 
@@ -160,9 +164,11 @@ export function canPreviewTweetSearch(
 export async function searchTweetPreviewsWithClickHouse(
   criteria: FilterCriteria,
   fetchImpl: typeof fetch = fetch,
+  signal?: AbortSignal,
 ): Promise<MappedClickHouseSearchResponse> {
   return requestClickHouseSearch(criteria, 1, 5, fetchImpl, {
     preview: true,
+    signal,
     excludeRetweets: criteria.excludeRetweets,
   })
 }

--- a/src/lib/pgSearch.ts
+++ b/src/lib/pgSearch.ts
@@ -189,7 +189,8 @@ export async function searchTweets(
   supabase: SupabaseClient<Database>,
   searchParams: SearchParams,
   limit: number = 50,
-  offset: number = 0
+  offset: number = 0,
+  signal?: AbortSignal
 ): Promise<SearchTweetRpcResponseItem[] | null> {
   const params = {
     search_query: searchParams.search_query,
@@ -201,7 +202,10 @@ export async function searchTweets(
     offset_: offset
   };
 
-  const { data, error } = await supabase.rpc('search_tweets', params);
+  const query = supabase.rpc('search_tweets', params);
+  if (signal) query.abortSignal(signal);
+  const { data, error } = await query;
+  signal?.throwIfAborted();
 
   if (error) {
     console.error('Error calling search_tweets RPC:', error);
@@ -228,9 +232,10 @@ export async function searchTweetsExactPhrase(
   supabase: SupabaseClient,
   params: ExactPhraseParams,
   limit: number = 50,
-  offset: number = 0
+  offset: number = 0,
+  signal?: AbortSignal
 ): Promise<SearchTweetRpcResponseItem[] | null> {
-  const { data, error } = await supabase.rpc('search_tweets_exact_phrase', {
+  const query = supabase.rpc('search_tweets_exact_phrase', {
     exact_phrase: params.exact_phrase,
     from_user: params.from_user || undefined,
     to_user: params.to_user || undefined,
@@ -239,6 +244,9 @@ export async function searchTweetsExactPhrase(
     limit_: limit,
     offset_: offset,
   });
+  if (signal) query.abortSignal(signal);
+  const { data, error } = await query;
+  signal?.throwIfAborted();
 
   if (error) {
     console.error('Error calling search_tweets_exact_phrase RPC:', error);

--- a/src/lib/queries/tweetQueries.test.ts
+++ b/src/lib/queries/tweetQueries.test.ts
@@ -199,7 +199,7 @@ describe('fetchTweets — exact phrase search via FTS simple', () => {
     expect(result.tweets[0].tweet_id).toBe('ch-1')
   })
 
-  it('falls back to the existing RPC when ClickHouse is unavailable', async () => {
+  it('fails without a second corpus scan when ClickHouse is unavailable', async () => {
     process.env.NEXT_PUBLIC_ENABLE_CLICKHOUSE_SEARCH = 'true'
     mockClickHouseSearch.mockRejectedValueOnce(new Error('gateway down'))
     mockRpcSearch.mockResolvedValueOnce([makeRpcTweet('pg-1')])
@@ -215,8 +215,10 @@ describe('fetchTweets — exact phrase search via FTS simple', () => {
     )
 
     expect(mockClickHouseSearch).toHaveBeenCalledTimes(1)
-    expect(mockRpcSearch).toHaveBeenCalledTimes(1)
-    expect(result.tweets[0].tweet_id).toBe('pg-1')
+    expect(mockRpcSearch).not.toHaveBeenCalled()
+    expect(mockRpcExactPhrase).not.toHaveBeenCalled()
+    expect(result.error.message).toBe('gateway down')
+    expect(result.tweets).toEqual([])
   })
 
   it('does not silently ignore a non-default sort when ClickHouse is disabled', async () => {
@@ -417,5 +419,71 @@ describe('fetchTweets — direct profile embeds', () => {
     expect(result.tweets[0].account.profile?.avatar_media_url).toBe(
       'https://example.com/avatar.jpg',
     )
+  })
+})
+
+describe('progressive canonical results', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env.NEXT_PUBLIC_ENABLE_CLICKHOUSE_SEARCH = 'true'
+  })
+  afterEach(() => delete process.env.NEXT_PUBLIC_ENABLE_CLICKHOUSE_SEARCH)
+
+  it('publishes filtered search hits without waiting for quote enrichment', async () => {
+    let finishQuotes!: (result: { data: never[]; error: null }) => void
+    const quoteRows = new Promise<{ data: never[]; error: null }>((resolve) => {
+      finishQuotes = resolve
+    })
+    const builder = {
+      select: jest.fn().mockReturnThis(),
+      in: jest.fn().mockReturnValue(quoteRows),
+    }
+    const client = { from: jest.fn().mockReturnValue(builder) } as any
+    const tweet = makeRpcTweet('canonical', 'Useful results')
+    mockClickHouseSearch.mockResolvedValueOnce([
+      tweet,
+      makeRpcTweet('retweet', 'RT @alice: duplicated'),
+    ])
+    const onBaseTweets = jest.fn()
+    const complete = fetchTweets(
+      client,
+      {
+        searchQuery: 'archive',
+        rawSearchQuery: 'archive',
+        includeQuoteTweets: true,
+        excludeRetweets: true,
+      },
+      1,
+      20,
+      { onBaseTweets },
+    )
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(onBaseTweets).toHaveBeenCalledWith([tweet])
+    finishQuotes({ data: [], error: null })
+    expect((await complete).tweets).toEqual([tweet])
+  })
+
+  it('propagates cancellation without falling back to PostgreSQL', async () => {
+    const controller = new AbortController()
+    let rejectSearch!: (error: Error) => void
+    mockClickHouseSearch.mockReturnValueOnce(
+      new Promise((_resolve, reject) => {
+        rejectSearch = reject
+      }),
+    )
+    const result = fetchTweets(
+      buildMockSupabase(),
+      { searchQuery: 'archive', rawSearchQuery: 'archive' },
+      1,
+      20,
+      { signal: controller.signal },
+    )
+    expect(mockClickHouseSearch.mock.calls[0][4]).toBe(controller.signal)
+    controller.abort()
+    rejectSearch(new DOMException('Cancelled', 'AbortError'))
+    await expect(result).rejects.toMatchObject({ name: 'AbortError' })
+    expect(mockRpcSearch).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/queries/tweetQueries.ts
+++ b/src/lib/queries/tweetQueries.ts
@@ -109,26 +109,38 @@ function transformRawTweetsToTimelineTweets(
   })
 }
 
+export interface TweetFetchOptions {
+  signal?: AbortSignal
+  /** Publish the canonical page before optional quote bodies finish loading. */
+  onBaseTweets?: (tweets: TimelineTweet[]) => void
+}
+
 async function finalizeTweets(
   supabase: SupabaseClient,
   tweets: TimelineTweet[],
   criteria: FilterCriteria,
+  options: TweetFetchOptions = {},
 ): Promise<TimelineTweet[]> {
   const filteredTweets = criteria.excludeRetweets
     ? tweets.filter((tweet) => !isRetweetText(tweet.full_text))
     : tweets
 
-  return criteria.includeQuoteTweets
-    ? enrichSearchTweets(supabase, filteredTweets)
-    : filteredTweets
+  options.signal?.throwIfAborted()
+  if (!criteria.includeQuoteTweets || filteredTweets.length === 0)
+    return filteredTweets
+  options.onBaseTweets?.(filteredTweets)
+  return enrichSearchTweets(supabase, filteredTweets, options.signal)
 }
 
 async function searchClickHousePage(
   criteria: FilterCriteria,
   page: number,
   pageSize: number,
+  signal?: AbortSignal,
 ): Promise<TimelineTweet[]> {
-  return searchTweetsWithClickHouse(criteria, page, pageSize)
+  return signal
+    ? searchTweetsWithClickHouse(criteria, page, pageSize, undefined, signal)
+    : searchTweetsWithClickHouse(criteria, page, pageSize)
 }
 
 /**
@@ -152,6 +164,7 @@ async function searchExactPhrase(
   criteria: FilterCriteria,
   pageSize: number,
   offset: number,
+  signal?: AbortSignal,
 ): Promise<TimelineTweet[]> {
   const data = await rpcSearchExactPhrase(
     supabase,
@@ -164,6 +177,7 @@ async function searchExactPhrase(
     },
     pageSize,
     offset,
+    signal,
   )
 
   return data ? transformRawTweetsToTimelineTweets(data, true) : []
@@ -174,7 +188,9 @@ export async function fetchTweets(
   criteria: FilterCriteria,
   page: number,
   pageSize: number = DEFAULT_PAGE_SIZE,
+  options: TweetFetchOptions = {},
 ): Promise<{ tweets: TimelineTweet[]; totalCount: number | null; error: any }> {
+  options.signal?.throwIfAborted()
   // Use RPC if a text search query is provided OR if any filters supported by the RPC are used.
   if (
     criteria.searchQuery || // Main keyword search
@@ -209,28 +225,24 @@ export async function fetchTweets(
       }
 
       if (rawText && clickHouseSearchEnabled) {
-        try {
-          const clickHouseTweets = await searchClickHousePage(
-            criteria,
-            page,
-            pageSize,
-          )
-          const finalizedTweets = await finalizeTweets(
-            supabase,
-            clickHouseTweets,
-            criteria,
-          )
-          return {
-            tweets: finalizedTweets,
-            totalCount: finalizedTweets.length === 0 ? 0 : null,
-            error: null,
-          }
-        } catch (error) {
-          console.warn(
-            'ClickHouse tweet search failed; falling back to Supabase:',
-            error,
-          )
-          if (criteria.sort && criteria.sort !== 'newest') throw error
+        // Do not start a second corpus scan against PostgreSQL when the
+        // analytical service fails or the reader has cancelled this search.
+        const clickHouseTweets = await searchClickHousePage(
+          criteria,
+          page,
+          pageSize,
+          options.signal,
+        )
+        const finalizedTweets = await finalizeTweets(
+          supabase,
+          clickHouseTweets,
+          criteria,
+          options,
+        )
+        return {
+          tweets: finalizedTweets,
+          totalCount: finalizedTweets.length === 0 ? 0 : null,
+          error: null,
         }
       }
 
@@ -245,9 +257,15 @@ export async function fetchTweets(
           criteria,
           pageSize,
           offset,
+          options.signal,
         )
         return {
-          tweets: await finalizeTweets(supabase, phraseResults, criteria),
+          tweets: await finalizeTweets(
+            supabase,
+            phraseResults,
+            criteria,
+            options,
+          ),
           totalCount: null,
           error: null,
         }
@@ -263,6 +281,7 @@ export async function fetchTweets(
         searchParams,
         pageSize,
         offset,
+        options.signal,
       )
 
       if (!rpcData || rpcData.length === 0) {
@@ -277,12 +296,14 @@ export async function fetchTweets(
           supabase,
           transformRawTweetsToTimelineTweets(rpcData, true),
           criteria,
+          options,
         ),
         totalCount: null,
         error: null,
       }
     } catch (error: any) {
-      console.error('Error fetching tweets via RPC:', error)
+      if (options.signal?.aborted) throw error
+      console.error('Error fetching search results:', error)
       if (error.message && error.message.includes('statement timeout')) {
         return {
           tweets: [],
@@ -367,7 +388,9 @@ export async function fetchTweets(
     query = query.order('created_at', { ascending: false })
     query = query.range((page - 1) * pageSize, page * pageSize - 1)
 
+    if (options.signal) query = query.abortSignal(options.signal)
     const { data: rawData, error, count } = await query
+    options.signal?.throwIfAborted()
 
     if (error) {
       console.error('Error fetching tweets directly:', error) // Clarified error source
@@ -389,7 +412,12 @@ export async function fetchTweets(
 
     const transformedTweets = transformRawTweetsToTimelineTweets(rawData, false)
     return {
-      tweets: await finalizeTweets(supabase, transformedTweets, criteria),
+      tweets: await finalizeTweets(
+        supabase,
+        transformedTweets,
+        criteria,
+        options,
+      ),
       totalCount: count,
       error: null,
     }

--- a/src/lib/searchTweetEnrichments.ts
+++ b/src/lib/searchTweetEnrichments.ts
@@ -28,14 +28,19 @@ function deletedQuotedTweet(tweetId: string) {
 export async function enrichSearchTweets(
   supabase: SupabaseClient,
   tweets: TimelineTweet[],
+  signal?: AbortSignal,
 ): Promise<TimelineTweet[]> {
   if (tweets.length === 0) return tweets
 
   const tweetIds = tweets.map((tweet) => tweet.tweet_id)
-  const { data: quoteRows, error: quoteError } = await supabase
+  signal?.throwIfAborted()
+  const quoteQuery = supabase
     .from('quote_tweets')
     .select('tweet_id, quoted_tweet_id')
     .in('tweet_id', tweetIds)
+  if (signal) quoteQuery.abortSignal(signal)
+  const { data: quoteRows, error: quoteError } = await quoteQuery
+  signal?.throwIfAborted()
 
   if (quoteError) {
     console.warn('Could not load quote relationships for search:', quoteError)
@@ -48,7 +53,7 @@ export async function enrichSearchTweets(
   const quotedTweetIds = Array.from(
     new Set(quoteRelations.map((row) => row.quoted_tweet_id)),
   )
-  const { data: quotedRows, error: quotedError } = await supabase
+  const quotedQuery = supabase
     .from('tweets')
     .select(
       `
@@ -75,6 +80,9 @@ export async function enrichSearchTweets(
       `,
     )
     .in('tweet_id', quotedTweetIds)
+  if (signal) quotedQuery.abortSignal(signal)
+  const { data: quotedRows, error: quotedError } = await quotedQuery
+  signal?.throwIfAborted()
 
   if (quotedError) {
     console.warn('Could not load quoted tweets for search:', quotedError)

--- a/src/lib/tweetSearchRoute.test.ts
+++ b/src/lib/tweetSearchRoute.test.ts
@@ -1,0 +1,58 @@
+import { NextRequest } from 'next/server'
+import { GET } from '@/app/api/tweet-search/route'
+
+const originalEnv = process.env
+beforeEach(() => {
+  process.env = {
+    ...originalEnv,
+    ENABLE_CLICKHOUSE_READS: 'true',
+    CLICKHOUSE_ANALYTICS_API_TOKEN: 'fixture-token',
+    CLICKHOUSE_SEARCH_API_URL: 'https://gateway.example/search-base/',
+  }
+})
+afterEach(() => {
+  process.env = originalEnv
+  jest.restoreAllMocks()
+})
+
+test('aborts the upstream fetch when the search request is cancelled', async () => {
+  const controller = new AbortController()
+  let upstreamSignal!: AbortSignal
+  jest.spyOn(global, 'fetch').mockImplementation(
+    (_url, options) =>
+      new Promise((_resolve, reject) => {
+        upstreamSignal = options!.signal as AbortSignal
+        upstreamSignal.addEventListener('abort', () =>
+          reject(new DOMException('Cancelled', 'AbortError')),
+        )
+      }),
+  )
+  const pending = GET(
+    new NextRequest('https://archive.example/api/tweet-search?q=archive', {
+      signal: controller.signal,
+    }),
+  )
+  controller.abort()
+  expect(upstreamSignal.aborted).toBe(true)
+  expect((await pending).status).toBe(499)
+})
+
+test('keeps search responses private and preserves filter forwarding', async () => {
+  const fetchMock = jest
+    .spyOn(global, 'fetch')
+    .mockResolvedValue(
+      new Response('{"data":{"tweets":[]}}', {
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+  const response = await GET(
+    new NextRequest(
+      'https://archive.example/api/tweet-search?q=archive&from_user=alice&since=2025-01-01&sort=likes&exclude_retweets=true&untrusted=ignored',
+    ),
+  )
+  const target = new URL(String(fetchMock.mock.calls[0][0]))
+  expect(target.searchParams.get('from_user')).toBe('alice')
+  expect(target.searchParams.get('sort')).toBe('likes')
+  expect(target.searchParams.has('untrusted')).toBe(false)
+  expect(response.headers.get('Cache-Control')).toBe('private, no-store')
+})


### PR DESCRIPTION
Search currently waits for the five-result preview before starting the canonical page, then withholds that page until quoted-tweet enrichment finishes. A live `open source` sample showed preview results at 1,415 ms and completion at 3,262 ms: the canonical request began only after the preview, and quote lookups added another ~0.8 s.

This change:
- Gives previews a maximum 250 ms head start, then allows one canonical request to proceed. Fast definitive-empty previews still avoid a second query; canonical results cancel and supersede late previews.
- Publishes the canonical page before quote enrichment, then attaches full quote content. Existing phrase matching, filters, sort, pagination, and rich CSV output remain intact.
- Cancels obsolete browser/Supabase requests and the proxy's upstream fetch, guards late callbacks, and avoids refetches caused only by equivalent parent rerenders.
- Adds explicit retry controls. When ClickHouse search is enabled, a failure no longer triggers a second corpus scan against PostgreSQL, in accordance with the repository's analytics boundary. The disabled-ClickHouse/filter-only paths remain available.
- Records query-free `search_results_received` timings for preview/canonical data availability.

Validation: focused component, query, mapping/enrichment, and proxy tests passed; TypeScript, focused ESLint, and production build passed. Regression tests cover slow/late previews, definitive emptiness, pending quote enrichment, cancellation, stale results, equivalent criteria, retry, and private proxy responses.

Local production-build browser check: with a preview delayed 1.5 s and quote relations delayed 2.5 s, the canonical 20 results were visible at 1,383 ms, while quote completion was 3,717 ms. The preview request was cancelled after ~676 ms when canonical results arrived. A fast-preview case also preserved early preview rendering and deferred quotes. No page/hydration errors occurred. These are controlled fixture observations, not a production before/after speed claim.

The bounded overlap can run preview and canonical reads concurrently; database execution cancellation remains the gateway's responsibility. No SQL, index, schema, consent, or production deployment changes are included.

GitHub CI passed on `337e295`: 168 test suites and 730 tests. The Vercel preview build also passed. Merged as `d7c3046b1d5d3e9a4a6ca0a9a9fd4041cdfcf013` and deployed to production.

Production rollout: Vercel deployment `dpl_Bbe94XHnJA81mhrGr7JCoWkmgBkk` is READY and owns `www.community-archive.org`. A live browser check for `community archive` showed first results at 1,779 ms and all 20 results at 3,403 ms, with quote enrichment still pending. Preview and canonical requests started 253 ms apart. Both returned HTTP 200; no page/hydration errors occurred. Fresh deployment error/fatal logs were empty. These are single observations, not percentile measurements or a guarantee that intermittent 10-second searches are resolved.

Before rollout, the same query's canonical response arrived around 3,530 ms and final quote response around 4,467 ms. After rollout the backend still took 1,587 ms across 13 database round trips, and the canonical HTTP request took 2,677 ms. Backend query/admission work remains a separate optimization target; no gateway or database changes were made here.

Rollback reference: preceding production deployment `dpl_HDgjgNnzH2bdYPYukBk4kBKR7BnS` at `27720593280d7e568f1c6545586d210cf1aeab2e` retains the concurrently merged QA fixes. Earlier verified deployment `dpl_9DBm2zKfLNhvK392AARd2ZqEjSX6` remains another rollback artifact.
