### PR TITLE
Add infinite scroll and immediate tweet text to Opportunities

### DIFF
--- a/src/components/TweetCard.test.tsx
+++ b/src/components/TweetCard.test.tsx
@@ -283,3 +283,20 @@ describe('TweetCard', () => {
     ).toHaveAttribute('href', 'https://x.com/alice/status/123')
   })
 })
+
+test('partial cards hide unknown counts without hiding text or outbound navigation', () => {
+  render(
+    <TweetCard
+      tweet={{ ...tweet, quotedTweet: undefined }}
+      showEngagement={false}
+      showExternalLink
+      previewHeight={240}
+    />,
+  )
+  expect(screen.queryByText('12 likes')).not.toBeInTheDocument()
+  expect(screen.queryByText('3 reposts')).not.toBeInTheDocument()
+  expect(
+    screen.getByRole('link', { name: 'View tweet on X (opens in a new tab)' }),
+  ).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'Read more' })).toBeInTheDocument()
+})

--- a/src/components/bulletin/OpportunityBoard.test.tsx
+++ b/src/components/bulletin/OpportunityBoard.test.tsx
@@ -27,26 +27,33 @@ const ask = {
   topics: ['gardening'],
 }
 jest.mock('@/components/TweetCard', () => ({
-  TweetCard: () => <div>Original card</div>,
+  TweetCard: ({ tweet }: { tweet: { text?: string } }) => (
+    <div>
+      Original card<span>{tweet.text}</span>
+    </div>
+  ),
 }))
 jest.mock('@/components/portal/TweetRow', () => ({
   TweetAvatar: () => <span />,
 }))
 let intersections: IntersectionObserverCallback[]
+let observed: Map<IntersectionObserverCallback, Element>
 beforeEach(() => {
   jest.useFakeTimers()
   window.history.replaceState(null, '', '/opportunities')
   intersections = []
+  observed = new Map()
   window.IntersectionObserver = jest.fn((callback) => {
     intersections.push(callback)
-    return { observe: jest.fn(), disconnect: jest.fn() }
+    return {
+      observe: (element: Element) => observed.set(callback, element),
+      disconnect: jest.fn(),
+    }
   }) as unknown as typeof IntersectionObserver
-  global.fetch = jest
-    .fn()
-    .mockResolvedValue({
-      ok: true,
-      json: async () => ({ tweets: [{ id: '1' }, { id: '2' }] }),
-    })
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ tweets: [{ id: '1' }, { id: '2' }] }),
+  })
 })
 afterEach(() => jest.useRealTimers())
 test('loads the original automatically near the viewport without fetching every notice', async () => {
@@ -141,7 +148,7 @@ test('coalesces visible cards into one request and reuses loaded cards after fil
   expect(fetch).toHaveBeenCalledTimes(1)
 })
 
-test('pages cards while search and counts still cover all notices', () => {
+test('automatically pages once per sentinel and preserves global search and counts', () => {
   const notices = Array.from({ length: 14 }, (_, i) => ({
     ...offer,
     tweet_id: String(i + 1),
@@ -155,7 +162,23 @@ test('pages cards while search and counts still cover all notices', () => {
   )
   expect(screen.getByRole('status')).toHaveTextContent('14 of 14 notices')
   expect(screen.getAllByRole('article')).toHaveLength(6)
-  fireEvent.click(screen.getByRole('button', { name: 'Load more offers' }))
+  expect(
+    screen.queryByRole('button', { name: 'Load more offers' }),
+  ).not.toBeInTheDocument()
+  const sentinel = screen.getByLabelText('Load more offers')
+  const nextPage = intersections.find(
+    (callback) => observed.get(callback) === sentinel,
+  )!
+  act(() => {
+    nextPage(
+      [{ isIntersecting: true } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    )
+    nextPage(
+      [{ isIntersecting: true } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    )
+  })
   expect(screen.getAllByRole('article')).toHaveLength(12)
   fireEvent.change(screen.getByLabelText('Search opportunities'), {
     target: { value: 'Offer number 14' },
@@ -163,5 +186,23 @@ test('pages cards while search and counts still cover all notices', () => {
   expect(screen.getByText('Offer number 14')).toBeInTheDocument()
   expect(
     screen.queryByRole('button', { name: 'Load more offers' }),
+  ).not.toBeInTheDocument()
+})
+
+test('shows verified tweet text immediately before requesting richer cards', () => {
+  render(
+    <OpportunityBoard
+      opportunities={[
+        { ...offer, preview_text: 'Verified complete original text' },
+      ]}
+      now={Date.parse('2026-09-09T00:00:00Z')}
+    />,
+  )
+  expect(
+    screen.getByText('Verified complete original text'),
+  ).toBeInTheDocument()
+  expect(fetch).not.toHaveBeenCalled()
+  expect(
+    screen.queryByLabelText('Loading original tweet'),
   ).not.toBeInTheDocument()
 })

--- a/src/components/bulletin/OpportunityBoard.tsx
+++ b/src/components/bulletin/OpportunityBoard.tsx
@@ -50,7 +50,11 @@ function ScrollMore({
     return () => observer.disconnect()
   }, [count])
   return (
-    <div ref={sentinel} aria-label={`Load more ${side}`} className="min-h-px">
+    <div
+      ref={sentinel}
+      aria-label={`Load more ${side}`}
+      className="min-h-[1px]"
+    >
       {manual ? (
         <Button variant="outline" onClick={onMore}>
           Load more {side}

--- a/src/components/bulletin/OpportunityBoard.tsx
+++ b/src/components/bulletin/OpportunityBoard.tsx
@@ -17,13 +17,59 @@ const EMPTY_GRAPH: BulletinRelationships = {
   outgoing: {},
   available: false,
 }
+function ScrollMore({
+  count,
+  side,
+  onMore,
+}: {
+  count: number
+  side: string
+  onMore: () => void
+}) {
+  const sentinel = useRef<HTMLDivElement>(null)
+  const callback = useRef(onMore)
+  callback.current = onMore
+  const [manual, setManual] = useState(false)
+  useEffect(() => {
+    if (typeof IntersectionObserver === 'undefined') {
+      setManual(true)
+      return
+    }
+    let fired = false
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && !fired) {
+          fired = true
+          observer.disconnect()
+          callback.current()
+        }
+      },
+      { rootMargin: '600px' },
+    )
+    if (sentinel.current) observer.observe(sentinel.current)
+    return () => observer.disconnect()
+  }, [count])
+  return (
+    <div ref={sentinel} aria-label={`Load more ${side}`} className="min-h-px">
+      {manual ? (
+        <Button variant="outline" onClick={onMore}>
+          Load more {side}
+        </Button>
+      ) : (
+        <span className="sr-only">More {side} load as you scroll</span>
+      )}
+    </div>
+  )
+}
+
 function Original({
-  id,
+  notice,
   loadTweet,
 }: {
-  id: string
+  notice: Opportunity
   loadTweet: (id: string) => Promise<PortalTweet>
 }) {
+  const id = notice.tweet_id
   const container = useRef<HTMLDivElement>(null)
   const [visible, setVisible] = useState(false)
   const [tweet, setTweet] = useState<PortalTweet | null>(null)
@@ -59,11 +105,32 @@ function Original({
       })
     return () => controller.abort()
   }, [id, visible, attempt, loadTweet])
+  const displayTweet =
+    tweet ||
+    (typeof notice.preview_text === 'string'
+      ? {
+          id,
+          accountId: notice.account_id,
+          username: notice.username,
+          name: notice.display_name || notice.username,
+          avatar: notice.avatar_url || null,
+          text: notice.preview_text,
+          createdAt: notice.posted_at,
+          observedAt: notice.posted_at,
+          likes: 0,
+          rts: 0,
+        }
+      : null)
   return (
-    <div ref={container} className="min-w-0">
-      {tweet ? (
+    <div
+      ref={container}
+      className="relative min-w-0"
+      aria-busy={!tweet && !error}
+    >
+      {displayTweet ? (
         <TweetCard
-          tweet={tweet}
+          tweet={displayTweet}
+          showEngagement={!!tweet}
           previewHeight={240}
           clickable={false}
           showDate
@@ -90,6 +157,14 @@ function Original({
           <div className="h-3 rounded bg-muted" />
           <div className="h-3 w-5/6 rounded bg-muted" />
         </div>
+      )}
+      {displayTweet && error && (
+        <button
+          className="absolute bottom-3 left-14 bg-card px-1 text-xs text-brand"
+          onClick={() => setAttempt((n) => n + 1)}
+        >
+          Retry post details
+        </button>
       )}
     </div>
   )
@@ -289,7 +364,7 @@ export function OpportunityBoard({
                       key={o.tweet_id}
                       className={`min-w-0 overflow-hidden rounded-lg border bg-card ${expired ? 'opacity-60' : ''} ${rel.rank < 3 ? 'border-brand/40' : ''}`}
                     >
-                      <Original id={o.tweet_id} loadTweet={loadTweet} />
+                      <Original notice={o} loadTweet={loadTweet} />
                       <div className="h-24 space-y-1 border-t px-3 py-2">
                         <div className="flex items-center justify-between gap-2 text-[11px] leading-4">
                           <span className="rounded bg-muted px-1.5 py-0.5 font-medium text-muted-foreground">
@@ -314,15 +389,14 @@ export function OpportunityBoard({
                 })}
             </div>
             {visible.filter((o) => o.side === side).length > pageSize[side] && (
-              <Button
-                variant="outline"
-                className="w-full"
-                onClick={() =>
+              <ScrollMore
+                key={`${kind}:${search}:${past}:${recommended}`}
+                side={side === 'offer' ? 'offers' : 'asks'}
+                count={pageSize[side]}
+                onMore={() =>
                   setPageSize((size) => ({ ...size, [side]: size[side] + 6 }))
                 }
-              >
-                Load more {side === 'offer' ? 'offers' : 'asks'}
-              </Button>
+              />
             )}
             {!visible.some((o) => o.side === side) && (
               <p className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">

--- a/src/components/portal/TweetRow.tsx
+++ b/src/components/portal/TweetRow.tsx
@@ -304,6 +304,8 @@ export interface TweetCardProps {
   showArchivedBadge?: boolean
   clickable?: boolean
   showExternalLink?: boolean
+  /** Hide unknown engagement counts while a partial tweet is being hydrated. */
+  showEngagement?: boolean
   quotedTweetDisplay?: 'full' | 'summary'
   origin?: TweetOrigin
   returnTo?: string
@@ -356,6 +358,7 @@ export function TweetRow({
   showArchivedBadge = false,
   clickable,
   showExternalLink = false,
+  showEngagement = true,
   quotedTweetDisplay = 'full',
   origin,
   returnTo,
@@ -545,20 +548,22 @@ export function TweetRow({
       {isPreview && expandButton}
       {!compact && (
         <div className="mt-1.5 flex shrink-0 flex-wrap gap-x-4 gap-y-1 text-[12px] tabular-nums text-zinc-500 dark:text-[#a7a7b4]">
-          {tweet.quoteCount !== undefined && (
+          {showEngagement && tweet.quoteCount !== undefined && (
             <ArchivedQuotesMetric
               count={tweet.quoteCount}
               href={href}
               onOpen={() => captureAction('open_archived_quotes')}
             />
           )}
-          <CountMetric
-            count={tweet.likes}
-            label={tweet.likes === 1 ? 'like' : 'likes'}
-          >
-            <PiHeart />
-          </CountMetric>
-          {tweet.retweetCountAvailable !== false ? (
+          {showEngagement && (
+            <CountMetric
+              count={tweet.likes}
+              label={tweet.likes === 1 ? 'like' : 'likes'}
+            >
+              <PiHeart />
+            </CountMetric>
+          )}
+          {showEngagement && tweet.retweetCountAvailable !== false ? (
             <CountMetric
               count={tweet.rts}
               label={tweet.rts === 1 ? 'repost' : 'reposts'}
@@ -612,7 +617,7 @@ export function TweetRow({
         />
       </Link>
       {details}
-      {compact && (
+      {compact && showEngagement && (
         <div className="whitespace-nowrap text-[11.5px] tabular-nums text-zinc-500 dark:text-[#a7a7b4]">
           <CountMetric
             count={tweet.likes}

--- a/src/lib/bulletin/data.test.ts
+++ b/src/lib/bulletin/data.test.ts
@@ -199,3 +199,31 @@ test('interaction responses for a different account are rejected', async () => {
     available: false,
   })
 })
+
+test('immediate preview text comes only from a currently verified ClickHouse source', async () => {
+  jest
+    .mocked(getCurrentUser)
+    .mockResolvedValue({ id: 'member', is_anonymous: false } as User)
+  const text = 'Offer: current original'
+  const content_hash = createHash('sha256').update(text).digest('hex')
+  rpc.mockResolvedValue({
+    data: [{ tweet_id: '1', account_id: '10', content_hash }],
+    error: null,
+  })
+  jest.mocked(fetchAnalyticsGatewayJson).mockResolvedValue({
+    data: [
+      {
+        tweet_id: '1',
+        account_id: '10',
+        full_text: text,
+        reply_to_tweet_id: null,
+        retweet: false,
+        created_at: '2026-09-08 00:00:00',
+        username: 'alice',
+      },
+    ],
+  })
+  await expect(loadOpportunities()).resolves.toMatchObject([
+    { tweet_id: '1', preview_text: text },
+  ])
+})

--- a/src/lib/bulletin/data.ts
+++ b/src/lib/bulletin/data.ts
@@ -71,6 +71,7 @@ export async function loadOpportunities(): Promise<Opportunity[]> {
         account_id: source.account_id,
         username: source.username,
         posted_at: utc(source.created_at),
+        preview_text: source.full_text,
         side: notice.side,
         kind: notice.kind,
         summary: notice.summary,

--- a/src/lib/bulletin/types.ts
+++ b/src/lib/bulletin/types.ts
@@ -4,6 +4,8 @@ export type Opportunity = Omit<
   Database['public']['Functions']['get_bulletin_opportunities']['Returns'][number],
   'full_text' | 'model' | 'expires_at' | 'place'
 > & {
+  /** Current, policy-checked ClickHouse text for immediate card rendering. */
+  preview_text?: string
   expires_at: string | null
   place: string | null
   account_created_at?: string | null


### PR DESCRIPTION
Replace the Opportunities Load more buttons with per-column infinite scroll. A sentinel starts loading the next six cards before reaching the column end; duplicate observations cannot append the same page twice. A manual fallback remains only for browsers without IntersectionObserver.

Render the already policy- and hash-verified ClickHouse tweet text immediately using the shared TweetCard. Images, quoted posts and engagement hydrate through the existing private batch API. Unknown engagement is hidden until hydration, and failed detail requests retain readable text with Retry. The initial preview introduces no new database reads and preserves the current consent/source checks.

New samples: Supabase notice state1.07s first/0.76s warm; ClickHouse source/enrichment1.39–1.68s; recommendations0.79s. Supabase contributes to the initial delay but is not its sole cause. This avoids the additional details-request wait before reading posts; it does not claim to eliminate initial database latency.

Validation:45focused card, infinite-scroll, preview-source and API/privacy tests passed; scoped lint and TypeScript passed. Browser verified twelve immediately readable posts with no placeholders/buttons, and scrolling automatically increased twelve to24shown without errors. No migrations, worker or gateway changes.
