### PR TITLE
Update homepage and docs for the daily data export

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 - [Agent entry point](https://www.community-archive.org/llms.txt) machine-readable index of the docs and API usage.
 - [Website docs](https://www.community-archive.org/docs) quickstart for agents, developers, and researchers.
-- [API docs](./api-doc.md) how owners download their private raw JSON or query the public database API.
+- [API docs](./api-doc.md) download the daily Parquet export, query the public API, or access your own private raw archive.
 - [Declarative schemas](./supabase-declarative-schemas.md) how to evolve the database using ordered schema files and migrations.
 - [Daily Digest](./daily-digest.md) explains the editorial lab, reproducible generation runs, publication boundary, and rollout gates.
 - [Website architecture](./website-architecture.md) feature ownership, tweet contracts, and client state boundaries.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -17,15 +17,22 @@ Source repository: https://github.com/TheExGenesis/community-archive
 ## Choose the right data access method
 
 1. Filtered or application queries: use the Supabase REST API.
-2. Bulk analysis: the historical Parquet artifact is unavailable while its exporter is rebuilt to enforce current consent.
+2. Bulk analysis: download the daily consent-safe Parquet package from the [latest release](https://github.com/TheExGenesis/community-archive/releases/latest).
 3. One user's original processed archive: authenticated owners may use the policy-aware web endpoint for their own archive.
 
 ## Bulk dump
 
-The historical `enriched_tweets.parquet` object and release verifier are
-disabled because that exporter did not apply current PostgreSQL consent to
-every nested author immediately before publication. Use filtered REST queries
-until a policy-aware replacement is available.
+The daily package contains enriched `tweets.parquet`, separate `profiles.parquet`,
+and `manifest.json` with row counts, schemas, and checksums. It includes eligible
+members and checks current PostgreSQL membership and opt-outs before publication,
+including consent for referenced authors.
+
+Start from the [latest GitHub release](https://github.com/TheExGenesis/community-archive/releases/latest).
+Scripts can read the stable [latest.json pointer](https://fabxmporizzqflnftavs.supabase.co/storage/v1/object/public/community-archive-public-export/latest.json)
+and follow its `manifest_url` to the current package. GitHub lists download links;
+the Parquet files remain in consent-managed storage. Superseded packages are
+removed, so do not bookmark versioned file URLs. Downloads may be temporarily
+withdrawn when consent changes.
 
 ## API
 
@@ -66,7 +73,7 @@ Important API rules:
 - Use PostgREST filters such as `username=eq.name`, `created_at=gte.2025-01-01`, and `order=created_at.desc`.
 - Select only needed columns.
 - Responses are capped at 1,000 rows. Paginate with `limit` and `offset` or HTTP Range headers, using a stable order.
-- Full-corpus bulk access is paused until the Parquet exporter is policy-aware.
+- Bulk exports include eligible members, not every account observed in the archive.
 
 ## Individual raw archives
 

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -3,6 +3,10 @@ import Link from 'next/link'
 import { ArrowUpRight, Bot, Braces, Database } from 'lucide-react'
 
 const API_URL = 'https://fabxmporizzqflnftavs.supabase.co'
+const EXPORT_RELEASE_URL =
+  'https://github.com/TheExGenesis/community-archive/releases/latest'
+const EXPORT_POINTER_URL =
+  'https://fabxmporizzqflnftavs.supabase.co/storage/v1/object/public/community-archive-public-export/latest.json'
 const ANON_KEY =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZhYnhtcG9yaXp6cWZsbmZ0YXZzIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MjIyNDQ5MTIsImV4cCI6MjAzNzgyMDkxMn0.UIEJiUNkLsW28tBHmG-RQDW-I5JNlJLt62CSk9D_qG8'
 export const metadata: Metadata = {
@@ -83,8 +87,8 @@ export default function DocsPage() {
               Build with the archive
             </h1>
             <p className="max-w-2xl text-lg leading-8 text-muted-foreground">
-              Query policy-filtered public records through the API or give an
-              agent one canonical starting point.
+              Download the daily data export, query public records through the
+              API, or give an agent one canonical starting point.
             </p>
             <div className="rounded-lg border border-brand/30 bg-brand/5 p-5">
               <p className="mb-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
@@ -117,12 +121,18 @@ export default function DocsPage() {
             <article className="rounded-lg border border-border bg-card p-6">
               <Database className="h-6 w-6 text-brand" aria-hidden="true" />
               <h3 className="mt-4 text-lg font-semibold text-foreground">
-                Bulk export paused
+                Bulk Parquet export
               </h3>
               <p className="mt-2 text-sm leading-6 text-muted-foreground">
-                The historical Parquet pipeline is private while it is rebuilt
-                to enforce current consent for every nested author.
+                Download tweets and profiles for bulk analysis. Each daily
+                export checks current membership and opt-outs before
+                publication.
               </p>
+              <div className="mt-4">
+                <ResourceLink href={EXPORT_RELEASE_URL}>
+                  Download the latest export
+                </ResourceLink>
+              </div>
             </article>
 
             <article className="rounded-lg border border-border bg-card p-6">
@@ -161,14 +171,30 @@ export default function DocsPage() {
         <section className="space-y-6" id="bulk-dump">
           <div className="max-w-3xl">
             <h2 className="text-3xl font-bold text-foreground">
-              Bulk export paused
+              Bulk Parquet export
             </h2>
             <p className="mt-2 leading-7 text-muted-foreground">
-              The former <code>enriched_tweets.parquet</code> artifact was not
-              able to apply current consent to every nested author immediately
-              before publication. It is no longer public. Use filtered API
-              requests until a policy-aware replacement is available.
+              The daily package contains enriched <code>tweets.parquet</code>,
+              separate <code>profiles.parquet</code>, and a{' '}
+              <code>manifest.json</code> with row counts, schemas, and
+              checksums. It includes eligible members and applies current
+              consent to referenced authors too.
             </p>
+            <p className="mt-3 leading-7 text-muted-foreground">
+              Use the latest release link below to find the most recent
+              successful export. GitHub lists the download links; the files stay
+              in consent-managed storage. Superseded packages are removed, so
+              bookmark the latest release rather than an individual Parquet URL.
+              Downloads may be temporarily withdrawn when consent changes.
+            </p>
+            <div className="mt-4 flex flex-wrap gap-4">
+              <ResourceLink href={EXPORT_RELEASE_URL}>
+                Download the latest export
+              </ResourceLink>
+              <ResourceLink href={EXPORT_POINTER_URL}>
+                Latest JSON pointer for scripts
+              </ResourceLink>
+            </div>
           </div>
         </section>
 

--- a/src/components/portal/Portal.tsx
+++ b/src/components/portal/Portal.tsx
@@ -23,7 +23,8 @@ import { CHROME_EXTENSION_URL } from '@/lib/browserExtension'
 export type PortalView = 'home' | 'stream'
 
 const HOME_LIVE_STREAM_LIMIT = 12
-const ARCHIVE_EXPORT_URL = '/docs#bulk-dump'
+const ARCHIVE_EXPORT_URL =
+  'https://github.com/TheExGenesis/community-archive/releases/latest'
 const COMMUNITY_BUILDS_URL = '/tweets/1835411943735140798'
 
 type DashboardDestination =
@@ -725,9 +726,9 @@ export function HomePortalLayout({
             <UtilityLink
               href={ARCHIVE_EXPORT_URL}
               destination="data_export"
-              title="Bulk export paused"
-              note="Why the historical Parquet file is private"
-              action="Details"
+              title="Daily data export"
+              note="Tweets and profiles in Parquet"
+              action="Download"
               icon={<FaDatabase className="h-[17px] w-[17px]" />}
             />
             <UtilityLink

--- a/src/components/portal/PortalLayout.test.tsx
+++ b/src/components/portal/PortalLayout.test.tsx
@@ -90,8 +90,11 @@ test('renders the balanced homepage composition and editorial labels', async () 
     screen.getByRole('link', { name: /All-time bangers/i }),
   ).toHaveAttribute('href', '/bangers?period=all')
   expect(
-    screen.getByRole('link', { name: /Bulk export paused/i }),
-  ).toHaveAttribute('href', '/docs#bulk-dump')
+    screen.getByRole('link', { name: /Daily data export/i }),
+  ).toHaveAttribute(
+    'href',
+    'https://github.com/TheExGenesis/community-archive/releases/latest',
+  )
   expect(
     screen.getByRole('link', { name: /Community Builds/i }),
   ).toHaveAttribute('href', '/tweets/1835411943735140798')


### PR DESCRIPTION
The homepage and website docs still described bulk exports as paused after the daily consent-safe exporter resumed publication. Replace that stale wording with a daily export card and links to the latest GitHub release.

The docs describe the tweets/profiles/manifest package, expose the stable JSON pointer for scripts, and explain why superseded file URLs expire. Update the agent entry point and documentation index to match.

Validation: both existing homepage layout tests pass; lint passes for the changed TSX files; full TypeScript check and `git diff --check` pass. The latest release and package were verified in the preceding production export run. The database-regeneration pre-commit hook was skipped for this copy/link-only change; no schema or generated API artifacts changed.
