### PR TITLE
Keep desktop navigation visible and credit the Bulletin prototype

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -100,7 +100,7 @@ export default function RootLayout({
                           priority
                         />
                         <span
-                          className="hidden whitespace-nowrap text-lg font-bold text-foreground sm:inline"
+                          className="hidden whitespace-nowrap text-lg font-bold text-foreground sm:inline lg:hidden 2xl:inline"
                           style={{
                             fontFamily:
                               'var(--font-petrona), Georgia, "Times New Roman", serif',
@@ -111,7 +111,7 @@ export default function RootLayout({
                       </PostHogLink>
                       <AudienceHeaderNavigation kind="primary" />
                     </div>
-                    <div className="flex flex-shrink-0 items-center space-x-3">
+                    <div className="flex flex-shrink-0 items-center space-x-2 2xl:space-x-3">
                       <AudienceHeaderNavigation kind="utility" />
                       <HeaderSearch />
                       <div className="text-sm">

--- a/src/app/opportunities/page.tsx
+++ b/src/app/opportunities/page.tsx
@@ -32,8 +32,12 @@ export default async function OpportunitiesPage() {
           <h1 className="text-2xl font-semibold tracking-tight">
             Opportunities
           </h1>
-          <p className="hidden text-sm text-muted-foreground sm:block">
-            Asks and offers from the community, collected daily.
+          <p className="text-xs text-muted-foreground">
+            Thanks to{' '}
+            <Link href="/user/maskys_" className="text-brand hover:underline">
+              @maskys_
+            </Link>{' '}
+            for the first prototype.
           </p>
         </div>
         <div className="flex items-center gap-3">

--- a/src/components/HeaderNavigation.tsx
+++ b/src/components/HeaderNavigation.tsx
@@ -21,7 +21,7 @@ export default function HeaderNavigation({ items }: { items: NavItem[] }) {
   const pathname = usePathname()
 
   return (
-    <NavigationMenu className="hidden 2xl:flex">
+    <NavigationMenu className="hidden lg:flex">
       <NavigationMenuList>
         {items.map((item) => {
           const isActive = isNavItemActive(pathname, item.href)
@@ -38,7 +38,7 @@ export default function HeaderNavigation({ items }: { items: NavItem[] }) {
                   }
                   className={cn(
                     navigationMenuTriggerStyle(),
-                    'px-2.5 text-xs transition-colors duration-150 hover:bg-accent 2xl:px-2.5 2xl:text-sm',
+                    'px-1.5 text-xs transition-colors duration-150 hover:bg-accent 2xl:px-2.5 2xl:text-sm',
                     isActive ? 'bg-muted font-semibold' : '',
                   )}
                 >

--- a/src/components/HeaderSearch.tsx
+++ b/src/components/HeaderSearch.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { Search } from 'lucide-react'
 import UserSearchInput from '@/components/UserSearchInput'
@@ -24,18 +25,30 @@ export default function HeaderSearch() {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="hidden items-center sm:flex">
-      <div className="relative">
-        <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-        <UserSearchInput
-          placeholder="Search tweets..."
-          value={query}
-          onValueChange={setQuery}
-          className="h-9 w-40 border-border bg-muted py-1.5 pl-8 pr-3 text-sm focus:ring-brand lg:w-56"
-          aria-label="Search Community Archive"
-          autoComplete="off"
-        />
-      </div>
-    </form>
+    <>
+      <Link
+        href="/search"
+        aria-label="Search Community Archive"
+        className="hidden h-9 w-9 items-center justify-center rounded-md border border-input hover:bg-accent lg:inline-flex 2xl:hidden"
+      >
+        <Search className="h-4 w-4" aria-hidden="true" />
+      </Link>
+      <form
+        onSubmit={handleSubmit}
+        className="hidden items-center sm:flex lg:hidden 2xl:flex"
+      >
+        <div className="relative">
+          <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <UserSearchInput
+            placeholder="Search tweets..."
+            value={query}
+            onValueChange={setQuery}
+            className="h-9 w-40 border-border bg-muted py-1.5 pl-8 pr-3 text-sm focus:ring-brand lg:w-56"
+            aria-label="Search Community Archive"
+            autoComplete="off"
+          />
+        </div>
+      </form>
+    </>
   )
 }

--- a/src/components/MobileNavigation.tsx
+++ b/src/components/MobileNavigation.tsx
@@ -26,7 +26,7 @@ export default function MobileNavigation({ items }: { items: NavItem[] }) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="icon" className="2xl:hidden">
+        <Button variant="outline" size="icon" className="lg:hidden">
           <Menu className="h-5 w-5" />
           <span className="sr-only">Open navigation menu</span>
         </Button>
@@ -34,7 +34,7 @@ export default function MobileNavigation({ items }: { items: NavItem[] }) {
       <DropdownMenuContent
         align="end"
         sideOffset={8}
-        className="w-56 rounded-lg p-2 2xl:hidden"
+        className="w-56 rounded-lg p-2 lg:hidden"
       >
         <DropdownMenuLabel className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
           Navigation

--- a/src/lib/projectContributors.ts
+++ b/src/lib/projectContributors.ts
@@ -17,6 +17,11 @@ export const currentProjectContributors: ProjectContributor[] = [
     username: 'christineist',
     role: 'Contributor',
   },
+  {
+    name: 'Kifah',
+    username: 'maskys_',
+    role: 'Bulletin prototype',
+  },
 ]
 
 export const pastProjectContributors: ProjectContributor[] = [


### PR DESCRIPTION
Show the full navbar from 1,024px wide, with a compact logo and search shortcut until the wider desktop layout fits. Smaller screens retain the navigation menu. Opportunities still requires login.

Thank @maskys_ for the first prototype on the Opportunities page, link to his archive profile, and add Kifah to the existing contributor roster so his profile receives the Archive contributor badge.

Validation: 18 focused navigation/profile tests and scoped lint passed. Browser verified the signed-in navbar fits at 1,057px with no horizontal overflow, the credit links correctly, and the badge appears on /user/maskys_. No database changes.
