### PR TITLE
Fix Enter submission from the search text box in Brave

### DIFF
--- a/src/components/UserSearchInput.test.tsx
+++ b/src/components/UserSearchInput.test.tsx
@@ -45,17 +45,23 @@ const suggestion = (
 
 const memberSuggestion = suggestion('exgenesis')
 
-function SearchHarness() {
+function SearchHarness({ onSubmit }: { onSubmit?: jest.Mock } = {}) {
   const [value, setValue] = useState('')
 
   return (
-    <div className="relative">
+    <form
+      className="relative"
+      onSubmit={(event) => {
+        event.preventDefault()
+        onSubmit?.(value)
+      }}
+    >
       <UserSearchInput
         aria-label="Search Community Archive"
         value={value}
         onValueChange={setValue}
       />
-    </div>
+    </form>
   )
 }
 
@@ -76,6 +82,64 @@ describe('UserSearchInput', () => {
     mockPush.mockReset()
     mockedFetchMemberDirectorySuggestions.mockReset()
     mockedFetchMemberSuggestions.mockReset()
+  })
+
+  it.each([false, true])(
+    'submits Enter exactly once with suggestions visible: %s',
+    async (showSuggestions) => {
+      mockedFetchMemberSuggestions.mockResolvedValue(
+        showSuggestions ? [memberSuggestion] : [],
+      )
+      mockedFetchMemberDirectorySuggestions.mockResolvedValue([])
+      const onSubmit = jest.fn()
+      render(<SearchHarness onSubmit={onSubmit} />)
+      const input = screen.getByRole('combobox')
+      await userEvent.type(input, 'cuties ai')
+      if (showSuggestions) await screen.findAllByRole('option')
+
+      // keyDown alone has no implicit form submission in jsdom: this catches
+      // regressions back to relying on the browser's default Enter action.
+      fireEvent.keyDown(input, { key: 'Enter' })
+
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+      expect(onSubmit).toHaveBeenCalledWith('cuties ai')
+      expect(mockPush).not.toHaveBeenCalled()
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+    },
+  )
+
+  it('submits once even when a native bubbling listener cancels Enter', async () => {
+    setDefaultSuggestions()
+    const onSubmit = jest.fn()
+    render(<SearchHarness onSubmit={onSubmit} />)
+    const input = screen.getByRole('combobox')
+    await userEvent.type(input, 'cuties ai')
+    await screen.findAllByRole('option')
+    input.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') event.preventDefault()
+    })
+
+    await userEvent.keyboard('{Enter}')
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(onSubmit).toHaveBeenCalledWith('cuties ai')
+    expect(mockPush).not.toHaveBeenCalled()
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('does not submit or select a suggestion while committing composed text', async () => {
+    setDefaultSuggestions()
+    const onSubmit = jest.fn()
+    render(<SearchHarness onSubmit={onSubmit} />)
+    const input = screen.getByRole('combobox')
+    await userEvent.type(input, 'exg')
+    await screen.findAllByRole('option')
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'Enter', isComposing: true })
+    fireEvent.keyDown(input, { key: 'Enter', keyCode: 229 })
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(mockPush).not.toHaveBeenCalled()
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
   })
 
   it('offers a profile row before a from: filter row', async () => {

--- a/src/components/UserSearchInput.tsx
+++ b/src/components/UserSearchInput.tsx
@@ -38,7 +38,7 @@ export default function UserSearchInput({
   onBlur,
   onClick,
   onFocus,
-  onKeyDown,
+  onKeyDownCapture,
   onKeyUp,
   type = 'search',
   ...inputProps
@@ -228,9 +228,30 @@ export default function UserSearchInput({
             )
           }
         }}
-        onKeyDown={(event) => {
-          onKeyDown?.(event)
-          if (event.defaultPrevented || !isOpen) return
+        // Handle combobox keys before native bubble listeners can cancel Enter
+        // (observed in Brave), preventing React from silently skipping submit.
+        onKeyDownCapture={(event) => {
+          onKeyDownCapture?.(event)
+          if (event.defaultPrevented) return
+          // Committing an IME composition must not submit or choose a suggestion.
+          if (
+            event.nativeEvent.isComposing ||
+            event.nativeEvent.keyCode === 229
+          )
+            return
+
+          if (event.key === 'Enter' && (!isOpen || activeIndex < 0)) {
+            const form = event.currentTarget.form
+            if (form) {
+              // Submit explicitly: implicit submission from a search combobox
+              // is not reliable across browsers.
+              event.preventDefault()
+              closeSuggestions()
+              form.requestSubmit()
+            }
+            return
+          }
+          if (!isOpen) return
 
           if (event.key === 'ArrowDown') {
             event.preventDefault()


### PR DESCRIPTION
On `/search` in Brave, Enter in the main text box could leave the query unchanged while clicking Search worked. A native bubbling key listener had already prevented Enter before React's combobox handler ran, causing its `defaultPrevented` guard to return; the browser's implicit submission was cancelled too.

Handle combobox keys during capture and explicitly request the owning form's submission when no suggestion is selected. Preserve arrow-selected profile/author actions, close suggestions on submit, and avoid submitting or selecting while committing IME text.

Fixes #886.

Validation: 11 focused UserSearchInput tests pass, including native bubbling cancellation, exactly-once submission, visible suggestions, arrow selection and IME guards. Type check and focused lint pass. Reproduced the failure in the existing production Brave page, then verified Enter on the local Brave build navigates to `/search?q=cuties+ai` without clicking Search. Temporary event tracing removed. No schema or backend changes.

A production search also returned a ClickHouse 429 during diagnosis; this separate backend rate-limit behavior is not changed by the keyboard fix.
