### PR TITLE
Reduce Opportunities loading work with batched tweets and Load more

### DIFF
--- a/src/app/api/bulletin/tweet/[id]/route.ts
+++ b/src/app/api/bulletin/tweet/[id]/route.ts
@@ -1,53 +1,9 @@
 import { NextResponse } from 'next/server'
-import {
-  requireOpportunityUser,
-  loadBulletinBoardState,
-} from '@/lib/bulletin/data'
-import { fetchAnalyticsGatewayJson } from '@/lib/clickhouseGateway'
-import { fetchClickHouseTweetPageData } from '@/lib/clickhouseTweetPage'
-import type { PortalTweet } from '@/lib/portal/types'
-import type { TweetData } from '@/lib/tweets/types'
+import { requireOpportunityUser } from '@/lib/bulletin/data'
+import { loadBulletinTweets } from '@/lib/bulletin/tweets'
 
 export const dynamic = 'force-dynamic'
 const headers = { 'Cache-Control': 'private, no-store' }
-function card(tweet: TweetData): PortalTweet {
-  const mapMedia = (items: TweetData['media'] | undefined) =>
-    (items || []).map((m) => ({
-      url: m.media_url,
-      type: m.media_type,
-      width: m.width,
-      height: m.height,
-    }))
-  const q = tweet.quoted_tweet
-  return {
-    id: tweet.tweet_id,
-    accountId: tweet.account_id,
-    username: tweet.username,
-    name: tweet.account_display_name,
-    avatar: tweet.avatar_media_url || null,
-    text: tweet.full_text,
-    createdAt: tweet.created_at,
-    observedAt: tweet.created_at,
-    likes: tweet.favorite_count || 0,
-    rts: tweet.retweet_count || 0,
-    media: mapMedia(tweet.media),
-    quotedTweet: q
-      ? {
-          id: q.tweet_id,
-          accountId: q.account_id,
-          username: q.username,
-          name: q.account_display_name,
-          avatar: q.avatar_media_url || null,
-          text: q.full_text,
-          createdAt: q.created_at,
-          likes: q.favorite_count || 0,
-          rts: q.retweet_count || 0,
-          media: mapMedia(q.media),
-          isDeleted: q.is_deleted,
-        }
-      : undefined,
-  }
-}
 export async function GET(
   _request: Request,
   { params }: { params: { id: string } },
@@ -59,52 +15,13 @@ export async function GET(
       { status: 400, headers },
     )
   try {
-    // These reads are independent; validate all results before returning content.
-    const [{ notices, allowedAccounts }, current, result] = await Promise.all([
-      loadBulletinBoardState(),
-      fetchAnalyticsGatewayJson<{
-        data: Array<{
-          tweet_id: string
-          account_id: string
-          content_hash: string
-          reply_to_tweet_id: string | null
-          retweet: boolean
-          full_text: string
-        }>
-      }>(['bulletin-sources'], new URLSearchParams({ ids: params.id })),
-      fetchClickHouseTweetPageData(params.id, (path, params) =>
-        fetchAnalyticsGatewayJson(path, params),
-      ),
-    ])
-    const notice = notices.find((n) => n.tweet_id === params.id)
-    if (!notice)
+    const result = await loadBulletinTweets([params.id])
+    if (!result.tweets.length)
       return NextResponse.json(
-        { error: 'Notice unavailable' },
-        { status: 404, headers },
+        { error: 'Original post unavailable' },
+        { status: result.errors[params.id] || 503, headers },
       )
-    const source = current.data.find((row) => row.tweet_id === params.id)
-    if (
-      !source ||
-      source.content_hash !== notice.content_hash ||
-      source.reply_to_tweet_id ||
-      source.retweet ||
-      source.full_text.startsWith('RT @')
-    )
-      throw new Error('Source unavailable')
-    if (
-      !result ||
-      (notice.account_id
-        ? result.account_id !== notice.account_id
-        : !allowedAccounts?.includes(result.account_id))
-    )
-      throw new Error('Source unavailable')
-    const { createHash } = await import('crypto')
-    if (
-      createHash('sha256').update(result.full_text).digest('hex') !==
-      notice.content_hash
-    )
-      throw new Error('Source changed')
-    return NextResponse.json(card(result), { headers })
+    return NextResponse.json(result.tweets[0], { headers })
   } catch {
     return NextResponse.json(
       { error: 'Original post could not be loaded. Try again.' },

--- a/src/app/api/bulletin/tweets/route.ts
+++ b/src/app/api/bulletin/tweets/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server'
+import { requireOpportunityUser } from '@/lib/bulletin/data'
+import { loadBulletinTweets } from '@/lib/bulletin/tweets'
+
+export const dynamic = 'force-dynamic'
+const headers = { 'Cache-Control': 'private, no-store' }
+export async function GET(request: Request) {
+  await requireOpportunityUser()
+  const ids = Array.from(
+    new Set((new URL(request.url).searchParams.get('ids') || '').split(',')),
+  )
+  if (ids.length > 8 || ids.some((id) => !/^\d{1,20}$/.test(id)))
+    return NextResponse.json(
+      { error: 'Provide 1–8 tweet IDs' },
+      { status: 400, headers },
+    )
+  try {
+    const result = await loadBulletinTweets(ids)
+    return NextResponse.json({ tweets: result.tweets }, { headers })
+  } catch {
+    return NextResponse.json(
+      { error: 'Original posts could not be loaded. Try again.' },
+      { status: 503, headers },
+    )
+  }
+}

--- a/src/app/opportunities/loading.tsx
+++ b/src/app/opportunities/loading.tsx
@@ -1,0 +1,24 @@
+export default function LoadingOpportunities() {
+  return (
+    <main
+      className="mx-auto w-full max-w-[1800px] space-y-4 px-4 py-4 sm:px-6"
+      aria-busy="true"
+    >
+      <h1 className="text-2xl font-semibold tracking-tight">Opportunities</h1>
+      <p role="status" className="text-sm text-muted-foreground">
+        Loading opportunities…
+      </p>
+      <div
+        className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4"
+        aria-hidden="true"
+      >
+        {Array.from({ length: 4 }, (_, i) => (
+          <div
+            key={i}
+            className="h-[338px] animate-pulse rounded-lg border bg-muted/40"
+          />
+        ))}
+      </div>
+    </main>
+  )
+}

--- a/src/app/opportunities/page.tsx
+++ b/src/app/opportunities/page.tsx
@@ -17,14 +17,11 @@ export const metadata: Metadata = {
 
 export default async function OpportunitiesPage() {
   await requireOpportunityUser()
-  const isAdmin = await isBulletinAdmin()
-  const personal = await loadBulletinRelationships()
-  let opportunities
-  try {
-    opportunities = await loadOpportunities()
-  } catch {
-    opportunities = null
-  }
+  const [isAdmin, personal, opportunities] = await Promise.all([
+    isBulletinAdmin(),
+    loadBulletinRelationships(),
+    loadOpportunities().catch(() => null),
+  ])
   return (
     <main className="mx-auto min-h-[70vh] w-full min-w-0 max-w-[1800px] space-y-4 px-4 py-4 sm:px-6">
       <header className="flex flex-wrap items-center justify-between gap-x-6 gap-y-2">
@@ -59,6 +56,7 @@ export default async function OpportunitiesPage() {
         </div>
       ) : (
         <OpportunityBoard
+          key={Date.now()}
           opportunities={opportunities}
           me={personal.account_id}
           username={personal.username}

--- a/src/components/bulletin/OpportunityBoard.test.tsx
+++ b/src/components/bulletin/OpportunityBoard.test.tsx
@@ -34,6 +34,7 @@ jest.mock('@/components/portal/TweetRow', () => ({
 }))
 let intersections: IntersectionObserverCallback[]
 beforeEach(() => {
+  jest.useFakeTimers()
   window.history.replaceState(null, '', '/opportunities')
   intersections = []
   window.IntersectionObserver = jest.fn((callback) => {
@@ -42,8 +43,12 @@ beforeEach(() => {
   }) as unknown as typeof IntersectionObserver
   global.fetch = jest
     .fn()
-    .mockResolvedValue({ ok: true, json: async () => ({ id: '1' }) })
+    .mockResolvedValue({
+      ok: true,
+      json: async () => ({ tweets: [{ id: '1' }, { id: '2' }] }),
+    })
 })
+afterEach(() => jest.useRealTimers())
 test('loads the original automatically near the viewport without fetching every notice', async () => {
   render(
     <OpportunityBoard
@@ -58,9 +63,12 @@ test('loads the original automatically near the viewport without fetching every 
       {} as IntersectionObserver,
     )
   })
+  await act(async () => {
+    jest.advanceTimersByTime(25)
+  })
   expect(fetch).toHaveBeenCalledTimes(1)
   expect(fetch).toHaveBeenCalledWith(
-    '/api/bulletin/tweet/1',
+    '/api/bulletin/tweets?ids=1',
     expect.objectContaining({ cache: 'no-store' }),
   )
   expect(screen.getByText('Original card')).toBeInTheDocument()
@@ -94,4 +102,66 @@ test('past toggle includes expired notices and preserves filters in the URL', ()
   expect(screen.getByRole('status')).toHaveTextContent('1 of 1 notices')
   expect(window.location.hash).toContain('past=1')
   expect(screen.getByText('Help with Python')).toBeInTheDocument()
+})
+
+test('coalesces visible cards into one request and reuses loaded cards after filtering', async () => {
+  render(
+    <OpportunityBoard
+      opportunities={[offer, ask]}
+      now={Date.parse('2026-09-09T00:00:00Z')}
+    />,
+  )
+  await act(async () => {
+    for (const callback of intersections)
+      callback(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      )
+  })
+  await act(async () => {
+    jest.advanceTimersByTime(25)
+  })
+  expect(fetch).toHaveBeenCalledTimes(1)
+  expect(fetch).toHaveBeenCalledWith(
+    '/api/bulletin/tweets?ids=1,2',
+    expect.any(Object),
+  )
+  expect(screen.getAllByText('Original card')).toHaveLength(2)
+  fireEvent.click(screen.getByRole('button', { name: 'Help 1' }))
+  fireEvent.click(screen.getByRole('button', { name: 'All categories 2' }))
+  await act(async () => {
+    intersections[intersections.length - 1](
+      [{ isIntersecting: true } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    )
+  })
+  await act(async () => {
+    jest.advanceTimersByTime(25)
+  })
+  expect(fetch).toHaveBeenCalledTimes(1)
+})
+
+test('pages cards while search and counts still cover all notices', () => {
+  const notices = Array.from({ length: 14 }, (_, i) => ({
+    ...offer,
+    tweet_id: String(i + 1),
+    summary: `Offer number ${i + 1}`,
+  }))
+  render(
+    <OpportunityBoard
+      opportunities={notices}
+      now={Date.parse('2026-09-09T00:00:00Z')}
+    />,
+  )
+  expect(screen.getByRole('status')).toHaveTextContent('14 of 14 notices')
+  expect(screen.getAllByRole('article')).toHaveLength(6)
+  fireEvent.click(screen.getByRole('button', { name: 'Load more offers' }))
+  expect(screen.getAllByRole('article')).toHaveLength(12)
+  fireEvent.change(screen.getByLabelText('Search opportunities'), {
+    target: { value: 'Offer number 14' },
+  })
+  expect(screen.getByText('Offer number 14')).toBeInTheDocument()
+  expect(
+    screen.queryByRole('button', { name: 'Load more offers' }),
+  ).not.toBeInTheDocument()
 })

--- a/src/components/bulletin/OpportunityBoard.tsx
+++ b/src/components/bulletin/OpportunityBoard.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { useTweetBatch } from './useTweetBatch'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { TweetCard } from '@/components/TweetCard'
@@ -16,7 +17,13 @@ const EMPTY_GRAPH: BulletinRelationships = {
   outgoing: {},
   available: false,
 }
-function Original({ id }: { id: string }) {
+function Original({
+  id,
+  loadTweet,
+}: {
+  id: string
+  loadTweet: (id: string) => Promise<PortalTweet>
+}) {
   const container = useRef<HTMLDivElement>(null)
   const [visible, setVisible] = useState(false)
   const [tweet, setTweet] = useState<PortalTweet | null>(null)
@@ -43,20 +50,15 @@ function Original({ id }: { id: string }) {
     if (!visible) return
     const controller = new AbortController()
     setError(false)
-    fetch(`/api/bulletin/tweet/${id}`, {
-      signal: controller.signal,
-      cache: 'no-store',
-    })
-      .then(async (r) => {
-        if (!r.ok) throw new Error()
-        return r.json()
+    loadTweet(id)
+      .then((tweet) => {
+        if (!controller.signal.aborted) setTweet(tweet)
       })
-      .then(setTweet)
       .catch(() => {
         if (!controller.signal.aborted) setError(true)
       })
     return () => controller.abort()
-  }, [id, visible, attempt])
+  }, [id, visible, attempt, loadTweet])
   return (
     <div ref={container} className="min-w-0">
       {tweet ? (
@@ -105,6 +107,8 @@ export function OpportunityBoard({
   graph?: BulletinRelationships
   now?: number
 }) {
+  const loadTweet = useTweetBatch()
+  const [pageSize, setPageSize] = useState({ offer: 6, ask: 6 })
   const [kind, setKind] = useState('all')
   const [search, setSearch] = useState('')
   const [past, setPast] = useState(false)
@@ -150,6 +154,15 @@ export function OpportunityBoard({
         now,
       ),
     [opportunities, kind, past, search, recommended, me, graph, now],
+  )
+  useEffect(() => {
+    setPageSize({ offer: 6, ask: 6 })
+  }, [kind, search, past, recommended])
+  const shown = (['offer', 'ask'] as const).reduce(
+    (count, side) =>
+      count +
+      Math.min(pageSize[side], visible.filter((o) => o.side === side).length),
+    0,
   )
   const own = opportunities.filter((o) => o.account_id === me)
   const answered = opportunities.filter(
@@ -223,6 +236,7 @@ export function OpportunityBoard({
       <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
         <p role="status">
           {visible.length} of {opportunities.length} notices
+          {shown < visible.length ? ` · ${shown} shown` : ''}
           {opportunities.length === 2000 ? ' · Latest 2,000 only' : ''}
         </p>
         <details>
@@ -266,6 +280,7 @@ export function OpportunityBoard({
             <div className="grid items-start gap-3 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2">
               {visible
                 .filter((o) => o.side === side)
+                .slice(0, pageSize[side])
                 .map((o) => {
                   const rel = relationship(o, me, graph)
                   const expired = isPast(o, now)
@@ -274,7 +289,7 @@ export function OpportunityBoard({
                       key={o.tweet_id}
                       className={`min-w-0 overflow-hidden rounded-lg border bg-card ${expired ? 'opacity-60' : ''} ${rel.rank < 3 ? 'border-brand/40' : ''}`}
                     >
-                      <Original id={o.tweet_id} />
+                      <Original id={o.tweet_id} loadTweet={loadTweet} />
                       <div className="h-24 space-y-1 border-t px-3 py-2">
                         <div className="flex items-center justify-between gap-2 text-[11px] leading-4">
                           <span className="rounded bg-muted px-1.5 py-0.5 font-medium text-muted-foreground">
@@ -298,6 +313,17 @@ export function OpportunityBoard({
                   )
                 })}
             </div>
+            {visible.filter((o) => o.side === side).length > pageSize[side] && (
+              <Button
+                variant="outline"
+                className="w-full"
+                onClick={() =>
+                  setPageSize((size) => ({ ...size, [side]: size[side] + 6 }))
+                }
+              >
+                Load more {side === 'offer' ? 'offers' : 'asks'}
+              </Button>
+            )}
             {!visible.some((o) => o.side === side) && (
               <p className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
                 No matching {side === 'offer' ? 'offers' : 'asks'}.

--- a/src/components/bulletin/useTweetBatch.ts
+++ b/src/components/bulletin/useTweetBatch.ts
@@ -1,0 +1,90 @@
+'use client'
+
+import { useCallback, useEffect, useRef } from 'react'
+import type { PortalTweet } from '@/lib/portal/types'
+
+const BATCH_SIZE = 8
+
+type Pending = {
+  resolve: (tweet: PortalTweet) => void
+  reject: (reason: Error) => void
+}
+
+/** Coalesce nearby cards; retain results only for this mounted board. */
+export function useTweetBatch() {
+  const promises = useRef(new Map<string, Promise<PortalTweet>>())
+  const pending = useRef(new Map<string, Pending>())
+  const queued = useRef(new Set<string>())
+  const controllers = useRef(new Set<AbortController>())
+  const timer = useRef<ReturnType<typeof setTimeout>>()
+
+  useEffect(
+    () => () => {
+      clearTimeout(timer.current)
+      timer.current = undefined
+      for (const controller of Array.from(controllers.current))
+        controller.abort()
+      for (const item of Array.from(pending.current.values()))
+        item.reject(new Error('Cancelled'))
+      pending.current.clear()
+      queued.current.clear()
+      promises.current.clear()
+    },
+    [],
+  )
+
+  return useCallback((id: string): Promise<PortalTweet> => {
+    const existing = promises.current.get(id)
+    if (existing) return existing
+    const promise = new Promise<PortalTweet>((resolve, reject) => {
+      pending.current.set(id, { resolve, reject })
+      queued.current.add(id)
+    })
+    promises.current.set(id, promise)
+    if (!timer.current) {
+      timer.current = setTimeout(() => {
+        timer.current = undefined
+        const ids = Array.from(queued.current)
+        queued.current.clear()
+        for (let offset = 0; offset < ids.length; offset += BATCH_SIZE) {
+          const batch = ids.slice(offset, offset + BATCH_SIZE)
+          const controller = new AbortController()
+          controllers.current.add(controller)
+          fetch(`/api/bulletin/tweets?ids=${batch.join(',')}`, {
+            cache: 'no-store',
+            signal: controller.signal,
+          })
+            .then(async (response) => {
+              if (controller.signal.aborted) return
+              if (!response.ok) throw new Error('Tweets unavailable')
+              const data = (await response.json()) as { tweets: PortalTweet[] }
+              const tweets = new Map(
+                data.tweets.map((tweet) => [tweet.id, tweet]),
+              )
+              for (const id of batch) {
+                const tweet = tweets.get(id)
+                if (tweet) pending.current.get(id)?.resolve(tweet)
+                else {
+                  promises.current.delete(id)
+                  pending.current
+                    .get(id)
+                    ?.reject(new Error('Tweet unavailable'))
+                }
+                pending.current.delete(id)
+              }
+            })
+            .catch(() => {
+              if (controller.signal.aborted) return
+              for (const id of batch) {
+                promises.current.delete(id)
+                pending.current.get(id)?.reject(new Error('Tweets unavailable'))
+                pending.current.delete(id)
+              }
+            })
+            .finally(() => controllers.current.delete(controller))
+        }
+      }, 20)
+    }
+    return promise
+  }, [])
+}

--- a/src/lib/bulletin/tweet-route.test.ts
+++ b/src/lib/bulletin/tweet-route.test.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'crypto'
+import { GET as BATCH_GET } from '@/app/api/bulletin/tweets/route'
 import { GET } from '@/app/api/bulletin/tweet/[id]/route'
 import {
   loadBulletinBoardState,
@@ -101,4 +102,70 @@ test.each([
   const result = await call()
   expect(result.status).toBe(reason === 'missing notice' ? 404 : 503)
   expect(await result.json()).not.toHaveProperty('text')
+})
+
+test('a batch shares policy/source reads and suppresses a changed tweet independently', async () => {
+  const other = { ...notice, tweet_id: '124' }
+  jest
+    .mocked(loadBulletinBoardState)
+    .mockResolvedValue({ notices: [notice, other] })
+  jest.mocked(fetchAnalyticsGatewayJson).mockResolvedValue({
+    data: [
+      {
+        ...notice,
+        full_text: 'Offer: help',
+        reply_to_tweet_id: null,
+        retweet: false,
+      },
+      {
+        ...other,
+        full_text: 'Offer: help',
+        reply_to_tweet_id: null,
+        retweet: false,
+      },
+    ],
+  })
+  jest
+    .mocked(fetchClickHouseTweetPageData)
+    .mockImplementation(async (id) => ({
+      ...detail,
+      tweet_id: id,
+      full_text: id === '124' ? 'changed' : detail.full_text,
+    }))
+  const response = await BATCH_GET(
+    new Request('http://localhost/api/bulletin/tweets?ids=123,124'),
+  )
+  expect(response.status).toBe(200)
+  expect(response.headers.get('Cache-Control')).toBe('private, no-store')
+  expect(await response.json()).toMatchObject({ tweets: [{ id: '123' }] })
+  expect(loadBulletinBoardState).toHaveBeenCalledTimes(1)
+  expect(fetchAnalyticsGatewayJson).toHaveBeenCalledTimes(1)
+  expect(fetchAnalyticsGatewayJson).toHaveBeenCalledWith(
+    ['bulletin-sources'],
+    new URLSearchParams({ ids: '123,124' }),
+  )
+})
+
+test.each(['', 'bad', '1,2,3,4,5,6,7,8,9'])(
+  'rejects invalid or oversized batches before reads: %s',
+  async (ids) => {
+    expect(
+      (
+        await BATCH_GET(
+          new Request('http://localhost/api/bulletin/tweets?ids=' + ids),
+        )
+      ).status,
+    ).toBe(400)
+    expect(loadBulletinBoardState).not.toHaveBeenCalled()
+    expect(fetchAnalyticsGatewayJson).not.toHaveBeenCalled()
+  },
+)
+
+test('batch reads require authentication', async () => {
+  jest.mocked(requireOpportunityUser).mockRejectedValue(new Error('Sign in'))
+  await expect(
+    BATCH_GET(new Request('http://localhost/api/bulletin/tweets?ids=123')),
+  ).rejects.toThrow('Sign in')
+  expect(loadBulletinBoardState).not.toHaveBeenCalled()
+  expect(fetchAnalyticsGatewayJson).not.toHaveBeenCalled()
 })

--- a/src/lib/bulletin/tweets.ts
+++ b/src/lib/bulletin/tweets.ts
@@ -1,0 +1,118 @@
+import 'server-only'
+import { createHash } from 'crypto'
+import { loadBulletinBoardState } from './data'
+import { fetchAnalyticsGatewayJson } from '@/lib/clickhouseGateway'
+import { fetchClickHouseTweetPageData } from '@/lib/clickhouseTweetPage'
+import type { PortalTweet } from '@/lib/portal/types'
+import type { TweetData } from '@/lib/tweets/types'
+
+function card(tweet: TweetData): PortalTweet {
+  const mapMedia = (items: TweetData['media'] | undefined) =>
+    (items || []).map((m) => ({
+      url: m.media_url,
+      type: m.media_type,
+      width: m.width,
+      height: m.height,
+    }))
+  const q = tweet.quoted_tweet
+  return {
+    id: tweet.tweet_id,
+    accountId: tweet.account_id,
+    username: tweet.username,
+    name: tweet.account_display_name,
+    avatar: tweet.avatar_media_url || null,
+    text: tweet.full_text,
+    createdAt: tweet.created_at,
+    observedAt: tweet.created_at,
+    likes: tweet.favorite_count || 0,
+    rts: tweet.retweet_count || 0,
+    media: mapMedia(tweet.media),
+    quotedTweet: q
+      ? {
+          id: q.tweet_id,
+          accountId: q.account_id,
+          username: q.username,
+          name: q.account_display_name,
+          avatar: q.avatar_media_url || null,
+          text: q.full_text,
+          createdAt: q.created_at,
+          likes: q.favorite_count || 0,
+          rts: q.retweet_count || 0,
+          media: mapMedia(q.media),
+          isDeleted: q.is_deleted,
+        }
+      : undefined,
+  }
+}
+
+export async function loadBulletinTweets(ids: string[]) {
+  // Share the live notice/policy read and source check across a small batch.
+  const [state, current, details] = await Promise.all([
+    loadBulletinBoardState(),
+    fetchAnalyticsGatewayJson<{
+      data: Array<{
+        tweet_id: string
+        account_id: string
+        content_hash: string
+        reply_to_tweet_id: string | null
+        retweet: boolean
+        full_text: string
+      }>
+    }>(['bulletin-sources'], new URLSearchParams({ ids: ids.join(',') })),
+    (async () => {
+      const details: Array<TweetData | null> = []
+      // Avoid an unbounded fan-out of expensive full-fidelity detail queries.
+      for (let offset = 0; offset < ids.length; offset += 4) {
+        details.push(
+          ...(await Promise.all(
+            ids
+              .slice(offset, offset + 4)
+              .map((id) =>
+                fetchClickHouseTweetPageData(id, (path, params) =>
+                  fetchAnalyticsGatewayJson(path, params),
+                ).catch(() => null),
+              ),
+          )),
+        )
+      }
+      return details
+    })(),
+  ])
+  const notices = new Map(
+    state.notices.map((notice) => [notice.tweet_id, notice]),
+  )
+  const sources = new Map(
+    current.data.map((source) => [source.tweet_id, source]),
+  )
+  const tweets: PortalTweet[] = []
+  const errors: Record<string, number> = {}
+  ids.forEach((id, index) => {
+    const notice = notices.get(id)
+    if (!notice) {
+      errors[id] = 404
+      return
+    }
+    const source = sources.get(id)
+    const detail = details[index]
+    if (
+      !source ||
+      !detail ||
+      detail.tweet_id !== id ||
+      source.content_hash !== notice.content_hash ||
+      source.account_id !== detail.account_id ||
+      source.reply_to_tweet_id ||
+      source.retweet ||
+      source.full_text.startsWith('RT @') ||
+      (notice.account_id
+        ? detail.account_id !== notice.account_id
+        : !state.allowedAccounts?.includes(detail.account_id)) ||
+      createHash('sha256').update(detail.full_text).digest('hex') !==
+        notice.content_hash
+    ) {
+      errors[id] = 503
+      return
+    }
+    tweets.push(card(detail))
+  })
+  return { tweets, errors }
+}


### PR DESCRIPTION
Reduce the Opportunities page’s request waterfall and repeated work. Page data loads in parallel, a loading state appears during navigation, and each column initially renders six cards with Load more. Search, category counts and recommendation ordering still cover the full loaded notice list.

Nearby visible tweet cards share bounded requests (up to eight IDs), one current policy/notice read and one source check per batch. Full ClickHouse tweet details retain media and quotes, with four concurrent detail reads at most per batch. Already-loaded cards are reused across filters within the mounted board; Refresh discards that temporary cache. Every request remains authenticated and private/no-store, and each returned tweet must pass current source, author, content-hash and policy checks.

Sampled production dependencies took ~1.3s for notice state, ~1.5s for board enrichment, ~0.8s for recommendations and ~0.6s for one full tweet. This removes sequential waits and duplicate state/source reads rather than claiming an end-to-end speedup percentage. This is progressive card pagination; lightweight notices are still loaded together to preserve global filtering and ranking.

Validation: 28 focused auth, source-change, batch-limit, shared-read, filter-cache and pagination tests passed; scoped ESLint and TypeScript passed. Local production-backed browser loaded original cards without errors and Load more increased shown cards from12 to18. No database migrations, gateway changes or worker changes.
