### PR TITLE
Improve search actions, automatic graph updates, and upload next steps

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,7 @@
 # Docs
 
+- [Use cases](./use-cases.md) examples of things to discover or build with the archive.
+
 - [Agent entry point](https://www.community-archive.org/llms.txt) machine-readable index of the docs and API usage.
 - [Website docs](https://www.community-archive.org/docs) quickstart for agents, developers, and researchers.
 - [API docs](./api-doc.md) how owners download their private raw JSON or query the public database API.

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,0 +1,31 @@
+# What can you do with Community Archive?
+
+Use the [website](https://www.community-archive.org/) to explore public conversations, or start with the [API guide](./api-doc.md) to build a tool. Coverage depends on available records and current consent; missing thread context is not proof that a reply never existed.
+
+- Preserve your own tweets and make them durable beyond X.
+- Backfill older posts, then keep new posts current through opt-in.
+- Search the community's public conversation with better filters.
+- Find a remembered quote, reply, link, or old discussion.
+- Read complete threads and recover conversational context.
+- Discover the community's best recent posts in Bangers.
+- See which topics and phrases are rising or fading in Trends.
+- Find when a term first appeared and how its meaning changed.
+- Build a personal or community “canon” from standout posts.
+- Research people, projects, events, and intellectual lineages.
+- Find who discussed a topic and who influenced whom.
+- Identify missing high-impact accounts and invite them to join.
+- Collect testimonials or reactions to a project or launch.
+- Analyze social graphs, interactions, mentions, and communities.
+- Revisit your own archive: themes, collaborators, and changing interests.
+- Make public-interest datasets, visualizations, exhibits, and research.
+- Create stable links and previews for noteworthy archived posts.
+- Support tools and AI research with a consent-aware corpus.
+- Keep community history accessible even when platforms change or posts disappear.
+
+## Starting points
+
+- [Search](https://www.community-archive.org/search) for a topic, phrase, author, or date range.
+- [Bangers](https://www.community-archive.org/bangers?period=week) for recent standout posts.
+- [Trends](https://www.community-archive.org/trends) and [Graph](https://www.community-archive.org/social-graph) for patterns.
+- [Community Gallery](https://www.community-archive.org/community) for existing tools and projects.
+- [Data policy](https://www.community-archive.org/data-policy) for reuse and consent boundaries.

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -172,6 +172,25 @@ export default function DocsPage() {
           </div>
         </section>
 
+        <section className="space-y-6" id="examples">
+          <h2 className="text-3xl font-bold text-foreground">
+            What can I build or discover?
+          </h2>
+          <ul className="grid gap-3 text-muted-foreground sm:grid-cols-2">
+            <li>Find a remembered quote, reply, link, or old discussion.</li>
+            <li>
+              Revisit your own themes, collaborators, and changing interests.
+            </li>
+            <li>Follow emerging ideas with Trends, Bangers, and the Digest.</li>
+            <li>Trace people, projects, events, and intellectual lineages.</li>
+            <li>Build a personal canon, visualization, or research dataset.</li>
+            <li>Analyze public interaction networks and communities.</li>
+          </ul>
+          <ResourceLink href="https://github.com/TheExGenesis/community-archive/blob/main/docs/use-cases.md">
+            More examples and starting points
+          </ResourceLink>
+        </section>
+
         <section className="space-y-8" id="api">
           <div className="max-w-3xl">
             <h2 className="text-3xl font-bold text-foreground">

--- a/src/app/social-graph/SocialGraphExplorer.test.tsx
+++ b/src/app/social-graph/SocialGraphExplorer.test.tsx
@@ -1,7 +1,7 @@
 /** @jest-environment jsdom */
 
 import '@testing-library/jest-dom'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { SocialGraphSnapshot } from '@/lib/socialGraph'
 import SocialGraphExplorer from './SocialGraphExplorer'
 
@@ -184,8 +184,54 @@ describe('SocialGraphExplorer defaults', () => {
       fireEvent.click(screen.getByRole('button', { name: preset }))
 
       await waitFor(() => {
-        expect(workerInstances[0].postMessage).toHaveBeenCalledTimes(2)
+        expect(workerInstances[0].terminate).toHaveBeenCalledTimes(1)
+        expect(workerInstances.at(-1)?.postMessage).toHaveBeenCalledTimes(1)
       })
     },
   )
+
+  it('debounces rapid filter changes, ignores obsolete worker replies, and cancels on unmount', () => {
+    jest.useFakeTimers()
+    try {
+      const { unmount } = render(<SocialGraphExplorer snapshot={snapshot} />)
+      act(() => jest.advanceTimersByTime(0))
+      const original = workerInstances[0]
+      const oldRequest = original.postMessage.mock.calls[0][0]
+      fireEvent.keyDown(
+        screen.getByRole('slider', { name: 'Interaction start year' }),
+        { key: 'ArrowRight' },
+      )
+      const superseded = workerInstances.at(-1)!
+      fireEvent.keyDown(
+        screen.getByRole('slider', { name: 'Interaction start year' }),
+        { key: 'ArrowLeft' },
+      )
+      const latest = workerInstances.at(-1)!
+      expect(original.terminate).toHaveBeenCalledTimes(1)
+      expect(superseded.terminate).toHaveBeenCalledTimes(1)
+      act(() => jest.advanceTimersByTime(349))
+      expect(latest.postMessage).not.toHaveBeenCalled()
+      const oldMessage = original.addEventListener.mock.calls.find(
+        ([event]) => event === 'message',
+      )![1]
+      act(() =>
+        oldMessage({ data: { id: oldRequest.id, error: 'obsolete error' } }),
+      )
+      expect(screen.queryByText('obsolete error')).not.toBeInTheDocument()
+      act(() => jest.advanceTimersByTime(1))
+      expect(latest.postMessage).toHaveBeenCalledTimes(1)
+      expect(superseded.postMessage).not.toHaveBeenCalled()
+      fireEvent.keyDown(
+        screen.getByRole('slider', { name: 'Interaction start year' }),
+        { key: 'ArrowRight' },
+      )
+      const pending = workerInstances.at(-1)!
+      unmount()
+      act(() => jest.advanceTimersByTime(350))
+      expect(pending.terminate).toHaveBeenCalledTimes(1)
+      expect(pending.postMessage).not.toHaveBeenCalled()
+    } finally {
+      jest.useRealTimers()
+    }
+  })
 })

--- a/src/app/social-graph/SocialGraphExplorer.tsx
+++ b/src/app/social-graph/SocialGraphExplorer.tsx
@@ -399,7 +399,7 @@ export default function SocialGraphExplorer({
   const workerRef = useRef<Worker | null>(null)
   const workerRequestRef = useRef(0)
   const workerSignatureRef = useRef('')
-  const completedPresetRecalculationRef = useRef(0)
+  const hasStartedAdaptiveGraph = useRef(false)
   const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const hoverCandidateRef = useRef<string | null>(null)
   const layoutReferenceRef = useRef(
@@ -848,6 +848,10 @@ export default function SocialGraphExplorer({
   }, [labelPercentage])
 
   useEffect(() => {
+    setAdaptiveError(null)
+    setIsAdapting(!isPending && filtered.nodes.length >= 2)
+    if (isPending || filtered.nodes.length < 2) return
+
     const worker = new Worker(
       new URL('../../workers/socialGraph.worker.ts', import.meta.url),
     )
@@ -855,7 +859,12 @@ export default function SocialGraphExplorer({
     worker.addEventListener(
       'message',
       (event: MessageEvent<SocialGraphWorkerResponse>) => {
-        if (event.data.id !== workerRequestRef.current) return
+        if (
+          workerRef.current !== worker ||
+          event.data.id !== workerRequestRef.current ||
+          workerSignatureRef.current !== adaptiveInputRef.current.signature
+        )
+          return
         setIsAdapting(false)
         if (event.data.error || !event.data.result) {
           setAdaptiveError(event.data.error || 'Adaptive graph failed')
@@ -875,29 +884,21 @@ export default function SocialGraphExplorer({
       },
     )
     worker.addEventListener('error', () => {
+      if (workerRef.current !== worker) return
       setIsAdapting(false)
       setAdaptiveError('Adaptive graph worker failed')
     })
-    requestAdaptiveGraph(worker)
+    // Cancel obsolete CPU work immediately, then wait for slider changes to settle.
+    const delay = hasStartedAdaptiveGraph.current ? 350 : 0
+    hasStartedAdaptiveGraph.current = true
+    const timer = window.setTimeout(() => requestAdaptiveGraph(worker), delay)
     return () => {
+      window.clearTimeout(timer)
       worker.terminate()
       if (workerRef.current === worker) workerRef.current = null
     }
-  }, [requestAdaptiveGraph])
-
-  useEffect(() => {
-    if (
-      presetRecalculationRequest === 0 ||
-      completedPresetRecalculationRef.current === presetRecalculationRequest ||
-      isPending ||
-      !workerRef.current ||
-      filtered.nodes.length < 2
-    ) {
-      return
-    }
-    completedPresetRecalculationRef.current = presetRecalculationRequest
-    requestAdaptiveGraph()
   }, [
+    adaptiveRunSignature,
     filtered.nodes.length,
     isPending,
     presetRecalculationRequest,
@@ -1175,7 +1176,7 @@ export default function SocialGraphExplorer({
                   ? `Find @${currentMemberNode.username}`
                   : 'Your signed-in X account is not in this snapshot'
               }
-              className="disabled:opacity-45 flex h-9 items-center justify-center gap-1.5 rounded-[3px] border border-zinc-200 px-2 text-[12px] font-medium hover:bg-zinc-50 disabled:cursor-not-allowed dark:border-[#35353a] dark:hover:bg-[#242428]"
+              className="flex h-9 items-center justify-center gap-1.5 rounded-[3px] border border-zinc-200 px-2 text-[12px] font-medium hover:bg-zinc-50 disabled:cursor-not-allowed disabled:opacity-45 dark:border-[#35353a] dark:hover:bg-[#242428]"
             >
               <LocateFixed className="h-3.5 w-3.5 text-brand" />
               Find yourself
@@ -1184,7 +1185,7 @@ export default function SocialGraphExplorer({
               type="button"
               onClick={exploreLargestGroup}
               disabled={!displayCommunities.length}
-              className="disabled:opacity-45 flex h-9 items-center justify-center gap-1.5 rounded-[3px] border border-zinc-200 px-2 text-[12px] font-medium hover:bg-zinc-50 dark:border-[#35353a] dark:hover:bg-[#242428]"
+              className="flex h-9 items-center justify-center gap-1.5 rounded-[3px] border border-zinc-200 px-2 text-[12px] font-medium hover:bg-zinc-50 disabled:opacity-45 dark:border-[#35353a] dark:hover:bg-[#242428]"
             >
               <Network className="h-3.5 w-3.5 text-brand" />
               Explore groups
@@ -1344,8 +1345,8 @@ export default function SocialGraphExplorer({
               <div>
                 <h2 className="text-[12px] font-semibold">Groups and layout</h2>
                 <p className={`mt-1 text-[12px] leading-relaxed ${MUTED}`}>
-                  Recalculate the algorithmic groups using only the people and
-                  ties in this view.
+                  Groups update automatically using only the people and ties in
+                  this view.
                 </p>
               </div>
               <button
@@ -1367,7 +1368,7 @@ export default function SocialGraphExplorer({
                 <p className={`text-[12px] leading-relaxed ${MUTED}`}>
                   {adaptiveIsCurrent
                     ? `${adaptiveResult.communityCount} groups in the current view.`
-                    : 'Filters changed; recalculate to update the groups.'}
+                    : 'Groups update automatically when filters settle.'}
                 </p>
               ) : null}
               {adaptiveError ? (

--- a/src/components/HighlightedText.test.tsx
+++ b/src/components/HighlightedText.test.tsx
@@ -1,0 +1,23 @@
+import { render } from '@testing-library/react'
+import { HighlightedText } from './HighlightedText'
+
+test('highlights literal phrases and regex punctuation without changing the text', () => {
+  const text = 'Open source: C++ and open SOURCE.'
+  const { container } = render(
+    <HighlightedText text={text} query={'"open source" C++'} />,
+  )
+  expect(container.textContent).toBe(text)
+  expect(
+    Array.from(container.querySelectorAll('mark'), (m) => m.textContent),
+  ).toEqual(['Open source', 'C++', 'open SOURCE'])
+})
+
+test('escapes markup in both tweets and queries', () => {
+  const text = '<script>alert(1)</script> & 😀'
+  const { container } = render(
+    <HighlightedText text={text} query={'<script> 😀'} />,
+  )
+  expect(container.textContent).toBe(text)
+  expect(container.querySelector('script')).toBeNull()
+  expect(container.querySelectorAll('mark')).toHaveLength(2)
+})

--- a/src/components/HighlightedText.tsx
+++ b/src/components/HighlightedText.tsx
@@ -1,0 +1,37 @@
+/** Render matches as React text nodes: never interpret query or tweet text as HTML. */
+export function HighlightedText({
+  text,
+  query,
+}: {
+  text: string
+  query?: string
+}) {
+  const terms = Array.from(
+    new Set(
+      (query?.match(/"[^"]+"|[^\s]+/g) ?? [])
+        .map((term) => term.replace(/^"|"$/g, ''))
+        .filter(Boolean),
+    ),
+  ).sort((a, b) => b.length - a.length)
+  if (!terms.length) return <>{text}</>
+  const pattern = new RegExp(
+    `(${terms.map((term) => term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})`,
+    'giu',
+  )
+  return (
+    <>
+      {text.split(pattern).map((part, index) =>
+        index % 2 ? (
+          <mark
+            key={index}
+            className="rounded-sm bg-amber-200/70 font-semibold text-inherit dark:bg-amber-500/25"
+          >
+            {part}
+          </mark>
+        ) : (
+          part
+        ),
+      )}
+    </>
+  )
+}

--- a/src/components/TweetComponent.tsx
+++ b/src/components/TweetComponent.tsx
@@ -18,6 +18,7 @@ import {
 import { Archive } from 'lucide-react'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { formatNumber } from '@/lib/formatNumber'
+import { HighlightedText } from '@/components/HighlightedText'
 import { decodeTweetText } from '@/lib/tweetText'
 import TweetAvatarImage from '@/components/TweetAvatarImage'
 import ImageLightbox from '@/components/ImageLightbox'
@@ -101,6 +102,7 @@ interface TweetComponentProps {
   compact?: boolean
   permalinkOrigin?: TweetOrigin
   permalinkReturnTo?: string
+  highlightQuery?: string
   isPermalinkPage?: boolean
 }
 
@@ -118,6 +120,7 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
   permalinkOrigin,
   permalinkReturnTo,
   isPermalinkPage = false,
+  highlightQuery,
 }) => {
   const [isTextExpanded, setIsTextExpanded] = React.useState(false)
   // Support both interface formats for backwards compatibility
@@ -203,25 +206,22 @@ export const TweetComponent: React.FC<TweetComponentProps> = ({
 
     // Simple URL detection and conversion to links for any remaining URLs
     const urlRegex = /(https?:\/\/[^\s]+)/g
-    return formattedText
-      .split(urlRegex)
-      .map((part, index) => {
-        if (urlRegex.test(part)) {
-          return (
-            <a
-              key={index}
-              href={part}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="break-all text-brand underline-offset-2"
-            >
-              {part}
-            </a>
-          )
-        }
-        return part
-      })
-      .filter((part) => part !== '') // Remove empty strings
+    return formattedText.split(urlRegex).map((part, index) => {
+      if (urlRegex.test(part)) {
+        return (
+          <a
+            key={index}
+            href={part}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="break-all text-brand underline-offset-2"
+          >
+            <HighlightedText text={part} query={highlightQuery} />
+          </a>
+        )
+      }
+      return <HighlightedText key={index} text={part} query={highlightQuery} />
+    })
   }
 
   const renderMedia = () => {

--- a/src/components/TweetList.tsx
+++ b/src/components/TweetList.tsx
@@ -325,6 +325,7 @@ export default function TweetList({
   return (
     <div className={compact ? 'space-y-5' : 'space-y-8'}>
       <UnifiedTweetList
+        highlightQuery={filterCriteria.rawSearchQuery}
         tweets={rawTweets}
         isLoading={isLoading}
         emptyMessage="No tweets to display for the current filters."

--- a/src/components/UnifiedTweetList.tsx
+++ b/src/components/UnifiedTweetList.tsx
@@ -8,6 +8,7 @@ import type { TweetOrigin } from '@/lib/navigation'
 import type { TweetSearchSort } from '@/lib/queries/tweetQueries'
 
 interface UnifiedTweetListProps {
+  highlightQuery?: string
   tweets: any[]
   isLoading?: boolean
   emptyMessage?: string
@@ -31,6 +32,7 @@ interface UnifiedTweetListProps {
  */
 export default function UnifiedTweetList({
   tweets,
+  highlightQuery,
   isLoading = false,
   emptyMessage = 'No tweets found',
   className = 'space-y-4',
@@ -271,9 +273,10 @@ export default function UnifiedTweetList({
                 <div
                   key={tweet.tweet_id}
                   role="row"
-                  className="hover:bg-muted/35 transition-colors"
+                  className="transition-colors hover:bg-muted/35"
                 >
                   <TweetComponent
+                    highlightQuery={highlightQuery}
                     tweet={tweet}
                     collapseLongText={collapseLongTweets}
                     compact
@@ -293,6 +296,7 @@ export default function UnifiedTweetList({
               className="rounded-lg border border-border bg-card p-4 transition-colors hover:border-foreground/20 sm:p-5"
             >
               <TweetComponent
+                highlightQuery={highlightQuery}
                 tweet={tweet}
                 collapseLongText={collapseLongTweets}
                 permalinkOrigin={permalinkOrigin}

--- a/src/components/UserSearchInput.test.tsx
+++ b/src/components/UserSearchInput.test.tsx
@@ -98,7 +98,7 @@ describe('UserSearchInput', () => {
     expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
   })
 
-  it('inserts a from: filter when the filter row is selected', async () => {
+  it('searches the selected author when the filter row is selected', async () => {
     setDefaultSuggestions()
     const input = renderSearch()
     await userEvent.type(input, 'exg')
@@ -110,7 +110,7 @@ describe('UserSearchInput', () => {
     await userEvent.click(filterOption)
 
     expect(input).toHaveValue('from:exgenesis')
-    expect(mockPush).not.toHaveBeenCalled()
+    expect(mockPush).toHaveBeenCalledWith('/search?fromUser=exgenesis')
     expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
   })
 
@@ -131,6 +131,7 @@ describe('UserSearchInput', () => {
     await userEvent.keyboard('{ArrowDown}{ArrowDown}{Enter}')
 
     expect(input).toHaveValue('from:exgenesis')
+    expect(mockPush).toHaveBeenLastCalledWith('/search?fromUser=exgenesis')
   })
 
   it('debounces typing before starting the member lookup', async () => {

--- a/src/components/UserSearchInput.tsx
+++ b/src/components/UserSearchInput.tsx
@@ -5,6 +5,7 @@ import { Search, UserRound } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Input, InputProps } from '@/components/ui/input'
+import { buildSearchParams } from '@/lib/searchParams'
 import { userProfileHref } from '@/lib/navigation'
 import {
   fetchMemberDirectorySuggestions,
@@ -166,6 +167,7 @@ export default function UserSearchInput({
 
     onValueChange(replacement.value)
     closeSuggestions()
+    router.push(`/search?${buildSearchParams(replacement.value).toString()}`)
     const restoreCaret = () => {
       inputRef.current?.focus()
       inputRef.current?.setSelectionRange(

--- a/src/components/file-upload-dialog.tsx
+++ b/src/components/file-upload-dialog.tsx
@@ -354,12 +354,23 @@ export function FileUploadDialog({
             <div className="space-y-2">
               <p className="text-sm text-green-600">We got your archive!</p>
               <p className="text-sm text-muted-foreground">
-                Your account should show up in the database in the next 20 mins
-                or so
+                Thank you for helping preserve the community. Your archive is
+                being processed; you can check its status in Settings.
               </p>
             </div>
+            <div className="flex flex-wrap gap-3 text-sm font-medium text-brand">
+              <Link href="/settings" onClick={onClose}>
+                Check upload status
+              </Link>
+              <Link href="/bangers?period=week" onClick={onClose}>
+                Explore recent Bangers
+              </Link>
+              <Link href="/docs#examples" onClick={onClose}>
+                What can I do with the archive?
+              </Link>
+            </div>
             <div className="grid grid-cols-2 gap-2 text-sm">
-              <div className="text-muted-foreground">Uploaded Tweets</div>
+              <div className="text-muted-foreground">Submitted Tweets</div>
               <div>{state.uploadedStats.uploadedTweets.toLocaleString()}</div>
               {state.uploadLikes && (
                 <>

--- a/src/components/portal/Portal.tsx
+++ b/src/components/portal/Portal.tsx
@@ -900,9 +900,17 @@ export function HomeTrendsPanel({
         {!failed &&
           weeklyBars.map((b) => (
             <div key={b.term} className="flex items-center gap-2 py-[6px]">
-              <span className="w-[82px] truncate text-[12px] font-semibold">
+              <Link
+                href={`/search?${new URLSearchParams({
+                  q: b.term,
+                  ...(b.sinceDate ? { sinceDate: b.sinceDate } : {}),
+                  ...(b.untilDate ? { untilDate: b.untilDate } : {}),
+                }).toString()}`}
+                title={`Search tweets mentioning ${b.term}`}
+                className="w-[82px] truncate text-[12px] font-semibold text-brand underline-offset-2 hover:underline"
+              >
                 {b.term}
-              </span>
+              </Link>
               <span className="w-[46px] text-right text-[11px] tabular-nums text-muted-foreground">
                 {b.last7.toLocaleString('en-US')}
               </span>

--- a/src/lib/portal/analytics.test.ts
+++ b/src/lib/portal/analytics.test.ts
@@ -117,6 +117,8 @@ describe('ClickHouse-backed portal analytics', () => {
     ).toEqual([10, 0, 0, 0, 0, 0, 0, 40])
     expect(trends.weekly.find(({ term }) => term === 'tpot')).toEqual({
       term: 'tpot',
+      sinceDate: '2026-08-01',
+      untilDate: '2026-08-07',
       last7: 8,
       prev7: 4,
       deltaPct: 100,

--- a/src/lib/portal/analytics.ts
+++ b/src/lib/portal/analytics.ts
@@ -859,6 +859,8 @@ export async function fetchPortalTrends(
     }
     return {
       term,
+      sinceDate: utcDateParam(from7),
+      untilDate: utcDateParam(today),
       last7,
       prev7,
       deltaPct: prev7 > 0 ? Math.round(((last7 - prev7) / prev7) * 100) : null,

--- a/src/lib/portal/types.ts
+++ b/src/lib/portal/types.ts
@@ -78,6 +78,8 @@ export interface PortalStats {
 }
 
 export interface TermWeek {
+  sinceDate?: string
+  untilDate?: string
   term: string
   last7: number
   prev7: number


### PR DESCRIPTION
This QA batch makes existing controls complete the action their labels promise and adds context to search results and upload completion.

- Graph filters recalculate groups after 350ms; obsolete workers are terminated and stale replies ignored while preserving layout alignment. Fixes #884.
- “Search posts from…” immediately searches the selected author, preserving other query terms. Addresses the action ambiguity in #834; plain Enter in the production From user field worked during QA (#886).
- Search results highlight literal words/phrases using escaped React text nodes, preserving links and full tweet text. Fixes #806.
- Homepage trend terms link to search with the exact cached seven-day date range. Fixes #829.
- Upload acknowledgment links to status, recent Bangers, and examples; removes the unsupported 20-minute promise. Fixes #525.
- Publish the existing use-case list and link it from website Docs. Fixes #566.

Validation: 46 focused tests across seven suites pass, type-check and focused lint pass. Local browser verification covered real graph workers under rapid filter changes, dated trend URLs, and highlight readability in light/dark mode with literal markup preserved. Temporary QA fixture removed. No schema changes or production data writes.

Remaining autocomplete cold latency in #834 and the exact reported #886 focus case remain separate from this action fix.
