### PR TITLE
Keep Settings responsive by loading tweets on demand

### DIFF
--- a/src/app/profile/ProfileContent.test.tsx
+++ b/src/app/profile/ProfileContent.test.tsx
@@ -3,6 +3,11 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import ProfileContent from './ProfileContent'
 
+const mockGetOwnLatestTweets = jest.fn()
+jest.mock('@/app/settings/tweet-actions', () => ({
+  getOwnLatestTweets: (...args: unknown[]) => mockGetOwnLatestTweets(...args),
+}))
+
 const mockFetch = jest.fn()
 const originalFetch = global.fetch
 const mockLogInsert = jest.fn().mockResolvedValue({ error: null })
@@ -181,4 +186,34 @@ describe('ProfileContent opt-in preference', () => {
     expect(await screen.findByText('Tweet deleted permanently')).toBeVisible()
     expect(screen.queryByText('A tweet I can remove')).not.toBeInTheDocument()
   })
+})
+
+test('loads tweets only when the tab is opened, with retry instead of an empty result on failure', async () => {
+  mockGetOwnLatestTweets
+    .mockRejectedValueOnce(new Error('temporary'))
+    .mockResolvedValueOnce([
+      {
+        tweet_id: '10',
+        created_at: '2026-09-06T00:00:00Z',
+        full_text: 'My lazy-loaded tweet',
+        favorite_count: 0,
+        retweet_count: 0,
+      },
+    ])
+  render(<ProfileContent user={user} initialOptInData={null} archives={[]} />)
+  expect(mockGetOwnLatestTweets).not.toHaveBeenCalled()
+  await userEvent.click(screen.getByRole('tab', { name: 'My Tweets' }))
+  expect(
+    await screen.findByRole('button', { name: 'Retry loading tweets' }),
+  ).toBeVisible()
+  expect(
+    screen.queryByText('No archived tweets found.'),
+  ).not.toBeInTheDocument()
+  await userEvent.click(
+    screen.getByRole('button', { name: 'Retry loading tweets' }),
+  )
+  expect(await screen.findByText('My lazy-loaded tweet')).toBeVisible()
+  await userEvent.click(screen.getByRole('tab', { name: 'Privacy Settings' }))
+  await userEvent.click(screen.getByRole('tab', { name: 'My Tweets' }))
+  expect(mockGetOwnLatestTweets).toHaveBeenCalledTimes(2)
 })

--- a/src/app/profile/ProfileContent.tsx
+++ b/src/app/profile/ProfileContent.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { getOwnLatestTweets } from '@/app/settings/tweet-actions'
 import { useRef, useState } from 'react'
 import { User } from '@supabase/supabase-js'
 import { Button } from '@/components/ui/button'
@@ -55,7 +56,7 @@ export default function ProfileContent({
   initialDownloadArchiveVisible = true,
   initialOptInData,
   archives,
-  initialTweets = [],
+  initialTweets,
 }: ProfileContentProps) {
   const router = useRouter()
   const { userMetadata } = useAuthAndArchive()
@@ -74,7 +75,27 @@ export default function ProfileContent({
   const [success, setSuccess] = useState<string | null>(null)
   const [deletingArchive, setDeletingArchive] = useState<string | null>(null)
   const [deletingTweetId, setDeletingTweetId] = useState<string | null>(null)
-  const [ownTweets, setOwnTweets] = useState(initialTweets)
+  const [ownTweets, setOwnTweets] = useState(initialTweets ?? [])
+  const tweetsLoaded = useRef(initialTweets !== undefined)
+  const tweetsRequestInFlight = useRef(false)
+  const [tweetsLoading, setTweetsLoading] = useState(false)
+  const [tweetsError, setTweetsError] = useState<string | null>(null)
+
+  const loadOwnTweets = async () => {
+    if (tweetsLoaded.current || tweetsRequestInFlight.current) return
+    tweetsRequestInFlight.current = true
+    setTweetsLoading(true)
+    setTweetsError(null)
+    try {
+      setOwnTweets(await getOwnLatestTweets())
+      tweetsLoaded.current = true
+    } catch {
+      setTweetsError('Your tweets could not be loaded.')
+    } finally {
+      tweetsRequestInFlight.current = false
+      setTweetsLoading(false)
+    }
+  }
   const [showDeleteAllDialog, setShowDeleteAllDialog] = useState(false)
   const [showOptOutDialog, setShowOptOutDialog] = useState(false)
   const supabase = createBrowserClient()
@@ -435,9 +456,10 @@ export default function ProfileContent({
       <Tabs
         defaultValue="privacy"
         className="w-full"
-        onValueChange={(tab) =>
+        onValueChange={(tab) => {
           capturePostHogEvent('settings_tab_selected', { tab })
-        }
+          if (tab === 'tweets') void loadOwnTweets()
+        }}
       >
         <TabsList className="grid w-full grid-cols-3">
           <TabsTrigger value="privacy">Privacy Settings</TabsTrigger>
@@ -653,7 +675,24 @@ export default function ProfileContent({
               </CardDescription>
             </CardHeader>
             <CardContent>
-              {ownTweets.length === 0 ? (
+              {tweetsLoading ? (
+                <p
+                  role="status"
+                  className="py-8 text-center text-muted-foreground"
+                >
+                  Loading your tweets…
+                </p>
+              ) : tweetsError ? (
+                <div role="alert" className="space-y-3 py-4">
+                  <p>{tweetsError}</p>
+                  <Button
+                    variant="outline"
+                    onClick={() => void loadOwnTweets()}
+                  >
+                    Retry loading tweets
+                  </Button>
+                </div>
+              ) : ownTweets.length === 0 ? (
                 <div className="py-8 text-center text-muted-foreground">
                   No archived tweets found.
                 </div>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -53,9 +53,9 @@ export default async function SettingsPage() {
   const [
     optInResponse,
     archivesResponse,
-    tweetsResponse,
     settings,
     pendingCommunityProjects,
+    digestSubscription,
   ] = await Promise.all([
     optInQuery,
     twitterAccountId
@@ -81,27 +81,16 @@ export default async function SettingsPage() {
           .order('created_at', { ascending: false })
       : Promise.resolve({ data: [], error: null }),
     twitterAccountId
-      ? supabase
-          .from('tweets')
-          .select(
-            'tweet_id, created_at, full_text, favorite_count, retweet_count',
-          )
-          .eq('account_id', twitterAccountId)
-          .order('created_at', { ascending: false })
-          .limit(100)
-      : Promise.resolve({ data: [], error: null }),
-    twitterAccountId
       ? getPublicProfileSettings(twitterAccountId)
       : Promise.resolve({ downloadArchiveVisible: true }),
     isAdmin
       ? loadPendingCommunityProjects().catch(() => [])
       : Promise.resolve([]),
+    twitterAccountId
+      ? getSubscriptionForAccount(twitterAccountId).catch(() => null)
+      : Promise.resolve(null),
   ])
 
-  // Tolerate the subscriptions table not existing yet (pre-migration).
-  const digestSubscription = twitterAccountId
-    ? await getSubscriptionForAccount(twitterAccountId).catch(() => null)
-    : null
   const digestEmailStatus: DigestEmailStatus = !digestSubscription
     ? 'none'
     : digestSubscription.unsubscribedAt
@@ -132,7 +121,6 @@ export default async function SettingsPage() {
           initialDownloadArchiveVisible={settings.downloadArchiveVisible}
           initialOptInData={optInResponse.data}
           archives={archivesResponse.data || []}
-          initialTweets={tweetsResponse.data || []}
         />
       </div>
     </main>

--- a/src/app/settings/tweet-actions.ts
+++ b/src/app/settings/tweet-actions.ts
@@ -1,0 +1,19 @@
+'use server'
+
+import { requireAuth } from '@/lib/auth-utils'
+
+export async function getOwnLatestTweets() {
+  const { user, supabase } = await requireAuth('/settings')
+  const accountId = user.app_metadata?.provider_id
+  if (typeof accountId !== 'string' || !/^\d{1,20}$/.test(accountId)) {
+    throw new Error('Your X account could not be verified')
+  }
+  const { data, error } = await supabase
+    .from('tweets')
+    .select('tweet_id, created_at, full_text, favorite_count, retweet_count')
+    .eq('account_id', accountId)
+    .order('created_at', { ascending: false })
+    .limit(100)
+  if (error) throw new Error('Your tweets could not be loaded. Please retry.')
+  return data ?? []
+}

--- a/src/lib/settingsTweetActions.test.ts
+++ b/src/lib/settingsTweetActions.test.ts
@@ -1,0 +1,25 @@
+import { getOwnLatestTweets } from '@/app/settings/tweet-actions'
+import { requireAuth } from '@/lib/auth-utils'
+jest.mock('@/lib/auth-utils', () => ({ requireAuth: jest.fn() }))
+test('scopes the bounded read to the verified account, ignoring mutable user metadata', async () => {
+  const limit = jest.fn().mockResolvedValue({ data: [], error: null })
+  const order = jest.fn(() => ({ limit }))
+  const eq = jest.fn(() => ({ order }))
+  const from = jest.fn(() => ({ select: jest.fn(() => ({ eq })) }))
+  ;(requireAuth as jest.Mock).mockResolvedValue({
+    user: {
+      app_metadata: { provider_id: '42' },
+      user_metadata: { provider_id: '99' },
+    },
+    supabase: { from },
+  })
+  await getOwnLatestTweets()
+  expect(eq).toHaveBeenCalledWith('account_id', '42')
+  expect(limit).toHaveBeenCalledWith(100)
+  ;(requireAuth as jest.Mock).mockResolvedValue({
+    user: { app_metadata: {}, user_metadata: { provider_id: '99' } },
+    supabase: { from },
+  })
+  await expect(getOwnLatestTweets()).rejects.toThrow('could not be verified')
+  expect(from).toHaveBeenCalledTimes(1)
+})


### PR DESCRIPTION
Settings currently waits for the most recent 100 tweets before displaying its default Privacy tab. Load those tweets only when My Tweets opens, using a server action scoped to the verified owner. Cache a successful response for the mounted page and show loading/retry states instead of reporting failures as an empty archive. The digest subscription lookup now runs alongside the other initial requests.

Addresses #820 by removing an unrelated corpus read from the initial Settings path. This is not a claim of a measured cold-load p95 target; archive and moderation queries still need separate measurement.

Validation: 6 focused UI/server-action tests pass, type-check and focused lint pass. Tests verify no tweet read on the default tab, retry after failure, reuse after reopening the tab, a 100-row bound, and ownership from trusted app metadata. No schema changes or production writes.
