### PR TITLE
Default Bangers to Last 7 Days

### DIFF
--- a/src/app/bangers/page.tsx
+++ b/src/app/bangers/page.tsx
@@ -40,14 +40,15 @@ export default function BangersPage({
     periodValue === 'week' ||
     periodValue === 'three-months'
       ? periodValue
-      : undefined
-  const allTime =
-    periodValue === 'all' || (period === undefined && year === undefined)
+      : periodValue === 'all' || year !== undefined
+        ? undefined
+        : 'week'
+  const allTime = periodValue === 'all'
   const query = paramValue(searchParams.q).trim().slice(0, 120)
   const initialPage = getInitialPortalBangersPage({
     scope,
     sort,
-    ...(period ? { period } : { year }),
+    ...(period ? { period } : { year: allTime ? undefined : year }),
     query,
   })
 
@@ -82,7 +83,7 @@ export default function BangersPage({
             scope={scope}
             sort={sort}
             currentYear={currentYear}
-            year={period ? undefined : year}
+            year={period || allTime ? undefined : year}
             period={period}
             allTime={allTime}
             initialQuery={query}

--- a/src/components/portal/PortalLayout.test.tsx
+++ b/src/components/portal/PortalLayout.test.tsx
@@ -88,7 +88,7 @@ test('renders the balanced homepage composition and editorial labels', async () 
   )
   expect(
     screen.getByRole('link', { name: /All-time bangers/i }),
-  ).toHaveAttribute('href', '/bangers?period=all')
+  ).toHaveAttribute('href', '/bangers?period=week')
   expect(
     screen.getByRole('link', { name: /Daily data export/i }),
   ).toHaveAttribute(

--- a/src/components/portal/PortalLayout.test.tsx
+++ b/src/components/portal/PortalLayout.test.tsx
@@ -88,7 +88,7 @@ test('renders the balanced homepage composition and editorial labels', async () 
   )
   expect(
     screen.getByRole('link', { name: /All-time bangers/i }),
-  ).toHaveAttribute('href', '/bangers?period=week')
+  ).toHaveAttribute('href', '/bangers?period=all')
   expect(
     screen.getByRole('link', { name: /Daily data export/i }),
   ).toHaveAttribute(

--- a/src/lib/bangersPageDefault.test.tsx
+++ b/src/lib/bangersPageDefault.test.tsx
@@ -1,0 +1,27 @@
+import BangersPage from '@/app/bangers/page'
+import { getInitialPortalBangersPage } from '@/lib/portal/data'
+jest.mock('@/lib/portal/data', () => ({
+  getInitialPortalBangersPage: jest.fn(),
+}))
+jest.mock('@/components/portal/BangersExplorer', () => ({
+  BangersExplorer: () => null,
+}))
+jest.mock('@/components/PagePerformance', () => ({ SectionReady: () => null }))
+const load = jest.mocked(getInitialPortalBangersPage)
+beforeEach(() => load.mockClear())
+test.each([
+  [{}, { period: 'week' }],
+  [{ period: 'nonsense' }, { period: 'week' }],
+  [{ year: '2024' }, { year: 2024 }],
+  [{ period: 'all' }, { year: undefined }],
+  [{ period: 'all', year: '2024' }, { year: undefined }],
+  [{ period: 'today', year: '2024' }, { period: 'today' }],
+])('resolves the page time selection %j', (searchParams, expected) => {
+  BangersPage({ searchParams })
+  expect(load).toHaveBeenCalledWith({
+    scope: 'all',
+    sort: 'quotes',
+    query: '',
+    ...expected,
+  })
+})

--- a/src/lib/navigation.test.ts
+++ b/src/lib/navigation.test.ts
@@ -30,7 +30,7 @@ describe('member navigation', () => {
 
   it('uses the requested primary order without a redundant Home link', () => {
     expect(getPrimaryNav(true)).toEqual([
-      { href: '/bangers?period=all', label: 'Bangers' },
+      { href: '/bangers?period=week', label: 'Bangers' },
       { href: '/digest', label: 'Digest' },
       { href: '/user-dir', label: 'Users' },
       { href: '/community', label: 'Apps' },
@@ -43,21 +43,21 @@ describe('member navigation', () => {
       expect.arrayContaining([
         { href: '/user-dir', label: 'Users' },
         { href: '/stream', label: 'Live stream' },
-        { href: '/bangers?period=all', label: 'Bangers' },
+        { href: '/bangers?period=week', label: 'Bangers' },
         { href: '/digest', label: 'Digest' },
         { href: '/search', label: 'Search' },
         { href: '/community', label: 'Apps' },
         { href: '/social-graph', label: 'Graph' },
       ]),
     )
-    expect(isNavItemActive('/bangers', '/bangers?period=all')).toBe(true)
+    expect(isNavItemActive('/bangers', '/bangers?period=week')).toBe(true)
     expect(isNavItemActive('/stream', '/stream')).toBe(true)
-    expect(isNavItemActive('/search', '/bangers?period=all')).toBe(false)
+    expect(isNavItemActive('/search', '/bangers?period=week')).toBe(false)
   })
 
   it('keeps Bangers public while reserving Trends for signed-in members', () => {
     expect(getPrimaryNav(false)).toContainEqual({
-      href: '/bangers?period=all',
+      href: '/bangers?period=week',
       label: 'Bangers',
     })
     expect(getPrimaryNav(false)).not.toContainEqual({

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -1,4 +1,4 @@
-import { BANGERS_ALL_TIME_HREF } from './portal/bangers'
+import { BANGERS_WEEK_HREF } from './portal/bangers'
 import { isTwitterUsername } from './apiInputValidation'
 
 export interface NavItem {
@@ -159,7 +159,7 @@ export const getPrimaryNav = (
 ): NavItem[] =>
   isMember || _isAdmin
     ? [
-        { href: BANGERS_ALL_TIME_HREF, label: 'Bangers' },
+        { href: BANGERS_WEEK_HREF, label: 'Bangers' },
         { href: '/digest', label: 'Digest' },
         { href: '/user-dir', label: 'Users' },
         { href: '/community', label: 'Apps' },
@@ -169,7 +169,7 @@ export const getPrimaryNav = (
         { href: '/research', label: 'Research' },
       ]
     : [
-        { href: BANGERS_ALL_TIME_HREF, label: 'Bangers' },
+        { href: BANGERS_WEEK_HREF, label: 'Bangers' },
         { href: '/digest', label: 'Digest' },
         { href: '/user-dir', label: 'Users' },
         { href: '/community', label: 'Apps' },


### PR DESCRIPTION
Opening Bangers without a time selection now shows Last 7 Days, and the site navigation links to that view. Explicit year, Today, Last 3 Months, and All Time selections are preserved.

Extracted from the larger native-apps draft so this can land independently. Validation: focused Bangers default, navigation, and portal layout tests; focused ESLint.

Closes #905
