### PR TITLE
Recover broken avatars and reset image state between profiles

### DIFF
--- a/src/app/api/profile/[account_id]/avatar/route.ts
+++ b/src/app/api/profile/[account_id]/avatar/route.ts
@@ -31,7 +31,7 @@ const avatarResponse = (
   )
 
 export async function GET(
-  _request: Request,
+  request: Request,
   { params }: { params: { account_id: string } },
 ) {
   if (!ACCOUNT_ID_PATTERN.test(params.account_id)) {
@@ -49,7 +49,8 @@ export async function GET(
   const storedAvatarUrl = page.tweets
     .map((tweet) => getHighResolutionAvatarUrl(tweet.avatar_media_url))
     .find(Boolean)
-  if (storedAvatarUrl) return avatarResponse(storedAvatarUrl, 200)
+  const refresh = new URL(request.url).searchParams.get('refresh') === '1'
+  if (storedAvatarUrl && !refresh) return avatarResponse(storedAvatarUrl, 200)
 
   const tweets = await fetchSyndicatedTweets(
     page.tweets.map((tweet) => tweet.tweet_id),

--- a/src/components/metaTwitter/ProfileAvatar.test.tsx
+++ b/src/components/metaTwitter/ProfileAvatar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { ProfileAvatar } from './ProfileAvatar'
 
 jest.mock('next/image', () => ({
@@ -48,4 +48,50 @@ test('recovers a missing avatar after rendering the initial fallback', async () 
     ),
   )
   expect(global.fetch).toHaveBeenCalledWith('/api/profile/42/avatar')
+})
+
+test('requests a fresh source after a stored avatar fails instead of retrying the same cached URL', async () => {
+  const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue({
+    ok: true,
+    json: async () => ({ avatar_media_url: 'https://pbs.twimg.com/new.jpg' }),
+  } as Response)
+  render(
+    <ProfileAvatar
+      accountId="42"
+      avatarUrl="https://pbs.twimg.com/old.jpg"
+      displayName="Alice"
+    />,
+  )
+  fireEvent.error(screen.getByAltText("Alice's avatar"))
+  await waitFor(() =>
+    expect(screen.getByAltText("Alice's avatar")).toHaveAttribute(
+      'src',
+      'https://pbs.twimg.com/new.jpg',
+    ),
+  )
+  expect(fetchMock).toHaveBeenCalledWith('/api/profile/42/avatar?refresh=1')
+  fireEvent.error(screen.getByAltText("Alice's avatar"))
+  expect(screen.getByText('A')).toBeVisible()
+  expect(fetchMock).toHaveBeenCalledTimes(1)
+})
+
+test('resets avatar state when navigating between profiles', () => {
+  const { rerender } = render(
+    <ProfileAvatar
+      accountId="42"
+      avatarUrl="https://pbs.twimg.com/alice.jpg"
+      displayName="Alice"
+    />,
+  )
+  rerender(
+    <ProfileAvatar
+      accountId="43"
+      avatarUrl="https://pbs.twimg.com/bob.jpg"
+      displayName="Bob"
+    />,
+  )
+  expect(screen.getByAltText("Bob's avatar")).toHaveAttribute(
+    'src',
+    'https://pbs.twimg.com/bob.jpg',
+  )
 })

--- a/src/components/metaTwitter/ProfileAvatar.tsx
+++ b/src/components/metaTwitter/ProfileAvatar.tsx
@@ -4,19 +4,30 @@ import Image from 'next/image'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { getHighResolutionAvatarUrl } from '@/lib/avatar'
 
-export function ProfileAvatar({
-  accountId,
-  avatarUrl,
-  displayName,
-}: {
+type ProfileAvatarProps = {
   accountId: string
   avatarUrl: string | null
   displayName: string
-}) {
+}
+
+export function ProfileAvatar(props: ProfileAvatarProps) {
+  return (
+    <ResolvedProfileAvatar
+      key={`${props.accountId}:${props.avatarUrl ?? ''}`}
+      {...props}
+    />
+  )
+}
+
+function ResolvedProfileAvatar({
+  accountId,
+  avatarUrl,
+  displayName,
+}: ProfileAvatarProps) {
   const [resolvedAvatarUrl, setResolvedAvatarUrl] = useState(
     getHighResolutionAvatarUrl(avatarUrl) ?? null,
   )
-  const attemptedRecovery = useRef(false)
+  const attemptedRecovery = useRef(new Set<boolean>())
   const mounted = useRef(true)
 
   useEffect(() => {
@@ -26,25 +37,30 @@ export function ProfileAvatar({
     }
   }, [])
 
-  const recoverAvatar = useCallback(() => {
-    if (attemptedRecovery.current) return
-    attemptedRecovery.current = true
-    void fetch(`/api/profile/${encodeURIComponent(accountId)}/avatar`)
-      .then(async (response) => {
-        if (!response.ok) return null
-        const body = (await response.json()) as { avatar_media_url?: unknown }
-        return typeof body.avatar_media_url === 'string' &&
-          body.avatar_media_url
-          ? body.avatar_media_url
-          : null
-      })
-      .then((recoveredAvatarUrl) => {
-        if (recoveredAvatarUrl && mounted.current) {
-          setResolvedAvatarUrl(recoveredAvatarUrl)
-        }
-      })
-      .catch(() => undefined)
-  }, [accountId])
+  const recoverAvatar = useCallback(
+    (refresh = false) => {
+      if (attemptedRecovery.current.has(refresh)) return
+      attemptedRecovery.current.add(refresh)
+      void fetch(
+        `/api/profile/${encodeURIComponent(accountId)}/avatar${refresh ? '?refresh=1' : ''}`,
+      )
+        .then(async (response) => {
+          if (!response.ok) return null
+          const body = (await response.json()) as { avatar_media_url?: unknown }
+          return typeof body.avatar_media_url === 'string' &&
+            body.avatar_media_url
+            ? body.avatar_media_url
+            : null
+        })
+        .then((recoveredAvatarUrl) => {
+          if (recoveredAvatarUrl && mounted.current) {
+            setResolvedAvatarUrl(recoveredAvatarUrl)
+          }
+        })
+        .catch(() => undefined)
+    },
+    [accountId],
+  )
 
   useEffect(() => {
     if (!avatarUrl) recoverAvatar()
@@ -61,7 +77,7 @@ export function ProfileAvatar({
         priority
         onError={() => {
           setResolvedAvatarUrl(null)
-          recoverAvatar()
+          recoverAvatar(true)
         }}
         className="relative z-10 -mt-[66px] h-[132px] w-[132px] rounded-full border-4 border-card bg-muted object-cover"
       />
@@ -78,7 +94,7 @@ export function ProfileAvatarPlaceholder({
 }) {
   return (
     <div className="relative z-10 -mt-[66px] grid h-[132px] w-[132px] place-items-center rounded-full border-4 border-card bg-muted text-4xl font-bold">
-      {displayName.charAt(0).toUpperCase()}
+      {(Array.from(displayName)[0] ?? '@').toUpperCase()}
     </div>
   )
 }

--- a/src/lib/profileAvatarRoute.test.ts
+++ b/src/lib/profileAvatarRoute.test.ts
@@ -1,113 +1,63 @@
-const getProfileBangersPageMock = jest.fn()
-const fetchSyndicatedTweetsMock = jest.fn()
-
-jest.mock('./metaTwitter/bangers', () => ({
-  getProfileBangersPage: (...args: unknown[]) =>
-    getProfileBangersPageMock(...args),
+import { GET } from '@/app/api/profile/[account_id]/avatar/route'
+import { getProfileBangersPage } from '@/lib/metaTwitter/bangers'
+import { fetchSyndicatedTweets } from '@/lib/twitterSyndication'
+jest.mock('@/lib/metaTwitter/bangers', () => ({
+  getProfileBangersPage: jest.fn(),
   PROFILE_BANGERS_INITIAL_LIMIT: 2,
 }))
-
-jest.mock('./twitterSyndication', () => ({
-  fetchSyndicatedTweets: (...args: unknown[]) =>
-    fetchSyndicatedTweetsMock(...args),
+jest.mock('@/lib/twitterSyndication', () => ({
+  fetchSyndicatedTweets: jest.fn(),
 }))
-
-import { GET } from '@/app/api/profile/[account_id]/avatar/route'
-
-const banger = (tweetId: string, avatarMediaUrl: string | null = null) => ({
-  tweet_id: tweetId,
-  avatar_media_url: avatarMediaUrl,
-})
-
 beforeEach(() => {
-  getProfileBangersPageMock.mockReset()
-  fetchSyndicatedTweetsMock.mockReset()
-})
-
-test('returns the stored high-resolution banger avatar without syndication', async () => {
-  getProfileBangersPageMock.mockResolvedValueOnce({
+  jest.clearAllMocks()
+  ;(getProfileBangersPage as jest.Mock).mockResolvedValue({
+    available: true,
     tweets: [
-      banger(
-        '100',
-        'https://pbs.twimg.com/profile_images/42/avatar_normal.jpg',
-      ),
+      { tweet_id: '100', avatar_media_url: 'https://pbs.twimg.com/old.jpg' },
     ],
-    available: true,
   })
-
-  const response = await GET(new Request('http://localhost'), {
-    params: { account_id: '42' },
-  })
-
-  expect(response.status).toBe(200)
-  await expect(response.json()).resolves.toEqual({
-    avatar_media_url:
-      'https://pbs.twimg.com/profile_images/42/avatar_400x400.jpg',
-  })
-  expect(response.headers.get('cache-control')).toBe(
-    'public, s-maxage=3600, stale-while-revalidate=86400',
-  )
-  expect(fetchSyndicatedTweetsMock).not.toHaveBeenCalled()
 })
-
-test('recovers an avatar from a bounded set of syndicated bangers', async () => {
-  getProfileBangersPageMock.mockResolvedValueOnce({
-    tweets: [banger('100'), banger('101')],
-    available: true,
+test('uses stored avatars for normal requests without external recovery', async () => {
+  const response = await GET(
+    new Request('https://archive.test/api/profile/42/avatar'),
+    { params: { account_id: '42' } },
+  )
+  expect(await response.json()).toEqual({
+    avatar_media_url: 'https://pbs.twimg.com/old.jpg',
   })
-  fetchSyndicatedTweetsMock.mockResolvedValueOnce(
+  expect(fetchSyndicatedTweets).not.toHaveBeenCalled()
+})
+test('a failed-image refresh bypasses the known stored avatar and checks the author', async () => {
+  ;(fetchSyndicatedTweets as jest.Mock).mockResolvedValue(
+    new Map([
+      [
+        '100',
+        { account_id: '42', avatar_media_url: 'https://pbs.twimg.com/new.jpg' },
+      ],
+    ]),
+  )
+  const response = await GET(
+    new Request('https://archive.test/api/profile/42/avatar?refresh=1'),
+    { params: { account_id: '42' } },
+  )
+  expect(await response.json()).toEqual({
+    avatar_media_url: 'https://pbs.twimg.com/new.jpg',
+  })
+  expect(fetchSyndicatedTweets).toHaveBeenCalledWith(['100'], { limit: 2 })
+  ;(fetchSyndicatedTweets as jest.Mock).mockResolvedValue(
     new Map([
       [
         '100',
         {
-          account_id: '42',
-          avatar_media_url:
-            'https://pbs.twimg.com/profile_images/42/avatar_normal.jpg',
+          account_id: '99',
+          avatar_media_url: 'https://pbs.twimg.com/wrong.jpg',
         },
       ],
-      ['101', null],
     ]),
   )
-
-  const response = await GET(new Request('http://localhost'), {
-    params: { account_id: '42' },
-  })
-
-  expect(fetchSyndicatedTweetsMock).toHaveBeenCalledWith(['100', '101'], {
-    limit: 2,
-  })
-  expect(response.status).toBe(200)
-  await expect(response.json()).resolves.toEqual({
-    avatar_media_url:
-      'https://pbs.twimg.com/profile_images/42/avatar_400x400.jpg',
-  })
-})
-
-test('short-caches a legitimate missing avatar', async () => {
-  getProfileBangersPageMock.mockResolvedValueOnce({
-    tweets: [],
-    available: true,
-  })
-  fetchSyndicatedTweetsMock.mockResolvedValueOnce(new Map())
-
-  const response = await GET(new Request('http://localhost'), {
-    params: { account_id: '42' },
-  })
-
-  expect(response.status).toBe(404)
-  expect(response.headers.get('cache-control')).toBe('public, s-maxage=300')
-})
-
-test('does not cache an upstream banger failure as a missing avatar', async () => {
-  getProfileBangersPageMock.mockResolvedValueOnce({
-    tweets: [],
-    available: false,
-  })
-
-  const response = await GET(new Request('http://localhost'), {
-    params: { account_id: '42' },
-  })
-
-  expect(response.status).toBe(502)
-  expect(response.headers.get('cache-control')).toBe('private, no-store')
+  const mismatch = await GET(
+    new Request('https://archive.test/api/profile/42/avatar?refresh=1'),
+    { params: { account_id: '42' } },
+  )
+  expect(mismatch.status).toBe(404)
 })


### PR DESCRIPTION
A broken profile avatar could request recovery and receive the same stored broken URL. Failed-image recovery now skips that stored candidate and uses the existing bounded syndication lookup, checking that the recovered author matches the profile. Normal avatar requests still avoid external recovery.

Profile avatar state also resets when the account or stored URL changes, so client navigation cannot carry another account's image/recovery flag forward. Each stored/fresh recovery path runs at most once, with initials retained on failure.

Addresses #747 and one stale-avatar cause relevant to #819. This does not claim that all navbar/profile identity mismatches are resolved.

Validation: 6 focused UI/route tests, type-check, and focused lint pass. Tests cover broken URLs, bounded retry, account navigation, and wrong-author rejection. No live account changes or corpus scan.
