### PR TITLE
Add Birdseye overview, compact topics, and local admin preview

### DIFF
--- a/docs/community-app-data.md
+++ b/docs/community-app-data.md
@@ -58,7 +58,9 @@ post count. Subtopics are ranked by cited count too. Profile switching lives at
 the profile itself. The large sidebar headings use sans-serif type, with subtle
 scrollbars revealed on hover or keyboard focus.
 
-Topic pages lead with two sample TweetCards. Exact-ID PostgreSQL metadata
+The compact profile header pairs the avatar and display name with a muted handle.
+Topic pages show an expandable two-line saved summary followed by three sample
+TweetCards in one desktop row (a swipeable row on mobile). Exact-ID PostgreSQL metadata
 lookups rank only that topic's cited references by likes, prioritizing the
 profile owner's posts. The final payloads use the configured shared archive
 reader and fresh opt-out checks; conversation-context samples are labeled.
@@ -69,11 +71,16 @@ it does not silently substitute arbitrary samples.
 Monthly bars derive UTC creation months from the saved tweet snowflakes,
 deduplicate references, fill interior empty months, and crop to the first/last
 cited month. Existing yearly summaries follow horizontally, cropped to the
-same year range. These counts include cited conversation context and do not
-claim full archive activity. Compact insight cards follow, starting with entities;
-known participant handles use available directory avatars, while unknown names
-remain text. The remaining six-at-a-time source feed excludes the samples and
-labels owner posts versus conversation context. Existing saved analysis content
+same year range. Hover, focus, or tap a month to see its count. These counts include cited conversation context and do not
+claim full archive activity. Compact insight panels follow, starting with entities. Each uses a three-column
+label grid; descriptions and source icons appear on hover or click, with keyboard
+and touch access. Known participant handles use available directory avatars.
+Popover portals carry the same analytics exclusion markers as the private page.
+The remaining six-at-a-time source feed excludes the three samples, labels owner
+posts versus conversation context, and groups related replies using exact-reference
+parent/conversation metadata. Each thread is ordered by tweet ID and stays together
+as subsequent pages load; no uncited parents or other thread content are fetched.
+Missing metadata leaves a post separate, and lookup failures are retryable errors. Existing saved analysis content
 and relationships are unchanged.
 
 The standard `dev` and `dev-remote-db` scripts bind to `127.0.0.1` and enable

--- a/docs/community-app-data.md
+++ b/docs/community-app-data.md
@@ -52,10 +52,31 @@ analytics. The redirect renders no page scripts; private responses use
 `no-store`, `no-referrer`, and `noindex`. The analysis/share UI is blocked from
 PostHog autocapture and session replay via `ph-no-capture`.
 
-Each topic row has a sparkline with a shared year range and individually scaled
-counts of cited posts. The topic page shows compact insight cards, icon source
-links, and lazy source tweet cards, with a Load more/retry fallback. The profile
-handle is the primary heading. The standard `dev` and `dev-remote-db` scripts bind to `127.0.0.1` and enable
+Birdseye opens on a macro-topic overview, ordered by each group's unique cited
+post count. Subtopics are ranked by cited count too. Profile switching lives at
+`/birdseye/profiles`, behind the same admin gate; it is a compact header link on
+the profile itself. The large sidebar headings use sans-serif type, with subtle
+scrollbars revealed on hover or keyboard focus.
+
+Topic pages lead with two sample TweetCards. Exact-ID PostgreSQL metadata
+lookups rank only that topic's cited references by likes, prioritizing the
+profile owner's posts. The final payloads use the configured shared archive
+reader and fresh opt-out checks; conversation-context samples are labeled.
+Ranking metadata is cached for five minutes. There is no whole-archive scan,
+new analysis, or inference. A ranking failure displays an unavailable notice;
+it does not silently substitute arbitrary samples.
+
+Monthly bars derive UTC creation months from the saved tweet snowflakes,
+deduplicate references, fill interior empty months, and crop to the first/last
+cited month. Existing yearly summaries follow horizontally, cropped to the
+same year range. These counts include cited conversation context and do not
+claim full archive activity. Compact insight cards follow, starting with entities;
+known participant handles use available directory avatars, while unknown names
+remain text. The remaining six-at-a-time source feed excludes the samples and
+labels owner posts versus conversation context. Existing saved analysis content
+and relationships are unchanged.
+
+The standard `dev` and `dev-remote-db` scripts bind to `127.0.0.1` and enable
 `LOCAL_ADMIN_PREVIEW=true`. On a loopback host in `NODE_ENV=development`, with
 no Vercel deployment marker, this starts a local admin read preview automatically.
 The header's Local admin menu signs out (persistent across reloads) and can

--- a/docs/community-app-data.md
+++ b/docs/community-app-data.md
@@ -27,7 +27,10 @@ index; they are not a newly reconstructed conversation corpus.
 
 ## Birdseye privacy and presentation
 
-Birdseye is owner-only by default; the public account catalog has been removed.
+Birdseye is private by default; the public account catalog has been removed.
+Verified administrators can use the profile picker to inspect all currently
+eligible analyses. This grants read access, not permission to share on behalf
+of another owner. Membership and opt-outs still apply to administrator reads.
 The page and `/api/birdseye/sources` verify the current Supabase Auth user,
 trusted Twitter identity, account ID against `user_directory`, and current
 membership/opt-out policy before loading analysis content. Source requests
@@ -52,9 +55,19 @@ PostHog autocapture and session replay via `ph-no-capture`.
 Each topic row has a sparkline with a shared year range and individually scaled
 counts of cited posts. The topic page shows compact insight cards, icon source
 links, and lazy source tweet cards, with a Load more/retry fallback. The profile
-handle is the primary heading. Local development against production Supabase
-uses real Twitter OAuth; mock login remains disabled for that project. Its OAuth
-redirect allowlist still needs to permit the local callback for local sign-in.
+handle is the primary heading. The standard `dev` and `dev-remote-db` scripts bind to `127.0.0.1` and enable
+`LOCAL_ADMIN_PREVIEW=true`. On a loopback host in `NODE_ENV=development`, with
+no Vercel deployment marker, this starts a local admin read preview automatically.
+The header's Local admin menu signs out (persistent across reloads) and can
+restart the preview. It does not create a Supabase user, fabricate an OAuth
+identity, grant production admin write permissions, or change sharing settings.
+Other development launchers must both bind to loopback and explicitly set the
+flag. Production/preview deployments and non-loopback hosts cannot use it.
+
+Set `COMMUNITY_APP_DATA_DIR` to an existing normalized display package to avoid
+Storage downloads while testing locally. Live membership/opt-out checks and
+source tweet reads still use the configured serving backends. Real Twitter OAuth
+remains available; mock login stays disabled against production Supabase.
 
 ## Display package
 

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "typescript"
   ],
   "scripts": {
-    "dev": "NODE_ENV=development NEXT_PUBLIC_USE_REMOTE_DEV_DB=false next dev",
+    "dev": "LOCAL_ADMIN_PREVIEW=true NODE_ENV=development NEXT_PUBLIC_USE_REMOTE_DEV_DB=false next dev --hostname 127.0.0.1",
     "dev-as-prod": "NODE_ENV=production next dev",
-    "dev-remote-db": "NEXT_PUBLIC_USE_REMOTE_DEV_DB=true next dev",
+    "dev-remote-db": "LOCAL_ADMIN_PREVIEW=true NEXT_PUBLIC_USE_REMOTE_DEV_DB=true next dev --hostname 127.0.0.1",
     "dev:importfiles": "tsx --env-file=.env scripts/import_from_files_to_db.ts",
     "dev:validateimport": "tsx --env-file=.env scripts/validate_db_import.ts",
     "dev:downloadarchive": "tsx --env-file=.env scripts/download_supabase_storage.mts",

--- a/src/app/api/auth/local-preview/route.ts
+++ b/src/app/api/auth/local-preview/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  LOCAL_ADMIN_COOKIE,
+  localAdminPreviewAllowed,
+} from '@/lib/localAdminPreview'
+export async function POST(request: NextRequest) {
+  if (!localAdminPreviewAllowed(request.headers.get('host')))
+    return new NextResponse('Not Found', { status: 404 })
+  if (request.headers.get('origin') !== request.nextUrl.origin)
+    return new NextResponse('Forbidden', { status: 403 })
+  const { enabled } = await request.json().catch(() => ({}))
+  if (typeof enabled !== 'boolean')
+    return new NextResponse('Invalid preview state', { status: 400 })
+  const response = NextResponse.json(
+    { enabled },
+    { headers: { 'Cache-Control': 'private, no-store' } },
+  )
+  response.cookies.set(LOCAL_ADMIN_COOKIE, enabled ? 'admin' : 'signed-out', {
+    httpOnly: true,
+    sameSite: 'strict',
+    secure: request.nextUrl.protocol === 'https:',
+    path: '/',
+    maxAge: 60 * 60 * 24 * 30,
+  })
+  if (!enabled) {
+    response.cookies.delete('dev_as_member')
+    response.cookies.delete('birdseye-share')
+  }
+  return response
+}

--- a/src/app/api/auth/navigation/route.ts
+++ b/src/app/api/auth/navigation/route.ts
@@ -1,3 +1,4 @@
+import { getLocalAdminPreview } from '@/lib/localAdminPreview'
 import { NextResponse } from 'next/server'
 import { isAdminUser } from '@/app/admin/data'
 import { getCurrentUser, getIsMember } from '@/lib/portal/auth'
@@ -5,11 +6,13 @@ import { getCurrentUser, getIsMember } from '@/lib/portal/auth'
 export const dynamic = 'force-dynamic'
 
 export async function GET() {
+  const localPreview = await getLocalAdminPreview()
   const [user, isMember] = await Promise.all([getCurrentUser(), getIsMember()])
 
   return NextResponse.json(
     {
-      isMember,
+      isMember: isMember || localPreview === 'admin',
+      localPreview,
       isAdmin: user ? isAdminUser(user) : false,
     },
     {

--- a/src/app/api/birdseye/sources/route.ts
+++ b/src/app/api/birdseye/sources/route.ts
@@ -25,7 +25,10 @@ export async function GET(request: NextRequest) {
       { error: 'Birdseye unavailable' },
       { status: 404, headers: PRIVATE_HEADERS },
     )
-  const ids = Array.from(new Set(cluster.tweetIds))
+  const excluded = new Set((params.get('exclude') ?? '').split(',').slice(0, 2))
+  const ids = Array.from(new Set(cluster.tweetIds)).filter(
+    (id) => !excluded.has(id),
+  )
   const page = ids.slice(offset, offset + 6)
   const tweets = await getStrandTweets(page)
   return NextResponse.json(

--- a/src/app/api/birdseye/sources/route.ts
+++ b/src/app/api/birdseye/sources/route.ts
@@ -1,3 +1,4 @@
+import { getBirdseyeSourceIndex } from '@/lib/community-apps/birdseye-source-index'
 import { NextRequest, NextResponse } from 'next/server'
 import {
   loadAccessibleBirdseye,
@@ -25,17 +26,26 @@ export async function GET(request: NextRequest) {
       { error: 'Birdseye unavailable' },
       { status: 404, headers: PRIVATE_HEADERS },
     )
-  const excluded = new Set((params.get('exclude') ?? '').split(',').slice(0, 2))
-  const ids = Array.from(new Set(cluster.tweetIds)).filter(
-    (id) => !excluded.has(id),
-  )
-  const page = ids.slice(offset, offset + 6)
-  const tweets = await getStrandTweets(page)
-  return NextResponse.json(
-    {
-      tweets: page.flatMap((id) => (tweets.has(id) ? [tweets.get(id)!] : [])),
-      nextOffset: offset + 6 < ids.length ? offset + 6 : null,
-    },
-    { headers: PRIVATE_HEADERS },
-  )
+  const excluded = new Set((params.get('exclude') ?? '').split(',').slice(0, 3))
+  try {
+    const index = (await getBirdseyeSourceIndex(cluster.tweetIds)).filter(
+      ({ id }) => !excluded.has(id),
+    )
+    const page = index.slice(offset, offset + 6)
+    const tweets = await getStrandTweets(page.map(({ id }) => id))
+    return NextResponse.json(
+      {
+        tweets: page.flatMap(({ id, threadId }) =>
+          tweets.has(id) ? [{ ...tweets.get(id)!, threadId }] : [],
+        ),
+        nextOffset: offset + 6 < index.length ? offset + 6 : null,
+      },
+      { headers: PRIVATE_HEADERS },
+    )
+  } catch {
+    return NextResponse.json(
+      { error: 'Source posts could not load' },
+      { status: 503, headers: PRIVATE_HEADERS },
+    )
+  }
 }

--- a/src/app/birdseye/page.tsx
+++ b/src/app/birdseye/page.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
+import { notFound, redirect } from 'next/navigation'
 import {
-  getBirdseyeProfiles,
+  getBirdseyeViewer,
   loadAccessibleBirdseye,
 } from '@/lib/community-apps/birdseye-access'
 import { BirdseyeView } from '@/components/birdseye/BirdseyeView'
@@ -22,8 +23,11 @@ export default async function BirdseyePage({
     typeof searchParams.username === 'string'
       ? searchParams.username
       : undefined
-  const profiles = await getBirdseyeProfiles()
-  const access = await loadAccessibleBirdseye(username || profiles[0])
+  const viewer = await getBirdseyeViewer()
+  if (!username && viewer.isAdmin && !viewer.user)
+    redirect('/birdseye/profiles')
+  const access = await loadAccessibleBirdseye(username)
+  if (!access && !username && viewer.isAdmin) redirect('/birdseye/profiles')
   if (!access)
     return (
       <main className="mx-auto min-h-[70vh] max-w-xl px-6 py-16">
@@ -54,10 +58,16 @@ export default async function BirdseyePage({
         </div>
       </main>
     )
+  if (
+    searchParams.cluster_id &&
+    !access.analysis.clusters.some(
+      (cluster) => cluster.id === searchParams.cluster_id,
+    )
+  )
+    notFound()
   return (
     <BirdseyeView
       {...access}
-      profiles={profiles}
       selectedId={
         typeof searchParams.cluster_id === 'string'
           ? searchParams.cluster_id

--- a/src/app/birdseye/page.tsx
+++ b/src/app/birdseye/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import { loadAccessibleBirdseye } from '@/lib/community-apps/birdseye-access'
+import {
+  getBirdseyeProfiles,
+  loadAccessibleBirdseye,
+} from '@/lib/community-apps/birdseye-access'
 import { BirdseyeView } from '@/components/birdseye/BirdseyeView'
 export const dynamic = 'force-dynamic'
 export const maxDuration = 60
@@ -19,7 +22,8 @@ export default async function BirdseyePage({
     typeof searchParams.username === 'string'
       ? searchParams.username
       : undefined
-  const access = await loadAccessibleBirdseye(username)
+  const profiles = await getBirdseyeProfiles()
+  const access = await loadAccessibleBirdseye(username || profiles[0])
   if (!access)
     return (
       <main className="mx-auto min-h-[70vh] max-w-xl px-6 py-16">
@@ -53,6 +57,7 @@ export default async function BirdseyePage({
   return (
     <BirdseyeView
       {...access}
+      profiles={profiles}
       selectedId={
         typeof searchParams.cluster_id === 'string'
           ? searchParams.cluster_id

--- a/src/app/birdseye/profiles/page.tsx
+++ b/src/app/birdseye/profiles/page.tsx
@@ -1,0 +1,28 @@
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import { getBirdseyeProfiles } from '@/lib/community-apps/birdseye-access'
+import { ProfilePicker } from '@/components/birdseye/ProfilePicker'
+export const dynamic = 'force-dynamic'
+export const metadata = {
+  title: 'Choose a Birdseye profile',
+  robots: { index: false, follow: false },
+}
+export default async function ProfilesPage() {
+  const profiles = await getBirdseyeProfiles()
+  if (!profiles.length) notFound()
+  return (
+    <main className="ph-no-capture mx-auto min-h-[75vh] max-w-4xl px-6 py-10">
+      <Link href="/community" className="text-xs text-brand">
+        ← Community Apps
+      </Link>
+      <h1 className="mb-3 mt-6 font-sans text-3xl font-bold">
+        Explore a Birdseye profile
+      </h1>
+      <p className="mb-6 text-sm text-muted-foreground">
+        Admin access · {profiles.length} available saved analyses. These
+        profiles remain private.
+      </p>
+      <ProfilePicker profiles={profiles} />
+    </main>
+  )
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -130,3 +130,33 @@
     animation: none;
   }
 }
+
+/* Birdseye navigation: unobtrusive scrollbars without losing keyboard access. */
+.birdseye-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+}
+.birdseye-scroll:hover,
+.birdseye-scroll:focus-within {
+  scrollbar-color: hsl(var(--muted-foreground) / 0.25) transparent;
+}
+.birdseye-scroll::-webkit-scrollbar {
+  width: 5px;
+  height: 5px;
+}
+.birdseye-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+.birdseye-scroll::-webkit-scrollbar-thumb {
+  background: transparent;
+  border-radius: 8px;
+}
+.birdseye-scroll:hover::-webkit-scrollbar-thumb,
+.birdseye-scroll:focus-within::-webkit-scrollbar-thumb {
+  background: hsl(var(--muted-foreground) / 0.25);
+}
+@media (hover: none) {
+  .birdseye-scroll {
+    scrollbar-color: hsl(var(--muted-foreground) / 0.2) transparent;
+  }
+}

--- a/src/components/LocalAdminMenu.tsx
+++ b/src/components/LocalAdminMenu.tsx
@@ -1,0 +1,59 @@
+'use client'
+import Link from 'next/link'
+import { useState } from 'react'
+import { createBrowserClient } from '@/utils/supabase'
+export function LocalAdminMenu({ active }: { active: boolean }) {
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState('')
+  async function toggle() {
+    setBusy(true)
+    setError('')
+    try {
+      const response = await fetch('/api/auth/local-preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled: !active }),
+      })
+      if (!response.ok) throw new Error('Could not change local preview.')
+      if (active) {
+        const { error } = await createBrowserClient().auth.signOut({
+          scope: 'local',
+        })
+        if (error) throw new Error('Could not sign out. Please try again.')
+      }
+      window.location.reload()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Please try again.')
+      setBusy(false)
+    }
+  }
+  return (
+    <details className="relative text-xs">
+      <summary className="cursor-pointer whitespace-nowrap rounded-lg border border-border px-3 py-2 font-semibold">
+        {active ? 'Local admin' : 'Signed out'}
+      </summary>
+      <div className="absolute right-0 z-50 mt-2 w-64 space-y-3 rounded-xl border border-border bg-card p-4 shadow-lg">
+        <p className="font-semibold">
+          {active ? 'Local admin preview' : 'Local preview is signed out'}
+        </p>
+        <p className="text-muted-foreground">
+          Browse Birdseye as an admin. This local preview does not grant
+          production write access.
+        </p>
+        {active && (
+          <Link href="/birdseye" className="block font-semibold text-brand">
+            Choose a Birdseye profile →
+          </Link>
+        )}
+        <button
+          disabled={busy}
+          onClick={() => void toggle()}
+          className="rounded-lg border border-border px-3 py-2 disabled:opacity-50"
+        >
+          {busy ? 'Updating…' : active ? 'Sign out' : 'Start local admin'}
+        </button>
+        {error && <p role="alert">{error}</p>}
+      </div>
+    </details>
+  )
+}

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import Link from 'next/link'
+import { useNavigationAudience } from '@/components/NavigationAudience'
+import { LocalAdminMenu } from '@/components/LocalAdminMenu'
 import { LogIn, LogOut, Settings, UserRound } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useAuthAndArchive } from '@/hooks/useAuthAndArchive'
@@ -16,6 +18,7 @@ import { userProfileHref } from '@/lib/navigation'
 import { capturePostHogEvent } from '@/lib/posthog'
 
 export default function MobileMenu() {
+  const { localPreview } = useNavigationAudience()
   const { userMetadata } = useAuthAndArchive()
   const profileHref = userProfileHref(
     userMetadata?.user_name,
@@ -43,6 +46,7 @@ export default function MobileMenu() {
     }
   }
 
+  if (localPreview) return <LocalAdminMenu active={localPreview === 'admin'} />
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>

--- a/src/components/NavigationAudience.tsx
+++ b/src/components/NavigationAudience.tsx
@@ -10,6 +10,7 @@ import { getMobileNav, getPrimaryNav, getUtilityNav } from '@/lib/navigation'
 type NavigationAudience = {
   isMember: boolean
   isAdmin: boolean
+  localPreview?: 'admin' | 'signed-out' | null
 }
 
 const PUBLIC_AUDIENCE: NavigationAudience = {
@@ -43,6 +44,7 @@ export function NavigationAudienceProvider({
         setAudience({
           isMember: nextAudience.isMember === true,
           isAdmin: nextAudience.isAdmin === true,
+          localPreview: nextAudience.localPreview ?? null,
         })
       })
       .catch((error: unknown) => {
@@ -102,3 +104,5 @@ export function AdminNavigationLink() {
     </Link>
   )
 }
+
+export const useNavigationAudience = () => useContext(NavigationAudienceContext)

--- a/src/components/SignIn.tsx
+++ b/src/components/SignIn.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { useNavigationAudience } from '@/components/NavigationAudience'
 import { useAuthAndArchive } from '@/hooks/useAuthAndArchive'
 import { devLog } from '@/lib/devLog'
 import { isProductionSupabaseUrl } from '@/lib/isProductionSupabaseUrl'
@@ -22,6 +23,7 @@ export default function SignIn({
 }: {
   alwaysVisible?: boolean
 }) {
+  const { localPreview } = useNavigationAudience()
   const searchParams = useSearchParams()
   const requestedRedirect = searchParams.get('redirect')
   const redirectTo =
@@ -125,7 +127,7 @@ export default function SignIn({
     }
   }
 
-  return userMetadata ? null : (
+  return userMetadata || localPreview === 'admin' ? null : (
     <div
       className={`${alwaysVisible ? 'inline-flex' : isStagingLogin ? 'hidden lg:inline-flex' : 'hidden sm:inline-flex'} items-center gap-2`}
     >

--- a/src/components/birdseye/BirdseyeView.tsx
+++ b/src/components/birdseye/BirdseyeView.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { Suspense } from 'react'
-import { AnalysisText } from '@/components/community-apps/AnalysisText'
+import { ProfileIdentity } from './ProfileIdentity'
+import { TopicSummary } from './TopicSummary'
 import type {
   BirdseyeAnalysis,
   BirdseyeCluster,
@@ -41,14 +42,6 @@ async function TopicContent({
         </p>
       )}
       <MonthlyTimeline cluster={cluster} />
-      <details className="rounded-xl bg-muted/30 p-4">
-        <summary className="cursor-pointer font-sans text-sm font-semibold">
-          About this topic · saved AI summary
-        </summary>
-        <div className="mt-3">
-          <AnalysisText>{cluster.summary}</AnalysisText>
-        </div>
-      </details>
       <Suspense
         fallback={
           <p className="text-sm text-muted-foreground">Loading insights…</p>
@@ -96,7 +89,7 @@ export function BirdseyeView({
   const topicHref = (cluster: BirdseyeCluster) =>
     `${overviewHref}&cluster_id=${encodeURIComponent(cluster.id)}`
   return (
-    <main className="ph-no-capture ph-mask mx-auto min-h-screen max-w-[1440px] px-5 py-5 sm:px-8">
+    <main className="ph-no-capture ph-mask mx-auto min-h-screen max-w-[1440px] px-5 py-3 sm:px-8">
       <div className="flex items-center justify-between gap-3 text-xs">
         <Link
           href="/community"
@@ -110,14 +103,20 @@ export function BirdseyeView({
           </Link>
         )}
       </div>
-      <header className="mb-6 mt-4 flex flex-wrap items-center justify-between gap-3 border-b border-border pb-4">
-        <div>
-          <p className="mb-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-brand">
+      <header className="mb-3 mt-2 flex flex-wrap items-center justify-between gap-3 border-b border-border pb-2">
+        <div className="min-w-0">
+          <p className="mb-1 text-[9px] font-semibold uppercase tracking-[0.16em] text-brand">
             Birdseye · Experimental
           </p>
-          <h1 className="break-all font-sans text-2xl font-bold tracking-tight sm:text-3xl">
-            <Link href={overviewHref}>@{analysis.username}</Link>
-          </h1>
+          <Suspense
+            fallback={
+              <h1 className="font-sans text-xl font-bold">
+                @{analysis.username}
+              </h1>
+            }
+          >
+            <ProfileIdentity username={analysis.username} />
+          </Suspense>
         </div>
         {isOwner ? (
           <ShareBirdseye initiallyEnabled={sharingEnabled} />
@@ -127,10 +126,10 @@ export function BirdseyeView({
           </span>
         )}
       </header>
-      <div className="grid items-start gap-6 lg:grid-cols-[290px_minmax(0,1fr)] lg:gap-10">
+      <div className="grid items-start gap-3 lg:grid-cols-[260px_minmax(0,1fr)] lg:gap-7">
         <nav
           aria-label="Archive topics"
-          className="birdseye-scroll max-h-28 space-y-5 overflow-y-auto pr-3 lg:sticky lg:top-20 lg:max-h-[calc(100vh-7rem)]"
+          className="birdseye-scroll max-h-20 space-y-5 overflow-y-auto pr-3 lg:sticky lg:top-20 lg:max-h-[calc(100vh-7rem)]"
         >
           <Link
             href={overviewHref}
@@ -177,24 +176,21 @@ export function BirdseyeView({
           ))}
         </nav>
         {selected ? (
-          <article className="min-w-0 space-y-7">
+          <article className="min-w-0 space-y-4">
             <div>
-              <h2 className="font-sans text-2xl font-bold leading-tight sm:text-3xl">
+              <h2 className="font-sans text-xl font-bold leading-tight sm:text-2xl">
                 {selected.name}
               </h2>
-              <p className="mt-2 text-xs leading-5 text-muted-foreground">
-                @{analysis.username}’s posts and the conversations around them.
-                Saved analysis; interpretations may be mistaken.
-              </p>
+              <TopicSummary key={selected.id} text={selected.summary} />
             </div>
             <Suspense
               key={selected.id}
               fallback={
                 <section
                   aria-label="Loading sample tweets"
-                  className="grid gap-3 xl:grid-cols-2"
+                  className="grid gap-3 md:grid-cols-3"
                 >
-                  {[0, 1].map((i) => (
+                  {[0, 1, 2].map((i) => (
                     <div
                       key={i}
                       className="h-52 animate-pulse rounded-xl bg-muted/40 p-5 text-sm text-muted-foreground"

--- a/src/components/birdseye/BirdseyeView.tsx
+++ b/src/components/birdseye/BirdseyeView.tsx
@@ -1,229 +1,269 @@
 import Link from 'next/link'
-import { Link2 } from 'lucide-react'
-import type { BirdseyeAnalysis } from '@/lib/community-apps/types'
+import { Suspense } from 'react'
 import { AnalysisText } from '@/components/community-apps/AnalysisText'
+import type {
+  BirdseyeAnalysis,
+  BirdseyeCluster,
+} from '@/lib/community-apps/types'
+import {
+  birdseyeGroups,
+  monthlyActivity,
+} from '@/lib/community-apps/birdseye-layout'
+import { getBirdseyeSamples } from '@/lib/community-apps/birdseye-samples'
 import { TopicSparkline } from './TopicSparkline'
+import { MonthlyTimeline } from './MonthlyTimeline'
+import { SampleTweets } from './SampleTweets'
+import { InsightCards } from './InsightCards'
 import { SourcePosts } from './SourcePosts'
 import { ShareBirdseye } from './ShareBirdseye'
+
+async function TopicContent({
+  cluster,
+  username,
+}: {
+  cluster: BirdseyeCluster
+  username: string
+}) {
+  let samples: Awaited<ReturnType<typeof getBirdseyeSamples>> = []
+  let sampleError = false
+  try {
+    samples = await getBirdseyeSamples(cluster.tweetIds, username)
+  } catch {
+    sampleError = true
+  }
+  return (
+    <>
+      <SampleTweets tweets={samples} username={username} />
+      {sampleError && (
+        <p className="text-xs text-muted-foreground">
+          Sample selection is temporarily unavailable. Source posts below can
+          still be loaded.
+        </p>
+      )}
+      <MonthlyTimeline cluster={cluster} />
+      <details className="rounded-xl bg-muted/30 p-4">
+        <summary className="cursor-pointer font-sans text-sm font-semibold">
+          About this topic · saved AI summary
+        </summary>
+        <div className="mt-3">
+          <AnalysisText>{cluster.summary}</AnalysisText>
+        </div>
+      </details>
+      <Suspense
+        fallback={
+          <p className="text-sm text-muted-foreground">Loading insights…</p>
+        }
+      >
+        <InsightCards cluster={cluster} />
+      </Suspense>
+      <SourcePosts
+        key={`${username}:${cluster.id}`}
+        username={username}
+        clusterId={cluster.id}
+        total={Array.from(new Set(cluster.tweetIds)).length - samples.length}
+        excludeIds={samples.map((tweet) => tweet.id)}
+      />
+    </>
+  )
+}
 
 export function BirdseyeView({
   analysis,
   selectedId,
   isOwner,
   sharingEnabled,
-  profiles = [],
   isAdmin = false,
 }: {
   analysis: BirdseyeAnalysis
   selectedId?: string
   isOwner: boolean
   sharingEnabled: boolean
-  profiles?: string[]
   isAdmin?: boolean
 }) {
-  const selected =
-    analysis.clusters.find((cluster) => cluster.id === selectedId) ??
-    analysis.clusters[0]
-  const dates = analysis.clusters.flatMap((cluster) =>
-    cluster.years.map((p) => p.year),
+  const selected = analysis.clusters.find(
+    (cluster) => cluster.id === selectedId,
   )
-  const start = dates.length ? Math.min(...dates) : 0
-  const end = dates.length ? Math.max(...dates) : 0
-  const groupedIds = new Set(
-    analysis.groups.flatMap((group) => group.clusterIds),
+  const groups = birdseyeGroups(analysis)
+  const ids = Array.from(
+    new Set(analysis.clusters.flatMap((cluster) => cluster.tweetIds)),
   )
-  const groups = [
-    ...analysis.groups,
-    {
-      name: 'More topics',
-      clusterIds: analysis.clusters
-        .filter((c) => !groupedIds.has(c.id))
-        .map((c) => c.id),
-    },
-  ]
-  const clusters = new Map(
-    analysis.clusters.map((cluster) => [cluster.id, cluster]),
-  )
+  const months = monthlyActivity(ids)
+  const start = months.length ? Number(months[0].month.slice(0, 4)) : 0
+  const end = months.length
+    ? Number(months[months.length - 1].month.slice(0, 4))
+    : 0
+  const overviewHref = `/birdseye?username=${analysis.username}`
+  const topicHref = (cluster: BirdseyeCluster) =>
+    `${overviewHref}&cluster_id=${encodeURIComponent(cluster.id)}`
   return (
-    <main className="ph-no-capture ph-mask mx-auto min-h-screen max-w-[1440px] px-5 py-8 sm:px-8">
-      <Link
-        href="/community"
-        className="text-xs font-semibold text-muted-foreground hover:text-brand"
-      >
-        ← Community Apps
-      </Link>
-      <header className="mb-9 mt-6 flex flex-wrap items-start justify-between gap-5 border-b border-border pb-7">
+    <main className="ph-no-capture ph-mask mx-auto min-h-screen max-w-[1440px] px-5 py-5 sm:px-8">
+      <div className="flex items-center justify-between gap-3 text-xs">
+        <Link
+          href="/community"
+          className="font-semibold text-muted-foreground hover:text-brand"
+        >
+          ← Community Apps
+        </Link>
+        {isAdmin && (
+          <Link href="/birdseye/profiles" className="font-semibold text-brand">
+            Change profile →
+          </Link>
+        )}
+      </div>
+      <header className="mb-6 mt-4 flex flex-wrap items-center justify-between gap-3 border-b border-border pb-4">
         <div>
-          <p className="mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-brand">
+          <p className="mb-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-brand">
             Birdseye · Experimental
           </p>
-          <h1 className="break-all text-4xl font-bold tracking-tight sm:text-5xl">
-            <Link href={`/user/${analysis.username}`}>
-              @{analysis.username}
-            </Link>
+          <h1 className="break-all font-sans text-2xl font-bold tracking-tight sm:text-3xl">
+            <Link href={overviewHref}>@{analysis.username}</Link>
           </h1>
-          <p className="mt-3 text-sm text-muted-foreground">
-            An archive in {analysis.clusters.length} topics. Ideas, interests,
-            and connections over time.
-          </p>
         </div>
         {isOwner ? (
           <ShareBirdseye initiallyEnabled={sharingEnabled} />
         ) : (
-          <span className="rounded-full bg-muted px-3 py-1.5 text-xs text-muted-foreground">
-            {isAdmin ? 'Admin view · private analysis' : 'Shared with you'}
+          <span className="rounded-full bg-muted/40 px-3 py-1.5 text-[11px] text-muted-foreground">
+            {isAdmin ? 'Admin view' : 'Shared with you'}
           </span>
         )}
       </header>
-      {profiles.length > 0 && (
-        <form
-          action="/birdseye"
-          className="mb-8 flex flex-wrap items-end gap-3 rounded-xl border border-border bg-muted/30 p-4"
-        >
-          <label className="min-w-0 flex-1 text-sm font-semibold">
-            Admin · Birdseye profile
-            <select
-              name="username"
-              defaultValue={analysis.username}
-              className="mt-2 block h-10 w-full rounded-lg border border-border bg-background px-3"
-              aria-label="Birdseye profile"
-            >
-              {profiles.map((username) => (
-                <option key={username} value={username}>
-                  @{username}
-                </option>
-              ))}
-            </select>
-          </label>
-          <button className="h-10 rounded-lg bg-brand px-4 text-sm font-semibold text-brand-foreground">
-            View profile
-          </button>
-          <p className="w-full text-xs text-muted-foreground">
-            {profiles.length} available profiles. Admin access does not make
-            these analyses public.
-          </p>
-        </form>
-      )}
-      <div className="grid items-start gap-8 lg:grid-cols-[330px_minmax(0,1fr)] lg:gap-12">
+      <div className="grid items-start gap-6 lg:grid-cols-[290px_minmax(0,1fr)] lg:gap-10">
         <nav
           aria-label="Archive topics"
-          className="max-h-56 space-y-6 overflow-y-auto pr-2 lg:sticky lg:top-20 lg:max-h-[calc(100vh-7rem)]"
+          className="birdseye-scroll max-h-28 space-y-5 overflow-y-auto pr-3 lg:sticky lg:top-20 lg:max-h-[calc(100vh-7rem)]"
         >
-          <div className="flex items-center justify-between text-[11px] text-muted-foreground">
-            <span>{analysis.clusters.length} TOPICS</span>
-            <span>
-              Cited posts · {start}–{end}
+          <Link
+            href={overviewHref}
+            aria-current={!selected ? 'page' : undefined}
+            className={`block rounded-lg px-2 py-2 font-sans text-base font-bold ${!selected ? 'bg-brand/10 text-brand' : 'hover:bg-muted/50'}`}
+          >
+            Overview{' '}
+            <span className="float-right text-xs font-normal">
+              {analysis.clusters.length} topics
             </span>
-          </div>
-          {groups.map((group) => {
-            const members = group.clusterIds.flatMap((id) =>
-              clusters.has(id) ? [clusters.get(id)!] : [],
-            )
-            return members.length ? (
-              <section key={group.name}>
-                <h2 className="mb-2 px-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          </Link>
+          {groups.map((group) => (
+            <section key={group.id}>
+              <h2 className="mb-2 px-2 font-sans text-lg font-bold leading-snug">
+                <Link
+                  href={`${overviewHref}#${group.id}`}
+                  className="hover:text-brand"
+                >
                   {group.name}
-                </h2>
-                <ul className="space-y-1">
-                  {members.map((cluster) => (
-                    <li key={cluster.id}>
-                      <Link
-                        prefetch={false}
-                        href={`/birdseye?username=${analysis.username}&cluster_id=${encodeURIComponent(cluster.id)}`}
-                        aria-current={
-                          selected?.id === cluster.id ? 'page' : undefined
-                        }
-                        className={`flex items-center justify-between gap-3 rounded-xl border p-3 text-sm transition-colors ${selected?.id === cluster.id ? 'border-brand/20 bg-brand/10 font-semibold text-foreground' : 'border-transparent text-muted-foreground hover:bg-muted'}`}
-                      >
-                        <span className="min-w-0">{cluster.name}</span>
-                        <TopicSparkline
-                          years={cluster.years}
-                          start={start}
-                          end={end}
-                        />
-                      </Link>
-                    </li>
-                  ))}
-                </ul>
-              </section>
-            ) : null
-          })}
+                </Link>
+              </h2>
+              <ul className="space-y-0.5">
+                {group.topics.map((cluster) => (
+                  <li key={cluster.id}>
+                    <Link
+                      prefetch={false}
+                      href={topicHref(cluster)}
+                      aria-current={
+                        selected?.id === cluster.id ? 'page' : undefined
+                      }
+                      className={`flex items-center justify-between gap-2 rounded-lg px-2 py-2 text-[13px] ${selected?.id === cluster.id ? 'bg-brand/10 font-semibold text-brand' : 'text-muted-foreground hover:bg-muted/40'}`}
+                    >
+                      <span className="min-w-0">{cluster.name}</span>
+                      <TopicSparkline
+                        years={cluster.years}
+                        start={start}
+                        end={end}
+                      />
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
         </nav>
         {selected ? (
-          <article className="min-w-0 space-y-8">
-            <section>
-              <p className="mb-3 text-xs text-muted-foreground">
-                TOPIC / {Array.from(new Set(selected.tweetIds)).length} CITED
-                POSTS
-              </p>
-              <h2 className="mb-4 text-3xl font-bold tracking-tight sm:text-4xl">
+          <article className="min-w-0 space-y-7">
+            <div>
+              <h2 className="font-sans text-2xl font-bold leading-tight sm:text-3xl">
                 {selected.name}
               </h2>
-              <AnalysisText>{selected.summary}</AnalysisText>
-            </section>
-            <p className="rounded-lg bg-muted/60 px-3 py-2 text-xs leading-5 text-muted-foreground">
-              AI-generated from a saved archive snapshot. Interpretations may be
-              mistaken. Charts count cited posts, not every tweet.
-            </p>
-            <div className="grid items-start gap-4 xl:grid-cols-2">
-              {selected.sections
-                .filter((section) => section.items.length)
-                .map((section) => (
-                  <section
-                    key={section.name}
-                    className="rounded-2xl border border-border bg-card p-4"
-                  >
-                    <h3 className="mb-3 flex items-center justify-between gap-2 text-sm font-bold">
-                      {section.name}
-                      <span className="font-normal text-muted-foreground">
-                        {section.items.length}
-                      </span>
-                    </h3>
-                    <div className="divide-y divide-border/60">
-                      {section.items.map((item, index) => (
-                        <div
-                          key={`${item.label}:${index}`}
-                          className="py-3 first:pt-0 last:pb-0"
-                        >
-                          <h4 className="text-sm font-semibold">
-                            {item.label}
-                          </h4>
-                          {item.description && (
-                            <p className="mt-1 text-[13px] leading-5 text-muted-foreground">
-                              {item.description}
-                            </p>
-                          )}
-                          <div className="mt-1 flex flex-wrap gap-1">
-                            {Array.from(new Set(item.tweetIds)).map(
-                              (id, sourceIndex) => (
-                                <Link
-                                  prefetch={false}
-                                  key={id}
-                                  href={`/tweets/${id}`}
-                                  aria-label={`Source ${sourceIndex + 1} for ${item.label}`}
-                                  title={`View source post ${sourceIndex + 1}`}
-                                  className="inline-flex h-7 w-7 items-center justify-center rounded-md text-brand hover:bg-brand/10"
-                                >
-                                  <Link2 size={13} aria-hidden="true" />
-                                </Link>
-                              ),
-                            )}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </section>
-                ))}
+              <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                @{analysis.username}’s posts and the conversations around them.
+                Saved analysis; interpretations may be mistaken.
+              </p>
             </div>
-            <SourcePosts
-              key={`${analysis.username}:${selected.id}`}
-              username={analysis.username}
-              clusterId={selected.id}
-              total={Array.from(new Set(selected.tweetIds)).length}
-            />
+            <Suspense
+              key={selected.id}
+              fallback={
+                <section
+                  aria-label="Loading sample tweets"
+                  className="grid gap-3 xl:grid-cols-2"
+                >
+                  {[0, 1].map((i) => (
+                    <div
+                      key={i}
+                      className="h-52 animate-pulse rounded-xl bg-muted/40 p-5 text-sm text-muted-foreground"
+                    >
+                      Loading sample posts…
+                    </div>
+                  ))}
+                </section>
+              }
+            >
+              <TopicContent cluster={selected} username={analysis.username} />
+            </Suspense>
           </article>
         ) : (
-          <p>No topics are currently available for this archive.</p>
+          <article className="min-w-0 space-y-6">
+            <div>
+              <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-brand">
+                The big picture
+              </p>
+              <h2 className="font-sans text-3xl font-bold">
+                @{analysis.username}’s topics, at a glance
+              </h2>
+              <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+                {groups.length} big themes across {analysis.clusters.length}{' '}
+                topics and {ids.length.toLocaleString()} cited posts
+                {start ? `, ${start}–${end}` : ''}. Start with a theme or choose
+                a subtopic.
+              </p>
+              <p className="mt-2 text-xs text-muted-foreground">
+                Based on saved analyses, ordered by cited-post count. This is a
+                snapshot, not a live profile.
+              </p>
+            </div>
+            <div className="grid items-start gap-4 xl:grid-cols-2">
+              {groups.map((group) => (
+                <section
+                  id={group.id}
+                  key={group.id}
+                  className="scroll-mt-20 rounded-2xl border border-border bg-card/60 p-5"
+                >
+                  <div className="mb-4">
+                    <h3 className="font-sans text-xl font-bold leading-snug">
+                      {group.name}
+                    </h3>
+                    <p className="mt-2 text-xs text-muted-foreground">
+                      {group.topics.length} subtopics ·{' '}
+                      {group.tweetIds.length.toLocaleString()} cited posts
+                    </p>
+                  </div>
+                  <ul className="space-y-1">
+                    {group.topics.map((cluster) => (
+                      <li key={cluster.id}>
+                        <Link
+                          prefetch={false}
+                          href={topicHref(cluster)}
+                          className="flex items-center justify-between gap-3 rounded-lg px-2 py-2 text-sm hover:bg-brand/5"
+                        >
+                          <span>{cluster.name}</span>
+                          <span className="shrink-0 text-xs text-muted-foreground">
+                            {new Set(cluster.tweetIds).size} ↗
+                          </span>
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              ))}
+            </div>
+          </article>
         )}
       </div>
     </main>

--- a/src/components/birdseye/BirdseyeView.tsx
+++ b/src/components/birdseye/BirdseyeView.tsx
@@ -11,11 +11,15 @@ export function BirdseyeView({
   selectedId,
   isOwner,
   sharingEnabled,
+  profiles = [],
+  isAdmin = false,
 }: {
   analysis: BirdseyeAnalysis
   selectedId?: string
   isOwner: boolean
   sharingEnabled: boolean
+  profiles?: string[]
+  isAdmin?: boolean
 }) {
   const selected =
     analysis.clusters.find((cluster) => cluster.id === selectedId) ??
@@ -67,10 +71,39 @@ export function BirdseyeView({
           <ShareBirdseye initiallyEnabled={sharingEnabled} />
         ) : (
           <span className="rounded-full bg-muted px-3 py-1.5 text-xs text-muted-foreground">
-            Shared with you
+            {isAdmin ? 'Admin view · private analysis' : 'Shared with you'}
           </span>
         )}
       </header>
+      {profiles.length > 0 && (
+        <form
+          action="/birdseye"
+          className="mb-8 flex flex-wrap items-end gap-3 rounded-xl border border-border bg-muted/30 p-4"
+        >
+          <label className="min-w-0 flex-1 text-sm font-semibold">
+            Admin · Birdseye profile
+            <select
+              name="username"
+              defaultValue={analysis.username}
+              className="mt-2 block h-10 w-full rounded-lg border border-border bg-background px-3"
+              aria-label="Birdseye profile"
+            >
+              {profiles.map((username) => (
+                <option key={username} value={username}>
+                  @{username}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button className="h-10 rounded-lg bg-brand px-4 text-sm font-semibold text-brand-foreground">
+            View profile
+          </button>
+          <p className="w-full text-xs text-muted-foreground">
+            {profiles.length} available profiles. Admin access does not make
+            these analyses public.
+          </p>
+        </form>
+      )}
       <div className="grid items-start gap-8 lg:grid-cols-[330px_minmax(0,1fr)] lg:gap-12">
         <nav
           aria-label="Archive topics"

--- a/src/components/birdseye/InsightCards.tsx
+++ b/src/components/birdseye/InsightCards.tsx
@@ -1,15 +1,5 @@
-import Link from 'next/link'
-import {
-  Box,
-  Heart,
-  Link2,
-  Smile,
-  Target,
-  UserRound,
-  Users,
-  Lightbulb,
-} from 'lucide-react'
-import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
+import { Box, Heart, Smile, Target, Users, Lightbulb } from 'lucide-react'
+import { InsightItem } from './InsightItem'
 import { createServerServiceRoleClient } from '@/utils/supabase'
 import { participantUsername } from '@/lib/community-apps/birdseye-layout'
 import type { BirdseyeCluster } from '@/lib/community-apps/types'
@@ -63,73 +53,34 @@ export async function InsightCards({ cluster }: { cluster: BirdseyeCluster }) {
         avatars.set(row.username.toLowerCase(), row.avatar_media_url)
   }
   return (
-    <div className="grid items-start gap-4 xl:grid-cols-2">
+    <div className="grid items-start gap-3 xl:grid-cols-2">
       {sections.map((section) => {
         const Icon = sectionIcon(section.name)
         return (
           <section
             key={section.name}
-            className="rounded-2xl border border-border bg-card/60 p-4"
+            className="rounded-xl border border-border bg-card/40 p-3"
           >
-            <h3 className="mb-4 flex items-center gap-2 font-sans text-sm font-bold">
-              <Icon size={16} className="text-brand" />
+            <h3 className="mb-2 flex items-center gap-2 font-sans text-xs font-bold">
+              <Icon size={14} className="text-brand" />
               {section.name}
               <span className="ml-auto font-normal text-muted-foreground">
                 {section.items.length}
               </span>
             </h3>
-            <div className="divide-y divide-border/50">
+            <div className="grid grid-cols-2 gap-1.5 sm:grid-cols-3">
               {section.items.map((item, index) => {
                 const username = participantUsername(
                   item.label,
                   cluster.participants,
                 )
                 return (
-                  <div
+                  <InsightItem
                     key={`${item.label}:${index}`}
-                    className="py-3 first:pt-0 last:pb-0"
-                  >
-                    <div className="flex items-center gap-2">
-                      {username && (
-                        <Avatar className="h-7 w-7 shrink-0">
-                          <AvatarImage src={avatars.get(username)} alt="" />
-                          <AvatarFallback>
-                            <UserRound size={14} />
-                          </AvatarFallback>
-                        </Avatar>
-                      )}
-                      <h4 className="font-sans text-sm font-semibold">
-                        {username ? (
-                          <Link
-                            href={`/user/${username}`}
-                            className="hover:text-brand"
-                          >
-                            @{username}
-                          </Link>
-                        ) : (
-                          item.label
-                        )}
-                      </h4>
-                    </div>
-                    {item.description && (
-                      <p className="mt-1 text-[13px] leading-5 text-muted-foreground">
-                        {item.description}
-                      </p>
-                    )}
-                    <div className="mt-1 flex flex-wrap gap-1">
-                      {Array.from(new Set(item.tweetIds)).map((id, i) => (
-                        <Link
-                          prefetch={false}
-                          key={id}
-                          href={`/tweets/${id}`}
-                          aria-label={`Source ${i + 1} for ${item.label}`}
-                          className="inline-flex h-7 w-7 items-center justify-center rounded-md text-brand hover:bg-brand/10"
-                        >
-                          <Link2 size={13} />
-                        </Link>
-                      ))}
-                    </div>
-                  </div>
+                    item={item}
+                    username={username}
+                    avatar={username ? avatars.get(username) : undefined}
+                  />
                 )
               })}
             </div>

--- a/src/components/birdseye/InsightCards.tsx
+++ b/src/components/birdseye/InsightCards.tsx
@@ -1,0 +1,141 @@
+import Link from 'next/link'
+import {
+  Box,
+  Heart,
+  Link2,
+  Smile,
+  Target,
+  UserRound,
+  Users,
+  Lightbulb,
+} from 'lucide-react'
+import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
+import { createServerServiceRoleClient } from '@/utils/supabase'
+import { participantUsername } from '@/lib/community-apps/birdseye-layout'
+import type { BirdseyeCluster } from '@/lib/community-apps/types'
+const sectionIcon = (name: string) =>
+  name.toLowerCase().includes('relation')
+    ? Users
+    : name.toLowerCase().includes('belief')
+      ? Heart
+      : name.toLowerCase().includes('goal')
+        ? Target
+        : name.toLowerCase().includes('mood')
+          ? Smile
+          : name.toLowerCase().includes('entit')
+            ? Box
+            : Lightbulb
+export async function InsightCards({ cluster }: { cluster: BirdseyeCluster }) {
+  const sections = cluster.sections
+    .filter(
+      (section) =>
+        section.items.length &&
+        section.name.toLowerCase() !== 'yearly summaries',
+    )
+    .sort(
+      (a, b) =>
+        Number(b.name.toLowerCase() === 'entities') -
+        Number(a.name.toLowerCase() === 'entities'),
+    )
+  const usernames = Array.from(
+    new Set(
+      sections.flatMap((section) =>
+        section.items.flatMap((item) => {
+          const name = participantUsername(item.label, cluster.participants)
+          return name ? [name] : []
+        }),
+      ),
+    ),
+  )
+  const avatars = new Map<string, string>()
+  for (let offset = 0; offset < usernames.length; offset += 40) {
+    const { data } = await createServerServiceRoleClient()
+      .from('user_directory')
+      .select('username,avatar_media_url')
+      .or(
+        usernames
+          .slice(offset, offset + 40)
+          .map((username) => `username.ilike.${username.replace(/_/g, '\\_')}`)
+          .join(','),
+      )
+    for (const row of data ?? [])
+      if (row.username && row.avatar_media_url)
+        avatars.set(row.username.toLowerCase(), row.avatar_media_url)
+  }
+  return (
+    <div className="grid items-start gap-4 xl:grid-cols-2">
+      {sections.map((section) => {
+        const Icon = sectionIcon(section.name)
+        return (
+          <section
+            key={section.name}
+            className="rounded-2xl border border-border bg-card/60 p-4"
+          >
+            <h3 className="mb-4 flex items-center gap-2 font-sans text-sm font-bold">
+              <Icon size={16} className="text-brand" />
+              {section.name}
+              <span className="ml-auto font-normal text-muted-foreground">
+                {section.items.length}
+              </span>
+            </h3>
+            <div className="divide-y divide-border/50">
+              {section.items.map((item, index) => {
+                const username = participantUsername(
+                  item.label,
+                  cluster.participants,
+                )
+                return (
+                  <div
+                    key={`${item.label}:${index}`}
+                    className="py-3 first:pt-0 last:pb-0"
+                  >
+                    <div className="flex items-center gap-2">
+                      {username && (
+                        <Avatar className="h-7 w-7 shrink-0">
+                          <AvatarImage src={avatars.get(username)} alt="" />
+                          <AvatarFallback>
+                            <UserRound size={14} />
+                          </AvatarFallback>
+                        </Avatar>
+                      )}
+                      <h4 className="font-sans text-sm font-semibold">
+                        {username ? (
+                          <Link
+                            href={`/user/${username}`}
+                            className="hover:text-brand"
+                          >
+                            @{username}
+                          </Link>
+                        ) : (
+                          item.label
+                        )}
+                      </h4>
+                    </div>
+                    {item.description && (
+                      <p className="mt-1 text-[13px] leading-5 text-muted-foreground">
+                        {item.description}
+                      </p>
+                    )}
+                    <div className="mt-1 flex flex-wrap gap-1">
+                      {Array.from(new Set(item.tweetIds)).map((id, i) => (
+                        <Link
+                          prefetch={false}
+                          key={id}
+                          href={`/tweets/${id}`}
+                          aria-label={`Source ${i + 1} for ${item.label}`}
+                          className="inline-flex h-7 w-7 items-center justify-center rounded-md text-brand hover:bg-brand/10"
+                        >
+                          <Link2 size={13} />
+                        </Link>
+                      ))}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </section>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/birdseye/InsightItem.tsx
+++ b/src/components/birdseye/InsightItem.tsx
@@ -1,0 +1,102 @@
+'use client'
+import { useEffect, useRef, useState } from 'react'
+import Link from 'next/link'
+import { Link2, UserRound } from 'lucide-react'
+import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import type { EvidenceItem } from '@/lib/community-apps/types'
+
+export function InsightItem({
+  item,
+  username,
+  avatar,
+}: {
+  item: EvidenceItem
+  username: string | null
+  avatar?: string
+}) {
+  const [open, setOpen] = useState(false)
+  const pinned = useRef(false)
+  const timer = useRef<ReturnType<typeof setTimeout>>()
+  const enter = () => {
+    clearTimeout(timer.current)
+    setOpen(true)
+  }
+  const leave = () => {
+    if (!pinned.current) timer.current = setTimeout(() => setOpen(false), 180)
+  }
+  useEffect(() => () => clearTimeout(timer.current), [])
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        pinned.current = next
+        setOpen(next)
+      }}
+    >
+      <PopoverTrigger asChild>
+        <button
+          onClick={(event) => {
+            event.preventDefault()
+            clearTimeout(timer.current)
+            pinned.current = !pinned.current
+            setOpen(pinned.current)
+          }}
+          onMouseEnter={enter}
+          onMouseLeave={leave}
+          className="min-h-10 flex w-full items-center gap-2 rounded-lg bg-muted/35 px-2.5 py-2 text-left text-xs font-medium hover:bg-brand/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+        >
+          {username && (
+            <Avatar className="h-6 w-6 shrink-0">
+              <AvatarImage src={avatar} alt="" />
+              <AvatarFallback>
+                <UserRound size={12} />
+              </AvatarFallback>
+            </Avatar>
+          )}
+          <span className="line-clamp-2">
+            {username ? `@${username}` : item.label}
+          </span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        aria-label={item.label}
+        onMouseEnter={enter}
+        onMouseLeave={leave}
+        onOpenAutoFocus={(event) => event.preventDefault()}
+        onCloseAutoFocus={(event) => event.preventDefault()}
+        className="ph-no-capture ph-mask w-72 p-3"
+      >
+        <p className="font-sans text-sm font-semibold">
+          {username ? (
+            <Link href={`/user/${username}`} className="text-brand">
+              @{username}
+            </Link>
+          ) : (
+            item.label
+          )}
+        </p>
+        <p className="mt-1 text-xs leading-5 text-muted-foreground">
+          {item.description}
+        </p>
+        <div className="mt-2 flex flex-wrap gap-1">
+          {Array.from(new Set(item.tweetIds)).map((id, i) => (
+            <Link
+              key={id}
+              prefetch={false}
+              href={`/tweets/${id}`}
+              aria-label={`Source ${i + 1} for ${item.label}`}
+              className="inline-flex h-7 w-7 items-center justify-center rounded text-brand hover:bg-brand/10"
+            >
+              <Link2 size={13} />
+            </Link>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/components/birdseye/MonthlyTimeline.tsx
+++ b/src/components/birdseye/MonthlyTimeline.tsx
@@ -1,3 +1,5 @@
+'use client'
+import { useState } from 'react'
 import {
   monthlyActivity,
   yearlySummaries,
@@ -11,6 +13,7 @@ function monthLabel(month: string) {
   })
 }
 export function MonthlyTimeline({ cluster }: { cluster: BirdseyeCluster }) {
+  const [active, setActive] = useState<number | null>(null)
   const months = monthlyActivity(cluster.tweetIds)
   if (!months.length) return null
   const max = Math.max(1, ...months.map((month) => month.count))
@@ -28,7 +31,7 @@ export function MonthlyTimeline({ cluster }: { cluster: BirdseyeCluster }) {
     ]),
   )
   return (
-    <section aria-label="Topic timeline" className="space-y-4">
+    <section aria-label="Topic timeline" className="space-y-2">
       <div className="flex flex-wrap items-baseline justify-between gap-2">
         <h3 className="font-sans text-lg font-bold">Through the years</h3>
         <p className="text-xs text-muted-foreground">
@@ -36,54 +39,92 @@ export function MonthlyTimeline({ cluster }: { cluster: BirdseyeCluster }) {
           {monthLabel(months[months.length - 1].month)}
         </p>
       </div>
-      <svg
-        viewBox="0 0 640 118"
-        role="img"
-        aria-label="Cited posts by month"
-        className="h-32 w-full overflow-visible text-brand"
-      >
-        {months.map(({ month, count }, index) => (
-          <g key={month}>
-            <title>{`${monthLabel(month)}: ${count} cited posts`}</title>
-            <rect
-              x={index * width + 0.5}
-              y={94 - (count / max) * 85}
-              width={Math.max(0.5, width - 1)}
-              height={Math.max(0.75, (count / max) * 85)}
-              rx={Math.min(2, width / 4)}
-              fill="currentColor"
-              opacity={count ? 0.7 : 0.1}
-            />
-          </g>
-        ))}
-        {ticks.map((index) => (
-          <text
-            key={index}
-            x={
-              index === 0
-                ? 0
-                : index === months.length - 1
-                  ? 640
-                  : (index + 0.5) * width
-            }
-            y="113"
-            fontSize="10"
-            fill="currentColor"
-            opacity="0.7"
-            textAnchor={
-              index === 0
-                ? 'start'
-                : index === months.length - 1
-                  ? 'end'
-                  : 'middle'
-            }
+      <div className="relative" onMouseLeave={() => setActive(null)}>
+        {active !== null && months[active] && (
+          <div
+            role="tooltip"
+            className="pointer-events-none absolute -top-1 z-10 -translate-x-1/2 rounded-md border border-border bg-popover px-2 py-1 text-xs text-popover-foreground shadow-sm"
+            style={{
+              left: `${Math.max(12, Math.min(88, ((active + 0.5) / months.length) * 100))}%`,
+            }}
           >
-            {index === 0 || index === months.length - 1
-              ? monthLabel(months[index].month)
-              : months[index].month.slice(0, 4)}
-          </text>
-        ))}
-      </svg>
+            {monthLabel(months[active].month)} · {months[active].count}{' '}
+            {months[active].count === 1 ? 'post' : 'posts'}
+          </div>
+        )}
+        <svg
+          viewBox="0 0 640 118"
+          role="group"
+          aria-label="Cited posts by month"
+          className="h-24 w-full overflow-visible text-brand"
+        >
+          {months.map(({ month, count }, index) => (
+            <g
+              key={month}
+              role="button"
+              tabIndex={0}
+              aria-label={`${monthLabel(month)}: ${count} cited posts`}
+              onMouseEnter={() => setActive(index)}
+              onFocus={() => setActive(index)}
+              onBlur={() => setActive(null)}
+              onClick={() => setActive(index)}
+              onKeyDown={(event) => {
+                if (event.key === 'Escape') setActive(null)
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault()
+                  setActive(index)
+                }
+              }}
+              className="outline-none"
+            >
+              <rect
+                x={index * width}
+                y={0}
+                width={width}
+                height={96}
+                fill="transparent"
+              />
+              <title>{`${monthLabel(month)}: ${count} cited posts`}</title>
+              <rect
+                x={index * width + 0.5}
+                y={94 - (count / max) * 85}
+                width={Math.max(0.5, width - 1)}
+                height={Math.max(0.75, (count / max) * 85)}
+                rx={Math.min(2, width / 4)}
+                fill="currentColor"
+                opacity={active === index ? 1 : count ? 0.7 : 0.1}
+              />
+            </g>
+          ))}
+          {ticks.map((index) => (
+            <text
+              key={index}
+              x={
+                index === 0
+                  ? 0
+                  : index === months.length - 1
+                    ? 640
+                    : (index + 0.5) * width
+              }
+              y="113"
+              fontSize="10"
+              fill="currentColor"
+              opacity="0.7"
+              textAnchor={
+                index === 0
+                  ? 'start'
+                  : index === months.length - 1
+                    ? 'end'
+                    : 'middle'
+              }
+            >
+              {index === 0 || index === months.length - 1
+                ? monthLabel(months[index].month)
+                : months[index].month.slice(0, 4)}
+            </text>
+          ))}
+        </svg>
+      </div>
       <p className="text-xs text-muted-foreground">
         Monthly counts of cited posts, including conversation context. Empty
         months have no cited posts.

--- a/src/components/birdseye/MonthlyTimeline.tsx
+++ b/src/components/birdseye/MonthlyTimeline.tsx
@@ -1,0 +1,113 @@
+import {
+  monthlyActivity,
+  yearlySummaries,
+} from '@/lib/community-apps/birdseye-layout'
+import type { BirdseyeCluster } from '@/lib/community-apps/types'
+function monthLabel(month: string) {
+  return new Date(`${month}-01T00:00:00Z`).toLocaleDateString('en-US', {
+    month: 'short',
+    year: 'numeric',
+    timeZone: 'UTC',
+  })
+}
+export function MonthlyTimeline({ cluster }: { cluster: BirdseyeCluster }) {
+  const months = monthlyActivity(cluster.tweetIds)
+  if (!months.length) return null
+  const max = Math.max(1, ...months.map((month) => month.count))
+  const summaries = yearlySummaries(cluster)
+  const width = 640 / months.length
+  const ticks = Array.from(
+    new Set([
+      0,
+      ...months.flatMap((month, index) =>
+        month.month.endsWith('-01') && index >= 7 && index < months.length - 7
+          ? [index]
+          : [],
+      ),
+      months.length - 1,
+    ]),
+  )
+  return (
+    <section aria-label="Topic timeline" className="space-y-4">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <h3 className="font-sans text-lg font-bold">Through the years</h3>
+        <p className="text-xs text-muted-foreground">
+          {monthLabel(months[0].month)} —{' '}
+          {monthLabel(months[months.length - 1].month)}
+        </p>
+      </div>
+      <svg
+        viewBox="0 0 640 118"
+        role="img"
+        aria-label="Cited posts by month"
+        className="h-32 w-full overflow-visible text-brand"
+      >
+        {months.map(({ month, count }, index) => (
+          <g key={month}>
+            <title>{`${monthLabel(month)}: ${count} cited posts`}</title>
+            <rect
+              x={index * width + 0.5}
+              y={94 - (count / max) * 85}
+              width={Math.max(0.5, width - 1)}
+              height={Math.max(0.75, (count / max) * 85)}
+              rx={Math.min(2, width / 4)}
+              fill="currentColor"
+              opacity={count ? 0.7 : 0.1}
+            />
+          </g>
+        ))}
+        {ticks.map((index) => (
+          <text
+            key={index}
+            x={
+              index === 0
+                ? 0
+                : index === months.length - 1
+                  ? 640
+                  : (index + 0.5) * width
+            }
+            y="113"
+            fontSize="10"
+            fill="currentColor"
+            opacity="0.7"
+            textAnchor={
+              index === 0
+                ? 'start'
+                : index === months.length - 1
+                  ? 'end'
+                  : 'middle'
+            }
+          >
+            {index === 0 || index === months.length - 1
+              ? monthLabel(months[index].month)
+              : months[index].month.slice(0, 4)}
+          </text>
+        ))}
+      </svg>
+      <p className="text-xs text-muted-foreground">
+        Monthly counts of cited posts, including conversation context. Empty
+        months have no cited posts.
+      </p>
+      {summaries.length > 0 && (
+        <div
+          aria-label="Yearly summaries"
+          className="birdseye-scroll flex snap-x gap-5 overflow-x-auto pb-3"
+        >
+          {summaries.map((item) => (
+            <section
+              key={item.label}
+              className="w-64 shrink-0 snap-start border-t-2 border-brand/30 pt-3"
+            >
+              <h4 className="mb-2 font-sans text-lg font-bold text-brand">
+                {item.label}
+              </h4>
+              <p className="text-sm leading-6 text-muted-foreground">
+                {item.description}
+              </p>
+            </section>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/birdseye/ProfileIdentity.tsx
+++ b/src/components/birdseye/ProfileIdentity.tsx
@@ -1,0 +1,31 @@
+import Link from 'next/link'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { createServerServiceRoleClient } from '@/utils/supabase'
+
+export async function ProfileIdentity({ username }: { username: string }) {
+  const { data } = await createServerServiceRoleClient()
+    .from('user_directory')
+    .select('account_display_name,avatar_media_url')
+    .ilike('username', username.replace(/_/g, '\\_'))
+    .limit(1)
+    .maybeSingle()
+  return (
+    <Link
+      href={`/birdseye?username=${username}`}
+      className="flex min-w-0 items-center gap-3"
+    >
+      <Avatar className="h-10 w-10 shrink-0">
+        <AvatarImage src={data?.avatar_media_url ?? undefined} alt="" />
+        <AvatarFallback>{username.slice(0, 1).toUpperCase()}</AvatarFallback>
+      </Avatar>
+      <h1 className="flex min-w-0 flex-wrap items-baseline gap-x-2 font-sans">
+        <span className="text-xl font-bold tracking-tight">
+          {data?.account_display_name || username}
+        </span>
+        <span className="text-sm font-normal text-muted-foreground">
+          @{username}
+        </span>
+      </h1>
+    </Link>
+  )
+}

--- a/src/components/birdseye/ProfilePicker.tsx
+++ b/src/components/birdseye/ProfilePicker.tsx
@@ -1,0 +1,38 @@
+'use client'
+import Link from 'next/link'
+import { useState } from 'react'
+export function ProfilePicker({ profiles }: { profiles: string[] }) {
+  const [query, setQuery] = useState('')
+  const matches = profiles.filter((name) =>
+    name.includes(query.trim().replace(/^@/, '').toLowerCase()),
+  )
+  return (
+    <>
+      <label className="mb-6 block text-sm font-semibold">
+        Search profiles
+        <input
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Find a username…"
+          className="mt-2 block h-12 w-full rounded-xl border border-border bg-background px-4 font-normal"
+        />
+      </label>
+      <div className="grid gap-3 sm:grid-cols-3">
+        {matches.map((username) => (
+          <Link
+            key={username}
+            prefetch={false}
+            href={`/birdseye?username=${username}`}
+            className="rounded-xl border border-border p-4 text-sm font-semibold hover:border-brand hover:bg-brand/5"
+          >
+            @{username} <span className="float-right text-brand">↗</span>
+          </Link>
+        ))}
+      </div>
+      {!matches.length && (
+        <p className="text-sm text-muted-foreground">No matching profiles.</p>
+      )}
+    </>
+  )
+}

--- a/src/components/birdseye/SampleTweets.tsx
+++ b/src/components/birdseye/SampleTweets.tsx
@@ -8,28 +8,29 @@ export function SampleTweets({
   username: string
 }) {
   return (
-    <section aria-label="Sample tweets" className="space-y-3">
+    <section aria-label="Sample tweets" className="space-y-2">
       <div className="flex flex-wrap items-baseline justify-between gap-2">
         <h3 className="font-sans text-sm font-semibold">Sample posts</h3>
         <span className="text-[11px] text-muted-foreground">
           @{username} first · ranked by likes
         </span>
       </div>
-      <div className="grid items-start gap-3 xl:grid-cols-2">
+      <div className="birdseye-scroll relative grid snap-x auto-cols-[88%] grid-flow-col items-start gap-2 overflow-x-auto pb-1 [contain:paint] md:auto-cols-auto md:grid-flow-row md:grid-cols-3 md:overflow-visible md:[contain:none]">
         {tweets.map((tweet) => (
           <div
             key={tweet.id}
-            className="overflow-hidden rounded-xl border border-border bg-card"
+            className="relative snap-start overflow-hidden rounded-xl border border-border bg-card"
           >
-            <p className="border-b border-border/50 px-4 py-2 text-[11px] font-semibold text-muted-foreground">
-              {tweet.username.toLowerCase() === username.toLowerCase()
-                ? `By @${username}`
-                : `Conversation context · @${tweet.username}`}
-            </p>
+            {tweet.username.toLowerCase() !== username.toLowerCase() && (
+              <p className="border-b border-border/50 px-3 py-1 text-[11px] font-semibold text-muted-foreground">
+                Conversation context · @{tweet.username}
+              </p>
+            )}
             <TweetCard
               tweet={tweet}
               compact
               collapsible
+              quotedTweetDisplay="summary"
               showDate
               showExternalLink
             />

--- a/src/components/birdseye/SampleTweets.tsx
+++ b/src/components/birdseye/SampleTweets.tsx
@@ -1,0 +1,47 @@
+import { TweetCard } from '@/components/TweetCard'
+import type { PortalTweet } from '@/lib/portal/types'
+export function SampleTweets({
+  tweets,
+  username,
+}: {
+  tweets: PortalTweet[]
+  username: string
+}) {
+  return (
+    <section aria-label="Sample tweets" className="space-y-3">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <h3 className="font-sans text-sm font-semibold">Sample posts</h3>
+        <span className="text-[11px] text-muted-foreground">
+          @{username} first · ranked by likes
+        </span>
+      </div>
+      <div className="grid items-start gap-3 xl:grid-cols-2">
+        {tweets.map((tweet) => (
+          <div
+            key={tweet.id}
+            className="overflow-hidden rounded-xl border border-border bg-card"
+          >
+            <p className="border-b border-border/50 px-4 py-2 text-[11px] font-semibold text-muted-foreground">
+              {tweet.username.toLowerCase() === username.toLowerCase()
+                ? `By @${username}`
+                : `Conversation context · @${tweet.username}`}
+            </p>
+            <TweetCard
+              tweet={tweet}
+              compact
+              collapsible
+              showDate
+              showExternalLink
+            />
+          </div>
+        ))}
+      </div>
+      {!tweets.length && (
+        <p className="rounded-xl bg-muted/40 p-4 text-sm text-muted-foreground">
+          No sample posts are currently available. Explore the source posts
+          below.
+        </p>
+      )}
+    </section>
+  )
+}

--- a/src/components/birdseye/SourcePosts.test.tsx
+++ b/src/components/birdseye/SourcePosts.test.tsx
@@ -19,7 +19,9 @@ test('loads on approach, retains earlier posts, retries a failed batch, and stop
     .mockResolvedValueOnce({
       ok: true,
       json: async () => ({
-        tweets: [{ id: '1', username: 'alice', text: 'First source' }],
+        tweets: [
+          { id: '1', threadId: '1', username: 'alice', text: 'First source' },
+        ],
         nextOffset: 6,
       }),
     } as Response)
@@ -27,7 +29,9 @@ test('loads on approach, retains earlier posts, retries a failed batch, and stop
     .mockResolvedValueOnce({
       ok: true,
       json: async () => ({
-        tweets: [{ id: '2', username: 'bob', text: 'Last source' }],
+        tweets: [
+          { id: '2', threadId: '1', username: 'bob', text: 'Last source' },
+        ],
         nextOffset: null,
       }),
     } as Response)
@@ -40,6 +44,12 @@ test('loads on approach, retains earlier posts, retries a failed batch, and stop
   fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
   expect(await screen.findByText('Last source')).toBeInTheDocument()
   expect(screen.getByText('First source')).toBeInTheDocument()
+  expect(
+    screen.getByRole('group', { name: 'Reply thread · 2 posts' }),
+  ).toHaveTextContent('First source')
+  expect(
+    screen.getByRole('group', { name: 'Reply thread · 2 posts' }),
+  ).toHaveTextContent('Last source')
   expect(screen.getByText('By @alice')).toBeInTheDocument()
   expect(screen.getByText('Conversation context · @bob')).toBeInTheDocument()
   await waitFor(() =>

--- a/src/components/birdseye/SourcePosts.test.tsx
+++ b/src/components/birdseye/SourcePosts.test.tsx
@@ -19,7 +19,7 @@ test('loads on approach, retains earlier posts, retries a failed batch, and stop
     .mockResolvedValueOnce({
       ok: true,
       json: async () => ({
-        tweets: [{ id: '1', text: 'First source' }],
+        tweets: [{ id: '1', username: 'alice', text: 'First source' }],
         nextOffset: 6,
       }),
     } as Response)
@@ -27,7 +27,7 @@ test('loads on approach, retains earlier posts, retries a failed batch, and stop
     .mockResolvedValueOnce({
       ok: true,
       json: async () => ({
-        tweets: [{ id: '2', text: 'Last source' }],
+        tweets: [{ id: '2', username: 'bob', text: 'Last source' }],
         nextOffset: null,
       }),
     } as Response)
@@ -40,6 +40,8 @@ test('loads on approach, retains earlier posts, retries a failed batch, and stop
   fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
   expect(await screen.findByText('Last source')).toBeInTheDocument()
   expect(screen.getByText('First source')).toBeInTheDocument()
+  expect(screen.getByText('By @alice')).toBeInTheDocument()
+  expect(screen.getByText('Conversation context · @bob')).toBeInTheDocument()
   await waitFor(() =>
     expect(screen.queryByRole('button')).not.toBeInTheDocument(),
   )

--- a/src/components/birdseye/SourcePosts.tsx
+++ b/src/components/birdseye/SourcePosts.tsx
@@ -3,6 +3,8 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { TweetCard } from '@/components/TweetCard'
 import type { PortalTweet } from '@/lib/portal/types'
 
+type SourceTweet = PortalTweet & { threadId?: string }
+
 export function SourcePosts({
   username,
   clusterId,
@@ -15,7 +17,7 @@ export function SourcePosts({
   excludeIds?: string[]
 }) {
   const excluded = excludeIds.join(',')
-  const [tweets, setTweets] = useState<PortalTweet[]>([])
+  const [tweets, setTweets] = useState<SourceTweet[]>([])
   const [offset, setOffset] = useState<number | null>(total ? 0 : null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
@@ -49,7 +51,7 @@ export function SourcePosts({
         )
       }
       const result = (await response.json()) as {
-        tweets: PortalTweet[]
+        tweets: SourceTweet[]
         nextOffset: number | null
       }
       setTweets((previous) => [
@@ -79,6 +81,11 @@ export function SourcePosts({
     observer.observe(sentinel.current)
     return () => observer.disconnect()
   }, [load, error, offset])
+  const threads = new Map<string, SourceTweet[]>()
+  for (const tweet of tweets) {
+    const key = tweet.threadId ?? tweet.id
+    threads.set(key, [...(threads.get(key) ?? []), tweet])
+  }
   return (
     <section aria-label="Source posts" className="space-y-4">
       <div className="flex items-baseline justify-between gap-3">
@@ -90,20 +97,50 @@ export function SourcePosts({
         </span>
       </div>
       <p className="text-xs text-muted-foreground">
-        Posts load a few at a time. Some cited posts may no longer be available.
+        Related replies stay together as posts load. Only cited posts are shown;
+        some may no longer be available.
       </p>
-      {tweets.map((tweet) => (
+      {Array.from(threads.entries()).map(([threadId, posts]) => (
         <div
-          id={`source-${tweet.id}`}
-          key={tweet.id}
+          key={threadId}
+          role="group"
+          aria-label={
+            posts.length > 1
+              ? `Reply thread · ${posts.length} posts`
+              : 'Source post'
+          }
           className="overflow-hidden rounded-xl border border-border bg-card"
         >
-          <p className="px-4 pt-3 text-xs text-muted-foreground">
-            {tweet.username.toLowerCase() === username.toLowerCase()
-              ? `By @${username}`
-              : `Conversation context · @${tweet.username}`}
-          </p>
-          <TweetCard tweet={tweet} noClamp showDate showExternalLink />
+          {posts.length > 1 && (
+            <p className="border-b border-border/50 bg-muted/25 px-4 py-2 text-xs font-semibold text-muted-foreground">
+              Reply thread · {posts.length} posts
+            </p>
+          )}
+          {posts.map((tweet, index) => (
+            <div
+              id={`source-${tweet.id}`}
+              key={tweet.id}
+              className={
+                posts.length > 1
+                  ? 'relative ml-5 border-l-2 border-brand/25 pl-2'
+                  : ''
+              }
+            >
+              {posts.length > 1 && (
+                <span
+                  aria-hidden="true"
+                  className="absolute -left-[5px] top-5 h-2 w-2 rounded-full bg-brand/60"
+                />
+              )}
+              <p className="px-4 pt-2 text-[11px] text-muted-foreground">
+                {index > 0 && <span className="mr-2 text-brand">↳</span>}
+                {tweet.username.toLowerCase() === username.toLowerCase()
+                  ? `By @${username}`
+                  : `Conversation context · @${tweet.username}`}
+              </p>
+              <TweetCard tweet={tweet} noClamp showDate showExternalLink />
+            </div>
+          ))}
         </div>
       ))}
       <div ref={sentinel} className="py-4 text-center">

--- a/src/components/birdseye/SourcePosts.tsx
+++ b/src/components/birdseye/SourcePosts.tsx
@@ -7,11 +7,14 @@ export function SourcePosts({
   username,
   clusterId,
   total,
+  excludeIds = [],
 }: {
   username: string
   clusterId: string
   total: number
+  excludeIds?: string[]
 }) {
+  const excluded = excludeIds.join(',')
   const [tweets, setTweets] = useState<PortalTweet[]>([])
   const [offset, setOffset] = useState<number | null>(total ? 0 : null)
   const [loading, setLoading] = useState(false)
@@ -32,6 +35,7 @@ export function SourcePosts({
         cluster_id: clusterId,
         offset: String(offset),
       })
+      if (excluded) query.set('exclude', excluded)
       const response = await fetch(`/api/birdseye/sources?${query}`, {
         signal: abort.signal,
         cache: 'no-store',
@@ -62,7 +66,7 @@ export function SourcePosts({
       inFlight.current = false
       if (!abort.signal.aborted) setLoading(false)
     }
-  }, [username, clusterId, offset])
+  }, [username, clusterId, offset, excluded])
   useEffect(() => () => controller.current?.abort(), [])
   useEffect(() => {
     if (!sentinel.current || error || offset === null) return
@@ -78,7 +82,9 @@ export function SourcePosts({
   return (
     <section aria-label="Source posts" className="space-y-4">
       <div className="flex items-baseline justify-between gap-3">
-        <h3 className="text-xl font-bold">Source posts</h3>
+        <h3 className="font-sans text-xl font-bold">
+          {excluded ? 'More source posts' : 'Source posts'}
+        </h3>
         <span className="text-xs text-muted-foreground">
           {total} cited posts
         </span>
@@ -92,6 +98,11 @@ export function SourcePosts({
           key={tweet.id}
           className="overflow-hidden rounded-xl border border-border bg-card"
         >
+          <p className="px-4 pt-3 text-xs text-muted-foreground">
+            {tweet.username.toLowerCase() === username.toLowerCase()
+              ? `By @${username}`
+              : `Conversation context · @${tweet.username}`}
+          </p>
           <TweetCard tweet={tweet} noClamp showDate showExternalLink />
         </div>
       ))}

--- a/src/components/birdseye/TopicInteractions.test.tsx
+++ b/src/components/birdseye/TopicInteractions.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { MonthlyTimeline } from './MonthlyTimeline'
+import { InsightItem } from './InsightItem'
+import type { BirdseyeCluster } from '@/lib/community-apps/types'
+
+const snowflake = (date: string) =>
+  (
+    (BigInt(Date.parse(date)) - BigInt('1288834974657')) <<
+    BigInt(22)
+  ).toString()
+test('month counts appear on hover, keyboard focus and tap, including empty months', () => {
+  render(
+    <MonthlyTimeline
+      cluster={
+        {
+          tweetIds: [snowflake('2022-01-01'), snowflake('2022-03-01')],
+          sections: [],
+        } as unknown as BirdseyeCluster
+      }
+    />,
+  )
+  const empty = screen.getByRole('button', { name: 'Feb 2022: 0 cited posts' })
+  fireEvent.mouseEnter(empty)
+  expect(screen.getByRole('tooltip')).toHaveTextContent('Feb 2022 · 0 posts')
+  fireEvent.keyDown(empty, { key: 'Escape' })
+  expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+  fireEvent.focus(
+    screen.getByRole('button', { name: 'Mar 2022: 1 cited posts' }),
+  )
+  expect(screen.getByRole('tooltip')).toHaveTextContent('Mar 2022 · 1 post')
+  fireEvent.click(empty)
+  expect(screen.getByRole('tooltip')).toHaveTextContent('Feb 2022 · 0 posts')
+})
+test('insight labels reveal descriptions and sources on hover and stay open when clicked', () => {
+  render(
+    <InsightItem
+      item={{
+        label: 'Community',
+        description: 'Nurture connections',
+        tweetIds: ['123'],
+      }}
+      username={null}
+    />,
+  )
+  const trigger = screen.getByRole('button', { name: 'Community' })
+  expect(screen.queryByText('Nurture connections')).not.toBeInTheDocument()
+  fireEvent.mouseEnter(trigger)
+  expect(screen.getByRole('dialog', { name: 'Community' })).toHaveTextContent(
+    'Nurture connections',
+  )
+  fireEvent.click(trigger)
+  expect(
+    screen.getByRole('link', { name: 'Source 1 for Community' }),
+  ).toHaveAttribute('href', '/tweets/123')
+  fireEvent.click(trigger)
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+})

--- a/src/components/birdseye/TopicSummary.tsx
+++ b/src/components/birdseye/TopicSummary.tsx
@@ -1,0 +1,24 @@
+'use client'
+import { useState } from 'react'
+import { AnalysisText } from '@/components/community-apps/AnalysisText'
+
+export function TopicSummary({ text }: { text: string }) {
+  const [expanded, setExpanded] = useState(false)
+  if (!text.trim()) return null
+  return (
+    <div className="mt-2">
+      <div
+        className={`${expanded ? '' : 'line-clamp-2'} [&>div]:space-y-1 [&>div]:text-[13px] [&>div]:leading-5 [&_p]:mb-1`}
+      >
+        <AnalysisText>{text}</AnalysisText>
+      </div>
+      <button
+        aria-expanded={expanded}
+        onClick={() => setExpanded(!expanded)}
+        className="mt-1 text-[11px] text-muted-foreground hover:text-brand"
+      >
+        Saved AI summary · {expanded ? 'Show less' : 'Read more'}
+      </button>
+    </div>
+  )
+}

--- a/src/lib/community-apps/birdseye-access.test.ts
+++ b/src/lib/community-apps/birdseye-access.test.ts
@@ -1,3 +1,5 @@
+import { isAdminUser } from '@/app/admin/data'
+import { getLocalAdminPreview } from '@/lib/localAdminPreview'
 import type { User } from '@supabase/supabase-js'
 import { cookies } from 'next/headers'
 import {
@@ -7,6 +9,7 @@ import {
 import { getAppDataManifest, getAppPolicy, getBirdseyeAnalysis } from './data'
 import {
   createBirdseyeShare,
+  getBirdseyeProfiles,
   loadAccessibleBirdseye,
   resolveBirdseyeShare,
   SHARE_COOKIE,
@@ -15,6 +18,10 @@ import { GET as sources } from '@/app/api/birdseye/sources/route'
 import { POST, DELETE } from '@/app/api/birdseye/sharing/route'
 import { getStrandTweets } from './strand-tweets'
 import { NextRequest } from 'next/server'
+jest.mock('@/app/admin/data', () => ({ isAdminUser: jest.fn() }))
+jest.mock('@/lib/localAdminPreview', () => ({
+  getLocalAdminPreview: jest.fn(),
+}))
 jest.mock('next/headers', () => ({ cookies: jest.fn() }))
 jest.mock('next/cache', () => ({ unstable_noStore: jest.fn() }))
 jest.mock('@/utils/supabase', () => ({
@@ -40,6 +47,8 @@ const getUserById = jest.fn()
 const member = jest.fn()
 beforeEach(() => {
   jest.clearAllMocks()
+  jest.mocked(isAdminUser).mockReturnValue(false)
+  jest.mocked(getLocalAdminPreview).mockResolvedValue(null)
   session = null
   stored = structuredClone(owner)
   cookie = undefined
@@ -219,4 +228,52 @@ test('a share link redirects without the secret and uses a private HttpOnly cook
     secure: true,
     sameSite: 'lax',
   })
+})
+
+test('real admins can list and read eligible profiles without becoming the owner', async () => {
+  session = {
+    ...owner,
+    identities: [
+      { provider: 'twitter', identity_data: { user_name: 'admin' } },
+    ],
+  } as unknown as User
+  jest.mocked(isAdminUser).mockReturnValue(true)
+  expect(await getBirdseyeProfiles()).toEqual(['alice'])
+  expect(await loadAccessibleBirdseye('alice')).toMatchObject({
+    isAdmin: true,
+    isOwner: false,
+  })
+  expect(member).not.toHaveBeenCalled()
+  jest
+    .mocked(getAppPolicy)
+    .mockResolvedValue({
+      members: new Set(),
+      blocked: new Set(['alice']),
+      blockedIds: new Set(),
+    })
+  expect(await getBirdseyeProfiles()).toEqual([])
+  expect(await loadAccessibleBirdseye('alice')).toBeNull()
+})
+
+test('local admin can browse sources, logout removes access, and no Auth identity is fabricated', async () => {
+  jest.mocked(getLocalAdminPreview).mockResolvedValue('admin')
+  expect(await getBirdseyeProfiles()).toEqual(['alice'])
+  expect(await loadAccessibleBirdseye('alice')).toMatchObject({
+    isAdmin: true,
+    isOwner: false,
+    sharingEnabled: false,
+  })
+  expect(
+    (
+      await sources(
+        new NextRequest(
+          'http://localhost:3031/api/birdseye/sources?username=alice&cluster_id=topic',
+        ),
+      )
+    ).status,
+  ).toBe(200)
+  expect(updateUserById).not.toHaveBeenCalled()
+  jest.mocked(getLocalAdminPreview).mockResolvedValue('signed-out')
+  expect(await getBirdseyeProfiles()).toEqual([])
+  expect(await loadAccessibleBirdseye('alice')).toBeNull()
 })

--- a/src/lib/community-apps/birdseye-access.test.ts
+++ b/src/lib/community-apps/birdseye-access.test.ts
@@ -1,3 +1,4 @@
+import { getBirdseyeSourceIndex } from './birdseye-source-index'
 import { isAdminUser } from '@/app/admin/data'
 import { getLocalAdminPreview } from '@/lib/localAdminPreview'
 import type { User } from '@supabase/supabase-js'
@@ -33,6 +34,9 @@ jest.mock('./data', () => ({
   getAppPolicy: jest.fn(),
   getBirdseyeAnalysis: jest.fn(),
 }))
+jest.mock('./birdseye-source-index', () => ({
+  getBirdseyeSourceIndex: jest.fn(),
+}))
 jest.mock('./strand-tweets', () => ({ getStrandTweets: jest.fn() }))
 const owner = {
   id: '12345678-1234-1234-1234-123456789abc',
@@ -47,6 +51,9 @@ const getUserById = jest.fn()
 const member = jest.fn()
 beforeEach(() => {
   jest.clearAllMocks()
+  jest
+    .mocked(getBirdseyeSourceIndex)
+    .mockImplementation(async (ids) => ids.map((id) => ({ id, threadId: id })))
   jest.mocked(isAdminUser).mockReturnValue(false)
   jest.mocked(getLocalAdminPreview).mockResolvedValue(null)
   session = null
@@ -119,6 +126,7 @@ test('private by default: anonymous, another owner, and user-editable metadata c
   ).toBe(404)
   expect(getBirdseyeAnalysis).not.toHaveBeenCalled()
   expect(getStrandTweets).not.toHaveBeenCalled()
+  expect(getBirdseyeSourceIndex).not.toHaveBeenCalled()
 })
 test('owner identity and matching account are required, with consent rechecked on every read', async () => {
   session = owner
@@ -276,7 +284,7 @@ test('local admin can browse sources, logout removes access, and no Auth identit
   expect(await loadAccessibleBirdseye('alice')).toBeNull()
 })
 
-test('remaining sources skip the two highlighted posts before applying pagination', async () => {
+test('remaining sources skip the highlighted posts before applying pagination', async () => {
   session = owner
   const response = await sources(
     new NextRequest(
@@ -286,4 +294,19 @@ test('remaining sources skip the two highlighted posts before applying paginatio
   expect(response.status).toBe(200)
   expect(getStrandTweets).toHaveBeenCalledWith(['2', '3', '4', '6', '7', '8'])
   expect(await response.json()).toMatchObject({ nextOffset: 6 })
+})
+
+test('source grouping failures remain private and retryable', async () => {
+  session = owner
+  jest
+    .mocked(getBirdseyeSourceIndex)
+    .mockRejectedValueOnce(new Error('offline'))
+  const response = await sources(
+    new NextRequest(
+      'https://ca.test/api/birdseye/sources?username=alice&cluster_id=topic',
+    ),
+  )
+  expect(response.status).toBe(503)
+  expect(response.headers.get('cache-control')).toContain('no-store')
+  expect(getStrandTweets).not.toHaveBeenCalled()
 })

--- a/src/lib/community-apps/birdseye-access.test.ts
+++ b/src/lib/community-apps/birdseye-access.test.ts
@@ -244,13 +244,11 @@ test('real admins can list and read eligible profiles without becoming the owner
     isOwner: false,
   })
   expect(member).not.toHaveBeenCalled()
-  jest
-    .mocked(getAppPolicy)
-    .mockResolvedValue({
-      members: new Set(),
-      blocked: new Set(['alice']),
-      blockedIds: new Set(),
-    })
+  jest.mocked(getAppPolicy).mockResolvedValue({
+    members: new Set(),
+    blocked: new Set(['alice']),
+    blockedIds: new Set(),
+  })
   expect(await getBirdseyeProfiles()).toEqual([])
   expect(await loadAccessibleBirdseye('alice')).toBeNull()
 })
@@ -276,4 +274,16 @@ test('local admin can browse sources, logout removes access, and no Auth identit
   jest.mocked(getLocalAdminPreview).mockResolvedValue('signed-out')
   expect(await getBirdseyeProfiles()).toEqual([])
   expect(await loadAccessibleBirdseye('alice')).toBeNull()
+})
+
+test('remaining sources skip the two highlighted posts before applying pagination', async () => {
+  session = owner
+  const response = await sources(
+    new NextRequest(
+      'https://ca.test/api/birdseye/sources?username=alice&cluster_id=topic&exclude=1,5',
+    ),
+  )
+  expect(response.status).toBe(200)
+  expect(getStrandTweets).toHaveBeenCalledWith(['2', '3', '4', '6', '7', '8'])
+  expect(await response.json()).toMatchObject({ nextOffset: 6 })
 })

--- a/src/lib/community-apps/birdseye-access.ts
+++ b/src/lib/community-apps/birdseye-access.ts
@@ -1,4 +1,6 @@
 import 'server-only'
+import { isAdminUser } from '@/app/admin/data'
+import { getLocalAdminPreview } from '@/lib/localAdminPreview'
 import { createHash, randomBytes, timingSafeEqual } from 'node:crypto'
 import type { User } from '@supabase/supabase-js'
 import { cookies } from 'next/headers'
@@ -35,6 +37,28 @@ export async function getBirdseyeOwner() {
     error,
   } = await createServerClient(await cookies()).auth.getUser()
   return error ? null : user
+}
+
+export async function getBirdseyeViewer() {
+  const localPreview = await getLocalAdminPreview()
+  // Local read preview never fabricates an Auth user or grants write access.
+  const user = localPreview === 'admin' ? null : await getBirdseyeOwner()
+  return {
+    user,
+    isAdmin: localPreview === 'admin' || (!!user && isAdminUser(user)),
+  }
+}
+
+export async function getBirdseyeProfiles() {
+  if (!(await getBirdseyeViewer()).isAdmin) return []
+  const manifest = await getAppDataManifest()
+  const policy = await getAppPolicy(
+    manifest.birdseye.map((entry) => entry.username),
+  )
+  return manifest.birdseye
+    .map((entry) => entry.username)
+    .filter((username) => policy.members.has(username))
+    .sort()
 }
 
 export function createBirdseyeShare(user: User) {
@@ -79,33 +103,39 @@ export async function resolveBirdseyeShare(token: string | undefined) {
 
 export async function loadAccessibleBirdseye(requestedUsername?: string) {
   noStore()
-  const user = await getBirdseyeOwner()
+  const { user, isAdmin } = await getBirdseyeViewer()
   const owner = birdseyeIdentity(user)
   const requested = requestedUsername?.toLowerCase()
   if (requested && !/^[a-z0-9_]{1,15}$/.test(requested)) return null
   const shared =
-    !owner || (requested && requested !== owner.username)
+    !isAdmin && (!owner || (requested && requested !== owner.username))
       ? await resolveBirdseyeShare((await cookies()).get(SHARE_COOKIE)?.value)
       : null
-  const username = requested || owner?.username || shared?.username
+  const username =
+    requested ||
+    owner?.username ||
+    shared?.username ||
+    (isAdmin ? (await getBirdseyeProfiles())[0] : undefined)
   const isOwner = !!owner && username === owner.username
   const identity = isOwner
     ? owner
     : shared?.username === username
       ? shared
       : null
-  if (!username || !identity) return null
+  if (!username || (!identity && !isAdmin)) return null
 
   const policy = await getAppPolicy([username])
   if (!policy.members.has(username)) return null
-  // A matching handle alone is insufficient if an account has been renamed.
-  const { data: member, error } = await createServerServiceRoleClient()
-    .from('user_directory')
-    .select('username')
-    .eq('account_id', identity.accountId)
-    .maybeSingle()
-  if (error) throw new Error('Birdseye ownership check unavailable')
-  if (member?.username?.toLowerCase() !== username) return null
+  if (!isAdmin) {
+    // A matching handle alone is insufficient if an account has been renamed.
+    const { data: member, error } = await createServerServiceRoleClient()
+      .from('user_directory')
+      .select('username')
+      .eq('account_id', identity!.accountId)
+      .maybeSingle()
+    if (error) throw new Error('Birdseye ownership check unavailable')
+    if (member?.username?.toLowerCase() !== username) return null
+  }
   const manifest = await getAppDataManifest()
   if (!manifest.birdseye.some((entry) => entry.username === username))
     return null
@@ -113,6 +143,7 @@ export async function loadAccessibleBirdseye(requestedUsername?: string) {
   return {
     analysis,
     isOwner,
+    isAdmin,
     sharingEnabled: isOwner && !!user?.app_metadata?.birdseye_share,
   }
 }

--- a/src/lib/community-apps/birdseye-layout.test.ts
+++ b/src/lib/community-apps/birdseye-layout.test.ts
@@ -1,0 +1,67 @@
+import {
+  monthlyActivity,
+  birdseyeGroups,
+  yearlySummaries,
+  participantUsername,
+} from './birdseye-layout'
+import type { BirdseyeAnalysis, BirdseyeCluster } from './types'
+const idAt = (date: string) =>
+  (
+    (BigInt(new Date(date).getTime()) - BigInt('1288834974657')) <<
+    BigInt(22)
+  ).toString()
+test('monthly chart starts and ends at cited months, fills gaps, and deduplicates IDs', () => {
+  const june = idAt('2021-06-15')
+  expect(
+    monthlyActivity([june, june, idAt('2021-08-03'), 'bad', '123']),
+  ).toEqual([
+    { month: '2021-06', count: 1 },
+    { month: '2021-07', count: 0 },
+    { month: '2021-08', count: 1 },
+  ])
+  expect(monthlyActivity([])).toEqual([])
+  expect(monthlyActivity([june])).toEqual([{ month: '2021-06', count: 1 }])
+})
+test('overview ranks macro topics by unique references and includes ungrouped topics', () => {
+  const analysis = {
+    groups: [
+      { name: 'Small', clusterIds: ['a'] },
+      { name: 'Big', clusterIds: ['b', 'c', 'hidden'] },
+    ],
+    clusters: [
+      { id: 'a', name: 'A', tweetIds: ['1'] },
+      { id: 'b', name: 'B', tweetIds: ['2', '3'] },
+      { id: 'c', name: 'C', tweetIds: ['3', '4', '5'] },
+      { id: 'd', name: 'D', tweetIds: ['6'] },
+    ],
+  } as BirdseyeAnalysis
+  const groups = birdseyeGroups(analysis)
+  expect(groups[0].name).toBe('Big')
+  expect(groups[0].tweetIds).toHaveLength(4)
+  expect(groups[0].topics.map((topic) => topic.id)).toEqual(['c', 'b'])
+  expect(
+    groups.find((group) => group.name === 'More topics')?.topics[0].id,
+  ).toBe('d')
+})
+test('year summaries are chronological and cropped to the cited date range', () => {
+  const cluster = {
+    tweetIds: [idAt('2020-05-04'), idAt('2022-09-12')],
+    sections: [
+      {
+        name: 'Yearly summaries',
+        items: ['2022', '2019', '2020', '2023'].map((label) => ({ label })),
+      },
+    ],
+  } as BirdseyeCluster
+  expect(yearlySummaries(cluster).map((item) => item.label)).toEqual([
+    '2020',
+    '2022',
+  ])
+})
+test('person avatars require a known participant handle, not just a short entity name', () => {
+  expect(participantUsername('@Christineist', ['christineist'])).toBe(
+    'christineist',
+  )
+  expect(participantUsername('Book', ['christineist'])).toBeNull()
+  expect(participantUsername('Wong Kar Wai', ['christineist'])).toBeNull()
+})

--- a/src/lib/community-apps/birdseye-layout.ts
+++ b/src/lib/community-apps/birdseye-layout.ts
@@ -1,0 +1,88 @@
+import type { BirdseyeAnalysis, BirdseyeCluster } from './types'
+
+export function monthlyActivity(ids: string[]) {
+  const counts = new Map<string, number>()
+  for (const id of Array.from(new Set(ids))) {
+    if (!/^\d{16,20}$/.test(id)) continue
+    const time = Number((BigInt(id) >> BigInt(22)) + BigInt('1288834974657'))
+    const date = new Date(time)
+    if (
+      !Number.isFinite(time) ||
+      date.getUTCFullYear() < 2010 ||
+      date.getUTCFullYear() > 2100
+    )
+      continue
+    const month = date.toISOString().slice(0, 7)
+    counts.set(month, (counts.get(month) ?? 0) + 1)
+  }
+  const months = Array.from(counts.keys()).sort()
+  if (!months.length) return []
+  const cursor = new Date(`${months[0]}-01T00:00:00Z`)
+  const end = months[months.length - 1]
+  const result: { month: string; count: number }[] = []
+  while (cursor.toISOString().slice(0, 7) <= end) {
+    const month = cursor.toISOString().slice(0, 7)
+    result.push({ month, count: counts.get(month) ?? 0 })
+    cursor.setUTCMonth(cursor.getUTCMonth() + 1)
+  }
+  return result
+}
+
+export function birdseyeGroups(analysis: BirdseyeAnalysis) {
+  const clusters = new Map(
+    analysis.clusters.map((cluster) => [cluster.id, cluster]),
+  )
+  const grouped = new Set(analysis.groups.flatMap((group) => group.clusterIds))
+  return [
+    ...analysis.groups,
+    {
+      name: 'More topics',
+      clusterIds: analysis.clusters
+        .filter((cluster) => !grouped.has(cluster.id))
+        .map((cluster) => cluster.id),
+    },
+  ]
+    .map((group, index) => {
+      const topics = Array.from(new Set(group.clusterIds))
+        .flatMap((id) => (clusters.has(id) ? [clusters.get(id)!] : []))
+        .sort(
+          (a, b) =>
+            new Set(b.tweetIds).size - new Set(a.tweetIds).size ||
+            a.name.localeCompare(b.name),
+        )
+      const tweetIds = Array.from(
+        new Set(topics.flatMap((topic) => topic.tweetIds)),
+      )
+      return { name: group.name, id: `group-${index}`, topics, tweetIds }
+    })
+    .filter((group) => group.topics.length)
+    .sort(
+      (a, b) =>
+        b.tweetIds.length - a.tweetIds.length || a.name.localeCompare(b.name),
+    )
+}
+
+export function yearlySummaries(cluster: BirdseyeCluster) {
+  const months = monthlyActivity(cluster.tweetIds)
+  if (!months.length) return []
+  const start = Number(months[0].month.slice(0, 4))
+  const end = Number(months[months.length - 1].month.slice(0, 4))
+  return cluster.sections
+    .filter((section) => section.name.toLowerCase() === 'yearly summaries')
+    .flatMap((section) => section.items)
+    .filter(
+      (item) =>
+        /^\d{4}$/.test(item.label) &&
+        Number(item.label) >= start &&
+        Number(item.label) <= end,
+    )
+    .sort((a, b) => Number(a.label) - Number(b.label))
+}
+
+export function participantUsername(label: string, participants: string[]) {
+  const username = label.replace(/^@/, '').toLowerCase()
+  return /^[a-z0-9_]{1,15}$/.test(username) &&
+    participants.some((name) => name.toLowerCase() === username)
+    ? username
+    : null
+}

--- a/src/lib/community-apps/birdseye-samples.test.ts
+++ b/src/lib/community-apps/birdseye-samples.test.ts
@@ -1,0 +1,82 @@
+import { getBirdseyeSamples } from './birdseye-samples'
+import { createServerServiceRoleClient } from '@/utils/supabase'
+import { getStrandTweets } from './strand-tweets'
+jest.mock('next/cache', () => ({ unstable_cache: (fn: unknown) => fn }))
+jest.mock('@/utils/supabase', () => ({
+  createServerServiceRoleClient: jest.fn(),
+}))
+jest.mock('./strand-tweets', () => ({ getStrandTweets: jest.fn() }))
+const query = {
+  select: jest.fn().mockReturnThis(),
+  in: jest.fn().mockReturnThis(),
+  ilike: jest.fn().mockReturnThis(),
+  order: jest.fn().mockReturnThis(),
+  limit: jest.fn(),
+}
+beforeEach(() => {
+  jest.clearAllMocks()
+  jest
+    .mocked(createServerServiceRoleClient)
+    .mockReturnValue({ from: () => query } as never)
+})
+test('selects owner posts by likes using only cited IDs, then renders the configured source records', async () => {
+  query.limit.mockResolvedValue({
+    data: [
+      { tweet_id: '1', favorite_count: 3 },
+      { tweet_id: '2', favorite_count: 8 },
+      { tweet_id: '3', favorite_count: 5 },
+    ],
+    error: null,
+  })
+  jest.mocked(getStrandTweets).mockResolvedValue(
+    new Map([
+      ['1', { id: '1', username: 'alice', likes: 3 }],
+      ['2', { id: '2', username: 'ALICE', likes: 8 }],
+      ['3', { id: '3', username: 'alice', likes: 5 }],
+    ] as never),
+  )
+  expect(
+    (await getBirdseyeSamples(['1', '2', '3', '1', 'bad'], 'alice')).map(
+      (tweet) => tweet.id,
+    ),
+  ).toEqual(['2', '3'])
+  expect(query.in).toHaveBeenCalledWith('tweet_id', ['1', '2', '3'])
+  expect(query.ilike).toHaveBeenCalledWith('username', 'alice')
+  expect(getStrandTweets).toHaveBeenCalledWith(['2', '3', '1'])
+})
+test('uses conversation context only when there are too few owner candidates', async () => {
+  query.limit
+    .mockResolvedValueOnce({
+      data: [{ tweet_id: '1', favorite_count: 2 }],
+      error: null,
+    })
+    .mockResolvedValueOnce({
+      data: [{ tweet_id: '2', favorite_count: 50 }],
+      error: null,
+    })
+  jest.mocked(getStrandTweets).mockResolvedValue(
+    new Map([
+      ['1', { id: '1', username: 'alice', likes: 2 }],
+      ['2', { id: '2', username: 'bob', likes: 50 }],
+    ] as never),
+  )
+  expect(
+    (await getBirdseyeSamples(['1', '2'], 'alice')).map((tweet) => tweet.id),
+  ).toEqual(['1', '2'])
+})
+test('does not silently select arbitrary posts when ranking is unavailable', async () => {
+  query.limit.mockResolvedValue({
+    data: null,
+    error: { message: 'Unavailable' },
+  })
+  await expect(getBirdseyeSamples(['1'], 'alice')).rejects.toThrow(
+    'Unable to rank',
+  )
+  expect(getStrandTweets).not.toHaveBeenCalled()
+})
+test('matches underscores in usernames literally', async () => {
+  query.limit.mockResolvedValue({ data: [], error: null })
+  jest.mocked(getStrandTweets).mockResolvedValue(new Map())
+  await getBirdseyeSamples(['1'], 'alice_bob')
+  expect(query.ilike).toHaveBeenCalledWith('username', 'alice\\_bob')
+})

--- a/src/lib/community-apps/birdseye-samples.test.ts
+++ b/src/lib/community-apps/birdseye-samples.test.ts
@@ -39,7 +39,7 @@ test('selects owner posts by likes using only cited IDs, then renders the config
     (await getBirdseyeSamples(['1', '2', '3', '1', 'bad'], 'alice')).map(
       (tweet) => tweet.id,
     ),
-  ).toEqual(['2', '3'])
+  ).toEqual(['2', '3', '1'])
   expect(query.in).toHaveBeenCalledWith('tweet_id', ['1', '2', '3'])
   expect(query.ilike).toHaveBeenCalledWith('username', 'alice')
   expect(getStrandTweets).toHaveBeenCalledWith(['2', '3', '1'])

--- a/src/lib/community-apps/birdseye-samples.ts
+++ b/src/lib/community-apps/birdseye-samples.ts
@@ -42,7 +42,7 @@ const rankedIds = unstable_cache(
 export async function getBirdseyeSamples(ids: string[], username: string) {
   const own = await rankedIds(ids, username)
   const candidates = [...own]
-  if (own.length < 2) candidates.push(...(await rankedIds(ids, null)))
+  if (own.length < 3) candidates.push(...(await rankedIds(ids, null)))
   const posts = await getStrandTweets(Array.from(new Set(candidates)))
   return Array.from(posts.values())
     .sort(
@@ -52,5 +52,5 @@ export async function getBirdseyeSamples(ids: string[], username: string) {
         b.likes - a.likes ||
         b.id.localeCompare(a.id),
     )
-    .slice(0, 2) as PortalTweet[]
+    .slice(0, 3) as PortalTweet[]
 }

--- a/src/lib/community-apps/birdseye-samples.ts
+++ b/src/lib/community-apps/birdseye-samples.ts
@@ -1,0 +1,56 @@
+import 'server-only'
+import { unstable_cache } from 'next/cache'
+import { createServerServiceRoleClient } from '@/utils/supabase'
+import { getStrandTweets } from './strand-tweets'
+import type { PortalTweet } from '@/lib/portal/types'
+
+type Candidate = { tweet_id: string | null; favorite_count: number | null }
+// Small indexed lookups against only this topic's saved references. Postgres
+// supplies ranking metadata, not a second full-text source. TweetCard payloads
+// continue to use the configured archive reader and its current opt-out checks.
+const rankedIds = unstable_cache(
+  async (input: string[], username: string | null) => {
+    const ids = Array.from(new Set(input.filter((id) => /^\d{1,20}$/.test(id))))
+    const candidates: Candidate[] = []
+    for (let offset = 0; offset < ids.length; offset += 150) {
+      let query = createServerServiceRoleClient()
+        .from('enriched_tweets')
+        .select('tweet_id,favorite_count')
+        .in('tweet_id', ids.slice(offset, offset + 150))
+      if (username)
+        query = query.ilike('username', username.replace(/_/g, '\\_'))
+      const { data, error } = await query
+        .order('favorite_count', { ascending: false, nullsFirst: false })
+        .order('tweet_id', { ascending: false })
+        .limit(6)
+      if (error) throw new Error('Unable to rank cited posts')
+      candidates.push(...(data ?? []))
+    }
+    return candidates
+      .sort(
+        (a, b) =>
+          (b.favorite_count ?? 0) - (a.favorite_count ?? 0) ||
+          (b.tweet_id ?? '').localeCompare(a.tweet_id ?? ''),
+      )
+      .flatMap((row) => (row.tweet_id ? [row.tweet_id] : []))
+      .slice(0, 6)
+  },
+  ['birdseye-cited-likes-v1'],
+  { revalidate: 300 },
+)
+
+export async function getBirdseyeSamples(ids: string[], username: string) {
+  const own = await rankedIds(ids, username)
+  const candidates = [...own]
+  if (own.length < 2) candidates.push(...(await rankedIds(ids, null)))
+  const posts = await getStrandTweets(Array.from(new Set(candidates)))
+  return Array.from(posts.values())
+    .sort(
+      (a, b) =>
+        Number(b.username.toLowerCase() === username.toLowerCase()) -
+          Number(a.username.toLowerCase() === username.toLowerCase()) ||
+        b.likes - a.likes ||
+        b.id.localeCompare(a.id),
+    )
+    .slice(0, 2) as PortalTweet[]
+}

--- a/src/lib/community-apps/birdseye-source-index.ts
+++ b/src/lib/community-apps/birdseye-source-index.ts
@@ -1,0 +1,27 @@
+import 'server-only'
+import { unstable_cache } from 'next/cache'
+import { createServerServiceRoleClient } from '@/utils/supabase'
+import { groupBirdseyeSources } from './birdseye-threads'
+
+// Exact-reference metadata only; full tweet payloads still come from the shared reader.
+export const getBirdseyeSourceIndex = unstable_cache(
+  async (input: string[]) => {
+    const ids = Array.from(new Set(input.filter((id) => /^\d{1,20}$/.test(id))))
+    const rows: {
+      tweet_id: string | null
+      reply_to_tweet_id: string | null
+      conversation_id: string | null
+    }[] = []
+    for (let offset = 0; offset < ids.length; offset += 150) {
+      const { data, error } = await createServerServiceRoleClient()
+        .from('enriched_tweets')
+        .select('tweet_id,reply_to_tweet_id,conversation_id')
+        .in('tweet_id', ids.slice(offset, offset + 150))
+      if (error) throw new Error('Unable to group cited posts')
+      rows.push(...(data ?? []))
+    }
+    return groupBirdseyeSources(ids, rows)
+  },
+  ['birdseye-source-threads-v1'],
+  { revalidate: 300 },
+)

--- a/src/lib/community-apps/birdseye-threads.test.ts
+++ b/src/lib/community-apps/birdseye-threads.test.ts
@@ -1,0 +1,47 @@
+import { groupBirdseyeSources } from './birdseye-threads'
+test('groups reply chains and shared conversation IDs in parent-first order without adding uncited posts', () => {
+  const rows = [
+    { tweet_id: '3', reply_to_tweet_id: '2', conversation_id: null },
+    { tweet_id: '2', reply_to_tweet_id: '1', conversation_id: null },
+    { tweet_id: '6', reply_to_tweet_id: '5', conversation_id: '4' },
+    { tweet_id: '7', reply_to_tweet_id: '99', conversation_id: '4' },
+    { tweet_id: '100', reply_to_tweet_id: '1', conversation_id: null },
+  ]
+  expect(
+    groupBirdseyeSources(['3', '8', '1', '7', '2', '6', '3'], rows),
+  ).toEqual([
+    { id: '1', threadId: '1' },
+    { id: '2', threadId: '1' },
+    { id: '3', threadId: '1' },
+    { id: '8', threadId: '8' },
+    { id: '6', threadId: '6' },
+    { id: '7', threadId: '6' },
+  ])
+})
+test('handles missing metadata, siblings with an uncited parent, and malformed cycles', () => {
+  expect(
+    groupBirdseyeSources(
+      ['2', '1', '3'],
+      [
+        { tweet_id: '1', reply_to_tweet_id: '2', conversation_id: null },
+        { tweet_id: '2', reply_to_tweet_id: '1', conversation_id: null },
+      ],
+    ),
+  ).toEqual([
+    { id: '1', threadId: '1' },
+    { id: '2', threadId: '1' },
+    { id: '3', threadId: '3' },
+  ])
+  expect(
+    groupBirdseyeSources(
+      ['2', '3'],
+      [
+        { tweet_id: '2', reply_to_tweet_id: '1', conversation_id: null },
+        { tweet_id: '3', reply_to_tweet_id: '1', conversation_id: null },
+      ],
+    ),
+  ).toEqual([
+    { id: '2', threadId: '2' },
+    { id: '3', threadId: '2' },
+  ])
+})

--- a/src/lib/community-apps/birdseye-threads.ts
+++ b/src/lib/community-apps/birdseye-threads.ts
@@ -1,0 +1,42 @@
+/** Groups only cited posts. Missing parents connect siblings but add no content. */
+export function groupBirdseyeSources(
+  ids: string[],
+  rows: {
+    tweet_id: string | null
+    reply_to_tweet_id: string | null
+    conversation_id: string | null
+  }[],
+) {
+  const parent = new Map<string, string>()
+  const root = (id: string): string => {
+    let current = id
+    const seen: string[] = []
+    while (parent.has(current) && parent.get(current) !== current) {
+      seen.push(current)
+      current = parent.get(current)!
+    }
+    for (const key of seen) parent.set(key, current)
+    return current
+  }
+  const join = (a: string, b: string) => {
+    const left = root(a),
+      right = root(b)
+    if (left !== right) parent.set(left, right)
+  }
+  const allowed = new Set(ids)
+  for (const row of rows) {
+    if (!row.tweet_id || !allowed.has(row.tweet_id)) continue
+    if (row.reply_to_tweet_id) join(row.tweet_id, row.reply_to_tweet_id)
+    if (row.conversation_id) join(row.tweet_id, row.conversation_id)
+  }
+  const groups = new Map<string, string[]>()
+  for (const id of Array.from(allowed)) {
+    const key = root(id)
+    groups.set(key, [...(groups.get(key) ?? []), id])
+  }
+  // Snowflake order puts parents before replies, including across page boundaries.
+  return Array.from(groups.values()).flatMap((group) => {
+    group.sort((a, b) => a.length - b.length || a.localeCompare(b))
+    return group.map((id) => ({ id, threadId: group[0] }))
+  })
+}

--- a/src/lib/localAdminPreview.test.ts
+++ b/src/lib/localAdminPreview.test.ts
@@ -1,0 +1,93 @@
+import { cookies, headers } from 'next/headers'
+import {
+  getLocalAdminPreview,
+  localAdminPreviewAllowed,
+} from './localAdminPreview'
+jest.mock('next/headers', () => ({ cookies: jest.fn(), headers: jest.fn() }))
+const originalEnv = process.env.NODE_ENV
+const originalPreview = process.env.LOCAL_ADMIN_PREVIEW
+beforeEach(() => {
+  process.env.LOCAL_ADMIN_PREVIEW = 'true'
+  jest.mocked(headers).mockReturnValue({ get: () => 'localhost:3031' } as never)
+  jest.mocked(cookies).mockReturnValue({ get: () => undefined } as never)
+})
+afterEach(() => {
+  if (originalPreview === undefined) delete process.env.LOCAL_ADMIN_PREVIEW
+  else process.env.LOCAL_ADMIN_PREVIEW = originalPreview
+  Object.defineProperty(process.env, 'NODE_ENV', {
+    value: originalEnv,
+    configurable: true,
+  })
+})
+test.each(['localhost:3031', '127.0.0.1:3000', '[::1]:3000'])(
+  'local development permits preview for %s only off deployment',
+  (host) => {
+    expect(localAdminPreviewAllowed(host, 'development', false)).toBe(true)
+    expect(localAdminPreviewAllowed(host, 'production', false)).toBe(false)
+    expect(localAdminPreviewAllowed(host, 'development', true)).toBe(false)
+  },
+)
+test.each([
+  null,
+  'community-archive.org',
+  'localhost.evil.test',
+  '192.168.1.1:3000',
+  'localhost@evil.test',
+])('does not unlock the preview on %s', (host) => {
+  expect(localAdminPreviewAllowed(host, 'development', false)).toBe(false)
+})
+test('starts in admin preview but honors logout on every subsequent request', async () => {
+  Object.defineProperty(process.env, 'NODE_ENV', {
+    value: 'development',
+    configurable: true,
+  })
+  expect(await getLocalAdminPreview()).toBe('admin')
+  jest
+    .mocked(cookies)
+    .mockReturnValue({ get: () => ({ value: 'signed-out' }) } as never)
+  expect(await getLocalAdminPreview()).toBe('signed-out')
+  Object.defineProperty(process.env, 'NODE_ENV', {
+    value: 'production',
+    configurable: true,
+  })
+  expect(await getLocalAdminPreview()).toBeNull()
+})
+
+test('requires the loopback-bound launcher opt-in', () => {
+  expect(
+    localAdminPreviewAllowed('localhost:3031', 'development', false, false),
+  ).toBe(false)
+})
+
+test('the preview session endpoint rejects cross-origin requests and persists logout', async () => {
+  const { NextRequest } = await import('next/server')
+  const { POST } = await import('@/app/api/auth/local-preview/route')
+  Object.defineProperty(process.env, 'NODE_ENV', {
+    value: 'development',
+    configurable: true,
+  })
+  const request = (origin: string) =>
+    new NextRequest('http://localhost:3031/api/auth/local-preview', {
+      method: 'POST',
+      headers: {
+        host: 'localhost:3031',
+        origin,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ enabled: false }),
+    })
+  expect((await POST(request('https://evil.test'))).status).toBe(403)
+  const response = await POST(request('http://localhost:3031'))
+  expect(response.status).toBe(200)
+  expect(response.cookies.get('ca-local-admin')).toMatchObject({
+    value: 'signed-out',
+    httpOnly: true,
+    sameSite: 'strict',
+  })
+  expect(response.cookies.get('birdseye-share')?.value).toBe('')
+  Object.defineProperty(process.env, 'NODE_ENV', {
+    value: 'production',
+    configurable: true,
+  })
+  expect((await POST(request('http://localhost:3031'))).status).toBe(404)
+})

--- a/src/lib/localAdminPreview.ts
+++ b/src/lib/localAdminPreview.ts
@@ -1,0 +1,22 @@
+import 'server-only'
+import { cookies, headers } from 'next/headers'
+
+export const LOCAL_ADMIN_COOKIE = 'ca-local-admin'
+/** UI/read preview only. Never use this to authorize a production mutation. */
+export function localAdminPreviewAllowed(
+  host: string | null,
+  nodeEnv = process.env.NODE_ENV,
+  deployed = !!process.env.VERCEL,
+  enabled = process.env.LOCAL_ADMIN_PREVIEW === 'true',
+) {
+  if (!enabled || nodeEnv !== 'development' || deployed || !host) return false
+  return /^(localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/.test(host)
+}
+export async function getLocalAdminPreview(): Promise<
+  'admin' | 'signed-out' | null
+> {
+  if (!localAdminPreviewAllowed((await headers()).get('host'))) return null
+  return (await cookies()).get(LOCAL_ADMIN_COOKIE)?.value === 'signed-out'
+    ? 'signed-out'
+    : 'admin'
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -511,7 +511,11 @@ export async function middleware(request: NextRequest) {
 
   // ── Stage 6: Security Headers (all responses) ──────────────────────────
   addSecurityHeaders(response)
-  if (pathname === '/birdseye' || pathname.startsWith('/api/birdseye/')) {
+  if (
+    pathname === '/birdseye' ||
+    pathname.startsWith('/birdseye/') ||
+    pathname.startsWith('/api/birdseye/')
+  ) {
     response.headers.set('Cache-Control', 'private, no-store')
     response.headers.set('Referrer-Policy', 'no-referrer')
     response.headers.set('X-Robots-Tag', 'noindex, nofollow')


### PR DESCRIPTION
Birdseye opens on a macro-topic overview ordered by cited-post count, with profile search on a separate admin page. A compact avatar/display-name header keeps the username visible in muted text. Topics show the expandable saved summary first, three samples ranked by likes with owner posts prioritized, a monthly chart with hover/focus/tap counts, horizontal yearly summaries, compact insight panels, and the remaining source feed. Three samples form one desktop row and a swipeable mobile row so the timeline stays visible.

Insight labels use small column grids; descriptions and source links open on hover, click, or keyboard activation. Recognized participants use available avatars. Related cited replies share thread blocks in chronological order, including when a thread spans multiple six-post pages. Samples are excluded from the remaining feed.

The page reuses existing analyses. Counts represent cited posts, including conversation context. Exact-reference metadata lookups provide ranking and reply grouping; the configured archive reader still provides full tweet payloads with current opt-out checks. No uncited parents, new analysis, or recommendations are fetched/generated. Private popover content retains analytics exclusion markers.

Local testing starts with a labeled admin read preview and supports persistent logout and restarting the preview. Verified real administrators and the local preview can select all currently policy-eligible profiles. Owners and shared-link visitors retain private access rules, and admin inspection never enables sharing. The preview requires an explicit server flag, development mode, a loopback Host, and no Vercel marker. It creates no Auth user and grants no production write permissions. Session changes require matching Origin; logout clears preview/member-preview/share cookies.

Validation: TypeScript and focused lint pass. This revision passed 19 focused tests covering sample ranking, thread grouping, pagination, authorization, retry behavior, and hover/click/keyboard interactions. Earlier overview/layout and local admin checks passed. Browser verification covered profile selection, overview/topic navigation, image-bearing samples, compact insight details, month counts, and grouped source replies. Desktop verification places the full chart within a 720px viewport; mobile verification confirms the swipeable layout has no horizontal page overflow. Local testing uses the already downloaded snapshots.

Stacked on #914 to isolate concurrent Strands work. Bangers defaulting to Last 7 Days landed separately in #921. This PR remains a draft.
