### PR TITLE
Stabilize Strands search and expand selected thread context

### DIFF
--- a/docs/community-app-data.md
+++ b/docs/community-app-data.md
@@ -126,8 +126,8 @@ forms ten spatial clusters. Each cluster shares the hue of its centroid's angle
 around the collection centroid. Clustering happens before request filtering;
 only policy-eligible strands reach the minimap. Live search and incremental loading preserve stable colors. The server renders
 the initial 24 cards; `/api/strands` returns further batches of at most 24, applying
-the existing policy and tweet checks on every request. Search matches titles,
-handwritten labels, summaries, and usernames. Debounced search replaces only the
+the existing policy and tweet checks on every request. Search ranks matches by title (including handwritten labels), seed-post text,
+author/participant usernames, then strand summary; original rating breaks ties. Debounced search replaces only the
 feed; stale requests are aborted, and the minimap stays mounted. Intersection-based
 loading appends cards, with a manual retry/load-more fallback. Responses are no-store. Cluster buttons highlight in place without navigation or filtering
 the cards; All clears the highlight. The map supports zoom and source navigation.
@@ -175,13 +175,14 @@ total post count. The landing page’s “How does it work?” disclosure explai
 selection, structural and semantic connections, and AI narration in four numbered
 steps, followed by a short note about the limits of this method.
 
-Key posts offer an on-demand thread preview at
+The map automatically renders the selected post inside its archived thread.
+Timeline rows offer the same context on demand at
 `/api/strands/<seed>/context?tweet_id=<key-post>`. The endpoint first verifies
 that the seed is still eligible and the selected ID belongs to that strand.
 It uses the existing ClickHouse thread read, or the existing permalink RPC
 when ClickHouse reads are disabled; it does not recover missing tweets or write
-data. Current opt-outs break traversal before selecting at most five ancestors
-and five chronological descendants. Nearby continuations take precedence over
+data. Current opt-outs break traversal before selecting at most 20 ancestors
+and 20 chronological descendants. Nearby continuations take precedence over
 much later direct replies. The bounded selection is hydrated with the same
 full-fidelity tweet cards and final opt-out checks as other Strands posts.
 Unavailable context has a retry state and a full-conversation link. Timeline

--- a/src/app/strands/page.tsx
+++ b/src/app/strands/page.tsx
@@ -33,7 +33,7 @@ export default async function StrandsPage({
     : undefined
   const initialPage = await getStrandPage(query, 0)
   return (
-    <main className="mx-auto min-h-screen max-w-[1500px] px-5 py-10 sm:px-7">
+    <main className="mx-auto min-h-screen w-full max-w-[1500px] px-5 py-10 sm:px-7">
       <Link href="/community" className="text-sm font-semibold text-brand">
         ← Community Apps
       </Link>

--- a/src/components/strands/StrandBrowser.tsx
+++ b/src/components/strands/StrandBrowser.tsx
@@ -77,7 +77,7 @@ export function StrandFeed({
     <>
       <p className="mb-5 text-sm text-muted-foreground" role="status">
         {page
-          ? `${page.total} ${page.total === 1 ? 'strand' : 'strands'} · ordered by the original analysis’s rating`
+          ? `${page.total} ${page.total === 1 ? 'strand' : 'strands'} · ${query ? 'ordered by search relevance' : 'ordered by the original analysis’s rating'}`
           : 'Searching strands…'}
       </p>
       <section aria-label="Strands" className="space-y-7" aria-busy={loading}>
@@ -134,7 +134,7 @@ export function StrandBrowser({
   }, [input])
   return (
     <StrandFocusProvider>
-      <div className="grid items-start gap-8 lg:grid-cols-[minmax(0,1fr)_480px]">
+      <div className="grid w-full items-start gap-8 lg:grid-cols-[minmax(0,1fr)_480px]">
         <div className="min-w-0">
           <form
             onSubmit={(event) => {

--- a/src/components/strands/StrandMinimap.tsx
+++ b/src/components/strands/StrandMinimap.tsx
@@ -158,7 +158,7 @@ export default function StrandMinimap({
   return (
     <aside
       aria-label="Strands minimap"
-      className="order-first border border-border bg-card p-4 lg:sticky lg:top-20 lg:order-last lg:max-h-[calc(100vh-6rem)] lg:overflow-y-auto"
+      className="order-first border border-border bg-card p-4 [scrollbar-width:none] lg:sticky lg:top-20 lg:order-last lg:max-h-[calc(100vh-6rem)] lg:overflow-y-auto [&::-webkit-scrollbar]:hidden"
     >
       <div className="flex items-center justify-between gap-3">
         <h2 className="text-sm font-bold">A map of ideas</h2>
@@ -185,7 +185,7 @@ export default function StrandMinimap({
         Nearby dots are related strands. Ringed dots have your original map
         labels. Zoom to see more labels.
       </p>
-      <div className="mt-3 max-h-[29rem] overflow-auto border border-border bg-background">
+      <div className="mt-3 max-h-[29rem] overflow-auto border border-border bg-background [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         <svg
           viewBox="0 0 600 440"
           role="group"
@@ -313,7 +313,7 @@ export default function StrandMinimap({
                 </p>
               </div>
             </div>
-            <p className="mt-2 max-h-40 overflow-y-auto whitespace-pre-wrap">
+            <p className="mt-2 max-h-40 overflow-y-auto whitespace-pre-wrap [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
               {decodeTweetText(selected.text)}
             </p>
             <a

--- a/src/components/strands/StrandThreadContext.test.tsx
+++ b/src/components/strands/StrandThreadContext.test.tsx
@@ -1,0 +1,79 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { StrandThreadContext } from './StrandThreadContext'
+import type { PortalTweet } from '@/lib/portal/types'
+jest.mock('@/components/TweetCard', () => ({
+  __esModule: true,
+  default: ({ tweet }: { tweet: PortalTweet }) => (
+    <article>{tweet.text}</article>
+  ),
+}))
+beforeEach(() => {
+  global.fetch = jest.fn()
+})
+const result = {
+  before: [{ id: '1', text: 'Before' }],
+  after: [{ id: '3', text: 'After' }],
+}
+test('automatically shows before, selected, and after in order without a duplicate selected card', async () => {
+  ;(fetch as jest.Mock).mockResolvedValue({
+    ok: true,
+    json: async () => result,
+  })
+  render(
+    <StrandThreadContext seedId="2" tweetId="2">
+      <article>Selected</article>
+    </StrandThreadContext>,
+  )
+  await screen.findByText('After')
+  expect(screen.getAllByRole('article').map((el) => el.textContent)).toEqual([
+    'Before',
+    'Selected',
+    'After',
+  ])
+  expect(fetch).toHaveBeenCalledTimes(1)
+  expect(screen.queryByText('Show thread context')).not.toBeInTheDocument()
+})
+test('timeline context stays lazy and failures offer an explicit retry', async () => {
+  ;(fetch as jest.Mock)
+    .mockResolvedValueOnce({ ok: false })
+    .mockResolvedValueOnce({ ok: true, json: async () => result })
+  render(<StrandThreadContext seedId="2" tweetId="2" />)
+  expect(fetch).not.toHaveBeenCalled()
+  fireEvent.click(screen.getByText('Show thread context'))
+  await screen.findByRole('alert')
+  expect(fetch).toHaveBeenCalledTimes(1)
+  fireEvent.click(screen.getByText('Try again'))
+  await screen.findByText('After')
+  expect(fetch).toHaveBeenCalledTimes(2)
+})
+test('switching selected posts aborts the previous request and ignores its late response', async () => {
+  let resolveOld!: (value: unknown) => void
+  ;(fetch as jest.Mock)
+    .mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveOld = resolve
+        }),
+    )
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ before: [], after: [] }),
+    })
+  const { rerender } = render(
+    <StrandThreadContext key="2" seedId="2" tweetId="2">
+      <article>Old</article>
+    </StrandThreadContext>,
+  )
+  const signal = (fetch as jest.Mock).mock.calls[0][1].signal
+  rerender(
+    <StrandThreadContext key="4" seedId="2" tweetId="4">
+      <article>New</article>
+    </StrandThreadContext>,
+  )
+  await screen.findByText(/No surrounding posts/)
+  await act(async () => resolveOld({ ok: true, json: async () => result }))
+  expect(signal.aborted).toBe(true)
+  expect(screen.getAllByRole('article').map((el) => el.textContent)).toEqual([
+    'New',
+  ])
+})

--- a/src/components/strands/StrandThreadContext.tsx
+++ b/src/components/strands/StrandThreadContext.tsx
@@ -1,57 +1,67 @@
 'use client'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import Link from 'next/link'
 import TweetCard from '@/components/TweetCard'
 import type { PortalTweet } from '@/lib/portal/types'
+
 export function StrandThreadContext({
   seedId,
   tweetId,
+  children,
 }: {
   seedId: string
   tweetId: string
+  children?: ReactNode
 }) {
-  const [open, setOpen] = useState(false)
+  // The map supplies its selected post; timeline rows stay collapsed until opened.
+  const automatic = children !== undefined
+  const [open, setOpen] = useState(automatic)
   const [data, setData] = useState<{
     before: PortalTweet[]
     after: PortalTweet[]
   } | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
-  const controller = useRef<AbortController>()
-  useEffect(() => () => controller.current?.abort(), [])
-  async function load() {
-    if (loading) return
-    setOpen(true)
-    if (data) return
+  const [attempt, setAttempt] = useState(0)
+  useEffect(() => {
+    if (!open || data) return
     const abort = new AbortController()
-    controller.current = abort
-    setLoading(true)
-    setError('')
-    try {
-      const response = await fetch(
-        `/api/strands/${seedId}/context?tweet_id=${tweetId}`,
-        { signal: abort.signal, cache: 'no-store' },
-      )
-      if (!response.ok)
-        throw new Error('Thread context could not load. Please try again.')
-      setData(await response.json())
-    } catch (err) {
-      if (!abort.signal.aborted)
-        setError(err instanceof Error ? err.message : 'Please try again.')
-    } finally {
-      if (!abort.signal.aborted) setLoading(false)
+    async function load() {
+      setLoading(true)
+      setError('')
+      try {
+        const response = await fetch(
+          `/api/strands/${seedId}/context?tweet_id=${tweetId}`,
+          { signal: abort.signal, cache: 'no-store' },
+        )
+        if (!response.ok)
+          throw new Error('Thread context could not load. Please try again.')
+        const result = await response.json()
+        if (!abort.signal.aborted) setData(result)
+      } catch (err) {
+        if (!abort.signal.aborted)
+          setError(err instanceof Error ? err.message : 'Please try again.')
+      } finally {
+        if (!abort.signal.aborted) setLoading(false)
+      }
     }
-  }
+    void load()
+    return () => abort.abort()
+  }, [open, data, seedId, tweetId, attempt])
   return (
     <div className="mt-4 border-t border-border pt-3">
       <div className="flex flex-wrap justify-between gap-3 text-xs font-semibold">
-        <button
-          aria-expanded={open}
-          onClick={() => (open ? setOpen(false) : void load())}
-          className="text-brand"
-        >
-          {open ? 'Hide thread context' : 'Show thread context'}
-        </button>
+        {automatic ? (
+          <h3>Selected post and its thread</h3>
+        ) : (
+          <button
+            aria-expanded={open}
+            onClick={() => setOpen(!open)}
+            className="text-brand"
+          >
+            {open ? 'Hide thread context' : 'Show thread context'}
+          </button>
+        )}
         <Link
           prefetch={false}
           href={`/tweets/${tweetId}`}
@@ -63,52 +73,47 @@ export function StrandThreadContext({
       {open && (
         <div className="mt-4 space-y-3 rounded-lg border border-border bg-muted/20 p-3">
           <p className="text-xs text-muted-foreground">
-            Up to five ancestors and five nearby replies, following this post’s
-            thread.
+            Archived thread · up to 20 posts before and 20 replies after the
+            selected post.
           </p>
           {loading && (
             <p role="status" className="text-sm">
-              Loading context…
+              Loading thread…
             </p>
           )}
           {error && (
             <p role="alert" className="text-sm">
               {error}{' '}
               <button
-                onClick={() => void load()}
+                onClick={() => setAttempt((n) => n + 1)}
                 className="text-brand underline"
               >
                 Try again
               </button>
             </p>
           )}
-          {data && (
-            <>
-              {data.before.length > 0 && (
-                <h4 className="text-xs font-bold uppercase tracking-wide">
-                  Before this post
-                </h4>
-              )}
-              {data.before.map((tweet) => (
-                <TweetCard key={tweet.id} tweet={tweet} noClamp showDate />
-              ))}
-              <div className="border-y border-dashed border-border py-3 text-center text-xs font-semibold">
-                Selected key post ↑
-              </div>
-              {data.after.length > 0 && (
-                <h4 className="text-xs font-bold uppercase tracking-wide">
-                  Nearby replies
-                </h4>
-              )}
-              {data.after.map((tweet) => (
-                <TweetCard key={tweet.id} tweet={tweet} noClamp showDate />
-              ))}
-              {!data.before.length && !data.after.length && (
-                <p className="text-sm text-muted-foreground">
-                  No surrounding posts are currently available in the archive.
-                </p>
-              )}
-            </>
+          {data?.before.map((tweet) => (
+            <TweetCard key={tweet.id} tweet={tweet} noClamp showDate />
+          ))}
+          {children ? (
+            <div className="border-y border-brand/40 py-4">
+              <p className="mb-3 text-xs font-semibold text-brand">
+                Selected post
+              </p>
+              {children}
+            </div>
+          ) : data ? (
+            <div className="border-y border-dashed border-border py-3 text-center text-xs font-semibold">
+              Selected key post ↑
+            </div>
+          ) : null}
+          {data?.after.map((tweet) => (
+            <TweetCard key={tweet.id} tweet={tweet} noClamp showDate />
+          ))}
+          {data && !data.before.length && !data.after.length && (
+            <p className="text-sm text-muted-foreground">
+              No surrounding posts are currently available in the archive.
+            </p>
           )}
         </div>
       )}

--- a/src/components/strands/StrandTimeline.test.tsx
+++ b/src/components/strands/StrandTimeline.test.tsx
@@ -8,6 +8,9 @@ jest.mock('@/components/TweetCard', () => ({
   ),
 }))
 jest.mock('@/components/portal/TweetRow', () => ({ TweetAvatar: () => null }))
+beforeEach(() => {
+  global.fetch = jest.fn(() => new Promise(() => {}))
+})
 const tweet = (id: string, createdAt: string): PortalTweet => ({
   id,
   createdAt,

--- a/src/components/strands/StrandTimeline.tsx
+++ b/src/components/strands/StrandTimeline.tsx
@@ -23,7 +23,15 @@ const date = (time: number) =>
     year: 'numeric',
     timeZone: 'UTC',
   })
-function Post({ post, seedId }: { post: StrandPost; seedId: string }) {
+function Post({
+  post,
+  seedId,
+  threadToggle = true,
+}: {
+  post: StrandPost
+  seedId: string
+  threadToggle?: boolean
+}) {
   return (
     <div className="min-w-0">
       <div className="mb-3 flex items-center gap-2 text-xs font-semibold text-muted-foreground">
@@ -52,7 +60,9 @@ function Post({ post, seedId }: { post: StrandPost; seedId: string }) {
       <p className="mt-4 text-sm leading-6 text-muted-foreground">
         {post.annotation}
       </p>
-      <StrandThreadContext key={post.id} seedId={seedId} tweetId={post.id} />
+      {threadToggle && (
+        <StrandThreadContext key={post.id} seedId={seedId} tweetId={post.id} />
+      )}
     </div>
   )
 }
@@ -296,7 +306,13 @@ export default function StrandTimeline({
                   Next post →
                 </button>
               </div>
-              <Post key={current.id} post={current} seedId={seedId} />
+              <StrandThreadContext
+                key={current.id}
+                seedId={seedId}
+                tweetId={current.id}
+              >
+                <Post post={current} seedId={seedId} threadToggle={false} />
+              </StrandThreadContext>
             </div>
           )}
         </>

--- a/src/lib/community-apps/strand-context.test.ts
+++ b/src/lib/community-apps/strand-context.test.ts
@@ -4,13 +4,13 @@ const node = (id: string, parent: string | null) => ({
   reply_to_tweet_id: parent,
   created_at: id.padStart(4, '0'),
 })
-test('bounds ancestry and descendants to five, preserves edges, and handles cycles', () => {
-  const nodes = Array.from({ length: 20 }, (_, i) =>
+test('bounds ancestry and descendants to twenty, preserves edges, and handles cycles', () => {
+  const nodes = Array.from({ length: 60 }, (_, i) =>
     node(String(i), i ? String(i - 1) : null),
   )
-  expect(selectStrandContext(nodes, '8')).toEqual({
-    before: ['3', '4', '5', '6', '7'],
-    after: ['9', '10', '11', '12', '13'],
+  expect(selectStrandContext(nodes, '30')).toEqual({
+    before: Array.from({ length: 20 }, (_, i) => String(i + 10)),
+    after: Array.from({ length: 20 }, (_, i) => String(i + 31)),
   })
   expect(selectStrandContext([node('1', '2'), node('2', '1')], '1')).toEqual({
     before: ['2'],

--- a/src/lib/community-apps/strand-context.ts
+++ b/src/lib/community-apps/strand-context.ts
@@ -12,7 +12,7 @@ export function selectStrandContext(
     after: string[] = [],
     seen = new Set([selectedId])
   let cursor = byId.get(selectedId)
-  while (cursor?.reply_to_tweet_id && before.length < 5) {
+  while (cursor?.reply_to_tweet_id && before.length < 20) {
     const parent = byId.get(cursor.reply_to_tweet_id)
     if (!parent || seen.has(parent.tweet_id)) break
     seen.add(parent.tweet_id)
@@ -32,7 +32,7 @@ export function selectStrandContext(
       ])
   }
   const queue = [...(children.get(selectedId) ?? [])]
-  while (queue.length && after.length < 5) {
+  while (queue.length && after.length < 20) {
     // Prioritize the nearby continuation over a years-later direct reply.
     queue.sort(
       (a, b) =>

--- a/src/lib/community-apps/strand-list.test.ts
+++ b/src/lib/community-apps/strand-list.test.ts
@@ -26,3 +26,40 @@ test('search and pagination hydrate at most 24 policy-filtered seeds, with stabl
   expect((await getStrandPage('no match', 0)).items).toEqual([])
   expect((await getStrandPage('Vibetober', 0)).total).toBe(27)
 })
+
+test('ranks title and handwritten labels, seed text, usernames, then summary before rating', async () => {
+  const base = {
+    title: 'Other',
+    text: '',
+    username: 'writer',
+    participants: [],
+    summary: 'Other',
+    rating: 0,
+  }
+  ;(getStrands as jest.Mock).mockResolvedValue({
+    strands: [
+      { ...base, id: 'summary', summary: 'Portal story', rating: 100 },
+      { ...base, id: 'username', username: 'portal', rating: 90 },
+      {
+        ...base,
+        id: 'participant',
+        participants: ['PortalFriend'],
+        rating: 80,
+      },
+      { ...base, id: 'text', text: 'Building PORTAL together', rating: 70 },
+      { ...base, id: 'title', title: 'Portal', rating: 60 },
+      { ...base, id: 'label', mapLabel: 'Portal in Porto', rating: 50 },
+      { ...base, id: 'absent', rating: 200 },
+    ],
+  })
+  ;(getStrandTweets as jest.Mock).mockResolvedValue(new Map())
+  expect((await getStrandPage(' PORTAL ', 0)).items.map((s) => s.id)).toEqual([
+    'title',
+    'label',
+    'text',
+    'username',
+    'participant',
+    'summary',
+  ])
+  expect((await getStrandPage('', 0)).items[0].id).toBe('absent')
+})

--- a/src/lib/community-apps/strand-list.ts
+++ b/src/lib/community-apps/strand-list.ts
@@ -10,12 +10,25 @@ export async function getStrandPage(
   const { strands } = await getStrands()
   const search = query.trim().slice(0, 120).toLowerCase()
   const filtered = strands
-    .filter((strand) =>
-      `${strand.title} ${strand.mapLabel ?? ''} ${strand.summary} ${strand.username}`
-        .toLowerCase()
-        .includes(search),
+    .map((strand) => ({
+      strand,
+      rank: search
+        ? [
+            `${strand.title} ${strand.mapLabel ?? ''}`,
+            strand.text ?? '',
+            [strand.username, ...(strand.participants ?? [])].join(' '),
+            strand.summary,
+          ].findIndex((field) => field.toLowerCase().includes(search))
+        : 0,
+    }))
+    .filter(({ rank }) => rank >= 0)
+    .sort(
+      (a, b) =>
+        a.rank - b.rank ||
+        b.strand.rating - a.strand.rating ||
+        a.strand.id.localeCompare(b.strand.id),
     )
-    .sort((a, b) => b.rating - a.rating || a.id.localeCompare(b.id))
+    .map(({ strand }) => strand)
   const visible = filtered.slice(offset, offset + 24)
   const tweets = await getStrandTweets(visible.map((s) => s.id))
   return {


### PR DESCRIPTION
Search briefly shrank the Strands columns when replacing cards with its loading state. Give the page its full available width and hide minimap scrollbars while preserving scrolling, so search and hover keep the same column widths.

Search now ranks title/handwritten-label matches before seed-post text, author/participant usernames, and summary matches, with original rating as the tie-breaker. Under the conversation map, the selected post automatically appears inside its archived thread, capped at 20 ancestors and 20 descendants. Timeline context remains on demand; switching posts aborts stale requests, and failures offer retry.

Validation: 16 focused tests passed (ranking, bounds/privacy boundaries, automatic context, stale responses, retries, and existing map/timeline/search behavior); TypeScript and scoped ESLint passed. Local browser confirmed identical desktop columns (857px / 480px) before search, during loading, and after results, plus hidden minimap scrollbars. A local strand detail automatically rendered the selected seed plus 20 thread posts with full tweet cards. No schema or data writes. Separate follow-up to the shipped #914 release.
