### PR TITLE
Fail nightly export releases when package or consent is stale

### DIFF
--- a/.github/workflows/update-data-export-release.yaml
+++ b/.github/workflows/update-data-export-release.yaml
@@ -2,7 +2,7 @@ name: Publish consent-safe bulk export release
 
 on:
   schedule:
-    - cron: "30 8 * * *"
+    - cron: '30 8 * * *'
   workflow_dispatch:
 
 permissions:
@@ -20,6 +20,9 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
+
+      - name: Verify freshness validation
+        run: node --test scripts/validate-public-export-freshness.test.mjs
 
       - name: Build verified release notes
         id: export

--- a/scripts/build-public-export-release-notes.sh
+++ b/scripts/build-public-export-release-notes.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 latest_url="https://fabxmporizzqflnftavs.supabase.co/storage/v1/object/public/community-archive-public-export/latest.json"
 output_dir="${1:-public-export-release}"
 
-for command in curl jq; do
+for command in curl jq node; do
   command -v "$command" >/dev/null || {
     echo "Required command not found: $command" >&2
     exit 1
@@ -14,6 +14,8 @@ done
 mkdir -p "$output_dir"
 curl --fail --silent --show-error --location --max-filesize 1048576 \
   "$latest_url" --output "$output_dir/latest.json"
+
+node "$(dirname "${BASH_SOURCE[0]}")/validate-public-export-freshness.mjs" "$output_dir/latest.json"
 
 export_id="$(jq -er '.export_id | select(type == "string" and length > 0)' "$output_dir/latest.json")"
 manifest_url="$(jq -er '.manifest_url | select(type == "string" and length > 0)' "$output_dir/latest.json")"

--- a/scripts/validate-public-export-freshness.mjs
+++ b/scripts/validate-public-export-freshness.mjs
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
+
+export function validatePublicExportFreshness(latest, now = Date.now()) {
+  const maxAgeMs = 36 * 60 * 60 * 1000
+  for (const [label, value] of Object.entries({
+    'export creation': latest.created_at,
+    'consent snapshot': latest.consent_snapshot_at,
+  })) {
+    // ClickHouse emits UTC without an offset; do not interpret it in runner-local time.
+    const normalized =
+      typeof value === 'string' &&
+      /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(\.\d+)?$/.test(value)
+        ? `${value.replace(' ', 'T')}Z`
+        : value
+    const timestamp =
+      typeof normalized === 'string' ? Date.parse(normalized) : NaN
+    if (!Number.isFinite(timestamp))
+      throw new Error(`Missing or invalid ${label} timestamp.`)
+    const age = now - timestamp
+    if (age < -5 * 60 * 1000 || age > maxAgeMs) {
+      throw new Error(
+        `Public ${label} is outside the 36-hour freshness window (${value}).`,
+      )
+    }
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  try {
+    validatePublicExportFreshness(
+      JSON.parse(readFileSync(process.argv[2], 'utf8')),
+    )
+  } catch (error) {
+    console.error(error.message)
+    process.exitCode = 1
+  }
+}

--- a/scripts/validate-public-export-freshness.test.mjs
+++ b/scripts/validate-public-export-freshness.test.mjs
@@ -1,0 +1,33 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { validatePublicExportFreshness } from './validate-public-export-freshness.mjs'
+const now = Date.parse('2026-09-06T12:00:00Z')
+const fresh = {
+  created_at: '2026-09-06T07:00:00.000Z',
+  consent_snapshot_at: '2026-09-06 07:12:00.000',
+}
+test('accepts fresh export and UTC consent timestamps', () => {
+  assert.doesNotThrow(() => validatePublicExportFreshness(fresh, now))
+})
+test('rejects an old export even if its files remain downloadable', () => {
+  assert.throws(
+    () =>
+      validatePublicExportFreshness(
+        { ...fresh, created_at: '2026-09-01T07:00:00Z' },
+        now,
+      ),
+    /freshness window/,
+  )
+})
+test('rejects stale or missing consent and future metadata', () => {
+  for (const consent_snapshot_at of [
+    '2026-09-01 07:00:00',
+    undefined,
+    'invalid',
+    '2026-09-07T07:00:00Z',
+  ]) {
+    assert.throws(() =>
+      validatePublicExportFreshness({ ...fresh, consent_snapshot_at }, now),
+    )
+  }
+})


### PR DESCRIPTION
The nightly release job has been succeeding against the same September 1 export because it verifies file availability but not age. Validate export creation and consent timestamps before probing downloads or publishing a release; fail outside a 36-hour window, on missing timestamps, or on future timestamps. ClickHouse timestamps without offsets are explicitly interpreted as UTC.

Related #882, #873, #786, and the regression from #666. This exposes stale publication; it does not restore the exporter or make the current package safe to advertise. The source mismatch and watchdog safeguard are tracked in TheExGenesis/community-archive-control-panel#208.

Validation: three Node tests pass, shell syntax check passes, and the current September 1 metadata is correctly rejected without downloading the corpus. No production changes.
