### PR TITLE
Recover stale homepage avatars from the current profile first

### DIFF
--- a/src/components/AvatarList.test.tsx
+++ b/src/components/AvatarList.test.tsx
@@ -36,7 +36,7 @@ it('recovers a missing homepage avatar through the bounded profile route', async
   expect(global.fetch).toHaveBeenCalledWith('/api/profile/42/avatar')
 })
 
-it('refreshes a failed preloaded image and stops after a failed recovery image', async () => {
+it('uses the current stored profile photo when a homepage snapshot image fails', async () => {
   jest.spyOn(global, 'fetch').mockResolvedValueOnce({
     ok: true,
     json: async () => ({ avatar_media_url: recovered }),
@@ -46,19 +46,49 @@ it('refreshes a failed preloaded image and stops after a failed recovery image',
       initialAvatars={[
         {
           ...archive,
-          avatar_media_url: 'https://pbs.twimg.com/broken_normal.jpg',
+          avatar_media_url: 'https://pbs.twimg.com/old_normal.jpg',
         },
       ]}
-      compact
     />,
   )
-  expect(screen.queryByAltText("alice's avatar")).not.toBeInTheDocument()
   fireEvent.error(pendingImages[0])
   await waitFor(() => expect(pendingImages).toHaveLength(2))
-  expect(global.fetch).toHaveBeenCalledWith('/api/profile/42/avatar?refresh=1')
-  fireEvent.error(pendingImages[1])
-  expect(screen.getByText('A')).toBeInTheDocument()
+  fireEvent.load(pendingImages[1])
+  expect(screen.getByAltText("alice's avatar")).toHaveAttribute(
+    'src',
+    recovered,
+  )
   expect(global.fetch).toHaveBeenCalledTimes(1)
+  expect(global.fetch).toHaveBeenCalledWith('/api/profile/42/avatar')
+})
+
+it('tries a fresh lookup only if the stored photo also fails, then stops', async () => {
+  const broken = 'https://pbs.twimg.com/broken_normal.jpg'
+  jest
+    .spyOn(global, 'fetch')
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ avatar_media_url: broken }),
+    } as Response)
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ avatar_media_url: recovered }),
+    } as Response)
+  render(
+    <AvatarList initialAvatars={[{ ...archive, avatar_media_url: broken }]} />,
+  )
+  fireEvent.error(pendingImages[0])
+  await waitFor(() => expect(pendingImages).toHaveLength(2))
+  fireEvent.error(pendingImages[1])
+  await waitFor(() => expect(pendingImages).toHaveLength(3))
+  expect(global.fetch).toHaveBeenNthCalledWith(1, '/api/profile/42/avatar')
+  expect(global.fetch).toHaveBeenNthCalledWith(
+    2,
+    '/api/profile/42/avatar?refresh=1',
+  )
+  fireEvent.error(pendingImages[2])
+  expect(screen.getByText('A')).toBeInTheDocument()
+  expect(global.fetch).toHaveBeenCalledTimes(2)
 })
 
 it('does not apply an old recovery response after the avatar input changes', async () => {

--- a/src/components/RecoverableAvatar.tsx
+++ b/src/components/RecoverableAvatar.tsx
@@ -82,7 +82,9 @@ function ResolvedAvatar({
             // Radix decodes off-DOM; failed images never mount an img/onError.
             if (status === 'error') {
               setUrl(null)
-              recover(true)
+              // Featured/OAuth URLs can lag behind the current profile photo.
+              // Try that stored photo before a fresh external lookup.
+              recover(attempted.current.has(false))
             }
           }}
         />


### PR DESCRIPTION
When a featured homepage or account-menu avatar URL is stale, image recovery currently skips the stored profile photo and goes straight to an external lookup. This can leave initials visible even when the profile has a working photo.

Try the current stored profile photo first, then request a fresh lookup only if that image also fails. Recovery remains bounded to one request per mode, with existing account/source reset and stale-response protection preserved.

Closes #819.

Validation: seven focused AvatarList/MobileMenu tests passed, including actual Radix preload failure, successful stored-photo recovery, and bounded failure of both recovery attempts. Focused ESLint, TypeScript, and diff checks passed. Production recovery endpoint probes were blocked/rate-limited, so successful recovery is covered by component tests rather than claimed as a live end-to-end check.
