### PR TITLE
Ship Birdseye independently of Strands

### DIFF
--- a/docs/birdseye.md
+++ b/docs/birdseye.md
@@ -1,0 +1,70 @@
+# Birdseye
+
+Birdseye is a native app at `/birdseye`, linked from Community Apps. It displays
+saved analyses without generating new content or depending on Modal at request time.
+
+## Access and data
+
+Analyses are private by default. Owners access their own analysis through a verified
+Twitter identity and matching account ID. Real administrators may inspect eligible
+profiles through `/birdseye/profiles`, without enabling sharing on another owner's
+behalf. Membership and explicit opt-outs apply on every read, including to admins.
+Saved topics naming an opted-out participant are withheld.
+
+The existing private Supabase Storage bucket `community-app-data` supplies
+`manifest.json` and `v1/<import-id>/birdseye/<username>.json`. The manifest includes
+its version, immutable prefix, and Birdseye username/hidden-topic catalog. Objects
+are read server-side with the existing service-role client; never expose bucket
+objects or signed URLs to the browser. No schema migration is required. Snapshot
+content is cached for five minutes, independently of the fresh policy checks.
+
+Owners may enable, rotate, or revoke a bearer share link. Only a SHA-256 hash and
+bound Twitter identity are stored in server-controlled Auth app metadata. Each
+read checks fresh Auth metadata. The link route validates the secret and redirects
+to a clean URL with an HttpOnly, SameSite=Lax cookie. Revocation stops future reads;
+it cannot recall downloaded copies. Private responses use no-store, no-referrer,
+and noindex headers. Private content, including insight popover portals, excludes
+PostHog capture. Do not log share tokens or include them in analytics.
+
+## Presentation
+
+Profiles open on an overview ordered by unique cited-post count. Topics show an
+expandable summary, three sample posts ranked by likes with owner posts prioritized,
+a monthly chart cropped to first/last cited month, horizontal yearly summaries,
+compact insight panels, and the remaining sources. Month counts work with hover,
+keyboard focus, and tap. Insight descriptions and source links open on demand.
+
+Sample ranking and reply grouping query only the topic's exact reference IDs.
+Full-fidelity TweetCard payloads use the configured archive reader and fresh opt-out
+checks; they never switch analytical record sources on failure. Related cited posts
+share thread blocks across six-post pages. No uncited parents or other conversation
+content is fetched. Samples are excluded from the remaining feed. Missing metadata
+leaves a source separate; lookup failures are retryable errors.
+
+Counts describe saved references, including conversation context, rather than all
+activity in an archive. Display changes do not refresh analyses.
+
+## Local development
+
+The standard dev scripts bind to loopback and enable `LOCAL_ADMIN_PREVIEW=true`.
+The local admin read preview requires development mode, a loopback Host, and no
+Vercel deployment marker. The account menu supports persistent logout and restarting
+the preview. It creates no Auth user and grants no production write permissions.
+Set `COMMUNITY_APP_DATA_DIR` to an existing normalized snapshot directory to avoid
+Storage downloads. OAuth remains available; mock login is disabled for production
+Supabase. Runtime credentials must come from the configured environment.
+
+## Release and rollback
+
+Before release, confirm the bucket is private and its manifest and a representative
+Birdseye object are readable using the production server credentials. Verify private
+access, sharing/revocation, opt-outs, and sample/source pagination with focused tests.
+Use local or staging identities for share mutation tests; never change a production
+owner's sharing for verification.
+
+Ship through the normal main-branch Vercel deployment. Check the Apps link and the
+private landing/API gates after deployment. A website rollback needs no database
+rollback: revert the release commit, or restore the previous ready production
+Vercel deployment. Storage remains private and unchanged. For a future snapshot
+replacement, upload immutable versioned objects before switching the manifest,
+and retain the old manifest for independent data rollback.

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "typescript"
   ],
   "scripts": {
-    "dev": "NODE_ENV=development NEXT_PUBLIC_USE_REMOTE_DEV_DB=false next dev",
+    "dev": "LOCAL_ADMIN_PREVIEW=true NODE_ENV=development NEXT_PUBLIC_USE_REMOTE_DEV_DB=false next dev --hostname 127.0.0.1",
     "dev-as-prod": "NODE_ENV=production next dev",
-    "dev-remote-db": "NEXT_PUBLIC_USE_REMOTE_DEV_DB=true next dev",
+    "dev-remote-db": "LOCAL_ADMIN_PREVIEW=true NEXT_PUBLIC_USE_REMOTE_DEV_DB=true next dev --hostname 127.0.0.1",
     "dev:importfiles": "tsx --env-file=.env scripts/import_from_files_to_db.ts",
     "dev:validateimport": "tsx --env-file=.env scripts/validate_db_import.ts",
     "dev:downloadarchive": "tsx --env-file=.env scripts/download_supabase_storage.mts",

--- a/src/app/api/auth/local-preview/route.ts
+++ b/src/app/api/auth/local-preview/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  LOCAL_ADMIN_COOKIE,
+  localAdminPreviewAllowed,
+} from '@/lib/localAdminPreview'
+export async function POST(request: NextRequest) {
+  if (!localAdminPreviewAllowed(request.headers.get('host')))
+    return new NextResponse('Not Found', { status: 404 })
+  if (request.headers.get('origin') !== request.nextUrl.origin)
+    return new NextResponse('Forbidden', { status: 403 })
+  const { enabled } = await request.json().catch(() => ({}))
+  if (typeof enabled !== 'boolean')
+    return new NextResponse('Invalid preview state', { status: 400 })
+  const response = NextResponse.json(
+    { enabled },
+    { headers: { 'Cache-Control': 'private, no-store' } },
+  )
+  response.cookies.set(LOCAL_ADMIN_COOKIE, enabled ? 'admin' : 'signed-out', {
+    httpOnly: true,
+    sameSite: 'strict',
+    secure: request.nextUrl.protocol === 'https:',
+    path: '/',
+    maxAge: 60 * 60 * 24 * 30,
+  })
+  if (!enabled) {
+    response.cookies.delete('dev_as_member')
+    response.cookies.delete('birdseye-share')
+  }
+  return response
+}

--- a/src/app/api/auth/navigation/route.ts
+++ b/src/app/api/auth/navigation/route.ts
@@ -1,3 +1,4 @@
+import { getLocalAdminPreview } from '@/lib/localAdminPreview'
 import { NextResponse } from 'next/server'
 import { isAdminUser } from '@/app/admin/data'
 import { getCurrentUser, getIsMember } from '@/lib/portal/auth'
@@ -5,11 +6,13 @@ import { getCurrentUser, getIsMember } from '@/lib/portal/auth'
 export const dynamic = 'force-dynamic'
 
 export async function GET() {
+  const localPreview = await getLocalAdminPreview()
   const [user, isMember] = await Promise.all([getCurrentUser(), getIsMember()])
 
   return NextResponse.json(
     {
-      isMember,
+      isMember: isMember || localPreview === 'admin',
+      localPreview,
       isAdmin: user ? isAdminUser(user) : false,
     },
     {

--- a/src/app/api/birdseye/share/[token]/route.ts
+++ b/src/app/api/birdseye/share/[token]/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  PRIVATE_HEADERS,
+  resolveBirdseyeShare,
+  SHARE_COOKIE,
+} from '@/lib/community-apps/birdseye-access'
+export const dynamic = 'force-dynamic'
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { token: string } },
+) {
+  const identity = await resolveBirdseyeShare(params.token)
+  if (!identity)
+    return new NextResponse(
+      'This share link is unavailable or has been revoked.',
+      { status: 404, headers: PRIVATE_HEADERS },
+    )
+  // Redirect before rendering any page or analytics, so the bearer secret is
+  // never included in topic links, page referrers, or client component props.
+  const response = NextResponse.redirect(
+    new URL(`/birdseye?username=${identity.username}`, request.url),
+    { status: 303, headers: PRIVATE_HEADERS },
+  )
+  response.cookies.set(SHARE_COOKIE, params.token, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: request.nextUrl.protocol === 'https:',
+    path: '/',
+    maxAge: 86400,
+  })
+  return response
+}

--- a/src/app/api/birdseye/sharing/route.ts
+++ b/src/app/api/birdseye/sharing/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  birdseyeIdentity,
+  createBirdseyeShare,
+  getBirdseyeOwner,
+  loadAccessibleBirdseye,
+  PRIVATE_HEADERS,
+} from '@/lib/community-apps/birdseye-access'
+import { createServerServiceRoleClient } from '@/utils/supabase'
+export const dynamic = 'force-dynamic'
+async function update(request: NextRequest, enabled: boolean) {
+  if (request.headers.get('origin') !== request.nextUrl.origin)
+    return NextResponse.json(
+      { error: 'Invalid origin' },
+      { status: 403, headers: PRIVATE_HEADERS },
+    )
+  const user = await getBirdseyeOwner()
+  if (!user || !birdseyeIdentity(user))
+    return NextResponse.json(
+      { error: 'Sign in to manage your Birdseye' },
+      { status: 401, headers: PRIVATE_HEADERS },
+    )
+  if (enabled && !(await loadAccessibleBirdseye())?.isOwner)
+    return NextResponse.json(
+      { error: 'No Birdseye available to share' },
+      { status: 404, headers: PRIVATE_HEADERS },
+    )
+  const share = enabled ? createBirdseyeShare(user) : null
+  const { error } =
+    await createServerServiceRoleClient().auth.admin.updateUserById(user.id, {
+      app_metadata: { birdseye_share: share?.setting ?? null },
+    })
+  if (error)
+    return NextResponse.json(
+      { error: 'Unable to update sharing. Please try again.' },
+      { status: 503, headers: PRIVATE_HEADERS },
+    )
+  return NextResponse.json(
+    {
+      url: share
+        ? new URL(`/api/birdseye/share/${share.token}`, request.url).href
+        : null,
+    },
+    { headers: PRIVATE_HEADERS },
+  )
+}
+export const POST = (request: NextRequest) => update(request, true)
+export const DELETE = (request: NextRequest) => update(request, false)

--- a/src/app/api/birdseye/sources/route.ts
+++ b/src/app/api/birdseye/sources/route.ts
@@ -1,0 +1,51 @@
+import { getBirdseyeSourceIndex } from '@/lib/community-apps/birdseye-source-index'
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  loadAccessibleBirdseye,
+  PRIVATE_HEADERS,
+} from '@/lib/community-apps/birdseye-access'
+import { getSourceTweets } from '@/lib/community-apps/source-tweets'
+export const dynamic = 'force-dynamic'
+export const maxDuration = 60
+export async function GET(request: NextRequest) {
+  const params = request.nextUrl.searchParams
+  const offset = Number(params.get('offset') ?? '0')
+  if (!Number.isSafeInteger(offset) || offset < 0)
+    return NextResponse.json(
+      { error: 'Invalid offset' },
+      { status: 400, headers: PRIVATE_HEADERS },
+    )
+  const access = await loadAccessibleBirdseye(
+    params.get('username') ?? undefined,
+  )
+  const cluster = access?.analysis.clusters.find(
+    (c) => c.id === params.get('cluster_id'),
+  )
+  if (!cluster)
+    return NextResponse.json(
+      { error: 'Birdseye unavailable' },
+      { status: 404, headers: PRIVATE_HEADERS },
+    )
+  const excluded = new Set((params.get('exclude') ?? '').split(',').slice(0, 3))
+  try {
+    const index = (await getBirdseyeSourceIndex(cluster.tweetIds)).filter(
+      ({ id }) => !excluded.has(id),
+    )
+    const page = index.slice(offset, offset + 6)
+    const tweets = await getSourceTweets(page.map(({ id }) => id))
+    return NextResponse.json(
+      {
+        tweets: page.flatMap(({ id, threadId }) =>
+          tweets.has(id) ? [{ ...tweets.get(id)!, threadId }] : [],
+        ),
+        nextOffset: offset + 6 < index.length ? offset + 6 : null,
+      },
+      { headers: PRIVATE_HEADERS },
+    )
+  } catch {
+    return NextResponse.json(
+      { error: 'Source posts could not load' },
+      { status: 503, headers: PRIVATE_HEADERS },
+    )
+  }
+}

--- a/src/app/birdseye/error.tsx
+++ b/src/app/birdseye/error.tsx
@@ -1,0 +1,2 @@
+'use client'
+export { default } from '@/components/community-apps/AppDataError'

--- a/src/app/birdseye/loading.tsx
+++ b/src/app/birdseye/loading.tsx
@@ -1,0 +1,9 @@
+export default function Loading() {
+  return (
+    <main className="mx-auto max-w-6xl px-5 py-16">
+      <p role="status" className="text-muted-foreground">
+        Loading the collection…
+      </p>
+    </main>
+  )
+}

--- a/src/app/birdseye/page.tsx
+++ b/src/app/birdseye/page.tsx
@@ -1,0 +1,78 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound, redirect } from 'next/navigation'
+import {
+  getBirdseyeViewer,
+  loadAccessibleBirdseye,
+} from '@/lib/community-apps/birdseye-access'
+import { BirdseyeView } from '@/components/birdseye/BirdseyeView'
+export const dynamic = 'force-dynamic'
+export const maxDuration = 60
+export const metadata: Metadata = {
+  title: 'Birdseye · Community Archive',
+  description: 'A private view of your archive by topic.',
+  robots: { index: false, follow: false },
+  referrer: 'no-referrer',
+}
+export default async function BirdseyePage({
+  searchParams,
+}: {
+  searchParams: { username?: string; cluster_id?: string }
+}) {
+  const username =
+    typeof searchParams.username === 'string'
+      ? searchParams.username
+      : undefined
+  const viewer = await getBirdseyeViewer()
+  if (!username && viewer.isAdmin && !viewer.user)
+    redirect('/birdseye/profiles')
+  const access = await loadAccessibleBirdseye(username)
+  if (!access && !username && viewer.isAdmin) redirect('/birdseye/profiles')
+  if (!access)
+    return (
+      <main className="mx-auto min-h-[70vh] max-w-xl px-6 py-16">
+        <Link href="/community" className="text-sm text-brand">
+          ← Community Apps
+        </Link>
+        <p className="mb-3 mt-10 text-xs font-semibold uppercase tracking-widest text-brand">
+          Birdseye · Experimental
+        </p>
+        <h1 className="text-4xl font-bold">Your archive, in perspective.</h1>
+        <p className="mt-5 leading-7 text-muted-foreground">
+          Birdseye is private by default. Sign in to view your own saved
+          analysis, or use a share link from its owner.
+        </p>
+        <p className="mt-3 text-sm text-muted-foreground">
+          Analyses are currently available for a limited set of archives.
+        </p>
+        <div className="mt-7 flex gap-4">
+          <Link
+            href="/login?redirect=%2Fbirdseye"
+            className="rounded-lg bg-brand px-4 py-2 text-sm font-semibold text-brand-foreground"
+          >
+            Sign in
+          </Link>
+          <Link href="/birdseye" className="px-3 py-2 text-sm text-brand">
+            My Birdseye
+          </Link>
+        </div>
+      </main>
+    )
+  if (
+    searchParams.cluster_id &&
+    !access.analysis.clusters.some(
+      (cluster) => cluster.id === searchParams.cluster_id,
+    )
+  )
+    notFound()
+  return (
+    <BirdseyeView
+      {...access}
+      selectedId={
+        typeof searchParams.cluster_id === 'string'
+          ? searchParams.cluster_id
+          : undefined
+      }
+    />
+  )
+}

--- a/src/app/birdseye/profiles/page.tsx
+++ b/src/app/birdseye/profiles/page.tsx
@@ -1,0 +1,28 @@
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import { getBirdseyeProfiles } from '@/lib/community-apps/birdseye-access'
+import { ProfilePicker } from '@/components/birdseye/ProfilePicker'
+export const dynamic = 'force-dynamic'
+export const metadata = {
+  title: 'Choose a Birdseye profile',
+  robots: { index: false, follow: false },
+}
+export default async function ProfilesPage() {
+  const profiles = await getBirdseyeProfiles()
+  if (!profiles.length) notFound()
+  return (
+    <main className="ph-no-capture mx-auto min-h-[75vh] max-w-4xl px-6 py-10">
+      <Link href="/community" className="text-xs text-brand">
+        ← Community Apps
+      </Link>
+      <h1 className="mb-3 mt-6 font-sans text-3xl font-bold">
+        Explore a Birdseye profile
+      </h1>
+      <p className="mb-6 text-sm text-muted-foreground">
+        Admin access · {profiles.length} available saved analyses. These
+        profiles remain private.
+      </p>
+      <ProfilePicker profiles={profiles} />
+    </main>
+  )
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -130,3 +130,32 @@
     animation: none;
   }
 }
+
+.birdseye-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+}
+.birdseye-scroll:hover,
+.birdseye-scroll:focus-within {
+  scrollbar-color: hsl(var(--muted-foreground) / 0.25) transparent;
+}
+.birdseye-scroll::-webkit-scrollbar {
+  width: 5px;
+  height: 5px;
+}
+.birdseye-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+.birdseye-scroll::-webkit-scrollbar-thumb {
+  background: transparent;
+  border-radius: 8px;
+}
+.birdseye-scroll:hover::-webkit-scrollbar-thumb,
+.birdseye-scroll:focus-within::-webkit-scrollbar-thumb {
+  background: hsl(var(--muted-foreground) / 0.25);
+}
+@media (hover: none) {
+  .birdseye-scroll {
+    scrollbar-color: hsl(var(--muted-foreground) / 0.2) transparent;
+  }
+}

--- a/src/components/LocalAdminMenu.tsx
+++ b/src/components/LocalAdminMenu.tsx
@@ -1,0 +1,59 @@
+'use client'
+import Link from 'next/link'
+import { useState } from 'react'
+import { createBrowserClient } from '@/utils/supabase'
+export function LocalAdminMenu({ active }: { active: boolean }) {
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState('')
+  async function toggle() {
+    setBusy(true)
+    setError('')
+    try {
+      const response = await fetch('/api/auth/local-preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled: !active }),
+      })
+      if (!response.ok) throw new Error('Could not change local preview.')
+      if (active) {
+        const { error } = await createBrowserClient().auth.signOut({
+          scope: 'local',
+        })
+        if (error) throw new Error('Could not sign out. Please try again.')
+      }
+      window.location.reload()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Please try again.')
+      setBusy(false)
+    }
+  }
+  return (
+    <details className="relative text-xs">
+      <summary className="cursor-pointer whitespace-nowrap rounded-lg border border-border px-3 py-2 font-semibold">
+        {active ? 'Local admin' : 'Signed out'}
+      </summary>
+      <div className="absolute right-0 z-50 mt-2 w-64 space-y-3 rounded-xl border border-border bg-card p-4 shadow-lg">
+        <p className="font-semibold">
+          {active ? 'Local admin preview' : 'Local preview is signed out'}
+        </p>
+        <p className="text-muted-foreground">
+          Browse Birdseye as an admin. This local preview does not grant
+          production write access.
+        </p>
+        {active && (
+          <Link href="/birdseye" className="block font-semibold text-brand">
+            Choose a Birdseye profile →
+          </Link>
+        )}
+        <button
+          disabled={busy}
+          onClick={() => void toggle()}
+          className="rounded-lg border border-border px-3 py-2 disabled:opacity-50"
+        >
+          {busy ? 'Updating…' : active ? 'Sign out' : 'Start local admin'}
+        </button>
+        {error && <p role="alert">{error}</p>}
+      </div>
+    </details>
+  )
+}

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import Link from 'next/link'
+import { useNavigationAudience } from '@/components/NavigationAudience'
+import { LocalAdminMenu } from '@/components/LocalAdminMenu'
 import { LogIn, LogOut, Settings, UserRound } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useAuthAndArchive } from '@/hooks/useAuthAndArchive'
@@ -16,6 +18,7 @@ import { userProfileHref } from '@/lib/navigation'
 import { capturePostHogEvent } from '@/lib/posthog'
 
 export default function MobileMenu() {
+  const { localPreview } = useNavigationAudience()
   const { userMetadata } = useAuthAndArchive()
   const profileHref = userProfileHref(
     userMetadata?.user_name,
@@ -41,6 +44,7 @@ export default function MobileMenu() {
     }
   }
 
+  if (localPreview) return <LocalAdminMenu active={localPreview === 'admin'} />
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>

--- a/src/components/NavigationAudience.tsx
+++ b/src/components/NavigationAudience.tsx
@@ -10,6 +10,7 @@ import { getMobileNav, getPrimaryNav, getUtilityNav } from '@/lib/navigation'
 type NavigationAudience = {
   isMember: boolean
   isAdmin: boolean
+  localPreview?: 'admin' | 'signed-out' | null
 }
 
 const PUBLIC_AUDIENCE: NavigationAudience = {
@@ -43,6 +44,7 @@ export function NavigationAudienceProvider({
         setAudience({
           isMember: nextAudience.isMember === true,
           isAdmin: nextAudience.isAdmin === true,
+          localPreview: nextAudience.localPreview ?? null,
         })
       })
       .catch((error: unknown) => {
@@ -102,3 +104,5 @@ export function AdminNavigationLink() {
     </Link>
   )
 }
+
+export const useNavigationAudience = () => useContext(NavigationAudienceContext)

--- a/src/components/SignIn.tsx
+++ b/src/components/SignIn.tsx
@@ -1,4 +1,6 @@
 'use client'
+import { useNavigationAudience } from '@/components/NavigationAudience'
+import { isProductionSupabaseUrl } from '@/lib/isProductionSupabaseUrl'
 import { useAuthAndArchive } from '@/hooks/useAuthAndArchive'
 import { devLog } from '@/lib/devLog'
 import { createBrowserClient } from '@/utils/supabase'
@@ -18,13 +20,21 @@ const STAGING_USERS = [
 ] as const
 
 export default function SignIn({ fullPage = false }: { fullPage?: boolean }) {
+  const { localPreview } = useNavigationAudience()
   const searchParams = useSearchParams()
   const redirectTo = safeAuthRedirect(searchParams.get('redirect'))
   const { userMetadata } = useAuthAndArchive()
+  const activeSupabaseUrl =
+    process.env.NODE_ENV === 'development' &&
+    process.env.NEXT_PUBLIC_USE_REMOTE_DEV_DB !== 'true'
+      ? process.env.NEXT_PUBLIC_LOCAL_SUPABASE_URL
+      : process.env.NEXT_PUBLIC_SUPABASE_URL
   const isDevLoginEnabled =
-    process.env.NODE_ENV === 'development' ||
-    process.env.NEXT_PUBLIC_ENABLE_STAGING_DEV_LOGIN === 'true'
+    (process.env.NODE_ENV === 'development' ||
+      process.env.NEXT_PUBLIC_ENABLE_STAGING_DEV_LOGIN === 'true') &&
+    !isProductionSupabaseUrl(activeSupabaseUrl)
   const isStagingLogin =
+    isDevLoginEnabled &&
     process.env.NODE_ENV !== 'development' &&
     process.env.NEXT_PUBLIC_ENABLE_STAGING_DEV_LOGIN === 'true'
 
@@ -110,7 +120,7 @@ export default function SignIn({ fullPage = false }: { fullPage?: boolean }) {
     }
   }
 
-  return userMetadata ? null : (
+  return userMetadata || localPreview === 'admin' ? null : (
     <div
       className={`${fullPage ? 'inline-flex' : isStagingLogin ? 'hidden lg:inline-flex' : 'hidden sm:inline-flex'} items-center gap-2`}
     >

--- a/src/components/birdseye/BirdseyeView.tsx
+++ b/src/components/birdseye/BirdseyeView.tsx
@@ -1,0 +1,267 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import { ProfileIdentity } from './ProfileIdentity'
+import { TopicSummary } from './TopicSummary'
+import type {
+  BirdseyeAnalysis,
+  BirdseyeCluster,
+} from '@/lib/community-apps/types'
+import {
+  birdseyeGroups,
+  monthlyActivity,
+} from '@/lib/community-apps/birdseye-layout'
+import { getBirdseyeSamples } from '@/lib/community-apps/birdseye-samples'
+import { TopicSparkline } from './TopicSparkline'
+import { MonthlyTimeline } from './MonthlyTimeline'
+import { SampleTweets } from './SampleTweets'
+import { InsightCards } from './InsightCards'
+import { SourcePosts } from './SourcePosts'
+import { ShareBirdseye } from './ShareBirdseye'
+
+async function TopicContent({
+  cluster,
+  username,
+}: {
+  cluster: BirdseyeCluster
+  username: string
+}) {
+  let samples: Awaited<ReturnType<typeof getBirdseyeSamples>> = []
+  let sampleError = false
+  try {
+    samples = await getBirdseyeSamples(cluster.tweetIds, username)
+  } catch {
+    sampleError = true
+  }
+  return (
+    <>
+      <SampleTweets tweets={samples} username={username} />
+      {sampleError && (
+        <p className="text-xs text-muted-foreground">
+          Sample selection is temporarily unavailable. Source posts below can
+          still be loaded.
+        </p>
+      )}
+      <MonthlyTimeline cluster={cluster} />
+      <Suspense
+        fallback={
+          <p className="text-sm text-muted-foreground">Loading insights…</p>
+        }
+      >
+        <InsightCards cluster={cluster} />
+      </Suspense>
+      <SourcePosts
+        key={`${username}:${cluster.id}`}
+        username={username}
+        clusterId={cluster.id}
+        total={Array.from(new Set(cluster.tweetIds)).length - samples.length}
+        excludeIds={samples.map((tweet) => tweet.id)}
+      />
+    </>
+  )
+}
+
+export function BirdseyeView({
+  analysis,
+  selectedId,
+  isOwner,
+  sharingEnabled,
+  isAdmin = false,
+}: {
+  analysis: BirdseyeAnalysis
+  selectedId?: string
+  isOwner: boolean
+  sharingEnabled: boolean
+  isAdmin?: boolean
+}) {
+  const selected = analysis.clusters.find(
+    (cluster) => cluster.id === selectedId,
+  )
+  const groups = birdseyeGroups(analysis)
+  const ids = Array.from(
+    new Set(analysis.clusters.flatMap((cluster) => cluster.tweetIds)),
+  )
+  const months = monthlyActivity(ids)
+  const start = months.length ? Number(months[0].month.slice(0, 4)) : 0
+  const end = months.length
+    ? Number(months[months.length - 1].month.slice(0, 4))
+    : 0
+  const overviewHref = `/birdseye?username=${analysis.username}`
+  const topicHref = (cluster: BirdseyeCluster) =>
+    `${overviewHref}&cluster_id=${encodeURIComponent(cluster.id)}`
+  return (
+    <main className="ph-no-capture ph-mask mx-auto min-h-screen max-w-[1440px] px-5 py-3 sm:px-8">
+      <div className="flex items-center justify-between gap-3 text-xs">
+        <Link
+          href="/community"
+          className="font-semibold text-muted-foreground hover:text-brand"
+        >
+          ← Community Apps
+        </Link>
+        {isAdmin && (
+          <Link href="/birdseye/profiles" className="font-semibold text-brand">
+            Change profile →
+          </Link>
+        )}
+      </div>
+      <header className="mb-3 mt-2 flex flex-wrap items-center justify-between gap-3 border-b border-border pb-2">
+        <div className="min-w-0">
+          <p className="mb-1 text-[9px] font-semibold uppercase tracking-[0.16em] text-brand">
+            Birdseye · Experimental
+          </p>
+          <Suspense
+            fallback={
+              <h1 className="font-sans text-xl font-bold">
+                @{analysis.username}
+              </h1>
+            }
+          >
+            <ProfileIdentity username={analysis.username} />
+          </Suspense>
+        </div>
+        {isOwner ? (
+          <ShareBirdseye initiallyEnabled={sharingEnabled} />
+        ) : (
+          <span className="rounded-full bg-muted/40 px-3 py-1.5 text-[11px] text-muted-foreground">
+            {isAdmin ? 'Admin view' : 'Shared with you'}
+          </span>
+        )}
+      </header>
+      <div className="grid items-start gap-3 lg:grid-cols-[260px_minmax(0,1fr)] lg:gap-7">
+        <nav
+          aria-label="Archive topics"
+          className="birdseye-scroll max-h-20 space-y-5 overflow-y-auto pr-3 lg:sticky lg:top-20 lg:max-h-[calc(100vh-7rem)]"
+        >
+          <Link
+            href={overviewHref}
+            aria-current={!selected ? 'page' : undefined}
+            className={`block rounded-lg px-2 py-2 font-sans text-base font-bold ${!selected ? 'bg-brand/10 text-brand' : 'hover:bg-muted/50'}`}
+          >
+            Overview{' '}
+            <span className="float-right text-xs font-normal">
+              {analysis.clusters.length} topics
+            </span>
+          </Link>
+          {groups.map((group) => (
+            <section key={group.id}>
+              <h2 className="mb-2 px-2 font-sans text-lg font-bold leading-snug">
+                <Link
+                  href={`${overviewHref}#${group.id}`}
+                  className="hover:text-brand"
+                >
+                  {group.name}
+                </Link>
+              </h2>
+              <ul className="space-y-0.5">
+                {group.topics.map((cluster) => (
+                  <li key={cluster.id}>
+                    <Link
+                      prefetch={false}
+                      href={topicHref(cluster)}
+                      aria-current={
+                        selected?.id === cluster.id ? 'page' : undefined
+                      }
+                      className={`flex items-center justify-between gap-2 rounded-lg px-2 py-2 text-[13px] ${selected?.id === cluster.id ? 'bg-brand/10 font-semibold text-brand' : 'text-muted-foreground hover:bg-muted/40'}`}
+                    >
+                      <span className="min-w-0">{cluster.name}</span>
+                      <TopicSparkline
+                        years={cluster.years}
+                        start={start}
+                        end={end}
+                      />
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </nav>
+        {selected ? (
+          <article className="min-w-0 space-y-4">
+            <div>
+              <h2 className="font-sans text-xl font-bold leading-tight sm:text-2xl">
+                {selected.name}
+              </h2>
+              <TopicSummary key={selected.id} text={selected.summary} />
+            </div>
+            <Suspense
+              key={selected.id}
+              fallback={
+                <section
+                  aria-label="Loading sample tweets"
+                  className="grid gap-3 md:grid-cols-3"
+                >
+                  {[0, 1, 2].map((i) => (
+                    <div
+                      key={i}
+                      className="h-52 animate-pulse rounded-xl bg-muted/40 p-5 text-sm text-muted-foreground"
+                    >
+                      Loading sample posts…
+                    </div>
+                  ))}
+                </section>
+              }
+            >
+              <TopicContent cluster={selected} username={analysis.username} />
+            </Suspense>
+          </article>
+        ) : (
+          <article className="min-w-0 space-y-6">
+            <div>
+              <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-brand">
+                The big picture
+              </p>
+              <h2 className="font-sans text-3xl font-bold">
+                @{analysis.username}’s topics, at a glance
+              </h2>
+              <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+                {groups.length} big themes across {analysis.clusters.length}{' '}
+                topics and {ids.length.toLocaleString()} cited posts
+                {start ? `, ${start}–${end}` : ''}. Start with a theme or choose
+                a subtopic.
+              </p>
+              <p className="mt-2 text-xs text-muted-foreground">
+                Based on saved analyses, ordered by cited-post count. This is a
+                snapshot, not a live profile.
+              </p>
+            </div>
+            <div className="grid items-start gap-4 xl:grid-cols-2">
+              {groups.map((group) => (
+                <section
+                  id={group.id}
+                  key={group.id}
+                  className="scroll-mt-20 rounded-2xl border border-border bg-card/60 p-5"
+                >
+                  <div className="mb-4">
+                    <h3 className="font-sans text-xl font-bold leading-snug">
+                      {group.name}
+                    </h3>
+                    <p className="mt-2 text-xs text-muted-foreground">
+                      {group.topics.length} subtopics ·{' '}
+                      {group.tweetIds.length.toLocaleString()} cited posts
+                    </p>
+                  </div>
+                  <ul className="space-y-1">
+                    {group.topics.map((cluster) => (
+                      <li key={cluster.id}>
+                        <Link
+                          prefetch={false}
+                          href={topicHref(cluster)}
+                          className="flex items-center justify-between gap-3 rounded-lg px-2 py-2 text-sm hover:bg-brand/5"
+                        >
+                          <span>{cluster.name}</span>
+                          <span className="shrink-0 text-xs text-muted-foreground">
+                            {new Set(cluster.tweetIds).size} ↗
+                          </span>
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              ))}
+            </div>
+          </article>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/src/components/birdseye/InsightCards.tsx
+++ b/src/components/birdseye/InsightCards.tsx
@@ -1,0 +1,92 @@
+import { Box, Heart, Smile, Target, Users, Lightbulb } from 'lucide-react'
+import { InsightItem } from './InsightItem'
+import { createServerServiceRoleClient } from '@/utils/supabase'
+import { participantUsername } from '@/lib/community-apps/birdseye-layout'
+import type { BirdseyeCluster } from '@/lib/community-apps/types'
+const sectionIcon = (name: string) =>
+  name.toLowerCase().includes('relation')
+    ? Users
+    : name.toLowerCase().includes('belief')
+      ? Heart
+      : name.toLowerCase().includes('goal')
+        ? Target
+        : name.toLowerCase().includes('mood')
+          ? Smile
+          : name.toLowerCase().includes('entit')
+            ? Box
+            : Lightbulb
+export async function InsightCards({ cluster }: { cluster: BirdseyeCluster }) {
+  const sections = cluster.sections
+    .filter(
+      (section) =>
+        section.items.length &&
+        section.name.toLowerCase() !== 'yearly summaries',
+    )
+    .sort(
+      (a, b) =>
+        Number(b.name.toLowerCase() === 'entities') -
+        Number(a.name.toLowerCase() === 'entities'),
+    )
+  const usernames = Array.from(
+    new Set(
+      sections.flatMap((section) =>
+        section.items.flatMap((item) => {
+          const name = participantUsername(item.label, cluster.participants)
+          return name ? [name] : []
+        }),
+      ),
+    ),
+  )
+  const avatars = new Map<string, string>()
+  for (let offset = 0; offset < usernames.length; offset += 40) {
+    const { data } = await createServerServiceRoleClient()
+      .from('user_directory')
+      .select('username,avatar_media_url')
+      .or(
+        usernames
+          .slice(offset, offset + 40)
+          .map((username) => `username.ilike.${username.replace(/_/g, '\\_')}`)
+          .join(','),
+      )
+    for (const row of data ?? [])
+      if (row.username && row.avatar_media_url)
+        avatars.set(row.username.toLowerCase(), row.avatar_media_url)
+  }
+  return (
+    <div className="grid items-start gap-3 xl:grid-cols-2">
+      {sections.map((section) => {
+        const Icon = sectionIcon(section.name)
+        return (
+          <section
+            key={section.name}
+            className="rounded-xl border border-border bg-card/40 p-3"
+          >
+            <h3 className="mb-2 flex items-center gap-2 font-sans text-xs font-bold">
+              <Icon size={14} className="text-brand" />
+              {section.name}
+              <span className="ml-auto font-normal text-muted-foreground">
+                {section.items.length}
+              </span>
+            </h3>
+            <div className="grid grid-cols-2 gap-1.5 sm:grid-cols-3">
+              {section.items.map((item, index) => {
+                const username = participantUsername(
+                  item.label,
+                  cluster.participants,
+                )
+                return (
+                  <InsightItem
+                    key={`${item.label}:${index}`}
+                    item={item}
+                    username={username}
+                    avatar={username ? avatars.get(username) : undefined}
+                  />
+                )
+              })}
+            </div>
+          </section>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/birdseye/InsightItem.tsx
+++ b/src/components/birdseye/InsightItem.tsx
@@ -1,0 +1,102 @@
+'use client'
+import { useEffect, useRef, useState } from 'react'
+import Link from 'next/link'
+import { Link2, UserRound } from 'lucide-react'
+import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import type { EvidenceItem } from '@/lib/community-apps/types'
+
+export function InsightItem({
+  item,
+  username,
+  avatar,
+}: {
+  item: EvidenceItem
+  username: string | null
+  avatar?: string
+}) {
+  const [open, setOpen] = useState(false)
+  const pinned = useRef(false)
+  const timer = useRef<ReturnType<typeof setTimeout>>()
+  const enter = () => {
+    clearTimeout(timer.current)
+    setOpen(true)
+  }
+  const leave = () => {
+    if (!pinned.current) timer.current = setTimeout(() => setOpen(false), 180)
+  }
+  useEffect(() => () => clearTimeout(timer.current), [])
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        pinned.current = next
+        setOpen(next)
+      }}
+    >
+      <PopoverTrigger asChild>
+        <button
+          onClick={(event) => {
+            event.preventDefault()
+            clearTimeout(timer.current)
+            pinned.current = !pinned.current
+            setOpen(pinned.current)
+          }}
+          onMouseEnter={enter}
+          onMouseLeave={leave}
+          className="min-h-10 flex w-full items-center gap-2 rounded-lg bg-muted/35 px-2.5 py-2 text-left text-xs font-medium hover:bg-brand/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+        >
+          {username && (
+            <Avatar className="h-6 w-6 shrink-0">
+              <AvatarImage src={avatar} alt="" />
+              <AvatarFallback>
+                <UserRound size={12} />
+              </AvatarFallback>
+            </Avatar>
+          )}
+          <span className="line-clamp-2">
+            {username ? `@${username}` : item.label}
+          </span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        aria-label={item.label}
+        onMouseEnter={enter}
+        onMouseLeave={leave}
+        onOpenAutoFocus={(event) => event.preventDefault()}
+        onCloseAutoFocus={(event) => event.preventDefault()}
+        className="ph-no-capture ph-mask w-72 p-3"
+      >
+        <p className="font-sans text-sm font-semibold">
+          {username ? (
+            <Link href={`/user/${username}`} className="text-brand">
+              @{username}
+            </Link>
+          ) : (
+            item.label
+          )}
+        </p>
+        <p className="mt-1 text-xs leading-5 text-muted-foreground">
+          {item.description}
+        </p>
+        <div className="mt-2 flex flex-wrap gap-1">
+          {Array.from(new Set(item.tweetIds)).map((id, i) => (
+            <Link
+              key={id}
+              prefetch={false}
+              href={`/tweets/${id}`}
+              aria-label={`Source ${i + 1} for ${item.label}`}
+              className="inline-flex h-7 w-7 items-center justify-center rounded text-brand hover:bg-brand/10"
+            >
+              <Link2 size={13} />
+            </Link>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/components/birdseye/MonthlyTimeline.tsx
+++ b/src/components/birdseye/MonthlyTimeline.tsx
@@ -1,0 +1,154 @@
+'use client'
+import { useState } from 'react'
+import {
+  monthlyActivity,
+  yearlySummaries,
+} from '@/lib/community-apps/birdseye-layout'
+import type { BirdseyeCluster } from '@/lib/community-apps/types'
+function monthLabel(month: string) {
+  return new Date(`${month}-01T00:00:00Z`).toLocaleDateString('en-US', {
+    month: 'short',
+    year: 'numeric',
+    timeZone: 'UTC',
+  })
+}
+export function MonthlyTimeline({ cluster }: { cluster: BirdseyeCluster }) {
+  const [active, setActive] = useState<number | null>(null)
+  const months = monthlyActivity(cluster.tweetIds)
+  if (!months.length) return null
+  const max = Math.max(1, ...months.map((month) => month.count))
+  const summaries = yearlySummaries(cluster)
+  const width = 640 / months.length
+  const ticks = Array.from(
+    new Set([
+      0,
+      ...months.flatMap((month, index) =>
+        month.month.endsWith('-01') && index >= 7 && index < months.length - 7
+          ? [index]
+          : [],
+      ),
+      months.length - 1,
+    ]),
+  )
+  return (
+    <section aria-label="Topic timeline" className="space-y-2">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <h3 className="font-sans text-lg font-bold">Through the years</h3>
+        <p className="text-xs text-muted-foreground">
+          {monthLabel(months[0].month)} —{' '}
+          {monthLabel(months[months.length - 1].month)}
+        </p>
+      </div>
+      <div className="relative" onMouseLeave={() => setActive(null)}>
+        {active !== null && months[active] && (
+          <div
+            role="tooltip"
+            className="pointer-events-none absolute -top-1 z-10 -translate-x-1/2 rounded-md border border-border bg-popover px-2 py-1 text-xs text-popover-foreground shadow-sm"
+            style={{
+              left: `${Math.max(12, Math.min(88, ((active + 0.5) / months.length) * 100))}%`,
+            }}
+          >
+            {monthLabel(months[active].month)} · {months[active].count}{' '}
+            {months[active].count === 1 ? 'post' : 'posts'}
+          </div>
+        )}
+        <svg
+          viewBox="0 0 640 118"
+          role="group"
+          aria-label="Cited posts by month"
+          className="h-24 w-full overflow-visible text-brand"
+        >
+          {months.map(({ month, count }, index) => (
+            <g
+              key={month}
+              role="button"
+              tabIndex={0}
+              aria-label={`${monthLabel(month)}: ${count} cited posts`}
+              onMouseEnter={() => setActive(index)}
+              onFocus={() => setActive(index)}
+              onBlur={() => setActive(null)}
+              onClick={() => setActive(index)}
+              onKeyDown={(event) => {
+                if (event.key === 'Escape') setActive(null)
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault()
+                  setActive(index)
+                }
+              }}
+              className="outline-none"
+            >
+              <rect
+                x={index * width}
+                y={0}
+                width={width}
+                height={96}
+                fill="transparent"
+              />
+              <title>{`${monthLabel(month)}: ${count} cited posts`}</title>
+              <rect
+                x={index * width + 0.5}
+                y={94 - (count / max) * 85}
+                width={Math.max(0.5, width - 1)}
+                height={Math.max(0.75, (count / max) * 85)}
+                rx={Math.min(2, width / 4)}
+                fill="currentColor"
+                opacity={active === index ? 1 : count ? 0.7 : 0.1}
+              />
+            </g>
+          ))}
+          {ticks.map((index) => (
+            <text
+              key={index}
+              x={
+                index === 0
+                  ? 0
+                  : index === months.length - 1
+                    ? 640
+                    : (index + 0.5) * width
+              }
+              y="113"
+              fontSize="10"
+              fill="currentColor"
+              opacity="0.7"
+              textAnchor={
+                index === 0
+                  ? 'start'
+                  : index === months.length - 1
+                    ? 'end'
+                    : 'middle'
+              }
+            >
+              {index === 0 || index === months.length - 1
+                ? monthLabel(months[index].month)
+                : months[index].month.slice(0, 4)}
+            </text>
+          ))}
+        </svg>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Monthly counts of cited posts, including conversation context. Empty
+        months have no cited posts.
+      </p>
+      {summaries.length > 0 && (
+        <div
+          aria-label="Yearly summaries"
+          className="birdseye-scroll flex snap-x gap-5 overflow-x-auto pb-3"
+        >
+          {summaries.map((item) => (
+            <section
+              key={item.label}
+              className="w-64 shrink-0 snap-start border-t-2 border-brand/30 pt-3"
+            >
+              <h4 className="mb-2 font-sans text-lg font-bold text-brand">
+                {item.label}
+              </h4>
+              <p className="text-sm leading-6 text-muted-foreground">
+                {item.description}
+              </p>
+            </section>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/birdseye/ProfileIdentity.tsx
+++ b/src/components/birdseye/ProfileIdentity.tsx
@@ -1,0 +1,31 @@
+import Link from 'next/link'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { createServerServiceRoleClient } from '@/utils/supabase'
+
+export async function ProfileIdentity({ username }: { username: string }) {
+  const { data } = await createServerServiceRoleClient()
+    .from('user_directory')
+    .select('account_display_name,avatar_media_url')
+    .ilike('username', username.replace(/_/g, '\\_'))
+    .limit(1)
+    .maybeSingle()
+  return (
+    <Link
+      href={`/birdseye?username=${username}`}
+      className="flex min-w-0 items-center gap-3"
+    >
+      <Avatar className="h-10 w-10 shrink-0">
+        <AvatarImage src={data?.avatar_media_url ?? undefined} alt="" />
+        <AvatarFallback>{username.slice(0, 1).toUpperCase()}</AvatarFallback>
+      </Avatar>
+      <h1 className="flex min-w-0 flex-wrap items-baseline gap-x-2 font-sans">
+        <span className="text-xl font-bold tracking-tight">
+          {data?.account_display_name || username}
+        </span>
+        <span className="text-sm font-normal text-muted-foreground">
+          @{username}
+        </span>
+      </h1>
+    </Link>
+  )
+}

--- a/src/components/birdseye/ProfilePicker.tsx
+++ b/src/components/birdseye/ProfilePicker.tsx
@@ -1,0 +1,38 @@
+'use client'
+import Link from 'next/link'
+import { useState } from 'react'
+export function ProfilePicker({ profiles }: { profiles: string[] }) {
+  const [query, setQuery] = useState('')
+  const matches = profiles.filter((name) =>
+    name.includes(query.trim().replace(/^@/, '').toLowerCase()),
+  )
+  return (
+    <>
+      <label className="mb-6 block text-sm font-semibold">
+        Search profiles
+        <input
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Find a username…"
+          className="mt-2 block h-12 w-full rounded-xl border border-border bg-background px-4 font-normal"
+        />
+      </label>
+      <div className="grid gap-3 sm:grid-cols-3">
+        {matches.map((username) => (
+          <Link
+            key={username}
+            prefetch={false}
+            href={`/birdseye?username=${username}`}
+            className="rounded-xl border border-border p-4 text-sm font-semibold hover:border-brand hover:bg-brand/5"
+          >
+            @{username} <span className="float-right text-brand">↗</span>
+          </Link>
+        ))}
+      </div>
+      {!matches.length && (
+        <p className="text-sm text-muted-foreground">No matching profiles.</p>
+      )}
+    </>
+  )
+}

--- a/src/components/birdseye/SampleTweets.tsx
+++ b/src/components/birdseye/SampleTweets.tsx
@@ -1,0 +1,48 @@
+import { TweetCard } from '@/components/TweetCard'
+import type { PortalTweet } from '@/lib/portal/types'
+export function SampleTweets({
+  tweets,
+  username,
+}: {
+  tweets: PortalTweet[]
+  username: string
+}) {
+  return (
+    <section aria-label="Sample tweets" className="space-y-2">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <h3 className="font-sans text-sm font-semibold">Sample posts</h3>
+        <span className="text-[11px] text-muted-foreground">
+          @{username} first · ranked by likes
+        </span>
+      </div>
+      <div className="birdseye-scroll relative grid snap-x auto-cols-[88%] grid-flow-col items-start gap-2 overflow-x-auto pb-1 [contain:paint] md:auto-cols-auto md:grid-flow-row md:grid-cols-3 md:overflow-visible md:[contain:none]">
+        {tweets.map((tweet) => (
+          <div
+            key={tweet.id}
+            className="relative snap-start overflow-hidden rounded-xl border border-border bg-card"
+          >
+            {tweet.username.toLowerCase() !== username.toLowerCase() && (
+              <p className="border-b border-border/50 px-3 py-1 text-[11px] font-semibold text-muted-foreground">
+                Conversation context · @{tweet.username}
+              </p>
+            )}
+            <TweetCard
+              tweet={tweet}
+              compact
+              collapsible
+              quotedTweetDisplay="summary"
+              showDate
+              showExternalLink
+            />
+          </div>
+        ))}
+      </div>
+      {!tweets.length && (
+        <p className="rounded-xl bg-muted/40 p-4 text-sm text-muted-foreground">
+          No sample posts are currently available. Explore the source posts
+          below.
+        </p>
+      )}
+    </section>
+  )
+}

--- a/src/components/birdseye/ShareBirdseye.tsx
+++ b/src/components/birdseye/ShareBirdseye.tsx
@@ -1,0 +1,95 @@
+'use client'
+import { useState } from 'react'
+import { LockKeyhole, Link2 } from 'lucide-react'
+export function ShareBirdseye({
+  initiallyEnabled,
+}: {
+  initiallyEnabled: boolean
+}) {
+  const [enabled, setEnabled] = useState(initiallyEnabled)
+  const [url, setUrl] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [message, setMessage] = useState('')
+  async function update(share: boolean) {
+    setBusy(true)
+    setMessage('')
+    try {
+      const response = await fetch('/api/birdseye/sharing', {
+        method: share ? 'POST' : 'DELETE',
+      })
+      const result = await response.json()
+      if (!response.ok)
+        throw new Error(result.error || 'Sharing could not be updated.')
+      setEnabled(share)
+      setUrl(result.url ?? '')
+      setMessage(
+        share
+          ? 'Link created. Anyone with this link can view all your Birdseye topics.'
+          : 'Link revoked. Your Birdseye is private.',
+      )
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Please try again.')
+    } finally {
+      setBusy(false)
+    }
+  }
+  return (
+    <details className="ph-no-capture ph-mask w-full rounded-xl border border-border bg-card p-3 sm:w-80">
+      <summary className="flex cursor-pointer list-none items-center gap-2 text-sm font-semibold">
+        {enabled ? <Link2 size={15} /> : <LockKeyhole size={15} />}
+        {enabled ? 'Shared by link' : 'Private to you'}
+        <span className="ml-auto text-brand">Share</span>
+      </summary>
+      <div className="mt-3 space-y-3 text-xs text-muted-foreground">
+        <p>
+          Share all your topics with anyone who has the link. You can revoke
+          access here anytime. Saved copies cannot be recalled.
+        </p>
+        <button
+          disabled={busy}
+          onClick={() => update(true)}
+          className="rounded-lg bg-brand px-3 py-2 font-semibold text-brand-foreground disabled:opacity-50"
+        >
+          {enabled ? 'Replace share link' : 'Create share link'}
+        </button>
+        {enabled && (
+          <button
+            disabled={busy}
+            onClick={() => update(false)}
+            className="ml-3 underline disabled:opacity-50"
+          >
+            Revoke link
+          </button>
+        )}
+        {enabled && !url && (
+          <p>Replacing the link disables the previous one.</p>
+        )}
+        {url && (
+          <div className="flex gap-2">
+            <input
+              aria-label="Birdseye share link"
+              readOnly
+              value={url}
+              className="min-w-0 flex-1 rounded border border-border bg-background p-2"
+              onFocus={(e) => e.target.select()}
+            />
+            <button
+              className="font-semibold text-brand"
+              onClick={async () => {
+                try {
+                  await navigator.clipboard.writeText(url)
+                  setMessage('Link copied.')
+                } catch {
+                  setMessage('Select and copy the link above.')
+                }
+              }}
+            >
+              Copy
+            </button>
+          </div>
+        )}
+        <p role="status">{busy ? 'Updating…' : message}</p>
+      </div>
+    </details>
+  )
+}

--- a/src/components/birdseye/SourcePosts.test.tsx
+++ b/src/components/birdseye/SourcePosts.test.tsx
@@ -1,0 +1,63 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { SourcePosts } from './SourcePosts'
+jest.mock('@/components/TweetCard', () => ({
+  TweetCard: ({ tweet }: { tweet: { text: string } }) => (
+    <article>{tweet.text}</article>
+  ),
+}))
+let intersect: (entries: { isIntersecting: boolean }[]) => void
+beforeEach(() => {
+  global.IntersectionObserver = jest.fn().mockImplementation((callback) => {
+    intersect = callback
+    return { observe: jest.fn(), disconnect: jest.fn() }
+  })
+  global.fetch = jest.fn()
+})
+test('loads on approach, retains earlier posts, retries a failed batch, and stops at the end', async () => {
+  jest
+    .mocked(fetch)
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        tweets: [
+          { id: '1', threadId: '1', username: 'alice', text: 'First source' },
+        ],
+        nextOffset: 6,
+      }),
+    } as Response)
+    .mockResolvedValueOnce({ ok: false, status: 503 } as Response)
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        tweets: [
+          { id: '2', threadId: '1', username: 'bob', text: 'Last source' },
+        ],
+        nextOffset: null,
+      }),
+    } as Response)
+  render(<SourcePosts username="alice" clusterId="topic" total={12} />)
+  expect(fetch).not.toHaveBeenCalled()
+  act(() => intersect([{ isIntersecting: true }]))
+  expect(await screen.findByText('First source')).toBeInTheDocument()
+  act(() => intersect([{ isIntersecting: true }]))
+  expect(await screen.findByRole('alert')).toHaveTextContent('could not load')
+  fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+  expect(await screen.findByText('Last source')).toBeInTheDocument()
+  expect(screen.getByText('First source')).toBeInTheDocument()
+  expect(
+    screen.getByRole('group', { name: 'Reply thread · 2 posts' }),
+  ).toHaveTextContent('First source')
+  expect(
+    screen.getByRole('group', { name: 'Reply thread · 2 posts' }),
+  ).toHaveTextContent('Last source')
+  expect(screen.getByText('By @alice')).toBeInTheDocument()
+  expect(screen.getByText('Conversation context · @bob')).toBeInTheDocument()
+  await waitFor(() =>
+    expect(screen.queryByRole('button')).not.toBeInTheDocument(),
+  )
+  expect(jest.mocked(fetch).mock.calls.map(([url]) => String(url))).toEqual([
+    '/api/birdseye/sources?username=alice&cluster_id=topic&offset=0',
+    '/api/birdseye/sources?username=alice&cluster_id=topic&offset=6',
+    '/api/birdseye/sources?username=alice&cluster_id=topic&offset=6',
+  ])
+})

--- a/src/components/birdseye/SourcePosts.tsx
+++ b/src/components/birdseye/SourcePosts.tsx
@@ -1,0 +1,174 @@
+'use client'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { TweetCard } from '@/components/TweetCard'
+import type { PortalTweet } from '@/lib/portal/types'
+
+type SourceTweet = PortalTweet & { threadId?: string }
+
+export function SourcePosts({
+  username,
+  clusterId,
+  total,
+  excludeIds = [],
+}: {
+  username: string
+  clusterId: string
+  total: number
+  excludeIds?: string[]
+}) {
+  const excluded = excludeIds.join(',')
+  const [tweets, setTweets] = useState<SourceTweet[]>([])
+  const [offset, setOffset] = useState<number | null>(total ? 0 : null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const sentinel = useRef<HTMLDivElement>(null)
+  const inFlight = useRef(false)
+  const controller = useRef<AbortController>()
+  const load = useCallback(async () => {
+    if (inFlight.current || offset === null) return
+    inFlight.current = true
+    const abort = new AbortController()
+    controller.current = abort
+    setLoading(true)
+    setError('')
+    try {
+      const query = new URLSearchParams({
+        username,
+        cluster_id: clusterId,
+        offset: String(offset),
+      })
+      if (excluded) query.set('exclude', excluded)
+      const response = await fetch(`/api/birdseye/sources?${query}`, {
+        signal: abort.signal,
+        cache: 'no-store',
+      })
+      if (!response.ok) {
+        if (response.status === 404) setTweets([])
+        throw new Error(
+          response.status === 404
+            ? 'This Birdseye is no longer available.'
+            : 'Source posts could not load. Please try again.',
+        )
+      }
+      const result = (await response.json()) as {
+        tweets: SourceTweet[]
+        nextOffset: number | null
+      }
+      setTweets((previous) => [
+        ...previous,
+        ...result.tweets.filter(
+          (tweet) => !previous.some((p) => p.id === tweet.id),
+        ),
+      ])
+      setOffset(result.nextOffset)
+    } catch (err) {
+      if (!abort.signal.aborted)
+        setError(err instanceof Error ? err.message : 'Please try again.')
+    } finally {
+      inFlight.current = false
+      if (!abort.signal.aborted) setLoading(false)
+    }
+  }, [username, clusterId, offset, excluded])
+  useEffect(() => () => controller.current?.abort(), [])
+  useEffect(() => {
+    if (!sentinel.current || error || offset === null) return
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) void load()
+      },
+      { rootMargin: '250px' },
+    )
+    observer.observe(sentinel.current)
+    return () => observer.disconnect()
+  }, [load, error, offset])
+  const threads = new Map<string, SourceTweet[]>()
+  for (const tweet of tweets) {
+    const key = tweet.threadId ?? tweet.id
+    threads.set(key, [...(threads.get(key) ?? []), tweet])
+  }
+  return (
+    <section aria-label="Source posts" className="space-y-4">
+      <div className="flex items-baseline justify-between gap-3">
+        <h3 className="font-sans text-xl font-bold">
+          {excluded ? 'More source posts' : 'Source posts'}
+        </h3>
+        <span className="text-xs text-muted-foreground">
+          {total} cited posts
+        </span>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Related replies stay together as posts load. Only cited posts are shown;
+        some may no longer be available.
+      </p>
+      {Array.from(threads.entries()).map(([threadId, posts]) => (
+        <div
+          key={threadId}
+          role="group"
+          aria-label={
+            posts.length > 1
+              ? `Reply thread · ${posts.length} posts`
+              : 'Source post'
+          }
+          className="overflow-hidden rounded-xl border border-border bg-card"
+        >
+          {posts.length > 1 && (
+            <p className="border-b border-border/50 bg-muted/25 px-4 py-2 text-xs font-semibold text-muted-foreground">
+              Reply thread · {posts.length} posts
+            </p>
+          )}
+          {posts.map((tweet, index) => (
+            <div
+              id={`source-${tweet.id}`}
+              key={tweet.id}
+              className={
+                posts.length > 1
+                  ? 'relative ml-5 border-l-2 border-brand/25 pl-2'
+                  : ''
+              }
+            >
+              {posts.length > 1 && (
+                <span
+                  aria-hidden="true"
+                  className="absolute -left-[5px] top-5 h-2 w-2 rounded-full bg-brand/60"
+                />
+              )}
+              <p className="px-4 pt-2 text-[11px] text-muted-foreground">
+                {index > 0 && <span className="mr-2 text-brand">↳</span>}
+                {tweet.username.toLowerCase() === username.toLowerCase()
+                  ? `By @${username}`
+                  : `Conversation context · @${tweet.username}`}
+              </p>
+              <TweetCard tweet={tweet} noClamp showDate showExternalLink />
+            </div>
+          ))}
+        </div>
+      ))}
+      <div ref={sentinel} className="py-4 text-center">
+        {error && (
+          <p role="alert" className="mb-3 text-sm text-muted-foreground">
+            {error}
+          </p>
+        )}
+        {offset !== null ? (
+          <button
+            disabled={loading}
+            onClick={() => void load()}
+            className="rounded-lg border border-border px-4 py-2 text-sm font-semibold disabled:opacity-50"
+          >
+            {loading
+              ? 'Loading posts…'
+              : error
+                ? 'Try again'
+                : 'Load more posts'}
+          </button>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            {tweets.length
+              ? 'You’ve reached the end of the sources.'
+              : 'No source posts are currently available.'}
+          </p>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/src/components/birdseye/TopicInteractions.test.tsx
+++ b/src/components/birdseye/TopicInteractions.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { MonthlyTimeline } from './MonthlyTimeline'
+import { InsightItem } from './InsightItem'
+import type { BirdseyeCluster } from '@/lib/community-apps/types'
+
+const snowflake = (date: string) =>
+  (
+    (BigInt(Date.parse(date)) - BigInt('1288834974657')) <<
+    BigInt(22)
+  ).toString()
+test('month counts appear on hover, keyboard focus and tap, including empty months', () => {
+  render(
+    <MonthlyTimeline
+      cluster={
+        {
+          tweetIds: [snowflake('2022-01-01'), snowflake('2022-03-01')],
+          sections: [],
+        } as unknown as BirdseyeCluster
+      }
+    />,
+  )
+  const empty = screen.getByRole('button', { name: 'Feb 2022: 0 cited posts' })
+  fireEvent.mouseEnter(empty)
+  expect(screen.getByRole('tooltip')).toHaveTextContent('Feb 2022 · 0 posts')
+  fireEvent.keyDown(empty, { key: 'Escape' })
+  expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+  fireEvent.focus(
+    screen.getByRole('button', { name: 'Mar 2022: 1 cited posts' }),
+  )
+  expect(screen.getByRole('tooltip')).toHaveTextContent('Mar 2022 · 1 post')
+  fireEvent.click(empty)
+  expect(screen.getByRole('tooltip')).toHaveTextContent('Feb 2022 · 0 posts')
+})
+test('insight labels reveal descriptions and sources on hover and stay open when clicked', () => {
+  render(
+    <InsightItem
+      item={{
+        label: 'Community',
+        description: 'Nurture connections',
+        tweetIds: ['123'],
+      }}
+      username={null}
+    />,
+  )
+  const trigger = screen.getByRole('button', { name: 'Community' })
+  expect(screen.queryByText('Nurture connections')).not.toBeInTheDocument()
+  fireEvent.mouseEnter(trigger)
+  expect(screen.getByRole('dialog', { name: 'Community' })).toHaveTextContent(
+    'Nurture connections',
+  )
+  fireEvent.click(trigger)
+  expect(
+    screen.getByRole('link', { name: 'Source 1 for Community' }),
+  ).toHaveAttribute('href', '/tweets/123')
+  fireEvent.click(trigger)
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+})

--- a/src/components/birdseye/TopicSparkline.tsx
+++ b/src/components/birdseye/TopicSparkline.tsx
@@ -1,0 +1,49 @@
+import type { BirdseyeCluster } from '@/lib/community-apps/types'
+
+export function TopicSparkline({
+  years,
+  start,
+  end,
+}: {
+  years: BirdseyeCluster['years']
+  start: number
+  end: number
+}) {
+  if (!years.length)
+    return <span className="text-xs text-muted-foreground">No dates</span>
+  const counts = new Map(years.map((p) => [p.year, p.count]))
+  const max = Math.max(1, ...years.map((p) => p.count))
+  const points = Array.from(
+    { length: Math.max(1, end - start + 1) },
+    (_, index) => {
+      const year = start + index
+      return `${3 + (index / Math.max(1, end - start)) * 94},${27 - ((counts.get(year) ?? 0) / max) * 24}`
+    },
+  ).join(' ')
+  return (
+    <svg
+      viewBox="0 0 100 32"
+      className="h-8 w-24 shrink-0 text-brand"
+      role="img"
+      aria-label={`Cited posts by year, ${start}–${end}: ${years.map((p) => `${p.year}: ${p.count}`).join(', ')}`}
+    >
+      <path d="M3 28H97" stroke="currentColor" opacity="0.15" />
+      <polyline
+        points={points}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+      {end === start && (
+        <circle
+          cx="3"
+          cy={27 - (years[0].count / max) * 24}
+          r="2"
+          fill="currentColor"
+        />
+      )}
+    </svg>
+  )
+}

--- a/src/components/birdseye/TopicSummary.tsx
+++ b/src/components/birdseye/TopicSummary.tsx
@@ -1,0 +1,24 @@
+'use client'
+import { useState } from 'react'
+import { AnalysisText } from '@/components/community-apps/AnalysisText'
+
+export function TopicSummary({ text }: { text: string }) {
+  const [expanded, setExpanded] = useState(false)
+  if (!text.trim()) return null
+  return (
+    <div className="mt-2">
+      <div
+        className={`${expanded ? '' : 'line-clamp-2'} [&>div]:space-y-1 [&>div]:text-[13px] [&>div]:leading-5 [&_p]:mb-1`}
+      >
+        <AnalysisText>{text}</AnalysisText>
+      </div>
+      <button
+        aria-expanded={expanded}
+        onClick={() => setExpanded(!expanded)}
+        className="mt-1 text-[11px] text-muted-foreground hover:text-brand"
+      >
+        Saved AI summary · {expanded ? 'Show less' : 'Read more'}
+      </button>
+    </div>
+  )
+}

--- a/src/components/community-apps/AnalysisText.tsx
+++ b/src/components/community-apps/AnalysisText.tsx
@@ -1,0 +1,43 @@
+import Link from 'next/link'
+import ReactMarkdown from 'react-markdown'
+
+export function AnalysisText({ children }: { children: string }) {
+  return (
+    <div className="space-y-4 text-[15px] leading-7 text-muted-foreground">
+      <ReactMarkdown
+        components={{
+          p: ({ children }) => <p className="mb-4 last:mb-0">{children}</p>,
+          a: ({ href, children }) => (
+            <a
+              href={href}
+              className="text-brand underline"
+              rel="noopener noreferrer"
+            >
+              {children}
+            </a>
+          ),
+          ul: ({ children }) => (
+            <ul className="mb-4 list-disc pl-5">{children}</ul>
+          ),
+        }}
+      >
+        {children}
+      </ReactMarkdown>
+    </div>
+  )
+}
+export function EvidenceLinks({ ids }: { ids: string[] }) {
+  return (
+    <span className="inline-flex flex-wrap gap-x-3 gap-y-1">
+      {ids.map((id, index) => (
+        <Link
+          key={id}
+          href={`/tweets/${id}`}
+          className="text-xs font-semibold text-brand hover:underline"
+        >
+          Source {index + 1} ↗
+        </Link>
+      ))}
+    </span>
+  )
+}

--- a/src/components/community-apps/AppDataError.tsx
+++ b/src/components/community-apps/AppDataError.tsx
@@ -1,0 +1,23 @@
+'use client'
+import Link from 'next/link'
+export default function AppDataError({ reset }: { reset: () => void }) {
+  return (
+    <main className="mx-auto max-w-3xl px-5 py-16">
+      <h1 className="text-3xl font-bold">
+        This collection is temporarily unavailable
+      </h1>
+      <p className="my-4 text-muted-foreground">
+        We couldn’t load the saved analysis. Please try again.
+      </p>
+      <button
+        onClick={reset}
+        className="rounded-lg bg-brand px-4 py-2 font-semibold text-brand-foreground"
+      >
+        Try again
+      </button>
+      <Link href="/community" className="ml-5 text-brand">
+        Community Apps
+      </Link>
+    </main>
+  )
+}

--- a/src/components/community/CommunityGallery.test.tsx
+++ b/src/components/community/CommunityGallery.test.tsx
@@ -50,7 +50,7 @@ describe('CommunityGallery', () => {
         name: 'Discover community-made tools, bots, visualizations, and more',
       }),
     ).toBeInTheDocument()
-    expect(screen.getByText('11 projects')).toBeInTheDocument()
+    expect(screen.getByText('12 projects')).toBeInTheDocument()
 
     await user.type(
       screen.getByRole('searchbox', { name: 'Search community projects' }),
@@ -158,7 +158,7 @@ describe('CommunityGallery', () => {
     ])
 
     await user.click(screen.getByRole('button', { name: 'Tools' }))
-    expect(screen.getByText('6 projects')).toBeInTheDocument()
+    expect(screen.getByText('7 projects')).toBeInTheDocument()
   })
 
   it('submits a project to the approval queue', async () => {

--- a/src/lib/community-apps/birdseye-access.test.ts
+++ b/src/lib/community-apps/birdseye-access.test.ts
@@ -1,0 +1,312 @@
+import { getBirdseyeSourceIndex } from './birdseye-source-index'
+import { isAdminUser } from '@/app/admin/data'
+import { getLocalAdminPreview } from '@/lib/localAdminPreview'
+import type { User } from '@supabase/supabase-js'
+import { cookies } from 'next/headers'
+import {
+  createServerClient,
+  createServerServiceRoleClient,
+} from '@/utils/supabase'
+import { getAppDataManifest, getAppPolicy, getBirdseyeAnalysis } from './data'
+import {
+  createBirdseyeShare,
+  getBirdseyeProfiles,
+  loadAccessibleBirdseye,
+  resolveBirdseyeShare,
+  SHARE_COOKIE,
+} from './birdseye-access'
+import { GET as sources } from '@/app/api/birdseye/sources/route'
+import { POST, DELETE } from '@/app/api/birdseye/sharing/route'
+import { getSourceTweets } from './source-tweets'
+import { NextRequest } from 'next/server'
+jest.mock('@/app/admin/data', () => ({ isAdminUser: jest.fn() }))
+jest.mock('@/lib/localAdminPreview', () => ({
+  getLocalAdminPreview: jest.fn(),
+}))
+jest.mock('next/headers', () => ({ cookies: jest.fn() }))
+jest.mock('next/cache', () => ({ unstable_noStore: jest.fn() }))
+jest.mock('@/utils/supabase', () => ({
+  createServerClient: jest.fn(),
+  createServerServiceRoleClient: jest.fn(),
+}))
+jest.mock('./data', () => ({
+  getAppDataManifest: jest.fn(),
+  getAppPolicy: jest.fn(),
+  getBirdseyeAnalysis: jest.fn(),
+}))
+jest.mock('./birdseye-source-index', () => ({
+  getBirdseyeSourceIndex: jest.fn(),
+}))
+jest.mock('./source-tweets', () => ({ getSourceTweets: jest.fn() }))
+const owner = {
+  id: '12345678-1234-1234-1234-123456789abc',
+  app_metadata: { provider_id: '123' },
+  identities: [{ provider: 'twitter', identity_data: { user_name: 'alice' } }],
+} as unknown as User
+let session: User | null
+let stored: User
+let cookie: string | undefined
+const updateUserById = jest.fn()
+const getUserById = jest.fn()
+const member = jest.fn()
+beforeEach(() => {
+  jest.clearAllMocks()
+  jest
+    .mocked(getBirdseyeSourceIndex)
+    .mockImplementation(async (ids) => ids.map((id) => ({ id, threadId: id })))
+  jest.mocked(isAdminUser).mockReturnValue(false)
+  jest.mocked(getLocalAdminPreview).mockResolvedValue(null)
+  session = null
+  stored = structuredClone(owner)
+  cookie = undefined
+  jest.mocked(cookies).mockImplementation(
+    () =>
+      ({
+        get: (name: string) =>
+          name === SHARE_COOKIE && cookie ? { value: cookie } : undefined,
+      }) as never,
+  )
+  jest.mocked(createServerClient).mockReturnValue({
+    auth: { getUser: async () => ({ data: { user: session }, error: null }) },
+  } as never)
+  getUserById.mockImplementation(async () => ({
+    data: { user: stored },
+    error: null,
+  }))
+  updateUserById.mockImplementation(async (_id, attributes) => {
+    stored.app_metadata = { ...stored.app_metadata, ...attributes.app_metadata }
+    return { error: null }
+  })
+  member.mockResolvedValue({ data: { username: 'alice' }, error: null })
+  jest.mocked(createServerServiceRoleClient).mockReturnValue({
+    auth: { admin: { getUserById, updateUserById } },
+    from: () => ({ select: () => ({ eq: () => ({ maybeSingle: member }) }) }),
+  } as never)
+  jest.mocked(getAppPolicy).mockResolvedValue({
+    members: new Set(['alice']),
+    blocked: new Set(),
+    blockedIds: new Set(),
+  })
+  jest
+    .mocked(getAppDataManifest)
+    .mockResolvedValue({ birdseye: [{ username: 'alice' }] } as never)
+  jest.mocked(getBirdseyeAnalysis).mockResolvedValue({
+    username: 'alice',
+    groups: [],
+    clusters: [
+      {
+        id: 'topic',
+        tweetIds: Array.from({ length: 14 }, (_, i) => String(i + 1)),
+      },
+    ],
+  } as never)
+  jest.mocked(getSourceTweets).mockResolvedValue(new Map())
+})
+test('private by default: anonymous, another owner, and user-editable metadata cannot read analysis or sources', async () => {
+  expect(await loadAccessibleBirdseye('alice')).toBeNull()
+  session = {
+    ...owner,
+    identities: [],
+    user_metadata: { user_name: 'alice', provider_id: '123' },
+  }
+  expect(await loadAccessibleBirdseye('alice')).toBeNull()
+  session = {
+    ...owner,
+    identities: [{ provider: 'twitter', identity_data: { user_name: 'bob' } }],
+  } as unknown as User
+  expect(await loadAccessibleBirdseye('alice')).toBeNull()
+  expect(
+    (
+      await sources(
+        new NextRequest(
+          'https://ca.test/api/birdseye/sources?username=alice&cluster_id=topic',
+        ),
+      )
+    ).status,
+  ).toBe(404)
+  expect(getBirdseyeAnalysis).not.toHaveBeenCalled()
+  expect(getSourceTweets).not.toHaveBeenCalled()
+  expect(getBirdseyeSourceIndex).not.toHaveBeenCalled()
+})
+test('owner identity and matching account are required, with consent rechecked on every read', async () => {
+  session = owner
+  expect(await loadAccessibleBirdseye()).toMatchObject({
+    isOwner: true,
+    sharingEnabled: false,
+  })
+  member.mockResolvedValue({ data: { username: 'bob' }, error: null })
+  expect(await loadAccessibleBirdseye()).toBeNull()
+  member.mockResolvedValue({ data: { username: 'alice' }, error: null })
+  jest.mocked(getAppPolicy).mockResolvedValue({
+    members: new Set(),
+    blocked: new Set(['alice']),
+    blockedIds: new Set(['123']),
+  })
+  expect(await loadAccessibleBirdseye()).toBeNull()
+})
+test('only the opaque share secret grants access; rotation, revocation, and identity changes invalidate existing cookies', async () => {
+  const share = createBirdseyeShare(owner)
+  stored.app_metadata.birdseye_share = share.setting
+  cookie = share.token
+  expect(await loadAccessibleBirdseye('alice')).toMatchObject({
+    isOwner: false,
+  })
+  expect(await loadAccessibleBirdseye('bob')).toBeNull()
+  expect(await resolveBirdseyeShare(`${owner.id}.${'0'.repeat(64)}`)).toBeNull()
+  expect(JSON.stringify(share.setting)).not.toContain(share.token.split('.')[1])
+  stored.app_metadata.birdseye_share = createBirdseyeShare(owner).setting
+  expect(await loadAccessibleBirdseye('alice')).toBeNull()
+  stored.app_metadata.birdseye_share = null
+  expect(await loadAccessibleBirdseye('alice')).toBeNull()
+  stored.app_metadata.birdseye_share = share.setting
+  stored.app_metadata.provider_id = '456'
+  expect(await resolveBirdseyeShare(share.token)).toBeNull()
+})
+test('source pagination selects only this authorized topic and bounds each read to six records', async () => {
+  session = owner
+  const response = await sources(
+    new NextRequest(
+      'https://ca.test/api/birdseye/sources?username=alice&cluster_id=topic&offset=6&ids=999',
+    ),
+  )
+  expect(response.headers.get('cache-control')).toContain('no-store')
+  expect(getSourceTweets).toHaveBeenCalledWith([
+    '7',
+    '8',
+    '9',
+    '10',
+    '11',
+    '12',
+  ])
+  expect(await response.json()).toMatchObject({ nextOffset: 12 })
+  expect(
+    (
+      await sources(
+        new NextRequest(
+          'https://ca.test/api/birdseye/sources?username=alice&cluster_id=hidden',
+        ),
+      )
+    ).status,
+  ).toBe(404)
+  expect(
+    (
+      await sources(
+        new NextRequest('https://ca.test/api/birdseye/sources?offset=-1'),
+      )
+    ).status,
+  ).toBe(400)
+})
+test('share mutation requires same-origin authenticated owner; revoke persists without changing unrelated metadata', async () => {
+  const request = (origin = 'https://ca.test') =>
+    new NextRequest('https://ca.test/api/birdseye/sharing', {
+      method: 'POST',
+      headers: { origin },
+    })
+  expect((await POST(request())).status).toBe(401)
+  session = owner
+  expect((await POST(request('https://evil.test'))).status).toBe(403)
+  expect(updateUserById).not.toHaveBeenCalled()
+  const response = await POST(request())
+  expect(response.status).toBe(200)
+  const { url } = await response.json()
+  expect(await resolveBirdseyeShare(url.split('/').pop())).toMatchObject({
+    username: 'alice',
+  })
+  expect((await DELETE(request())).status).toBe(200)
+  expect(await resolveBirdseyeShare(url.split('/').pop())).toBeNull()
+  expect(stored.app_metadata.provider_id).toBe('123')
+})
+
+test('a share link redirects without the secret and uses a private HttpOnly cookie', async () => {
+  const { GET } = await import('@/app/api/birdseye/share/[token]/route')
+  const share = createBirdseyeShare(owner)
+  stored.app_metadata.birdseye_share = share.setting
+  const response = await GET(
+    new NextRequest(`https://ca.test/api/birdseye/share/${share.token}`),
+    { params: { token: share.token } },
+  )
+  expect(response.status).toBe(303)
+  expect(response.headers.get('location')).toBe(
+    'https://ca.test/birdseye?username=alice',
+  )
+  expect(response.headers.get('referrer-policy')).toBe('no-referrer')
+  expect(response.headers.get('cache-control')).toContain('no-store')
+  expect(response.cookies.get(SHARE_COOKIE)).toMatchObject({
+    httpOnly: true,
+    secure: true,
+    sameSite: 'lax',
+  })
+})
+
+test('real admins can list and read eligible profiles without becoming the owner', async () => {
+  session = {
+    ...owner,
+    identities: [
+      { provider: 'twitter', identity_data: { user_name: 'admin' } },
+    ],
+  } as unknown as User
+  jest.mocked(isAdminUser).mockReturnValue(true)
+  expect(await getBirdseyeProfiles()).toEqual(['alice'])
+  expect(await loadAccessibleBirdseye('alice')).toMatchObject({
+    isAdmin: true,
+    isOwner: false,
+  })
+  expect(member).not.toHaveBeenCalled()
+  jest.mocked(getAppPolicy).mockResolvedValue({
+    members: new Set(),
+    blocked: new Set(['alice']),
+    blockedIds: new Set(),
+  })
+  expect(await getBirdseyeProfiles()).toEqual([])
+  expect(await loadAccessibleBirdseye('alice')).toBeNull()
+})
+
+test('local admin can browse sources, logout removes access, and no Auth identity is fabricated', async () => {
+  jest.mocked(getLocalAdminPreview).mockResolvedValue('admin')
+  expect(await getBirdseyeProfiles()).toEqual(['alice'])
+  expect(await loadAccessibleBirdseye('alice')).toMatchObject({
+    isAdmin: true,
+    isOwner: false,
+    sharingEnabled: false,
+  })
+  expect(
+    (
+      await sources(
+        new NextRequest(
+          'http://localhost:3031/api/birdseye/sources?username=alice&cluster_id=topic',
+        ),
+      )
+    ).status,
+  ).toBe(200)
+  expect(updateUserById).not.toHaveBeenCalled()
+  jest.mocked(getLocalAdminPreview).mockResolvedValue('signed-out')
+  expect(await getBirdseyeProfiles()).toEqual([])
+  expect(await loadAccessibleBirdseye('alice')).toBeNull()
+})
+
+test('remaining sources skip the highlighted posts before applying pagination', async () => {
+  session = owner
+  const response = await sources(
+    new NextRequest(
+      'https://ca.test/api/birdseye/sources?username=alice&cluster_id=topic&exclude=1,5',
+    ),
+  )
+  expect(response.status).toBe(200)
+  expect(getSourceTweets).toHaveBeenCalledWith(['2', '3', '4', '6', '7', '8'])
+  expect(await response.json()).toMatchObject({ nextOffset: 6 })
+})
+
+test('source grouping failures remain private and retryable', async () => {
+  session = owner
+  jest
+    .mocked(getBirdseyeSourceIndex)
+    .mockRejectedValueOnce(new Error('offline'))
+  const response = await sources(
+    new NextRequest(
+      'https://ca.test/api/birdseye/sources?username=alice&cluster_id=topic',
+    ),
+  )
+  expect(response.status).toBe(503)
+  expect(response.headers.get('cache-control')).toContain('no-store')
+  expect(getSourceTweets).not.toHaveBeenCalled()
+})

--- a/src/lib/community-apps/birdseye-access.ts
+++ b/src/lib/community-apps/birdseye-access.ts
@@ -1,0 +1,149 @@
+import 'server-only'
+import { isAdminUser } from '@/app/admin/data'
+import { getLocalAdminPreview } from '@/lib/localAdminPreview'
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto'
+import type { User } from '@supabase/supabase-js'
+import { cookies } from 'next/headers'
+import { unstable_noStore as noStore } from 'next/cache'
+import {
+  createServerClient,
+  createServerServiceRoleClient,
+} from '@/utils/supabase'
+import { getSessionTwitterUsername } from '@/lib/sessionTwitterUsername'
+import { getAppDataManifest, getAppPolicy, getBirdseyeAnalysis } from './data'
+
+export const SHARE_COOKIE = 'birdseye-share'
+export const PRIVATE_HEADERS = {
+  'Cache-Control': 'private, no-store',
+  'Referrer-Policy': 'no-referrer',
+  'X-Robots-Tag': 'noindex, nofollow',
+}
+const TOKEN = /^([a-f0-9-]{36})\.([a-f0-9]{64})$/
+const hash = (secret: string) =>
+  createHash('sha256').update(secret).digest('hex')
+
+export function birdseyeIdentity(user: User | null) {
+  const username = user && getSessionTwitterUsername(user)
+  const accountId = user?.app_metadata?.provider_id
+  return username && typeof accountId === 'string' && accountId.trim()
+    ? { username, accountId }
+    : null
+}
+
+export async function getBirdseyeOwner() {
+  noStore()
+  const {
+    data: { user },
+    error,
+  } = await createServerClient(await cookies()).auth.getUser()
+  return error ? null : user
+}
+
+export async function getBirdseyeViewer() {
+  const localPreview = await getLocalAdminPreview()
+  // Local read preview never fabricates an Auth user or grants write access.
+  const user = localPreview === 'admin' ? null : await getBirdseyeOwner()
+  return {
+    user,
+    isAdmin: localPreview === 'admin' || (!!user && isAdminUser(user)),
+  }
+}
+
+export async function getBirdseyeProfiles() {
+  if (!(await getBirdseyeViewer()).isAdmin) return []
+  const manifest = await getAppDataManifest()
+  const policy = await getAppPolicy(
+    manifest.birdseye.map((entry) => entry.username),
+  )
+  return manifest.birdseye
+    .map((entry) => entry.username)
+    .filter((username) => policy.members.has(username))
+    .sort()
+}
+
+export function createBirdseyeShare(user: User) {
+  const identity = birdseyeIdentity(user)
+  if (!identity) throw new Error('Twitter identity required')
+  const secret = randomBytes(32).toString('hex')
+  return {
+    token: `${user.id}.${secret}`,
+    setting: { ...identity, tokenHash: hash(secret) },
+  }
+}
+
+export async function resolveBirdseyeShare(token: string | undefined) {
+  noStore()
+  const match = token?.match(TOKEN)
+  if (!match) return null
+  // Read current Auth metadata, never a cached JWT: revocation takes effect on
+  // the very next page or source request, including an existing share cookie.
+  const {
+    data: { user },
+    error,
+  } = await createServerServiceRoleClient().auth.admin.getUserById(match[1])
+  if (error || !user) return null
+  const identity = birdseyeIdentity(user)
+  const share = user.app_metadata?.birdseye_share
+  if (
+    !identity ||
+    !share ||
+    share.username !== identity.username ||
+    share.accountId !== identity.accountId ||
+    typeof share.tokenHash !== 'string' ||
+    !/^[a-f0-9]{64}$/.test(share.tokenHash)
+  )
+    return null
+  return timingSafeEqual(
+    Buffer.from(share.tokenHash, 'hex'),
+    Buffer.from(hash(match[2]), 'hex'),
+  )
+    ? identity
+    : null
+}
+
+export async function loadAccessibleBirdseye(requestedUsername?: string) {
+  noStore()
+  const { user, isAdmin } = await getBirdseyeViewer()
+  const owner = birdseyeIdentity(user)
+  const requested = requestedUsername?.toLowerCase()
+  if (requested && !/^[a-z0-9_]{1,15}$/.test(requested)) return null
+  const shared =
+    !isAdmin && (!owner || (requested && requested !== owner.username))
+      ? await resolveBirdseyeShare((await cookies()).get(SHARE_COOKIE)?.value)
+      : null
+  const username =
+    requested ||
+    owner?.username ||
+    shared?.username ||
+    (isAdmin ? (await getBirdseyeProfiles())[0] : undefined)
+  const isOwner = !!owner && username === owner.username
+  const identity = isOwner
+    ? owner
+    : shared?.username === username
+      ? shared
+      : null
+  if (!username || (!identity && !isAdmin)) return null
+
+  const policy = await getAppPolicy([username])
+  if (!policy.members.has(username)) return null
+  if (!isAdmin) {
+    // A matching handle alone is insufficient if an account has been renamed.
+    const { data: member, error } = await createServerServiceRoleClient()
+      .from('user_directory')
+      .select('username')
+      .eq('account_id', identity!.accountId)
+      .maybeSingle()
+    if (error) throw new Error('Birdseye ownership check unavailable')
+    if (member?.username?.toLowerCase() !== username) return null
+  }
+  const manifest = await getAppDataManifest()
+  if (!manifest.birdseye.some((entry) => entry.username === username))
+    return null
+  const analysis = await getBirdseyeAnalysis(username, manifest, policy.blocked)
+  return {
+    analysis,
+    isOwner,
+    isAdmin,
+    sharingEnabled: isOwner && !!user?.app_metadata?.birdseye_share,
+  }
+}

--- a/src/lib/community-apps/birdseye-layout.test.ts
+++ b/src/lib/community-apps/birdseye-layout.test.ts
@@ -1,0 +1,67 @@
+import {
+  monthlyActivity,
+  birdseyeGroups,
+  yearlySummaries,
+  participantUsername,
+} from './birdseye-layout'
+import type { BirdseyeAnalysis, BirdseyeCluster } from './types'
+const idAt = (date: string) =>
+  (
+    (BigInt(new Date(date).getTime()) - BigInt('1288834974657')) <<
+    BigInt(22)
+  ).toString()
+test('monthly chart starts and ends at cited months, fills gaps, and deduplicates IDs', () => {
+  const june = idAt('2021-06-15')
+  expect(
+    monthlyActivity([june, june, idAt('2021-08-03'), 'bad', '123']),
+  ).toEqual([
+    { month: '2021-06', count: 1 },
+    { month: '2021-07', count: 0 },
+    { month: '2021-08', count: 1 },
+  ])
+  expect(monthlyActivity([])).toEqual([])
+  expect(monthlyActivity([june])).toEqual([{ month: '2021-06', count: 1 }])
+})
+test('overview ranks macro topics by unique references and includes ungrouped topics', () => {
+  const analysis = {
+    groups: [
+      { name: 'Small', clusterIds: ['a'] },
+      { name: 'Big', clusterIds: ['b', 'c', 'hidden'] },
+    ],
+    clusters: [
+      { id: 'a', name: 'A', tweetIds: ['1'] },
+      { id: 'b', name: 'B', tweetIds: ['2', '3'] },
+      { id: 'c', name: 'C', tweetIds: ['3', '4', '5'] },
+      { id: 'd', name: 'D', tweetIds: ['6'] },
+    ],
+  } as BirdseyeAnalysis
+  const groups = birdseyeGroups(analysis)
+  expect(groups[0].name).toBe('Big')
+  expect(groups[0].tweetIds).toHaveLength(4)
+  expect(groups[0].topics.map((topic) => topic.id)).toEqual(['c', 'b'])
+  expect(
+    groups.find((group) => group.name === 'More topics')?.topics[0].id,
+  ).toBe('d')
+})
+test('year summaries are chronological and cropped to the cited date range', () => {
+  const cluster = {
+    tweetIds: [idAt('2020-05-04'), idAt('2022-09-12')],
+    sections: [
+      {
+        name: 'Yearly summaries',
+        items: ['2022', '2019', '2020', '2023'].map((label) => ({ label })),
+      },
+    ],
+  } as BirdseyeCluster
+  expect(yearlySummaries(cluster).map((item) => item.label)).toEqual([
+    '2020',
+    '2022',
+  ])
+})
+test('person avatars require a known participant handle, not just a short entity name', () => {
+  expect(participantUsername('@Christineist', ['christineist'])).toBe(
+    'christineist',
+  )
+  expect(participantUsername('Book', ['christineist'])).toBeNull()
+  expect(participantUsername('Wong Kar Wai', ['christineist'])).toBeNull()
+})

--- a/src/lib/community-apps/birdseye-layout.ts
+++ b/src/lib/community-apps/birdseye-layout.ts
@@ -1,0 +1,88 @@
+import type { BirdseyeAnalysis, BirdseyeCluster } from './types'
+
+export function monthlyActivity(ids: string[]) {
+  const counts = new Map<string, number>()
+  for (const id of Array.from(new Set(ids))) {
+    if (!/^\d{16,20}$/.test(id)) continue
+    const time = Number((BigInt(id) >> BigInt(22)) + BigInt('1288834974657'))
+    const date = new Date(time)
+    if (
+      !Number.isFinite(time) ||
+      date.getUTCFullYear() < 2010 ||
+      date.getUTCFullYear() > 2100
+    )
+      continue
+    const month = date.toISOString().slice(0, 7)
+    counts.set(month, (counts.get(month) ?? 0) + 1)
+  }
+  const months = Array.from(counts.keys()).sort()
+  if (!months.length) return []
+  const cursor = new Date(`${months[0]}-01T00:00:00Z`)
+  const end = months[months.length - 1]
+  const result: { month: string; count: number }[] = []
+  while (cursor.toISOString().slice(0, 7) <= end) {
+    const month = cursor.toISOString().slice(0, 7)
+    result.push({ month, count: counts.get(month) ?? 0 })
+    cursor.setUTCMonth(cursor.getUTCMonth() + 1)
+  }
+  return result
+}
+
+export function birdseyeGroups(analysis: BirdseyeAnalysis) {
+  const clusters = new Map(
+    analysis.clusters.map((cluster) => [cluster.id, cluster]),
+  )
+  const grouped = new Set(analysis.groups.flatMap((group) => group.clusterIds))
+  return [
+    ...analysis.groups,
+    {
+      name: 'More topics',
+      clusterIds: analysis.clusters
+        .filter((cluster) => !grouped.has(cluster.id))
+        .map((cluster) => cluster.id),
+    },
+  ]
+    .map((group, index) => {
+      const topics = Array.from(new Set(group.clusterIds))
+        .flatMap((id) => (clusters.has(id) ? [clusters.get(id)!] : []))
+        .sort(
+          (a, b) =>
+            new Set(b.tweetIds).size - new Set(a.tweetIds).size ||
+            a.name.localeCompare(b.name),
+        )
+      const tweetIds = Array.from(
+        new Set(topics.flatMap((topic) => topic.tweetIds)),
+      )
+      return { name: group.name, id: `group-${index}`, topics, tweetIds }
+    })
+    .filter((group) => group.topics.length)
+    .sort(
+      (a, b) =>
+        b.tweetIds.length - a.tweetIds.length || a.name.localeCompare(b.name),
+    )
+}
+
+export function yearlySummaries(cluster: BirdseyeCluster) {
+  const months = monthlyActivity(cluster.tweetIds)
+  if (!months.length) return []
+  const start = Number(months[0].month.slice(0, 4))
+  const end = Number(months[months.length - 1].month.slice(0, 4))
+  return cluster.sections
+    .filter((section) => section.name.toLowerCase() === 'yearly summaries')
+    .flatMap((section) => section.items)
+    .filter(
+      (item) =>
+        /^\d{4}$/.test(item.label) &&
+        Number(item.label) >= start &&
+        Number(item.label) <= end,
+    )
+    .sort((a, b) => Number(a.label) - Number(b.label))
+}
+
+export function participantUsername(label: string, participants: string[]) {
+  const username = label.replace(/^@/, '').toLowerCase()
+  return /^[a-z0-9_]{1,15}$/.test(username) &&
+    participants.some((name) => name.toLowerCase() === username)
+    ? username
+    : null
+}

--- a/src/lib/community-apps/birdseye-samples.test.ts
+++ b/src/lib/community-apps/birdseye-samples.test.ts
@@ -1,0 +1,82 @@
+import { getBirdseyeSamples } from './birdseye-samples'
+import { createServerServiceRoleClient } from '@/utils/supabase'
+import { getSourceTweets } from './source-tweets'
+jest.mock('next/cache', () => ({ unstable_cache: (fn: unknown) => fn }))
+jest.mock('@/utils/supabase', () => ({
+  createServerServiceRoleClient: jest.fn(),
+}))
+jest.mock('./source-tweets', () => ({ getSourceTweets: jest.fn() }))
+const query = {
+  select: jest.fn().mockReturnThis(),
+  in: jest.fn().mockReturnThis(),
+  ilike: jest.fn().mockReturnThis(),
+  order: jest.fn().mockReturnThis(),
+  limit: jest.fn(),
+}
+beforeEach(() => {
+  jest.clearAllMocks()
+  jest
+    .mocked(createServerServiceRoleClient)
+    .mockReturnValue({ from: () => query } as never)
+})
+test('selects owner posts by likes using only cited IDs, then renders the configured source records', async () => {
+  query.limit.mockResolvedValue({
+    data: [
+      { tweet_id: '1', favorite_count: 3 },
+      { tweet_id: '2', favorite_count: 8 },
+      { tweet_id: '3', favorite_count: 5 },
+    ],
+    error: null,
+  })
+  jest.mocked(getSourceTweets).mockResolvedValue(
+    new Map([
+      ['1', { id: '1', username: 'alice', likes: 3 }],
+      ['2', { id: '2', username: 'ALICE', likes: 8 }],
+      ['3', { id: '3', username: 'alice', likes: 5 }],
+    ] as never),
+  )
+  expect(
+    (await getBirdseyeSamples(['1', '2', '3', '1', 'bad'], 'alice')).map(
+      (tweet) => tweet.id,
+    ),
+  ).toEqual(['2', '3', '1'])
+  expect(query.in).toHaveBeenCalledWith('tweet_id', ['1', '2', '3'])
+  expect(query.ilike).toHaveBeenCalledWith('username', 'alice')
+  expect(getSourceTweets).toHaveBeenCalledWith(['2', '3', '1'])
+})
+test('uses conversation context only when there are too few owner candidates', async () => {
+  query.limit
+    .mockResolvedValueOnce({
+      data: [{ tweet_id: '1', favorite_count: 2 }],
+      error: null,
+    })
+    .mockResolvedValueOnce({
+      data: [{ tweet_id: '2', favorite_count: 50 }],
+      error: null,
+    })
+  jest.mocked(getSourceTweets).mockResolvedValue(
+    new Map([
+      ['1', { id: '1', username: 'alice', likes: 2 }],
+      ['2', { id: '2', username: 'bob', likes: 50 }],
+    ] as never),
+  )
+  expect(
+    (await getBirdseyeSamples(['1', '2'], 'alice')).map((tweet) => tweet.id),
+  ).toEqual(['1', '2'])
+})
+test('does not silently select arbitrary posts when ranking is unavailable', async () => {
+  query.limit.mockResolvedValue({
+    data: null,
+    error: { message: 'Unavailable' },
+  })
+  await expect(getBirdseyeSamples(['1'], 'alice')).rejects.toThrow(
+    'Unable to rank',
+  )
+  expect(getSourceTweets).not.toHaveBeenCalled()
+})
+test('matches underscores in usernames literally', async () => {
+  query.limit.mockResolvedValue({ data: [], error: null })
+  jest.mocked(getSourceTweets).mockResolvedValue(new Map())
+  await getBirdseyeSamples(['1'], 'alice_bob')
+  expect(query.ilike).toHaveBeenCalledWith('username', 'alice\\_bob')
+})

--- a/src/lib/community-apps/birdseye-samples.ts
+++ b/src/lib/community-apps/birdseye-samples.ts
@@ -1,0 +1,56 @@
+import 'server-only'
+import { unstable_cache } from 'next/cache'
+import { createServerServiceRoleClient } from '@/utils/supabase'
+import { getSourceTweets } from './source-tweets'
+import type { PortalTweet } from '@/lib/portal/types'
+
+type Candidate = { tweet_id: string | null; favorite_count: number | null }
+// Small indexed lookups against only this topic's saved references. Postgres
+// supplies ranking metadata, not a second full-text source. TweetCard payloads
+// continue to use the configured archive reader and its current opt-out checks.
+const rankedIds = unstable_cache(
+  async (input: string[], username: string | null) => {
+    const ids = Array.from(new Set(input.filter((id) => /^\d{1,20}$/.test(id))))
+    const candidates: Candidate[] = []
+    for (let offset = 0; offset < ids.length; offset += 150) {
+      let query = createServerServiceRoleClient()
+        .from('enriched_tweets')
+        .select('tweet_id,favorite_count')
+        .in('tweet_id', ids.slice(offset, offset + 150))
+      if (username)
+        query = query.ilike('username', username.replace(/_/g, '\\_'))
+      const { data, error } = await query
+        .order('favorite_count', { ascending: false, nullsFirst: false })
+        .order('tweet_id', { ascending: false })
+        .limit(6)
+      if (error) throw new Error('Unable to rank cited posts')
+      candidates.push(...(data ?? []))
+    }
+    return candidates
+      .sort(
+        (a, b) =>
+          (b.favorite_count ?? 0) - (a.favorite_count ?? 0) ||
+          (b.tweet_id ?? '').localeCompare(a.tweet_id ?? ''),
+      )
+      .flatMap((row) => (row.tweet_id ? [row.tweet_id] : []))
+      .slice(0, 6)
+  },
+  ['birdseye-cited-likes-v1'],
+  { revalidate: 300 },
+)
+
+export async function getBirdseyeSamples(ids: string[], username: string) {
+  const own = await rankedIds(ids, username)
+  const candidates = [...own]
+  if (own.length < 3) candidates.push(...(await rankedIds(ids, null)))
+  const posts = await getSourceTweets(Array.from(new Set(candidates)))
+  return Array.from(posts.values())
+    .sort(
+      (a, b) =>
+        Number(b.username.toLowerCase() === username.toLowerCase()) -
+          Number(a.username.toLowerCase() === username.toLowerCase()) ||
+        b.likes - a.likes ||
+        b.id.localeCompare(a.id),
+    )
+    .slice(0, 3) as PortalTweet[]
+}

--- a/src/lib/community-apps/birdseye-source-index.ts
+++ b/src/lib/community-apps/birdseye-source-index.ts
@@ -1,0 +1,27 @@
+import 'server-only'
+import { unstable_cache } from 'next/cache'
+import { createServerServiceRoleClient } from '@/utils/supabase'
+import { groupBirdseyeSources } from './birdseye-threads'
+
+// Exact-reference metadata only; full tweet payloads still come from the shared reader.
+export const getBirdseyeSourceIndex = unstable_cache(
+  async (input: string[]) => {
+    const ids = Array.from(new Set(input.filter((id) => /^\d{1,20}$/.test(id))))
+    const rows: {
+      tweet_id: string | null
+      reply_to_tweet_id: string | null
+      conversation_id: string | null
+    }[] = []
+    for (let offset = 0; offset < ids.length; offset += 150) {
+      const { data, error } = await createServerServiceRoleClient()
+        .from('enriched_tweets')
+        .select('tweet_id,reply_to_tweet_id,conversation_id')
+        .in('tweet_id', ids.slice(offset, offset + 150))
+      if (error) throw new Error('Unable to group cited posts')
+      rows.push(...(data ?? []))
+    }
+    return groupBirdseyeSources(ids, rows)
+  },
+  ['birdseye-source-threads-v1'],
+  { revalidate: 300 },
+)

--- a/src/lib/community-apps/birdseye-threads.test.ts
+++ b/src/lib/community-apps/birdseye-threads.test.ts
@@ -1,0 +1,47 @@
+import { groupBirdseyeSources } from './birdseye-threads'
+test('groups reply chains and shared conversation IDs in parent-first order without adding uncited posts', () => {
+  const rows = [
+    { tweet_id: '3', reply_to_tweet_id: '2', conversation_id: null },
+    { tweet_id: '2', reply_to_tweet_id: '1', conversation_id: null },
+    { tweet_id: '6', reply_to_tweet_id: '5', conversation_id: '4' },
+    { tweet_id: '7', reply_to_tweet_id: '99', conversation_id: '4' },
+    { tweet_id: '100', reply_to_tweet_id: '1', conversation_id: null },
+  ]
+  expect(
+    groupBirdseyeSources(['3', '8', '1', '7', '2', '6', '3'], rows),
+  ).toEqual([
+    { id: '1', threadId: '1' },
+    { id: '2', threadId: '1' },
+    { id: '3', threadId: '1' },
+    { id: '8', threadId: '8' },
+    { id: '6', threadId: '6' },
+    { id: '7', threadId: '6' },
+  ])
+})
+test('handles missing metadata, siblings with an uncited parent, and malformed cycles', () => {
+  expect(
+    groupBirdseyeSources(
+      ['2', '1', '3'],
+      [
+        { tweet_id: '1', reply_to_tweet_id: '2', conversation_id: null },
+        { tweet_id: '2', reply_to_tweet_id: '1', conversation_id: null },
+      ],
+    ),
+  ).toEqual([
+    { id: '1', threadId: '1' },
+    { id: '2', threadId: '1' },
+    { id: '3', threadId: '3' },
+  ])
+  expect(
+    groupBirdseyeSources(
+      ['2', '3'],
+      [
+        { tweet_id: '2', reply_to_tweet_id: '1', conversation_id: null },
+        { tweet_id: '3', reply_to_tweet_id: '1', conversation_id: null },
+      ],
+    ),
+  ).toEqual([
+    { id: '2', threadId: '2' },
+    { id: '3', threadId: '2' },
+  ])
+})

--- a/src/lib/community-apps/birdseye-threads.ts
+++ b/src/lib/community-apps/birdseye-threads.ts
@@ -1,0 +1,42 @@
+/** Groups only cited posts. Missing parents connect siblings but add no content. */
+export function groupBirdseyeSources(
+  ids: string[],
+  rows: {
+    tweet_id: string | null
+    reply_to_tweet_id: string | null
+    conversation_id: string | null
+  }[],
+) {
+  const parent = new Map<string, string>()
+  const root = (id: string): string => {
+    let current = id
+    const seen: string[] = []
+    while (parent.has(current) && parent.get(current) !== current) {
+      seen.push(current)
+      current = parent.get(current)!
+    }
+    for (const key of seen) parent.set(key, current)
+    return current
+  }
+  const join = (a: string, b: string) => {
+    const left = root(a),
+      right = root(b)
+    if (left !== right) parent.set(left, right)
+  }
+  const allowed = new Set(ids)
+  for (const row of rows) {
+    if (!row.tweet_id || !allowed.has(row.tweet_id)) continue
+    if (row.reply_to_tweet_id) join(row.tweet_id, row.reply_to_tweet_id)
+    if (row.conversation_id) join(row.tweet_id, row.conversation_id)
+  }
+  const groups = new Map<string, string[]>()
+  for (const id of Array.from(allowed)) {
+    const key = root(id)
+    groups.set(key, [...(groups.get(key) ?? []), id])
+  }
+  // Snowflake order puts parents before replies, including across page boundaries.
+  return Array.from(groups.values()).flatMap((group) => {
+    group.sort((a, b) => a.length - b.length || a.localeCompare(b))
+    return group.map((id) => ({ id, threadId: group[0] }))
+  })
+}

--- a/src/lib/community-apps/data.test.ts
+++ b/src/lib/community-apps/data.test.ts
@@ -1,0 +1,94 @@
+import {
+  getAppPolicy,
+  hasBlockedParticipant,
+  getBirdseyeAnalysis,
+} from './data'
+import { createServerServiceRoleClient } from '@/utils/supabase'
+jest.mock('next/cache', () => ({ unstable_cache: (fn: unknown) => fn }))
+jest.mock('@/utils/supabase', () => ({
+  createServerServiceRoleClient: jest.fn(),
+}))
+const makeClient = jest.mocked(createServerServiceRoleClient)
+
+function stubDatabase({
+  optedOut = ['withdrawn'],
+  members = ['member', 'withdrawn'],
+  fail = false,
+} = {}) {
+  const from = jest.fn((table: string) => {
+    const response =
+      table === 'optin'
+        ? {
+            data: optedOut.map((username) => ({ username })),
+            error: fail ? new Error('offline') : null,
+          }
+        : {
+            data: members.map((username) => ({
+              username,
+              has_archive: true,
+              is_opted_in: false,
+            })),
+            error: null,
+          }
+    const chain: Record<string, unknown> = {
+      then: (resolve: (value: unknown) => void) =>
+        Promise.resolve(response).then(resolve),
+    }
+    for (const method of ['select', 'eq', 'order', 'range', 'or'])
+      chain[method] = jest.fn(() => chain)
+    return chain
+  })
+  makeClient.mockReturnValue({ from } as never)
+  return from
+}
+afterEach(() => jest.clearAllMocks())
+test('explicit withdrawal overrides archived membership with case-insensitive matching', async () => {
+  stubDatabase({ optedOut: ['WiThDrAwN'] })
+  const policy = await getAppPolicy(['member', 'withdrawn'])
+  expect(Array.from(policy.members)).toEqual(['member'])
+  expect(hasBlockedParticipant(['WITHDRAWN', 'member'], policy.blocked)).toBe(
+    true,
+  )
+  expect(hasBlockedParticipant(['member'], policy.blocked)).toBe(false)
+})
+test('policy lookup failure fails closed instead of serving the saved snapshot', async () => {
+  const from = stubDatabase({ fail: true })
+  await expect(getAppPolicy(['member'])).rejects.toThrow('consent check failed')
+  expect(from).toHaveBeenCalledTimes(1)
+})
+test('rejects path traversal before accessing display storage', async () => {
+  await expect(
+    getBirdseyeAnalysis('../member', { prefix: 'v1/test' } as never, new Set()),
+  ).rejects.toThrow('Invalid Birdseye username')
+  expect(makeClient).not.toHaveBeenCalled()
+})
+
+test('withholds topics flagged by the original analysis or naming a withdrawn participant', async () => {
+  const clusters = [
+    { id: 'good', participants: ['member'] },
+    { id: 'low-quality', participants: ['member'] },
+    { id: 'withdrawn', participants: ['other'] },
+  ]
+  makeClient.mockReturnValue({
+    storage: {
+      from: () => ({
+        download: async () => ({
+          data: {
+            text: async () =>
+              JSON.stringify({ username: 'member', groups: [], clusters }),
+          },
+          error: null,
+        }),
+      }),
+    },
+  } as never)
+  const analysis = await getBirdseyeAnalysis(
+    'member',
+    {
+      prefix: 'v1/test',
+      birdseye: [{ username: 'member', hiddenClusterIds: ['low-quality'] }],
+    } as never,
+    new Set(['other']),
+  )
+  expect(analysis.clusters).toEqual([clusters[0]])
+})

--- a/src/lib/community-apps/data.ts
+++ b/src/lib/community-apps/data.ts
@@ -1,0 +1,113 @@
+import 'server-only'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { unstable_cache } from 'next/cache'
+import { createServerServiceRoleClient } from '@/utils/supabase'
+import type { AppDataManifest, BirdseyeAnalysis } from './types'
+const BUCKET = 'community-app-data'
+// Only normalized display data lives here. Never expose private Storage URLs,
+// credentials, pickle files, original archives, or embedding vectors.
+const readSnapshot = unstable_cache(
+  async (key: string): Promise<unknown> => {
+    if (!/^[a-zA-Z0-9_./-]+$/.test(key) || key.includes('..'))
+      throw new Error('Invalid app data path')
+    if (process.env.COMMUNITY_APP_DATA_DIR) {
+      return JSON.parse(
+        await readFile(
+          path.join(process.env.COMMUNITY_APP_DATA_DIR, key),
+          'utf8',
+        ),
+      )
+    }
+    const { data, error } = await createServerServiceRoleClient()
+      .storage.from(BUCKET)
+      .download(key)
+    if (error || !data) throw new Error('Community app data is unavailable')
+    return JSON.parse(await data.text())
+  },
+  ['community-app-display-data-v2'],
+  { revalidate: 300 },
+)
+
+export async function getAppDataManifest(): Promise<AppDataManifest> {
+  const manifest = (await readSnapshot('manifest.json')) as AppDataManifest
+  if (manifest.version !== 1 || !/^v1\/[a-zA-Z0-9_-]+$/.test(manifest.prefix))
+    throw new Error('Unsupported community app data manifest')
+  return manifest
+}
+// Policy is checked on every request, independently of the snapshot cache.
+export async function getAppPolicy(usernames: string[]) {
+  const admin = createServerServiceRoleClient()
+  const blocked = new Set<string>()
+  const blockedIds = new Set<string>()
+  for (let offset = 0; ; offset += 1000) {
+    const { data, error } = await admin
+      .from('optin')
+      .select('username,twitter_user_id')
+      .eq('explicit_optout', true)
+      .order('id')
+      .range(offset, offset + 999)
+    if (error) throw new Error('Community app consent check failed')
+    for (const row of data ?? []) {
+      blocked.add(row.username.toLowerCase())
+      if (row.twitter_user_id) blockedIds.add(row.twitter_user_id)
+    }
+    if ((data ?? []).length < 1000) break
+  }
+  const members = new Set<string>()
+  const names = Array.from(
+    new Set(usernames.map((name) => name.toLowerCase())),
+  ).filter((name) => /^[a-z0-9_]{1,15}$/.test(name))
+  for (let offset = 0; offset < names.length; offset += 40) {
+    const { data, error } = await admin
+      .from('user_directory')
+      .select('account_id,username,has_archive,is_opted_in')
+      .or(
+        names
+          .slice(offset, offset + 40)
+          .map((name) => `username.ilike.${name}`)
+          .join(','),
+      )
+    if (error) throw new Error('Community app membership check failed')
+    for (const row of data ?? []) {
+      if (
+        row.username &&
+        names.includes(row.username.toLowerCase()) &&
+        !blockedIds.has(row.account_id ?? '') &&
+        (row.has_archive || row.is_opted_in) &&
+        !blocked.has(row.username.toLowerCase())
+      )
+        members.add(row.username.toLowerCase())
+    }
+  }
+  return { blocked, blockedIds, members }
+}
+export function hasBlockedParticipant(
+  participants: string[],
+  blocked: Set<string>,
+) {
+  return participants.some((username) => blocked.has(username.toLowerCase()))
+}
+export async function getBirdseyeAnalysis(
+  username: string,
+  manifest: AppDataManifest,
+  blocked: Set<string>,
+) {
+  if (!/^[a-z0-9_]{1,15}$/.test(username))
+    throw new Error('Invalid Birdseye username')
+  const analysis = (await readSnapshot(
+    `${manifest.prefix}/birdseye/${username}.json`,
+  )) as BirdseyeAnalysis
+  const hidden = new Set(
+    manifest.birdseye.find((entry) => entry.username === username)
+      ?.hiddenClusterIds ?? [],
+  )
+  return {
+    ...analysis,
+    clusters: analysis.clusters.filter(
+      (cluster) =>
+        !hidden.has(cluster.id) &&
+        !hasBlockedParticipant(cluster.participants, blocked),
+    ),
+  }
+}

--- a/src/lib/community-apps/source-tweets.test.ts
+++ b/src/lib/community-apps/source-tweets.test.ts
@@ -1,0 +1,91 @@
+import { getSourceTweets } from './source-tweets'
+import { createServerServiceRoleClient } from '@/utils/supabase'
+import { isClickHouseReadsEnabled } from '@/lib/clickhouseGateway'
+import { fetchClickHouseTweetPageData } from '@/lib/clickhouseTweetPage'
+import { enrichPortalTweets } from '@/lib/portal/data'
+import { getAppPolicy } from './data'
+jest.mock('@/utils/supabase', () => ({
+  createServerServiceRoleClient: jest.fn(),
+}))
+jest.mock('@/lib/clickhouseGateway', () => ({
+  isClickHouseReadsEnabled: jest.fn(),
+}))
+jest.mock('@/lib/clickhouseTweetPage', () => ({
+  fetchClickHouseTweetPageData: jest.fn(),
+}))
+jest.mock('@/lib/portal/data', () => ({ enrichPortalTweets: jest.fn() }))
+jest.mock('./data', () => ({ getAppPolicy: jest.fn() }))
+beforeEach(() => {
+  jest.clearAllMocks()
+  jest.mocked(getAppPolicy).mockResolvedValue({
+    blocked: new Set(['withdrawn']),
+    blockedIds: new Set(['blocked-id']),
+    members: new Set(),
+  })
+})
+test('current opt-outs filter both authors and quoted authors after full enrichment', async () => {
+  jest.mocked(isClickHouseReadsEnabled).mockReturnValue(false)
+  const query = {
+    select: jest.fn().mockReturnThis(),
+    in: jest.fn().mockResolvedValue({
+      data: [
+        {
+          tweet_id: '123',
+          username: 'member',
+          created_at: '2020-01-01',
+          full_text: 'complete source',
+        },
+      ],
+      error: null,
+    }),
+  }
+  jest
+    .mocked(createServerServiceRoleClient)
+    .mockReturnValue({ from: () => query } as never)
+  const media = [{ url: 'https://example.org/photo.jpg', type: 'photo' }]
+  jest.mocked(enrichPortalTweets).mockImplementation(async (tweets) => [
+    {
+      ...tweets[0],
+      media,
+      quotedTweet: {
+        id: '234',
+        username: 'WITHDRAWN',
+        name: 'removed',
+        text: 'hidden',
+      } as never,
+    },
+    { ...tweets[0], id: '345', username: 'renamed', accountId: 'blocked-id' },
+  ])
+  const result = await getSourceTweets(['123', '123', '../bad'])
+  expect(query.in).toHaveBeenCalledWith('tweet_id', ['123'])
+  expect(Array.from(result.keys())).toEqual(['123'])
+  expect(result.get('123')).toMatchObject({
+    text: 'complete source',
+    media,
+    quotedTweet: undefined,
+  })
+})
+test('ClickHouse failures propagate without querying another record source', async () => {
+  jest.mocked(isClickHouseReadsEnabled).mockReturnValue(true)
+  jest
+    .mocked(fetchClickHouseTweetPageData)
+    .mockRejectedValue(new Error('offline'))
+  await expect(getSourceTweets(['123'])).rejects.toThrow('offline')
+  expect(createServerServiceRoleClient).not.toHaveBeenCalled()
+})
+test('oversized reads are rejected before querying', async () => {
+  await expect(
+    getSourceTweets(Array.from({ length: 101 }, (_, i) => String(i))),
+  ).rejects.toThrow('Too many')
+  expect(createServerServiceRoleClient).not.toHaveBeenCalled()
+})
+test('an absent ClickHouse post stays absent without breaking source loading', async () => {
+  jest.mocked(isClickHouseReadsEnabled).mockReturnValue(true)
+  jest
+    .mocked(fetchClickHouseTweetPageData)
+    .mockRejectedValue(
+      new Error('ClickHouse analytics request failed (404): not found'),
+    )
+  expect((await getSourceTweets(['123'])).size).toBe(0)
+  expect(createServerServiceRoleClient).not.toHaveBeenCalled()
+})

--- a/src/lib/community-apps/source-tweets.ts
+++ b/src/lib/community-apps/source-tweets.ts
@@ -1,0 +1,128 @@
+import 'server-only'
+import { createServerServiceRoleClient } from '@/utils/supabase'
+import { isClickHouseReadsEnabled } from '@/lib/clickhouseGateway'
+import { fetchClickHouseTweetPageData } from '@/lib/clickhouseTweetPage'
+import { enrichPortalTweets } from '@/lib/portal/data'
+import type { PortalTweet } from '@/lib/portal/types'
+import type { TweetData } from '@/lib/tweets/types'
+import { getAppPolicy } from './data'
+
+function fromTweet(tweet: TweetData): PortalTweet {
+  const quoted = tweet.quoted_tweet
+  return {
+    id: tweet.tweet_id,
+    accountId: tweet.account_id,
+    username: tweet.username,
+    name: tweet.account_display_name,
+    text: tweet.full_text,
+    avatar: tweet.avatar_media_url,
+    createdAt: tweet.created_at,
+    observedAt: tweet.created_at,
+    likes: tweet.favorite_count,
+    rts: tweet.retweet_count ?? 0,
+    retweetCountAvailable: tweet.retweet_count !== null,
+    media: tweet.media.map((m) => ({
+      url: m.media_url,
+      type: m.media_type,
+      width: m.width,
+      height: m.height,
+    })),
+    quotedTweet: quoted
+      ? {
+          id: quoted.tweet_id,
+          accountId: quoted.account_id,
+          username: quoted.username,
+          name: quoted.account_display_name,
+          avatar: quoted.avatar_media_url ?? null,
+          text: quoted.full_text,
+          createdAt: quoted.created_at,
+          likes: quoted.favorite_count,
+          rts: quoted.retweet_count ?? 0,
+          media: (quoted.media ?? []).map((m) => ({
+            url: m.media_url,
+            type: m.media_type,
+            width: m.width,
+            height: m.height,
+          })),
+          isDeleted: quoted.is_deleted,
+        }
+      : undefined,
+  }
+}
+
+/** Bounded cited-post reads with current opt-out checks. No corpus scan. */
+export async function getSourceTweets(input: string[]) {
+  const ids = Array.from(new Set(input.filter((id) => /^\d{1,20}$/.test(id))))
+  if (ids.length > 100) throw new Error('Too many source posts requested')
+  if (!ids.length) return new Map<string, PortalTweet>()
+  let tweets: PortalTweet[] = []
+  if (isClickHouseReadsEnabled()) {
+    // Use the same record source as /tweets/:id, with bounded concurrency.
+    for (let offset = 0; offset < ids.length; offset += 4) {
+      const rows = await Promise.all(
+        ids.slice(offset, offset + 4).map(async (id) => {
+          try {
+            return await fetchClickHouseTweetPageData(id)
+          } catch (error) {
+            if (
+              error instanceof Error &&
+              error.message.startsWith(
+                'ClickHouse analytics request failed (404):',
+              )
+            )
+              return null
+            throw error
+          }
+        }),
+      )
+      tweets.push(
+        ...rows.filter((t): t is TweetData => t !== null).map(fromTweet),
+      )
+    }
+  } else {
+    const { data, error } = await createServerServiceRoleClient()
+      .from('enriched_tweets')
+      .select(
+        'tweet_id,account_id,username,account_display_name,avatar_media_url,full_text,created_at,favorite_count,retweet_count',
+      )
+      .in('tweet_id', ids)
+    if (error) throw new Error('Unable to load source posts')
+    tweets = await enrichPortalTweets(
+      (data ?? []).flatMap((row) =>
+        row.tweet_id && row.username && row.created_at
+          ? [
+              {
+                id: row.tweet_id,
+                accountId: row.account_id ?? undefined,
+                username: row.username,
+                name: row.account_display_name ?? row.username,
+                avatar: row.avatar_media_url,
+                text: row.full_text ?? '',
+                createdAt: row.created_at,
+                observedAt: row.created_at,
+                likes: row.favorite_count ?? 0,
+                rts: row.retweet_count ?? 0,
+                retweetCountAvailable: row.retweet_count !== null,
+              },
+            ]
+          : [],
+      ),
+    )
+  }
+  const { blocked, blockedIds } = await getAppPolicy([])
+  const allowed = (tweet: { username: string; accountId?: string }) =>
+    !blocked.has(tweet.username.toLowerCase()) &&
+    !blockedIds.has(tweet.accountId ?? '')
+  return new Map(
+    tweets.filter(allowed).map((tweet) => [
+      tweet.id,
+      {
+        ...tweet,
+        quotedTweet:
+          tweet.quotedTweet && !allowed(tweet.quotedTweet)
+            ? undefined
+            : tweet.quotedTweet,
+      },
+    ]),
+  )
+}

--- a/src/lib/community-apps/types.ts
+++ b/src/lib/community-apps/types.ts
@@ -1,0 +1,25 @@
+export interface EvidenceItem {
+  label: string
+  description: string
+  tweetIds: string[]
+}
+export interface BirdseyeCluster {
+  id: string
+  name: string
+  summary: string
+  participants: string[]
+  tweetIds: string[]
+  years: { year: number; count: number }[]
+  sections: { name: string; items: EvidenceItem[] }[]
+}
+export interface BirdseyeAnalysis {
+  username: string
+  groups: { name: string; clusterIds: string[] }[]
+  clusters: BirdseyeCluster[]
+}
+export interface AppDataManifest {
+  version: 1
+  prefix: string
+  importedAt: string
+  birdseye: { username: string; hiddenClusterIds?: string[] }[]
+}

--- a/src/lib/communityProjects.test.ts
+++ b/src/lib/communityProjects.test.ts
@@ -5,7 +5,7 @@ import {
 
 describe('community project catalog', () => {
   it('contains only verified entries with source posts and no prototype filler', () => {
-    expect(COMMUNITY_PROJECTS).toHaveLength(11)
+    expect(COMMUNITY_PROJECTS).toHaveLength(12)
     expect(COMMUNITY_PROJECTS).not.toEqual(
       expect.arrayContaining([
         expect.objectContaining({ name: 'Ratio Radar' }),
@@ -20,6 +20,9 @@ describe('community project catalog', () => {
         expect(project.image).toBe(
           '/images/community/conversation-map-cover.png',
         )
+      } else if (project.slug === 'birdseye') {
+        expect(project.projectUrl).toBe('/birdseye')
+        expect(project.sourceTweetId).toBeUndefined()
       } else expect(project.sourceTweetId).toMatch(/^\d+$/)
       expect(project.projectUrl ?? '').not.toContain('example.com')
       expect(project.image ?? '').not.toContain('pbs.twimg.com')
@@ -50,7 +53,7 @@ describe('community project catalog', () => {
       'All',
       'Newest',
     )
-    expect(newest[0].name).toBe('Conversation Map')
+    expect(newest[0].name).toBe('Birdseye')
 
     const alphabetical = filterCommunityProjects(
       COMMUNITY_PROJECTS,
@@ -107,6 +110,7 @@ describe('community project catalog', () => {
     )
 
     expect(tools.map((project) => project.name)).toEqual([
+      'Birdseye',
       'Bangers.page',
       'Tweet Harvest',
       'Semantic Search',

--- a/src/lib/communityProjects.ts
+++ b/src/lib/communityProjects.ts
@@ -42,6 +42,22 @@ export interface CommunityProject {
  */
 export const COMMUNITY_PROJECTS: CommunityProject[] = [
   {
+    slug: 'birdseye',
+    name: 'Birdseye',
+    creator: 'Community Archive',
+    summary: 'Explore the topics and recurring ideas in a personal archive.',
+    description:
+      'A topic-by-topic view of saved archive analyses, with themes, ideas, referenced posts over time, and links to the original conversations.',
+    archiveUse:
+      'Reuses existing Birdseye analyses of archived posts. Browse topic groups and follow the cited source tweets on Community Archive.',
+    category: 'Tools',
+    tags: ['Personal archive', 'Topics', 'AI analysis'],
+    projectUrl: '/birdseye',
+    coverClass: 'from-[#d7e4ef] via-[#8bd2ee] to-[#1e9bcd]',
+    featured: true,
+    publishedAt: '2026-09-07',
+  },
+  {
     slug: 'conversation-map',
     name: 'Conversation Map',
     creator: 'Community Archive',

--- a/src/lib/localAdminPreview.test.ts
+++ b/src/lib/localAdminPreview.test.ts
@@ -1,0 +1,93 @@
+import { cookies, headers } from 'next/headers'
+import {
+  getLocalAdminPreview,
+  localAdminPreviewAllowed,
+} from './localAdminPreview'
+jest.mock('next/headers', () => ({ cookies: jest.fn(), headers: jest.fn() }))
+const originalEnv = process.env.NODE_ENV
+const originalPreview = process.env.LOCAL_ADMIN_PREVIEW
+beforeEach(() => {
+  process.env.LOCAL_ADMIN_PREVIEW = 'true'
+  jest.mocked(headers).mockReturnValue({ get: () => 'localhost:3031' } as never)
+  jest.mocked(cookies).mockReturnValue({ get: () => undefined } as never)
+})
+afterEach(() => {
+  if (originalPreview === undefined) delete process.env.LOCAL_ADMIN_PREVIEW
+  else process.env.LOCAL_ADMIN_PREVIEW = originalPreview
+  Object.defineProperty(process.env, 'NODE_ENV', {
+    value: originalEnv,
+    configurable: true,
+  })
+})
+test.each(['localhost:3031', '127.0.0.1:3000', '[::1]:3000'])(
+  'local development permits preview for %s only off deployment',
+  (host) => {
+    expect(localAdminPreviewAllowed(host, 'development', false)).toBe(true)
+    expect(localAdminPreviewAllowed(host, 'production', false)).toBe(false)
+    expect(localAdminPreviewAllowed(host, 'development', true)).toBe(false)
+  },
+)
+test.each([
+  null,
+  'community-archive.org',
+  'localhost.evil.test',
+  '192.168.1.1:3000',
+  'localhost@evil.test',
+])('does not unlock the preview on %s', (host) => {
+  expect(localAdminPreviewAllowed(host, 'development', false)).toBe(false)
+})
+test('starts in admin preview but honors logout on every subsequent request', async () => {
+  Object.defineProperty(process.env, 'NODE_ENV', {
+    value: 'development',
+    configurable: true,
+  })
+  expect(await getLocalAdminPreview()).toBe('admin')
+  jest
+    .mocked(cookies)
+    .mockReturnValue({ get: () => ({ value: 'signed-out' }) } as never)
+  expect(await getLocalAdminPreview()).toBe('signed-out')
+  Object.defineProperty(process.env, 'NODE_ENV', {
+    value: 'production',
+    configurable: true,
+  })
+  expect(await getLocalAdminPreview()).toBeNull()
+})
+
+test('requires the loopback-bound launcher opt-in', () => {
+  expect(
+    localAdminPreviewAllowed('localhost:3031', 'development', false, false),
+  ).toBe(false)
+})
+
+test('the preview session endpoint rejects cross-origin requests and persists logout', async () => {
+  const { NextRequest } = await import('next/server')
+  const { POST } = await import('@/app/api/auth/local-preview/route')
+  Object.defineProperty(process.env, 'NODE_ENV', {
+    value: 'development',
+    configurable: true,
+  })
+  const request = (origin: string) =>
+    new NextRequest('http://localhost:3031/api/auth/local-preview', {
+      method: 'POST',
+      headers: {
+        host: 'localhost:3031',
+        origin,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ enabled: false }),
+    })
+  expect((await POST(request('https://evil.test'))).status).toBe(403)
+  const response = await POST(request('http://localhost:3031'))
+  expect(response.status).toBe(200)
+  expect(response.cookies.get('ca-local-admin')).toMatchObject({
+    value: 'signed-out',
+    httpOnly: true,
+    sameSite: 'strict',
+  })
+  expect(response.cookies.get('birdseye-share')?.value).toBe('')
+  Object.defineProperty(process.env, 'NODE_ENV', {
+    value: 'production',
+    configurable: true,
+  })
+  expect((await POST(request('http://localhost:3031'))).status).toBe(404)
+})

--- a/src/lib/localAdminPreview.ts
+++ b/src/lib/localAdminPreview.ts
@@ -1,0 +1,22 @@
+import 'server-only'
+import { cookies, headers } from 'next/headers'
+
+export const LOCAL_ADMIN_COOKIE = 'ca-local-admin'
+/** UI/read preview only. Never use this to authorize a production mutation. */
+export function localAdminPreviewAllowed(
+  host: string | null,
+  nodeEnv = process.env.NODE_ENV,
+  deployed = !!process.env.VERCEL,
+  enabled = process.env.LOCAL_ADMIN_PREVIEW === 'true',
+) {
+  if (!enabled || nodeEnv !== 'development' || deployed || !host) return false
+  return /^(localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/.test(host)
+}
+export async function getLocalAdminPreview(): Promise<
+  'admin' | 'signed-out' | null
+> {
+  if (!localAdminPreviewAllowed((await headers()).get('host'))) return null
+  return (await cookies()).get(LOCAL_ADMIN_COOKIE)?.value === 'signed-out'
+    ? 'signed-out'
+    : 'admin'
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -520,6 +520,15 @@ export async function middleware(request: NextRequest) {
 
   // ── Stage 6: Security Headers (all responses) ──────────────────────────
   addSecurityHeaders(response)
+  if (
+    pathname === '/birdseye' ||
+    pathname.startsWith('/birdseye/') ||
+    pathname.startsWith('/api/birdseye/')
+  ) {
+    response.headers.set('Cache-Control', 'private, no-store')
+    response.headers.set('Referrer-Policy', 'no-referrer')
+    response.headers.set('X-Robots-Tag', 'noindex, nofollow')
+  }
 
   // Set rate limit cookie on final response
   const newRlData = (request as any).__newRlData as RateLimitData | undefined


### PR DESCRIPTION
Ship Birdseye independently of the unfinished Strands work. This branch starts from current main and adds only Birdseye, its Apps entry, protected saved-data readers, and the previously requested local admin preview.

Profiles open on a topic overview. Topic pages show the avatar/display-name header, expandable summary, three ranked samples, interactive monthly chart, yearly summaries, compact insight details, and grouped source reply threads. Analyses remain private by default, with owner-controlled revocable share links and read-only admin profile selection. Current membership and opt-outs apply to every read. The local admin preview is disabled in production and on deployed hosts.

No Strands routes, components, catalog entry, map data, or other unfinished issue-batch changes are included. Newer main-branch navigation, avatar, and search-rate-limit fixes are preserved. This supersedes the Birdseye portion of #914 and #922.

Validation: TypeScript, focused lint, and 56 focused tests pass, covering authorization, sharing/revocation, production preview denial, opt-outs, source fidelity, ranking, thread pagination, interactions, and affected navigation/catalog behavior. The existing production Storage bucket is private; its 208-profile manifest and a representative analysis are readable. No data upload, schema change, or new service is required. Local integration is verified against private Storage rather than a filesystem override before release.

Rollback: revert this release commit or restore the previous ready Vercel production deployment, dpl_B413gwHLfxy5ogFtDS2qnidzxgz9 (main 481d49c). Stored analyses and Auth sharing settings need no migration or rollback.
