### PR TITLE
Reduce idle function cost with Fluid Compute

### DIFF
--- a/docs/website-performance.md
+++ b/docs/website-performance.md
@@ -5,6 +5,21 @@ soon as its own data is ready. Profiles require current public eligibility and
 identity before rendering; optional enrichment streams afterward. Background
 work follows user intent or viewport proximity.
 
+## Vercel compute
+
+`vercel.json` enables Fluid Compute so external-service waits incur provisioned
+memory charges without active CPU charges. It keeps a 15-second default for
+`src/app/**`; route-level `maxDuration` exports retain their explicit limits.
+This prevents enabling Fluid from silently increasing ordinary requests to its
+300-second default. The digest email cron schedule is unchanged.
+
+The setting takes effect on deployment. Before production rollout, verify the
+generated function configuration and exercise a public profile and signed-in
+session on a preview. Compare active CPU plus provisioned memory cost against
+legacy duration cost; legacy GB-hours alone are no longer comparable. Fluid
+does not fix slow queries or make waiting free. Roll back with the previous
+deployment, or revert this configuration and redeploy.
+
 ## Loading boundaries
 
 - `startHomepageData()` returns an object of independent promises, not one

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,11 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "fluid": true,
+  "functions": {
+    "src/app/**/*": {
+      "maxDuration": 15
+    }
+  },
   "crons": [
     {
       "path": "/api/cron/digest-email",


### PR DESCRIPTION
## Problem and change
Production uses legacy function-duration billing. The supplied usage snapshot attributes 58.4 of 78.1 GB-hours to timeouts. A scoped runtime-log investigation identified profile pages as the dominant source; current timing logs show the uncached profile eligibility lookup sometimes taking 10–14.5 seconds of the 15-second budget.

Enable Fluid Compute to avoid active CPU charges during upstream waits and allow concurrent requests to share instances. Keep the default for `src/app/**/*` at 15 seconds; explicit route-level `maxDuration` exports retain their existing overrides. Preserve the digest email cron. Document billing comparison and rollback.

This reduces the cost of waiting; it does not fix the slow eligibility lookup. Memory remains billable. The policy lookup must remain fresh so opt-outs take effect immediately.

## Validation
- Configured properties validated against the current official Vercel JSON schema.
- Existing cron configuration compared against HEAD and preserved exactly.
- Changed JSON and new documentation passed Prettier checks; `git diff --check` passed.
- No application code changed; no database or broad application tests run.
- The normal commit hook cannot initialize in this isolated worktree and generates unrelated database types/API docs; bypassed after the focused checks above.

## Rollout
Draft only; no production deployment or settings mutation performed. Before promotion, inspect generated function settings and smoke-test public profiles plus signed-in session handling on a preview. Compare combined active CPU and provisioned-memory spend with the legacy baseline. Roll back to the previous deployment if necessary.
