### PR TITLE
Recover failed avatars and fix profile, upload, and sharing UX

### DIFF
--- a/src/app/admin/RecentArchiveUploads.test.tsx
+++ b/src/app/admin/RecentArchiveUploads.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react'
+import { RecentArchiveUploads } from './RecentArchiveUploads'
+
+test('shows separate upload records from the same existing account', () => {
+  const base = {
+    account_id: '42',
+    username: 'alice',
+    archive_at: '2026-08-01T00:00:00Z',
+    upload_phase: 'completed' as const,
+  }
+  render(
+    <RecentArchiveUploads
+      failed={false}
+      uploads={[
+        { ...base, id: 102, created_at: '2026-09-07T10:00:00Z' },
+        { ...base, id: 101, created_at: '2026-09-06T10:00:00Z' },
+      ]}
+    />,
+  )
+  expect(screen.getAllByRole('link', { name: '@alice' })).toHaveLength(2)
+  expect(screen.getByText('#102')).toBeVisible()
+  expect(screen.getByText('#101')).toBeVisible()
+  expect(screen.getByText('2026-09-07 10:00 UTC')).toBeVisible()
+})
+
+test('distinguishes an unavailable upload list from an empty one', () => {
+  render(<RecentArchiveUploads failed uploads={[]} />)
+  expect(screen.getByRole('alert')).toHaveTextContent('could not be loaded')
+  expect(screen.queryByText('No archive uploads yet.')).not.toBeInTheDocument()
+})

--- a/src/app/admin/RecentArchiveUploads.tsx
+++ b/src/app/admin/RecentArchiveUploads.tsx
@@ -1,0 +1,85 @@
+import Link from 'next/link'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { userProfileHref } from '@/lib/navigation'
+import type { RecentArchiveUploadsData } from './recentUploads'
+
+function date(value: string | null) {
+  if (!value) return 'Unknown'
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime())
+    ? 'Unknown'
+    : parsed.toISOString().replace('T', ' ').slice(0, 16) + ' UTC'
+}
+
+export function RecentArchiveUploads({
+  uploads,
+  failed,
+}: RecentArchiveUploadsData) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Recent archive uploads</CardTitle>
+        <CardDescription>
+          The latest 20 archive processing records, including repeat uploads by
+          existing members. Each upload is listed separately.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {failed ? (
+          <p role="alert">
+            Recent uploads could not be loaded. Refresh to try again.
+          </p>
+        ) : uploads.length === 0 ? (
+          <p>No archive uploads yet.</p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Upload</TableHead>
+                <TableHead>Account</TableHead>
+                <TableHead>Received</TableHead>
+                <TableHead>Archive date</TableHead>
+                <TableHead>Status</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {uploads.map((upload) => (
+                <TableRow key={upload.id}>
+                  <TableCell>#{upload.id}</TableCell>
+                  <TableCell>
+                    <Link
+                      href={userProfileHref(upload.username, upload.account_id)}
+                    >
+                      {upload.username
+                        ? `@${upload.username}`
+                        : upload.account_id}
+                    </Link>
+                  </TableCell>
+                  <TableCell>{date(upload.created_at)}</TableCell>
+                  <TableCell>{date(upload.archive_at)}</TableCell>
+                  <TableCell>
+                    {upload.upload_phase?.replaceAll('_', ' ') ?? 'Unknown'}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -10,6 +10,8 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { Suspense } from 'react'
 import { AdminTable } from './AdminTable'
 import { RecentPrivacyActivity } from './RecentPrivacyActivity'
+import { RecentArchiveUploads } from './RecentArchiveUploads'
+import { loadRecentArchiveUploads } from './recentUploads'
 import { loadRecentPrivacyActivity } from './activity'
 import {
   ADMIN_USERNAMES,
@@ -28,6 +30,10 @@ export const maxDuration = 300
 async function RecentPrivacyActivitySection() {
   const activity = await loadRecentPrivacyActivity()
   return <RecentPrivacyActivity activity={activity} />
+}
+
+async function RecentUploadsSection() {
+  return <RecentArchiveUploads {...await loadRecentArchiveUploads()} />
 }
 
 function SectionSkeleton({ label }: { label: string }) {
@@ -112,6 +118,12 @@ export default async function AdminPage({
             <Badge variant="secondary">@{twitterUsername}</Badge>
           </div>
         </section>
+
+        <Suspense
+          fallback={<SectionSkeleton label="Loading recent archive uploads" />}
+        >
+          <RecentUploadsSection />
+        </Suspense>
 
         <Suspense
           fallback={<SectionSkeleton label="Loading recent privacy activity" />}

--- a/src/app/admin/recentUploads.test.ts
+++ b/src/app/admin/recentUploads.test.ts
@@ -1,0 +1,30 @@
+import { loadRecentArchiveUploads } from './recentUploads'
+import { getAdminClient } from './data'
+jest.mock('./data', () => ({ getAdminClient: jest.fn() }))
+const getClient = getAdminClient as jest.Mock
+
+test('reads a bounded, deterministic upload history without deduplicating accounts', async () => {
+  const uploads = [
+    { id: 2, account_id: '42' },
+    { id: 1, account_id: '42' },
+  ]
+  const query = {
+    select: jest.fn().mockReturnThis(),
+    order: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockResolvedValue({ data: uploads, error: null }),
+  }
+  const from = jest.fn(() => query)
+  getClient.mockResolvedValue({ from })
+  expect(await loadRecentArchiveUploads()).toEqual({ uploads, failed: false })
+  expect(from).toHaveBeenCalledWith('archive_upload')
+  expect(query.order.mock.calls).toEqual([
+    ['created_at', { ascending: false, nullsFirst: false }],
+    ['id', { ascending: false }],
+  ])
+  expect(query.limit).toHaveBeenCalledWith(20)
+})
+
+test('keeps the admin identity gate outside error-to-empty handling', async () => {
+  getClient.mockRejectedValueOnce(new Error('Admin required'))
+  await expect(loadRecentArchiveUploads()).rejects.toThrow('Admin required')
+})

--- a/src/app/admin/recentUploads.ts
+++ b/src/app/admin/recentUploads.ts
@@ -1,0 +1,34 @@
+import 'server-only'
+import type { Database } from '@/database-types'
+import { getAdminClient } from './data'
+
+type Upload = Database['public']['Tables']['archive_upload']['Row']
+export type RecentArchiveUpload = Pick<
+  Upload,
+  | 'id'
+  | 'account_id'
+  | 'username'
+  | 'created_at'
+  | 'archive_at'
+  | 'upload_phase'
+>
+export type RecentArchiveUploadsData = {
+  uploads: RecentArchiveUpload[]
+  failed: boolean
+}
+
+export async function loadRecentArchiveUploads(): Promise<RecentArchiveUploadsData> {
+  const admin = await getAdminClient()
+  try {
+    const { data, error } = await admin
+      .from('archive_upload')
+      .select('id, account_id, username, created_at, archive_at, upload_phase')
+      .order('created_at', { ascending: false, nullsFirst: false })
+      .order('id', { ascending: false })
+      .limit(20)
+    if (error) throw error
+    return { uploads: data ?? [], failed: false }
+  } catch {
+    return { uploads: [], failed: true }
+  }
+}

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,64 @@
+import { ImageResponse } from 'next/og'
+
+export const alt = 'Community Archive — explore the conversations we preserve'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          width: '100%',
+          height: '100%',
+          padding: '72px 80px',
+          background: '#f8fbfd',
+          color: '#111113',
+          borderTop: '18px solid #25aadf',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            color: '#168bb8',
+            fontSize: 25,
+            letterSpacing: 3,
+          }}
+        >
+          COMMUNITY-ARCHIVE.ORG
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+          <div
+            style={{
+              display: 'flex',
+              fontSize: 88,
+              fontWeight: 700,
+              letterSpacing: -4,
+            }}
+          >
+            Community Archive
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              marginTop: 26,
+              fontSize: 36,
+              lineHeight: 1.35,
+              maxWidth: 900,
+              color: '#5e6570',
+            }}
+          >
+            Explore the people, ideas, and conversations we preserve together.
+          </div>
+        </div>
+        <div style={{ display: 'flex', fontSize: 25, color: '#168bb8' }}>
+          Search tweets · Discover people · Follow the conversation
+        </div>
+      </div>
+    ),
+    size,
+  )
+}

--- a/src/components/AvatarList.test.tsx
+++ b/src/components/AvatarList.test.tsx
@@ -1,64 +1,46 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import AvatarList from './AvatarList'
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ prefetch: jest.fn() }),
 }))
 
-jest.mock('@/components/ui/avatar', () => ({
-  Avatar: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
-  ),
-  AvatarImage: ({
-    alt = '',
-    ...props
-  }: React.ImgHTMLAttributes<HTMLImageElement>) => (
-    // eslint-disable-next-line @next/next/no-img-element
-    <img alt={alt} {...props} />
-  ),
-  AvatarFallback: ({ children }: { children: React.ReactNode }) => (
-    <span>{children}</span>
-  ),
-}))
+const archive = { account_id: '42', username: 'alice', avatar_media_url: '' }
+const pendingImages: HTMLImageElement[] = []
+const recovered = 'https://pbs.twimg.com/recovered_normal.jpg'
 
-const archive = {
-  account_id: '42',
-  username: 'alice',
-  avatar_media_url: '',
-}
-
-afterEach(() => {
-  jest.restoreAllMocks()
+beforeEach(() => {
+  pendingImages.length = 0
+  // Exercise real Radix preload behavior: failed images never mount in the DOM.
+  jest.spyOn(window, 'Image').mockImplementation(() => {
+    const image = document.createElement('img')
+    pendingImages.push(image)
+    return image
+  })
 })
+afterEach(() => jest.restoreAllMocks())
 
 it('recovers a missing homepage avatar through the bounded profile route', async () => {
   jest.spyOn(global, 'fetch').mockResolvedValueOnce({
     ok: true,
-    json: async () => ({
-      avatar_media_url: 'https://pbs.twimg.com/recovered_normal.jpg',
-    }),
+    json: async () => ({ avatar_media_url: recovered }),
   } as Response)
-
   render(<AvatarList initialAvatars={[archive]} compact />)
-
   expect(screen.getByText('A')).toBeInTheDocument()
-  await waitFor(() =>
-    expect(screen.getByAltText("alice's avatar")).toHaveAttribute(
-      'src',
-      'https://pbs.twimg.com/recovered_normal.jpg',
-    ),
+  await waitFor(() => expect(pendingImages).toHaveLength(1))
+  fireEvent.load(pendingImages[0])
+  expect(screen.getByAltText("alice's avatar")).toHaveAttribute(
+    'src',
+    recovered,
   )
   expect(global.fetch).toHaveBeenCalledWith('/api/profile/42/avatar')
 })
 
-it('tries recovery once when a stored avatar fails to load', async () => {
+it('refreshes a failed preloaded image and stops after a failed recovery image', async () => {
   jest.spyOn(global, 'fetch').mockResolvedValueOnce({
     ok: true,
-    json: async () => ({
-      avatar_media_url: 'https://pbs.twimg.com/recovered_normal.jpg',
-    }),
+    json: async () => ({ avatar_media_url: recovered }),
   } as Response)
-
   render(
     <AvatarList
       initialAvatars={[
@@ -70,16 +52,42 @@ it('tries recovery once when a stored avatar fails to load', async () => {
       compact
     />,
   )
-
-  fireEvent.error(screen.getByAltText("alice's avatar"))
-
-  await waitFor(() =>
-    expect(screen.getByAltText("alice's avatar")).toHaveAttribute(
-      'src',
-      'https://pbs.twimg.com/recovered_normal.jpg',
-    ),
-  )
+  expect(screen.queryByAltText("alice's avatar")).not.toBeInTheDocument()
+  fireEvent.error(pendingImages[0])
+  await waitFor(() => expect(pendingImages).toHaveLength(2))
+  expect(global.fetch).toHaveBeenCalledWith('/api/profile/42/avatar?refresh=1')
+  fireEvent.error(pendingImages[1])
+  expect(screen.getByText('A')).toBeInTheDocument()
   expect(global.fetch).toHaveBeenCalledTimes(1)
+})
+
+it('does not apply an old recovery response after the avatar input changes', async () => {
+  let resolve!: (response: Response) => void
+  jest.spyOn(global, 'fetch').mockReturnValueOnce(
+    new Promise((r) => {
+      resolve = r
+    }),
+  )
+  const { rerender } = render(<AvatarList initialAvatars={[archive]} />)
+  const newUrl = 'https://pbs.twimg.com/current_normal.jpg'
+  rerender(
+    <AvatarList initialAvatars={[{ ...archive, avatar_media_url: newUrl }]} />,
+  )
+  await act(async () =>
+    resolve({
+      ok: true,
+      json: async () => ({ avatar_media_url: recovered }),
+    } as Response),
+  )
+  expect(pendingImages).toHaveLength(1)
+  fireEvent.load(pendingImages[0])
+  expect(screen.getByAltText("alice's avatar")).toHaveAttribute('src', newUrl)
+})
+
+it('keeps Unicode initials intact when no photo is available', () => {
+  jest.spyOn(global, 'fetch').mockResolvedValue({ ok: false } as Response)
+  render(<AvatarList initialAvatars={[{ ...archive, username: '🌻alice' }]} />)
+  expect(screen.getByText('🌻')).toBeInTheDocument()
 })
 
 it('shows archived tweet count instead of follower count', () => {
@@ -88,7 +96,7 @@ it('shows archived tweet count instead of follower count', () => {
       initialAvatars={[
         {
           ...archive,
-          avatar_media_url: 'https://pbs.twimg.com/alice_normal.jpg',
+          avatar_media_url: recovered,
           num_tweets: 12_345,
           num_followers: 98_765,
         },
@@ -96,7 +104,6 @@ it('shows archived tweet count instead of follower count', () => {
       compact
     />,
   )
-
   expect(screen.getByText('12.3K tweets')).toBeInTheDocument()
   expect(screen.queryByText(/followers/)).not.toBeInTheDocument()
 })

--- a/src/components/AvatarList.tsx
+++ b/src/components/AvatarList.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useCallback, useEffect, useRef, useState } from 'react'
-import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
+import { useEffect, useState } from 'react'
+import RecoverableAvatar from '@/components/RecoverableAvatar'
 import { AvatarType } from '@/lib/types'
 import { formatNumber } from '@/lib/formatNumber'
 import Link from '@/components/IntentLink'
@@ -11,65 +11,6 @@ type AvatarListProps = {
   initialAvatars: AvatarType[]
   title?: string
   compact?: boolean
-}
-
-function RecoverableArchiveAvatar({
-  avatar,
-  compact,
-}: {
-  avatar: AvatarType
-  compact: boolean
-}) {
-  const [avatarUrl, setAvatarUrl] = useState(
-    avatar.avatar_media_url || undefined,
-  )
-  const attemptedRecovery = useRef(false)
-
-  useEffect(() => {
-    attemptedRecovery.current = false
-    setAvatarUrl(avatar.avatar_media_url || undefined)
-  }, [avatar.account_id, avatar.avatar_media_url])
-
-  const recoverAvatar = useCallback(() => {
-    if (attemptedRecovery.current) return
-    attemptedRecovery.current = true
-    void fetch(`/api/profile/${encodeURIComponent(avatar.account_id)}/avatar`)
-      .then(async (response) => {
-        if (!response.ok) return null
-        const body = (await response.json()) as { avatar_media_url?: unknown }
-        return typeof body.avatar_media_url === 'string' &&
-          body.avatar_media_url
-          ? body.avatar_media_url
-          : null
-      })
-      .then((recoveredAvatarUrl) => {
-        if (recoveredAvatarUrl) setAvatarUrl(recoveredAvatarUrl)
-      })
-      .catch(() => undefined)
-  }, [avatar.account_id])
-
-  useEffect(() => {
-    if (!avatar.avatar_media_url) recoverAvatar()
-  }, [avatar.avatar_media_url, recoverAvatar])
-
-  return (
-    <Avatar className={compact ? 'h-10 w-10' : 'h-12 w-12'}>
-      {avatarUrl ? (
-        <AvatarImage
-          src={avatarUrl}
-          alt={`${avatar.username}'s avatar`}
-          // Radix only mounts the image once it has decoded, so the fade runs
-          // exactly when the photo replaces the letter fallback.
-          className="home-fade-in"
-          onError={() => {
-            setAvatarUrl(undefined)
-            recoverAvatar()
-          }}
-        />
-      ) : null}
-      <AvatarFallback>{avatar.username[0].toUpperCase()}</AvatarFallback>
-    </Avatar>
-  )
 }
 
 const AvatarList = ({
@@ -102,7 +43,14 @@ const AvatarList = ({
                 compact ? 'w-20' : 'w-24'
               }`}
             >
-              <RecoverableArchiveAvatar avatar={avatar} compact={compact} />
+              <RecoverableAvatar
+                accountId={avatar.account_id}
+                avatarUrl={avatar.avatar_media_url}
+                displayName={avatar.username}
+                alt={`${avatar.username}'s avatar`}
+                className={compact ? 'h-10 w-10' : 'h-12 w-12'}
+                imageClassName="home-fade-in"
+              />
               <span
                 className={`mt-1 w-full min-w-0 leading-tight [overflow-wrap:anywhere] ${
                   compact ? 'min-h-7 text-[11px]' : 'text-xs'

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -11,7 +11,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import RecoverableAvatar from '@/components/RecoverableAvatar'
 import { userProfileHref } from '@/lib/navigation'
 import { capturePostHogEvent } from '@/lib/posthog'
 
@@ -26,8 +26,6 @@ export default function MobileMenu() {
     userMetadata?.picture ??
     userMetadata?.profile_image_url_https ??
     userMetadata?.profile_image_url
-  const avatarFallback =
-    userMetadata?.user_name?.slice(0, 2).toUpperCase() ?? 'ME'
 
   const handleSignOut = async () => {
     capturePostHogEvent('navigation_item_clicked', {
@@ -53,12 +51,15 @@ export default function MobileMenu() {
           className="overflow-hidden rounded-full"
         >
           {userMetadata ? (
-            <Avatar className="h-9 w-9">
-              <AvatarImage src={avatarUrl} alt="" className="object-cover" />
-              <AvatarFallback className="text-xs font-semibold">
-                {avatarFallback}
-              </AvatarFallback>
-            </Avatar>
+            <RecoverableAvatar
+              accountId={String(userMetadata.provider_id ?? '')}
+              avatarUrl={avatarUrl}
+              displayName={userMetadata.user_name || 'ME'}
+              className="h-9 w-9"
+              imageClassName="object-cover"
+              fallbackClassName="text-xs font-semibold"
+              fallbackLength={2}
+            />
           ) : (
             <UserRound className="h-5 w-5" />
           )}

--- a/src/components/RecoverableAvatar.tsx
+++ b/src/components/RecoverableAvatar.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+
+type Props = {
+  accountId: string
+  avatarUrl?: string | null
+  displayName: string
+  alt?: string
+  className?: string
+  imageClassName?: string
+  fallbackClassName?: string
+  fallbackLength?: number
+}
+
+export default function RecoverableAvatar(props: Props) {
+  return (
+    <ResolvedAvatar
+      key={`${props.accountId}:${props.avatarUrl ?? ''}`}
+      {...props}
+    />
+  )
+}
+
+function ResolvedAvatar({
+  accountId,
+  avatarUrl,
+  displayName,
+  alt = '',
+  className,
+  imageClassName,
+  fallbackClassName,
+  fallbackLength = 1,
+}: Props) {
+  const [url, setUrl] = useState(avatarUrl || null)
+  const attempted = useRef(new Set<boolean>())
+  const mounted = useRef(true)
+  useEffect(() => {
+    mounted.current = true
+    return () => {
+      mounted.current = false
+    }
+  }, [])
+
+  const recover = useCallback(
+    (refresh = false) => {
+      if (!/^\d{1,20}$/.test(accountId) || attempted.current.has(refresh))
+        return
+      attempted.current.add(refresh)
+      void fetch(
+        `/api/profile/${encodeURIComponent(accountId)}/avatar${refresh ? '?refresh=1' : ''}`,
+      )
+        .then(async (response) => {
+          if (!response.ok) return null
+          const body = (await response.json()) as { avatar_media_url?: unknown }
+          return typeof body.avatar_media_url === 'string' &&
+            body.avatar_media_url
+            ? body.avatar_media_url
+            : null
+        })
+        .then((recovered) => {
+          if (mounted.current && recovered) setUrl(recovered)
+        })
+        .catch(() => undefined)
+    },
+    [accountId],
+  )
+
+  useEffect(() => {
+    if (!avatarUrl) recover()
+  }, [avatarUrl, recover])
+
+  return (
+    <Avatar className={className}>
+      {url ? (
+        <AvatarImage
+          src={url}
+          alt={alt}
+          className={imageClassName}
+          onLoadingStatusChange={(status) => {
+            // Radix decodes off-DOM; failed images never mount an img/onError.
+            if (status === 'error') {
+              setUrl(null)
+              recover(true)
+            }
+          }}
+        />
+      ) : null}
+      <AvatarFallback className={fallbackClassName}>
+        {(
+          Array.from(displayName).slice(0, fallbackLength).join('') || '@'
+        ).toUpperCase()}
+      </AvatarFallback>
+    </Avatar>
+  )
+}

--- a/src/components/metaTwitter/ProfileArchive.test.tsx
+++ b/src/components/metaTwitter/ProfileArchive.test.tsx
@@ -964,3 +964,42 @@ test('shows no sections when none are provided', () => {
   // Sectionless chapters stay directly clickable.
   expect(screen.getAllByRole('link', { name: '2025 4' })).not.toHaveLength(0)
 })
+
+test('refills the visible people list from the reserve after a dismissal', async () => {
+  const user = userEvent.setup()
+  renderProfileArchive(
+    <ProfileArchive
+      accountId="42"
+      avatarUrl={null}
+      basePath="/user/alice"
+      chapters={chapters}
+      displayName="Alice"
+      initialYear={null}
+      initialPage={{
+        tweets: [],
+        yearCounts: [],
+        total: 0,
+        nextOffset: null,
+        available: true,
+      }}
+      initialSidebar={{
+        media: [],
+        mediaCount: 0,
+        people: Array.from({ length: 10 }, (_, i) => ({
+          user_id: String(100 + i),
+          screen_name: `person${i}`,
+          name: `Person ${i}`,
+          interactions: 20 - i,
+        })),
+      }}
+    />,
+    { withEditButton: true },
+  )
+  await user.click(screen.getByRole('button', { name: 'Edit profile' }))
+  expect(screen.getByText('Person 0')).toBeVisible()
+  expect(screen.queryByText('Person 8')).not.toBeInTheDocument()
+  await user.click(screen.getByRole('button', { name: 'Dismiss @person0' }))
+  await waitFor(() => expect(screen.getByText('Person 8')).toBeVisible())
+  expect(screen.queryByText('Person 0')).not.toBeInTheDocument()
+  expect(screen.queryByText('Person 9')).not.toBeInTheDocument()
+})

--- a/src/components/metaTwitter/ProfileArchive.tsx
+++ b/src/components/metaTwitter/ProfileArchive.tsx
@@ -309,7 +309,7 @@ export function ProfileArchive({
         bangersLoading={activeFeedLoading || (!activeFeed && !activeFeedFailed)}
         media={activeMedia?.media ?? []}
         mediaCount={activeMedia?.mediaCount ?? 0}
-        people={activePeople?.people ?? []}
+        people={(activePeople?.people ?? []).slice(0, 8)}
         peopleTitle={activeYear ? `People in ${activeYear}` : 'Top people'}
         mediaLoading={
           activeMediaLoading || (!activeMedia && !activeMediaFailed)

--- a/src/lib/metaTwitter/clickhouseSidebar.test.ts
+++ b/src/lib/metaTwitter/clickhouseSidebar.test.ts
@@ -130,3 +130,17 @@ test('omits the year for the all-time sidebar and rejects scope drift', async ()
     fetchClickHouseProfileSidebar('42', 2025, wrongYearFetcher),
   ).rejects.toThrow('mismatched profile sidebar scope')
 })
+
+test('loads a bounded reserve of people for the editable all-time profile', async () => {
+  const payload = response(null)
+  payload.query.peopleLimit = 25
+  const fetcher = jest.fn(
+    async () => payload,
+  ) as unknown as AnalyticsGatewayFetcher
+  await fetchClickHouseProfileInteractions('42', undefined, fetcher)
+  expect(fetcher).toHaveBeenCalledWith(
+    ['user', '42', 'interactions'],
+    new URLSearchParams({ limit: '25' }),
+    { timeoutMs: 30_000 },
+  )
+})

--- a/src/lib/metaTwitter/clickhouseSidebar.ts
+++ b/src/lib/metaTwitter/clickhouseSidebar.ts
@@ -216,15 +216,18 @@ export async function fetchClickHouseProfileInteractions(
   if (!ID_PATTERN.test(accountId)) {
     throw new Error('Profile interactions require a numeric account ID')
   }
+  // Keep a bounded reserve so hiding a top person can reveal the next one.
+  // The gateway supports at most 25 candidates; year views are not editable.
+  const candidateLimit = year === undefined ? 25 : PEOPLE_LIMIT
   const response = await fetcher<InteractionsResponse>(
     ['user', accountId, 'interactions'],
-    profileParams(year, PEOPLE_LIMIT),
+    profileParams(year, candidateLimit),
     { timeoutMs: 30_000 },
   )
   if (
     response.query?.accountId !== accountId ||
     response.query?.year !== (year ?? null) ||
-    Number(response.query?.peopleLimit) !== PEOPLE_LIMIT
+    Number(response.query?.peopleLimit) !== candidateLimit
   ) {
     throw new Error('ClickHouse returned mismatched profile interactions scope')
   }
@@ -301,7 +304,7 @@ const getCachedClickHouseProfileMedia = unstable_cache(
 
 const getCachedClickHouseProfileInteractions = unstable_cache(
   fetchClickHouseProfileInteractions,
-  ['meta-twitter-clickhouse-profile-interactions-v1'],
+  ['meta-twitter-clickhouse-profile-interactions-v2'],
   { revalidate: DAY },
 )
 

--- a/src/lib/portal/data.test.ts
+++ b/src/lib/portal/data.test.ts
@@ -570,6 +570,74 @@ describe('portal reads', () => {
     expect(tweetsInit?.signal).toBeInstanceOf(AbortSignal)
   })
 
+  test.each([true, false])(
+    'preserves stream quote targets (available=%s)',
+    async (available) => {
+      const quote = {
+        tweetId: '99',
+        accountId: '8',
+        createdAt: '2026-08-07 18:00:00.000',
+        fullText: 'The quoted context',
+        favoriteCount: '9',
+        retweetCount: '1',
+        username: 'quoted_author',
+        accountDisplayName: 'Quoted Author',
+        avatarMediaUrl: null,
+        media: [
+          {
+            mediaUrl: 'https://pbs.twimg.com/media/quote.jpg',
+            mediaType: 'photo',
+            width: 800,
+            height: 600,
+          },
+        ],
+      }
+      jest
+        .spyOn(global, 'fetch')
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          text: async () =>
+            JSON.stringify({
+              data: {
+                tweets: [
+                  {
+                    ...quote,
+                    tweetId: '100',
+                    latestObservedAt: '2026-08-07 20:00:00.000',
+                    followerCount: '5',
+                    quoteTweetId: '99',
+                    quotedTweet: available ? quote : null,
+                  },
+                ],
+                updateCursor: null,
+              },
+            }),
+        } as Response)
+      const [tweet] = await getPortalStreamUpdates(1)
+      expect(tweet.quotedTweet).toMatchObject(
+        available
+          ? {
+              id: '99',
+              accountId: '8',
+              username: 'quoted_author',
+              text: 'The quoted context',
+              createdAt: '2026-08-07T18:00:00.000Z',
+              likes: 9,
+              media: [
+                {
+                  url: 'https://pbs.twimg.com/media/quote.jpg',
+                  type: 'photo',
+                  width: 800,
+                  height: 600,
+                },
+              ],
+            }
+          : { id: '99', text: '', isDeleted: true },
+      )
+    },
+  )
+
   test('loads the initial bangers explorer in a 30-row page', async () => {
     fetchPortalBangersPageMock.mockResolvedValueOnce({
       tweets: [],

--- a/src/lib/portal/data.ts
+++ b/src/lib/portal/data.ts
@@ -297,15 +297,13 @@ function validatedPageCursor(
   return { createdAt: createdAt.toISOString(), id: cursor.id }
 }
 
-interface ClickHousePortalStreamTweet {
+interface ClickHousePortalTweet {
   tweetId: string
   accountId: string
   createdAt: string
-  latestObservedAt: string
   fullText: string
   favoriteCount: string | number
   retweetCount: string | number
-  followerCount: string | number
   username: string | null
   accountDisplayName: string | null
   avatarMediaUrl: string | null
@@ -315,6 +313,13 @@ interface ClickHousePortalStreamTweet {
     width: number | null
     height: number | null
   }>
+}
+
+interface ClickHousePortalStreamTweet extends ClickHousePortalTweet {
+  latestObservedAt: string
+  followerCount: string | number
+  quoteTweetId?: string | null
+  quotedTweet?: ClickHousePortalTweet | null
 }
 
 interface ClickHousePortalStreamResponse {
@@ -343,9 +348,9 @@ function clickHousePortalTimestamp(value: string, field: string): string {
   return timestamp.toISOString()
 }
 
-function mapClickHousePortalStreamTweet(
-  row: ClickHousePortalStreamTweet,
-): PortalTweet {
+function mapClickHousePortalTweet(
+  row: ClickHousePortalTweet,
+): PortalQuotedTweet {
   if (
     !/^\d{1,32}$/.test(row.tweetId) ||
     !/^\d{1,32}$/.test(row.accountId) ||
@@ -361,14 +366,9 @@ function mapClickHousePortalStreamTweet(
     name: row.accountDisplayName || username,
     avatar: row.avatarMediaUrl || null,
     text: row.fullText,
-    observedAt: clickHousePortalTimestamp(
-      row.latestObservedAt,
-      'observation timestamp',
-    ),
     createdAt: clickHousePortalTimestamp(row.createdAt, 'authored timestamp'),
     likes: clickHousePortalCount(row.favoriteCount, 'favorite count'),
     rts: clickHousePortalCount(row.retweetCount, 'repost count'),
-    followers: clickHousePortalCount(row.followerCount, 'follower count'),
     media: (row.media || []).flatMap((item): PortalMedia[] => {
       if (!item.mediaUrl || !item.mediaType) return []
       return [
@@ -380,6 +380,37 @@ function mapClickHousePortalStreamTweet(
         },
       ]
     }),
+  }
+}
+
+function mapClickHousePortalStreamTweet(
+  row: ClickHousePortalStreamTweet,
+): PortalTweet {
+  const tweet = mapClickHousePortalTweet(row)
+  const quotedTweet = row.quotedTweet
+    ? mapClickHousePortalTweet(row.quotedTweet)
+    : row.quoteTweetId && /^\d{1,32}$/.test(row.quoteTweetId)
+      ? {
+          id: row.quoteTweetId,
+          username: '',
+          name: '',
+          avatar: null,
+          text: '',
+          createdAt: tweet.createdAt,
+          likes: 0,
+          rts: 0,
+          media: [],
+          isDeleted: true,
+        }
+      : undefined
+  return {
+    ...tweet,
+    observedAt: clickHousePortalTimestamp(
+      row.latestObservedAt,
+      'observation timestamp',
+    ),
+    followers: clickHousePortalCount(row.followerCount, 'follower count'),
+    ...(quotedTweet ? { quotedTweet } : {}),
   }
 }
 


### PR DESCRIPTION
Failed homepage and account-menu avatars can remain stuck on initials because Radix preloads images off-DOM, so the previous `onError` handler never runs. Use its loading-status callback for bounded recovery, reset recovery when the account/source changes, and discard stale responses.

This QA batch also:
- Keeps up to 25 top-interaction candidates while showing eight, so dismissing a person reveals the next candidate. Year-specific lists stay unchanged. Fixes #725.
- Adds an admin-only recent-upload table with one row per processing record, including repeat uploads from existing members. Fixes #761.
- Adds a default 1200×630 social card for the homepage and routes without their own card. The existing RichDecibels profile image and its Open Graph/Twitter metadata were verified on production. Fixes #816.
- Preserves quoted text, author, and media from the live-stream response, with the existing unavailable-quote presentation when only an ID is known. Refs #814; requires https://github.com/TheExGenesis/community-archive-control-panel/pull/213 to be deployed first.

Refs #819 for failed corner-avatar recovery. Whether that issue also describes an older but still valid photo remains to be confirmed, so it should stay open for now.

Validation: 60 focused website tests passed across avatar/menu, profile interactions, admin uploads, and portal data/rendering; TypeScript and focused ESLint passed. Local browser fixtures verified quote rendering, separate rows for repeat uploads, and the failed-image recovery request. The new default PNG was rendered and visually reviewed, with both OG and Twitter discovery verified. The local checkout lacks the gateway credential, so successful upstream avatar recovery was validated in component tests rather than end-to-end against production. Temporary QA fixtures were removed.

Release notes: deploy and smoke the compatible gateway quote response before releasing this website change. The adapter accepts older gateway responses during rollout. No merge, production deployment, user curation changes, or bulk data operations were performed. #882 remains outside this fix: production docs currently report that bulk export is paused.
