### PR TITLE
Redesign Opportunities and paginate verified notices

### DIFF
--- a/src/app/api/bulletin/board/route.ts
+++ b/src/app/api/bulletin/board/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server'
+import { requireOpportunityUser } from '@/lib/bulletin/data'
+import { BulletinCursorExpired, loadBulletinPage } from '@/lib/bulletin/page'
+import { KIND_LABELS } from '@/lib/bulletin/types'
+export const dynamic = 'force-dynamic'
+const headers = { 'Cache-Control': 'private, no-store' }
+export async function GET(request: Request) {
+  await requireOpportunityUser()
+  const p = new URL(request.url).searchParams
+  const kind = p.get('kind') || 'all'
+  const side = p.get('side') || 'all'
+  const search = (p.get('q') || '').trim()
+  const after = p.get('after') || undefined
+  if (
+    (kind !== 'all' &&
+      !Object.prototype.hasOwnProperty.call(KIND_LABELS, kind)) ||
+    !['all', 'ask', 'offer'].includes(side) ||
+    search.length > 300 ||
+    (after && (!/^\d{1,20}$/.test(after) || kind === 'all'))
+  )
+    return NextResponse.json(
+      { error: 'Invalid board filters' },
+      { status: 400, headers },
+    )
+  try {
+    return NextResponse.json(
+      await loadBulletinPage(
+        {
+          kind,
+          side,
+          search,
+          past: p.get('past') === '1',
+          recommended: p.get('sort') !== 'newest',
+        },
+        after,
+      ),
+      { headers },
+    )
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof BulletinCursorExpired
+            ? error.message
+            : 'Notices could not be loaded. Try again.',
+      },
+      { status: error instanceof BulletinCursorExpired ? 409 : 503, headers },
+    )
+  }
+}

--- a/src/app/opportunities/fonts.ts
+++ b/src/app/opportunities/fonts.ts
@@ -1,0 +1,12 @@
+import { Figtree, Source_Serif_4 } from 'next/font/google'
+
+export const uiFont = Figtree({
+  subsets: ['latin'],
+  variable: '--bulletin-ui',
+  display: 'swap',
+})
+export const displayFont = Source_Serif_4({
+  subsets: ['latin'],
+  variable: '--bulletin-display',
+  display: 'swap',
+})

--- a/src/app/opportunities/loading.tsx
+++ b/src/app/opportunities/loading.tsx
@@ -1,22 +1,29 @@
+import styles from '@/components/bulletin/OpportunityBoard.module.css'
+import { uiFont, displayFont } from './fonts'
+
 export default function LoadingOpportunities() {
   return (
     <main
-      className="mx-auto w-full max-w-[1800px] space-y-4 px-4 py-4 sm:px-6"
+      className={`${styles.page} ${uiFont.variable} ${displayFont.variable}`}
       aria-busy="true"
     >
-      <h1 className="text-2xl font-semibold tracking-tight">Opportunities</h1>
-      <p role="status" className="text-sm text-muted-foreground">
-        Loading opportunities…
-      </p>
-      <div
-        className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4"
-        aria-hidden="true"
-      >
-        {Array.from({ length: 4 }, (_, i) => (
-          <div
-            key={i}
-            className="h-[338px] animate-pulse rounded-lg border bg-muted/40"
-          />
+      <header className={styles.subbar}>
+        <h1 className={styles.title}>Opportunities</h1>
+        <p role="status" className={styles.lede}>
+          Loading opportunities…
+        </p>
+      </header>
+      <div className={styles.board} aria-hidden="true">
+        {Array.from({ length: 5 }, (_, i) => (
+          <div className={styles.lane} key={i}>
+            <div className="h-6 w-2/3 animate-pulse rounded bg-muted/40" />
+            {Array.from({ length: 3 }, (_, j) => (
+              <div
+                key={j}
+                className="h-[180px] animate-pulse rounded-[10px] border bg-muted/20"
+              />
+            ))}
+          </div>
         ))}
       </div>
     </main>

--- a/src/app/opportunities/page.tsx
+++ b/src/app/opportunities/page.tsx
@@ -1,14 +1,10 @@
 import type { Metadata } from 'next'
-import Link from 'next/link'
-import {
-  isBulletinAdmin,
-  loadOpportunities,
-  loadBulletinRelationships,
-  requireOpportunityUser,
-} from '@/lib/bulletin/data'
+import { uiFont, displayFont } from './fonts'
+import styles from '@/components/bulletin/OpportunityBoard.module.css'
+import { isBulletinAdmin, requireOpportunityUser } from '@/lib/bulletin/data'
+import { loadBulletinPage } from '@/lib/bulletin/page'
+import { DEFAULT_BULLETIN_FILTERS } from '@/lib/bulletin/types'
 import { OpportunityBoard } from '@/components/bulletin/OpportunityBoard'
-import { RefreshButton } from '@/components/bulletin/RefreshButton'
-
 export const dynamic = 'force-dynamic'
 export const metadata: Metadata = {
   title: 'Opportunities | Community Archive',
@@ -17,73 +13,30 @@ export const metadata: Metadata = {
 
 export default async function OpportunitiesPage() {
   await requireOpportunityUser()
-  const [isAdmin, personal, opportunities] = await Promise.all([
+  const [isAdmin, page] = await Promise.all([
     isBulletinAdmin(),
-    loadBulletinRelationships(),
-    loadOpportunities().catch(() => null),
+    loadBulletinPage(DEFAULT_BULLETIN_FILTERS).catch(() => null),
   ])
   return (
-    <main className="mx-auto min-h-[70vh] w-full min-w-0 max-w-[1800px] space-y-4 px-4 py-4 sm:px-6">
-      <header className="flex flex-wrap items-center justify-between gap-x-6 gap-y-2">
-        <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1">
-          <h1 className="text-2xl font-semibold tracking-tight">
-            Opportunities
-          </h1>
-          <p className="text-xs text-muted-foreground">
-            Thanks to{' '}
-            <Link href="/user/maskys_" className="text-brand hover:underline">
-              @maskys_
-            </Link>{' '}
-            for the first prototype.
-          </p>
-        </div>
-        <div className="flex items-center gap-3">
-          {isAdmin && (
-            <Link
-              href="/admin/opportunities"
-              className="text-xs text-brand hover:underline"
-            >
-              <span className="sm:hidden">Runs</span>
-              <span className="hidden sm:inline">Run dashboard →</span>
-            </Link>
-          )}
-          <RefreshButton />
-        </div>
-      </header>
-      {opportunities === null ? (
+    <main
+      className={`${styles.page} ${uiFont.variable} ${displayFont.variable}`}
+    >
+      {page === null ? (
         <div role="alert" className="rounded-lg border p-6">
           Opportunities could not be loaded. Refresh to try again.
         </div>
       ) : (
         <OpportunityBoard
           key={Date.now()}
-          opportunities={opportunities}
-          me={personal.account_id}
-          username={personal.username}
-          graph={personal}
-          now={Date.now()}
+          opportunities={page.opportunities}
+          initialPage={page}
+          me={page.personal.account_id}
+          username={page.personal.username}
+          graph={page.personal}
+          now={page.now}
+          isAdmin={isAdmin}
         />
       )}
-      <details className="rounded-lg border bg-card p-5 text-sm text-muted-foreground">
-        <summary className="cursor-pointer font-medium text-foreground">
-          How these notices are found
-        </summary>
-        <p className="mt-3 leading-6">
-          After the daily archive refresh, we check recent original posts from
-          participating accounts for phrases suggesting an ask or offer. AI
-          checks those candidates and writes the summaries. Read the original
-          post before responding; a notice may be misclassified or no longer
-          available.
-        </p>
-        <p className="mt-2 leading-6">
-          This is a selection, not a complete directory. Replies, reposts, posts
-          arriving more than two days late, and notices without matching phrases
-          can be missed. The daily scan covers the previous two UTC days in
-          ClickHouse. Undated asks expire after 14 days and offers after 60
-          days; standing offers stay open. Use “Show past notices” to include
-          expired notices.
-        </p>
-      </details>
     </main>
   )
 }

--- a/src/components/TweetAvatar.tsx
+++ b/src/components/TweetAvatar.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import TweetAvatarImage from './TweetAvatarImage'
+import { Avatar, AvatarFallback } from './ui/avatar'
+import type { PortalTweet } from '@/lib/portal/types'
+
+const HUES = [262, 32, 145, 4, 155, 200, 217, 88, 240, 190, 340, 45, 280, 20]
+export const avatarHue = (username: string) => {
+  let h = 0
+  for (let i = 0; i < username.length; i++) {
+    h = (h * 31 + username.charCodeAt(i)) >>> 0
+  }
+  return HUES[h % HUES.length]
+}
+
+export function TweetAvatar({
+  tweet,
+  size = 34,
+}: {
+  tweet: Pick<PortalTweet, 'id' | 'username' | 'avatar'>
+  size?: number
+}) {
+  const initials = tweet.username.slice(0, 2).toUpperCase()
+  return (
+    <Avatar className="flex-shrink-0" style={{ width: size, height: size }}>
+      <TweetAvatarImage
+        src={tweet.avatar}
+        alt=""
+        username={tweet.username}
+        tweetId={tweet.id}
+      />
+      <AvatarFallback
+        className="text-[12px] font-extrabold text-white"
+        style={{ background: `hsl(${avatarHue(tweet.username)},42%,42%)` }}
+      >
+        {initials}
+      </AvatarFallback>
+    </Avatar>
+  )
+}

--- a/src/components/bulletin/OpportunityBoard.module.css
+++ b/src/components/bulletin/OpportunityBoard.module.css
@@ -1,0 +1,382 @@
+.page {
+  --ink: #111111;
+  --muted: #6b7280;
+  --faint: #9ca3af;
+  --line: #ececea;
+  --line-strong: #e4e4e1;
+  --card-line: #e8e8e5;
+  --surface: #ffffff;
+  --surface-2: #fbfbfa;
+  --surface-3: #f4f4f2;
+  --accent: #0369a1;
+  --ask: #9a5b1a;
+  color: var(--ink);
+  background: var(--surface);
+  font-family: var(--bulletin-ui), system-ui, sans-serif;
+  min-height: 70vh;
+  width: 100%;
+}
+:global(.dark) .page {
+  --ink: #eeeeec;
+  --muted: #a1a1aa;
+  --faint: #85858e;
+  --line: #29292d;
+  --line-strong: #37373b;
+  --card-line: #333337;
+  --surface: #19191c;
+  --surface-2: #151517;
+  --surface-3: #27272b;
+  --accent: #7dd3fc;
+  --ask: #e7ad70;
+}
+.page a {
+  font-weight: inherit;
+}
+.subbar {
+  padding: 26px 32px 18px;
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  flex-wrap: wrap;
+  border-bottom: 1px solid var(--line);
+}
+.title {
+  margin: 0;
+  font-family: var(--bulletin-display), Georgia, serif;
+  font-size: 32px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+}
+.lede {
+  font-size: 14px;
+  color: var(--muted);
+}
+.controls {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.segmented {
+  display: flex;
+  background: var(--surface-3);
+  border: 1px solid var(--card-line);
+  border-radius: 8px;
+  padding: 3px;
+}
+.segmented button {
+  border: 0;
+  background: transparent;
+  padding: 6px 12px;
+  font-size: 13px;
+  color: var(--muted);
+  border-radius: 6px;
+  line-height: normal;
+}
+.segmented button[aria-pressed='true'] {
+  background: var(--surface);
+  color: var(--ink);
+  font-weight: 600;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 6%);
+}
+.field {
+  width: 260px;
+  height: 34px;
+  border: 1px solid var(--line-strong);
+  border-radius: 8px;
+  padding: 0 12px;
+  font-size: 13px;
+  font-family: inherit;
+  color: var(--ink);
+  background: var(--surface);
+}
+.field::placeholder {
+  color: var(--faint);
+}
+.refresh {
+  border: 1px solid var(--line-strong);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--ink);
+  padding: 7px 13px;
+  height: 34px;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+}
+.refresh svg {
+  display: none;
+}
+.refresh:hover {
+  background: var(--surface-3);
+}
+.board {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 16px;
+  align-items: start;
+  padding: 24px 32px 48px;
+  background: var(--surface-2);
+  border-top: 1px solid var(--line);
+  min-height: 60vh;
+}
+.lane {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+}
+.laneGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  min-width: 0;
+}
+.laneHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 0 4px 8px;
+  border-bottom: 1px solid var(--line-strong);
+}
+.laneHead h2 {
+  margin: 0;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  line-height: 1.45;
+}
+.laneCount {
+  font-size: 12px;
+  color: var(--faint);
+}
+.more {
+  min-height: 1px;
+  text-align: center;
+  font-size: 12px;
+  color: var(--faint);
+}
+.more button {
+  border: 0;
+  background: transparent;
+  padding: 6px;
+}
+.notice {
+  border: 1px solid var(--card-line);
+  border-radius: 10px;
+  background: var(--surface);
+  padding: 12px 13px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+.notice:hover {
+  border-color: var(--line-strong);
+  box-shadow: 0 1px 3px rgb(0 0 0 / 4%);
+}
+.noticeHead {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.kind {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  line-height: 1.45;
+}
+.offer {
+  color: var(--accent);
+}
+.ask {
+  color: var(--ask);
+}
+.date {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--faint);
+  white-space: nowrap;
+}
+.summary {
+  margin: 0;
+  font-size: 13.5px;
+  line-height: 1.45;
+  font-weight: 500;
+  color: var(--ink);
+  overflow-wrap: anywhere;
+}
+.summary a {
+  color: inherit;
+  text-decoration: none;
+}
+.summary a:hover {
+  color: var(--accent);
+  text-decoration: underline;
+}
+.text {
+  margin: 0;
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: var(--muted);
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+  text-align: left;
+}
+.textButton {
+  border: 0;
+  background: transparent;
+  padding: 0;
+  font-family: inherit;
+  cursor: pointer;
+}
+.textButton:hover {
+  color: var(--ink);
+}
+.noticeFoot {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding-top: 8px;
+  border-top: 1px solid var(--line);
+}
+.handle {
+  font-size: 11.5px;
+  color: var(--muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.likes {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--faint);
+  white-space: nowrap;
+}
+.outbound {
+  color: var(--faint);
+  flex: none;
+}
+.badge {
+  align-self: flex-end;
+  font-size: 10px;
+  color: var(--muted);
+  background: var(--surface-3);
+  padding: 2px 5px;
+  border-radius: 4px;
+}
+.empty {
+  font-size: 12px;
+  color: var(--faint);
+  padding: 12px 4px;
+}
+.footer {
+  border-top: 1px solid var(--line);
+  padding: 16px 32px 24px;
+  font-size: 12px;
+  color: var(--muted);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 24px;
+  align-items: baseline;
+}
+.footer a {
+  color: var(--accent);
+}
+.options {
+  width: 100%;
+}
+.options summary {
+  cursor: pointer;
+  width: fit-content;
+}
+.optionFields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 20px;
+  align-items: center;
+  margin-top: 12px;
+}
+.optionFields label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.optionFields select {
+  border: 1px solid var(--line-strong);
+  border-radius: 6px;
+  padding: 4px;
+  color: var(--ink);
+  background: var(--surface);
+}
+.method {
+  max-width: 700px;
+  margin-top: 12px;
+  line-height: 1.6;
+}
+@media (max-width: 1280px) {
+  .board {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+@media (max-width: 840px) {
+  .board {
+    grid-template-columns: 1fr;
+    padding: 20px;
+  }
+  .subbar {
+    padding: 20px;
+  }
+  .controls {
+    margin-left: 0;
+    width: 100%;
+  }
+  .field {
+    flex: 1;
+    min-width: 140px;
+    width: 160px;
+  }
+  .footer {
+    padding: 16px 20px 24px;
+  }
+}
+
+.description {
+  flex-basis: 100%;
+  max-width: 900px;
+  margin: -4px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.55;
+}
+.readMore {
+  display: block;
+  margin-top: 5px;
+  font-size: 11.5px;
+  line-height: 1.45;
+  color: var(--accent);
+  text-align: left;
+}
+.textButton:hover .readMore {
+  text-decoration: underline;
+}
+
+.expanded {
+  min-width: 0;
+  overflow: hidden;
+  border-top: 1px solid var(--line);
+}
+.fullText {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font-size: 12.5px;
+  line-height: 1.5;
+}

--- a/src/components/bulletin/OpportunityBoard.test.tsx
+++ b/src/components/bulletin/OpportunityBoard.test.tsx
@@ -1,12 +1,16 @@
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import { OpportunityBoard } from './OpportunityBoard'
 import type { Opportunity } from '@/lib/bulletin/types'
+jest.mock('./RefreshButton', () => ({
+  RefreshButton: () => <button>Refresh</button>,
+}))
+jest.mock('./OpportunityBoard.module.css', () => ({}))
 const offer = {
   tweet_id: '1',
   account_id: 'a',
   username: 'alice',
   posted_at: '2026-09-08T00:00:00Z',
-  full_text: 'Happy to help with Python.',
+  preview_text: 'Happy to help with Python.',
   side: 'offer',
   kind: 'help',
   summary: 'Help with Python',
@@ -33,7 +37,7 @@ jest.mock('@/components/TweetCard', () => ({
     </div>
   ),
 }))
-jest.mock('@/components/portal/TweetRow', () => ({
+jest.mock('@/components/TweetAvatar', () => ({
   TweetAvatar: () => <span />,
 }))
 let intersections: IntersectionObserverCallback[]
@@ -52,11 +56,16 @@ beforeEach(() => {
   }) as unknown as typeof IntersectionObserver
   global.fetch = jest.fn().mockResolvedValue({
     ok: true,
-    json: async () => ({ tweets: [{ id: '1' }, { id: '2' }] }),
+    json: async () => ({
+      tweets: [
+        { id: '1', likes: 0 },
+        { id: '2', likes: 0 },
+      ],
+    }),
   })
 })
 afterEach(() => jest.useRealTimers())
-test('loads the original automatically near the viewport without fetching every notice', async () => {
+test('loads full details only on inline expansion', async () => {
   render(
     <OpportunityBoard
       opportunities={[offer, ask]}
@@ -65,9 +74,8 @@ test('loads the original automatically near the viewport without fetching every 
   )
   expect(fetch).not.toHaveBeenCalled()
   await act(async () => {
-    intersections[0](
-      [{ isIntersecting: true } as IntersectionObserverEntry],
-      {} as IntersectionObserver,
+    fireEvent.click(
+      screen.getAllByRole('button', { name: 'Read full tweet by @alice' })[0],
     )
   })
   await act(async () => {
@@ -78,21 +86,32 @@ test('loads the original automatically near the viewport without fetching every 
     '/api/bulletin/tweets?ids=1',
     expect.objectContaining({ cache: 'no-store' }),
   )
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+
   expect(screen.getByText('Original card')).toBeInTheDocument()
+  fireEvent.click(
+    screen.getByRole('button', { name: 'Collapse tweet by @alice' }),
+  )
+  expect(screen.queryByText('Original card')).not.toBeInTheDocument()
   expect(screen.queryByText(/Until|On X since/)).not.toBeInTheDocument()
 })
-test('shows ask/offer columns and combines category and search filters', () => {
+test('shows category lanes and combines side, category and search filters', () => {
   render(
     <OpportunityBoard
       opportunities={[offer, ask]}
       now={Date.parse('2026-09-09T00:00:00Z')}
     />,
   )
-  expect(screen.getByRole('region', { name: 'Offers' })).toBeInTheDocument()
-  expect(screen.getByRole('region', { name: 'Asks' })).toBeInTheDocument()
-  fireEvent.click(screen.getByRole('button', { name: 'Help 1' }))
+  expect(screen.getByRole('region', { name: 'Help' })).toBeInTheDocument()
+  expect(screen.getByRole('region', { name: 'Feedback' })).toBeInTheDocument()
+  fireEvent.change(screen.getByLabelText('Category'), {
+    target: { value: 'help' },
+  })
   expect(screen.queryByText('Feedback on a garden')).not.toBeInTheDocument()
-  fireEvent.change(screen.getByLabelText('Search opportunities'), {
+  fireEvent.click(screen.getByRole('button', { name: 'Asks' }))
+  expect(screen.queryByText('Help with Python')).not.toBeInTheDocument()
+  expect(window.location.hash).toContain('side=ask')
+  fireEvent.change(screen.getByLabelText('Filter notices'), {
     target: { value: 'gardening' },
   })
   expect(screen.getByRole('status')).toHaveTextContent('0 of 2 notices')
@@ -111,7 +130,7 @@ test('past toggle includes expired notices and preserves filters in the URL', ()
   expect(screen.getByText('Help with Python')).toBeInTheDocument()
 })
 
-test('coalesces visible cards into one request and reuses loaded cards after filtering', async () => {
+test('coalesces expanded cards and reuses their details after filtering', async () => {
   render(
     <OpportunityBoard
       opportunities={[offer, ask]}
@@ -119,11 +138,10 @@ test('coalesces visible cards into one request and reuses loaded cards after fil
     />,
   )
   await act(async () => {
-    for (const callback of intersections)
-      callback(
-        [{ isIntersecting: true } as IntersectionObserverEntry],
-        {} as IntersectionObserver,
-      )
+    for (const button of screen.getAllByRole('button', {
+      name: 'Read full tweet by @alice',
+    }))
+      fireEvent.click(button)
   })
   await act(async () => {
     jest.advanceTimersByTime(25)
@@ -133,14 +151,18 @@ test('coalesces visible cards into one request and reuses loaded cards after fil
     '/api/bulletin/tweets?ids=1,2',
     expect.any(Object),
   )
-  expect(screen.getAllByText('Original card')).toHaveLength(2)
-  fireEvent.click(screen.getByRole('button', { name: 'Help 1' }))
-  fireEvent.click(screen.getByRole('button', { name: 'All categories 2' }))
+  expect(screen.getAllByLabelText('0 likes')).toHaveLength(2)
+  fireEvent.change(screen.getByLabelText('Category'), {
+    target: { value: 'help' },
+  })
+  fireEvent.change(screen.getByLabelText('Category'), {
+    target: { value: 'all' },
+  })
   await act(async () => {
-    intersections[intersections.length - 1](
-      [{ isIntersecting: true } as IntersectionObserverEntry],
-      {} as IntersectionObserver,
-    )
+    for (const button of screen.queryAllByRole('button', {
+      name: 'Read full tweet by @alice',
+    }))
+      fireEvent.click(button)
   })
   await act(async () => {
     jest.advanceTimersByTime(25)
@@ -161,11 +183,11 @@ test('automatically pages once per sentinel and preserves global search and coun
     />,
   )
   expect(screen.getByRole('status')).toHaveTextContent('14 of 14 notices')
-  expect(screen.getAllByRole('article')).toHaveLength(6)
+  expect(screen.getAllByRole('article')).toHaveLength(4)
   expect(
-    screen.queryByRole('button', { name: 'Load more offers' }),
+    screen.queryByRole('button', { name: 'Load more Help' }),
   ).not.toBeInTheDocument()
-  const sentinel = screen.getByLabelText('Load more offers')
+  const sentinel = screen.getByLabelText('Load more Help')
   const nextPage = intersections.find(
     (callback) => observed.get(callback) === sentinel,
   )!
@@ -179,13 +201,13 @@ test('automatically pages once per sentinel and preserves global search and coun
       {} as IntersectionObserver,
     )
   })
-  expect(screen.getAllByRole('article')).toHaveLength(12)
-  fireEvent.change(screen.getByLabelText('Search opportunities'), {
+  expect(screen.getAllByRole('article')).toHaveLength(8)
+  fireEvent.change(screen.getByLabelText('Filter notices'), {
     target: { value: 'Offer number 14' },
   })
   expect(screen.getByText('Offer number 14')).toBeInTheDocument()
   expect(
-    screen.queryByRole('button', { name: 'Load more offers' }),
+    screen.queryByRole('button', { name: 'Load more Help' }),
   ).not.toBeInTheDocument()
 })
 
@@ -205,4 +227,81 @@ test('shows verified tweet text immediately before requesting richer cards', () 
   expect(
     screen.queryByLabelText('Loading original tweet'),
   ).not.toBeInTheDocument()
+})
+
+const page = (notices: Opportunity[], cursor: string | null = null) => ({
+  opportunities: notices,
+  counts: { help: 8 },
+  cursors: { help: cursor },
+  total: 8,
+  now: Date.parse('2026-09-09T00:00:00Z'),
+  personal: { account_id: '', username: '', outgoing: {}, available: false },
+})
+test('requests and appends a server page on scroll without fetching tweet details', async () => {
+  const initial = page([offer], '1')
+  const more = { ...offer, tweet_id: '3', summary: 'Another offer' }
+  jest
+    .mocked(fetch)
+    .mockResolvedValue({ ok: true, json: async () => page([more]) } as Response)
+  render(
+    <OpportunityBoard
+      opportunities={[offer]}
+      initialPage={initial}
+      now={initial.now}
+    />,
+  )
+  expect(fetch).not.toHaveBeenCalled()
+  const sentinel = screen.getByLabelText('Load more Help')
+  const callback = intersections.find((cb) => observed.get(cb) === sentinel)!
+  await act(async () => {
+    callback(
+      [{ isIntersecting: true } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    )
+  })
+  expect(fetch).toHaveBeenCalledTimes(1)
+  expect(String(jest.mocked(fetch).mock.calls[0][0])).toContain('kind=help')
+  expect(String(jest.mocked(fetch).mock.calls[0][0])).toContain('after=1')
+  expect(screen.getByText('Help with Python')).toBeInTheDocument()
+  expect(screen.getByText('Another offer')).toBeInTheDocument()
+  expect(screen.queryByLabelText('Load more Help')).not.toBeInTheDocument()
+})
+test('searches the server for unloaded matches and ignores stale filter responses', async () => {
+  const initial = page([offer])
+  let resolveOld!: (value: Response) => void
+  jest.mocked(fetch).mockImplementationOnce(
+    () =>
+      new Promise((resolve) => {
+        resolveOld = resolve
+      }),
+  )
+  jest.mocked(fetch).mockResolvedValueOnce({
+    ok: true,
+    json: async () =>
+      page([{ ...offer, tweet_id: '99', summary: 'Unloaded match' }]),
+  } as Response)
+  render(
+    <OpportunityBoard
+      opportunities={[offer]}
+      initialPage={initial}
+      now={initial.now}
+    />,
+  )
+  fireEvent.change(screen.getByLabelText('Filter notices'), {
+    target: { value: 'old' },
+  })
+  await act(async () => {
+    jest.advanceTimersByTime(200)
+  })
+  fireEvent.change(screen.getByLabelText('Filter notices'), {
+    target: { value: 'Unloaded match' },
+  })
+  await act(async () => {
+    jest.advanceTimersByTime(200)
+  })
+  await act(async () => {
+    resolveOld({ ok: true, json: async () => page([offer]) } as Response)
+  })
+  expect(screen.getByText('Unloaded match')).toBeInTheDocument()
+  expect(screen.queryByText('Help with Python')).not.toBeInTheDocument()
 })

--- a/src/components/bulletin/OpportunityBoard.tsx
+++ b/src/components/bulletin/OpportunityBoard.tsx
@@ -1,29 +1,50 @@
 'use client'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react'
+import Link from 'next/link'
+import { PiArrowSquareOut } from 'react-icons/pi'
 import { useTweetBatch } from './useTweetBatch'
-import { Input } from '@/components/ui/input'
-import { Button } from '@/components/ui/button'
-import { TweetCard } from '@/components/TweetCard'
+import { useBoardPages } from './useBoardPages'
+import { RefreshButton } from './RefreshButton'
+import { TweetAvatar } from '@/components/TweetAvatar'
 import type { PortalTweet } from '@/lib/portal/types'
-import { KIND_LABELS, type Opportunity } from '@/lib/bulletin/types'
+import { decodeTweetText } from '@/lib/tweetText'
+import { tweetPermalinkHref, userProfileHref } from '@/lib/navigation'
+import {
+  KIND_LABELS,
+  type BulletinPage,
+  type Opportunity,
+} from '@/lib/bulletin/types'
 import {
   isPast,
   relationship,
   sortNotices,
   type BulletinRelationships,
 } from '@/lib/bulletin/board'
+import styles from './OpportunityBoard.module.css'
 
-const EMPTY_GRAPH: BulletinRelationships = {
-  outgoing: {},
-  available: false,
-}
+const ExpandedTweetCard = lazy(() =>
+  import('@/components/TweetCard').then((module) => ({
+    default: module.TweetCard,
+  })),
+)
+
+const EMPTY_GRAPH: BulletinRelationships = { outgoing: {}, available: false }
+const LANE_GROUPS = [
+  ['free'],
+  ['opportunity'],
+  ['invite'],
+  ['intro'],
+  ['help', 'feedback'],
+]
+const PAGE_SIZE = 4
+
 function ScrollMore({
   count,
-  side,
+  label,
   onMore,
 }: {
   count: number
-  side: string
+  label: string
   onMore: () => void
 }) {
   const sentinel = useRef<HTMLDivElement>(null)
@@ -44,7 +65,7 @@ function ScrollMore({
           callback.current()
         }
       },
-      { rootMargin: '600px' },
+      { rootMargin: '200px' },
     )
     if (sentinel.current) observer.observe(sentinel.current)
     return () => observer.disconnect()
@@ -52,150 +73,211 @@ function ScrollMore({
   return (
     <div
       ref={sentinel}
-      aria-label={`Load more ${side}`}
-      className="min-h-[1px]"
+      aria-label={`Load more ${label}`}
+      className={styles.more}
     >
       {manual ? (
-        <Button variant="outline" onClick={onMore}>
-          Load more {side}
-        </Button>
+        <button onClick={onMore}>Show more</button>
       ) : (
-        <span className="sr-only">More {side} load as you scroll</span>
+        <span className="sr-only">More {label} load as you scroll</span>
       )}
     </div>
   )
 }
 
-function Original({
+function NoticeCard({
   notice,
   loadTweet,
+  badge,
+  expired,
 }: {
   notice: Opportunity
   loadTweet: (id: string) => Promise<PortalTweet>
+  badge: string
+  expired: boolean
 }) {
-  const id = notice.tweet_id
-  const container = useRef<HTMLDivElement>(null)
-  const [visible, setVisible] = useState(false)
+  const [open, setOpen] = useState(false)
   const [tweet, setTweet] = useState<PortalTweet | null>(null)
   const [error, setError] = useState(false)
   const [attempt, setAttempt] = useState(0)
   useEffect(() => {
-    if (typeof IntersectionObserver === 'undefined') {
-      setVisible(true)
-      return
-    }
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          setVisible(true)
-          observer.disconnect()
-        }
-      },
-      { rootMargin: '200px' },
-    )
-    if (container.current) observer.observe(container.current)
-    return () => observer.disconnect()
-  }, [])
-  useEffect(() => {
-    if (!visible) return
-    const controller = new AbortController()
+    if (!open) return
+    let active = true
     setError(false)
-    loadTweet(id)
-      .then((tweet) => {
-        if (!controller.signal.aborted) setTweet(tweet)
+    loadTweet(notice.tweet_id)
+      .then((value) => {
+        if (active) setTweet(value)
       })
       .catch(() => {
-        if (!controller.signal.aborted) setError(true)
+        if (active) setError(true)
       })
-    return () => controller.abort()
-  }, [id, visible, attempt, loadTweet])
-  const displayTweet =
-    tweet ||
-    (typeof notice.preview_text === 'string'
-      ? {
-          id,
-          accountId: notice.account_id,
-          username: notice.username,
-          name: notice.display_name || notice.username,
-          avatar: notice.avatar_url || null,
-          text: notice.preview_text,
-          createdAt: notice.posted_at,
-          observedAt: notice.posted_at,
-          likes: 0,
-          rts: 0,
-        }
-      : null)
+    return () => {
+      active = false
+    }
+  }, [notice.tweet_id, open, attempt, loadTweet])
+  const fallback: PortalTweet = {
+    id: notice.tweet_id,
+    accountId: notice.account_id,
+    username: notice.username,
+    name: notice.display_name || notice.username,
+    avatar: notice.avatar_url || null,
+    text: notice.preview_text || '',
+    createdAt: notice.posted_at,
+    observedAt: notice.posted_at,
+    likes: 0,
+    rts: 0,
+  }
+  const date = new Date(notice.posted_at).toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    timeZone: 'UTC',
+  })
+  const text = decodeTweetText(tweet?.text || notice.preview_text || '')
   return (
-    <div
-      ref={container}
-      className="relative min-w-0"
-      aria-busy={!tweet && !error}
+    <article
+      className={styles.notice}
+      style={expired ? { opacity: 0.6 } : undefined}
     >
-      {displayTweet ? (
-        <TweetCard
-          tweet={displayTweet}
-          showEngagement={!!tweet}
-          previewHeight={240}
-          clickable={false}
-          showDate
-          showExternalLink
-          origin="opportunities"
-          returnTo="/opportunities"
-        />
-      ) : error ? (
-        <div role="alert" className="h-[240px] p-4 text-sm">
-          The original could not be loaded.{' '}
-          <button
-            className="text-brand underline"
-            onClick={() => setAttempt((n) => n + 1)}
-          >
-            Retry
-          </button>
-        </div>
-      ) : (
-        <div
-          className="h-[240px] animate-pulse space-y-3 p-4"
-          aria-label="Loading original tweet"
+      <div className={styles.noticeHead}>
+        <span
+          className={`${styles.kind} ${notice.side === 'offer' ? styles.offer : styles.ask}`}
         >
-          <div className="h-8 w-2/3 rounded bg-muted" />
-          <div className="h-3 rounded bg-muted" />
-          <div className="h-3 w-5/6 rounded bg-muted" />
+          {notice.side === 'offer' ? 'Offer' : 'Ask'}
+        </span>
+        <time dateTime={notice.posted_at} className={styles.date}>
+          {date}
+        </time>
+      </div>
+      <p className={styles.summary}>
+        <Link
+          href={tweetPermalinkHref(
+            notice.tweet_id,
+            'opportunities',
+            '/opportunities',
+          )}
+        >
+          {notice.summary}
+        </Link>
+      </p>
+      <button
+        className={styles.textButton}
+        aria-label={`${open ? 'Collapse' : 'Read full'} tweet by @${notice.username}`}
+        aria-expanded={open}
+        aria-controls={`original-${notice.tweet_id}`}
+        onClick={() => setOpen((value) => !value)}
+      >
+        {!open && (
+          <span className={styles.text}>{text || 'Read original tweet'}</span>
+        )}
+        <span className={styles.readMore}>
+          {open ? 'Show less' : 'Read more'}
+        </span>
+      </button>
+      {open && (
+        <div id={`original-${notice.tweet_id}`} className={styles.expanded}>
+          <Suspense fallback={<p className={styles.fullText}>{text}</p>}>
+            <ExpandedTweetCard
+              tweet={tweet || fallback}
+              showEngagement={!!tweet}
+              clickable={false}
+              showDate
+              showExternalLink
+              origin="opportunities"
+              returnTo="/opportunities"
+            />
+          </Suspense>
+          {!tweet && !error && (
+            <p className="text-xs text-muted-foreground">
+              Loading post details…
+            </p>
+          )}
+          {error && (
+            <button
+              className="text-sm text-brand"
+              onClick={() => setAttempt((n) => n + 1)}
+            >
+              Retry post details
+            </button>
+          )}
         </div>
       )}
-      {displayTweet && error && (
-        <button
-          className="absolute bottom-3 left-14 bg-card px-1 text-xs text-brand"
-          onClick={() => setAttempt((n) => n + 1)}
+      <footer className={styles.noticeFoot}>
+        <Link
+          href={userProfileHref(notice.username, notice.account_id)}
+          aria-label={`View @${notice.username}'s profile`}
         >
-          Retry post details
-        </button>
+          <TweetAvatar tweet={tweet || fallback} size={22} />
+        </Link>
+        <Link
+          className={styles.handle}
+          href={userProfileHref(notice.username, notice.account_id)}
+        >
+          @{notice.username}
+        </Link>
+        <span
+          className={styles.likes}
+          aria-label={tweet ? `${tweet.likes} likes` : undefined}
+        >
+          {tweet ? `♡ ${tweet.likes.toLocaleString()}` : ''}
+        </span>
+        <a
+          className={styles.outbound}
+          href={`https://twitter.com/${encodeURIComponent(notice.username)}/status/${notice.tweet_id}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="View original on X"
+        >
+          <PiArrowSquareOut size={12} />
+        </a>
+      </footer>
+      {(badge || expired) && (
+        <span className={styles.badge}>
+          {badge}
+          {expired ? `${badge ? ' · ' : ''}Past` : ''}
+        </span>
       )}
-    </div>
+    </article>
   )
 }
+
 export function OpportunityBoard({
   opportunities,
+  initialPage,
   me = '',
   username = '',
   graph = EMPTY_GRAPH,
   now = Date.now(),
+  isAdmin = false,
 }: {
   opportunities: Opportunity[]
+  initialPage?: BulletinPage
   me?: string
   username?: string
   graph?: BulletinRelationships
   now?: number
+  isAdmin?: boolean
 }) {
   const loadTweet = useTweetBatch()
-  const [pageSize, setPageSize] = useState({ offer: 6, ask: 6 })
+  const [pageSize, setPageSize] = useState<Record<string, number>>({})
+  const [side, setSide] = useState('all')
   const [kind, setKind] = useState('all')
   const [search, setSearch] = useState('')
   const [past, setPast] = useState(false)
   const [recommended, setRecommended] = useState(true)
   const [hydrated, setHydrated] = useState(false)
+  const pages = useBoardPages(
+    initialPage,
+    { kind, side, search, past, recommended },
+    hydrated,
+  )
+  const loaded = pages.page?.opportunities || opportunities
   useEffect(() => {
     const p = new URLSearchParams(window.location.hash.slice(1))
-    setKind(p.get('kind') || 'all')
+    const savedKind = p.get('kind') || 'all'
+    setKind(savedKind in KIND_LABELS ? savedKind : 'all')
+    setSide(
+      ['ask', 'offer'].includes(p.get('side') || '') ? p.get('side')! : 'all',
+    )
     setPast(p.get('past') === '1')
     setRecommended(p.get('sort') !== 'newest')
     setHydrated(true)
@@ -204,6 +286,7 @@ export function OpportunityBoard({
     if (!hydrated) return
     const p = new URLSearchParams()
     if (kind !== 'all') p.set('kind', kind)
+    if (side !== 'all') p.set('side', side)
     if (past) p.set('past', '1')
     if (!recommended) p.set('sort', 'newest')
     window.history.replaceState(
@@ -213,15 +296,16 @@ export function OpportunityBoard({
         window.location.search +
         (p.toString() ? '#' + p.toString() : ''),
     )
-  }, [kind, past, recommended, hydrated])
+  }, [kind, side, past, recommended, hydrated])
   const visible = useMemo(
     () =>
       sortNotices(
-        opportunities.filter(
+        loaded.filter(
           (o) =>
             (past || !isPast(o, now)) &&
             (kind === 'all' || o.kind === kind) &&
-            [o.summary, o.username, o.place, ...o.topics]
+            (side === 'all' || o.side === side) &&
+            [o.summary, o.preview_text, o.username, o.place, ...o.topics]
               .filter(Boolean)
               .join(' ')
               .toLowerCase()
@@ -232,193 +316,233 @@ export function OpportunityBoard({
         graph,
         now,
       ),
-    [opportunities, kind, past, search, recommended, me, graph, now],
+    [loaded, kind, side, past, search, recommended, me, graph, now],
   )
   useEffect(() => {
-    setPageSize({ offer: 6, ask: 6 })
-  }, [kind, search, past, recommended])
-  const shown = (['offer', 'ask'] as const).reduce(
-    (count, side) =>
-      count +
-      Math.min(pageSize[side], visible.filter((o) => o.side === side).length),
-    0,
-  )
-  const own = opportunities.filter((o) => o.account_id === me)
-  const answered = opportunities.filter(
+    setPageSize({})
+  }, [kind, side, search, past, recommended])
+  const shown = initialPage
+    ? visible.length
+    : Object.keys(KIND_LABELS).reduce(
+        (count, id) =>
+          count +
+          Math.min(
+            pageSize[id] || PAGE_SIZE,
+            visible.filter((o) => o.kind === id).length,
+          ),
+        0,
+      )
+  const count = initialPage
+    ? Object.values(pages.page?.counts || {}).reduce((n, count) => n + count, 0)
+    : visible.length
+  const total = pages.page?.total ?? opportunities.length
+  const own = loaded.filter((o) => o.account_id === me)
+  const answered = loaded.filter(
     (o) => o.account_id !== me && o.reply_account_ids?.includes(me),
   ).length
   return (
-    <div className="space-y-3">
-      <div className="space-y-2">
-        <div className="flex flex-wrap items-center gap-2">
-          <Button
-            size="sm"
-            aria-pressed={recommended}
-            variant={recommended ? 'default' : 'outline'}
-            onClick={() => setRecommended(true)}
+    <>
+      <header className={styles.subbar}>
+        <h1 className={styles.title}>Opportunities</h1>
+        <p className={styles.lede}>{count} notices · collected daily</p>
+        <div className={styles.controls}>
+          <div
+            className={styles.segmented}
+            role="group"
+            aria-label="Notice type"
           >
-            Recommended
-          </Button>
-          <Button
-            size="sm"
-            aria-pressed={!recommended}
-            variant={!recommended ? 'default' : 'outline'}
-            onClick={() => setRecommended(false)}
-          >
-            Newest
-          </Button>
-          <Input
-            className="h-9 min-w-[160px] flex-1 sm:max-w-xs"
-            aria-label="Search opportunities"
-            placeholder="Search topics, people, or places"
+            {(['all', 'offer', 'ask'] as const).map((id) => (
+              <button
+                key={id}
+                type="button"
+                aria-pressed={side === id}
+                onClick={() => setSide(id)}
+              >
+                {id === 'all' ? 'All' : id === 'offer' ? 'Offers' : 'Asks'}
+              </button>
+            ))}
+          </div>
+          <input
+            className={styles.field}
+            type="search"
+            aria-label="Filter notices"
+            placeholder="Filter notices"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
           />
-          <label className="flex items-center gap-2 text-xs">
-            <input
-              type="checkbox"
-              checked={past}
-              onChange={(e) => setPast(e.target.checked)}
-            />
-            Show past notices
-          </label>
+          <RefreshButton className={styles.refresh} />
         </div>
-        <div
-          className="flex gap-2 overflow-x-auto pb-1 sm:flex-wrap"
-          aria-label="Categories"
-        >
-          {Object.entries({ all: 'All categories', ...KIND_LABELS }).map(
-            ([id, label]) => (
-              <Button
-                key={id}
-                className="shrink-0"
-                size="sm"
-                variant={kind === id ? 'default' : 'outline'}
-                aria-pressed={kind === id}
-                onClick={() => setKind(id)}
-              >
-                {label}
-                <span className="ml-1.5 opacity-60">
-                  {
-                    opportunities.filter(
-                      (o) =>
-                        (past || !isPast(o, now)) &&
-                        (id === 'all' || o.kind === id),
-                    ).length
-                  }
-                </span>
-              </Button>
-            ),
-          )}
-        </div>
-      </div>
-      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
-        <p role="status">
-          {visible.length} of {opportunities.length} notices
-          {shown < visible.length ? ` · ${shown} shown` : ''}
-          {opportunities.length === 2000 ? ' · Latest 2,000 only' : ''}
+        <p className={styles.description}>
+          This page may contain opportunities. We filter tweets for asks and
+          offers. Things like free services, invitations to events, grants,
+          collaborations, requests for feedback or introductions, and more. We
+          show you things that may be relevant to you first.
         </p>
-        <details>
-          <summary className="cursor-pointer">
-            {recommended ? 'About recommendations' : 'About sorting'}
-            {me ? ' & your activity' : ''}
-          </summary>
-          <p className="mt-2 max-w-2xl">
-            {recommended && graph.available
-              ? 'Free things first, then work & collaboration, invitations, introductions, help, and feedback. Within each category: your notices, then your top outgoing interactions, then everyone else. This uses the profile’s top 25 all-time interaction counts (mentions, replies, quotes and reposts); missing people are not necessarily strangers.'
-              : recommended
-                ? 'Top outgoing interactions are unavailable. Showing categories in priority order, with your notices first within each category, then newest.'
-                : 'Newest notices first.'}{' '}
+      </header>
+      {pages.pending && (
+        <p role="status" className="px-8 py-4 text-sm text-muted-foreground">
+          {pages.error || 'Loading matching notices…'}
+          {pages.error && (
+            <button className="ml-2 text-brand" onClick={pages.retry}>
+              Retry
+            </button>
+          )}
+        </p>
+      )}
+      <div className={styles.board} aria-busy={pages.pending}>
+        {LANE_GROUPS.filter(
+          (group) => !pages.pending && (kind === 'all' || group.includes(kind)),
+        ).map((group) => (
+          <div className={styles.laneGroup} key={group[0]}>
+            {group
+              .filter((id) => kind === 'all' || kind === id)
+              .map((id) => {
+                const notices = visible.filter((o) => o.kind === id)
+                const limit = initialPage
+                  ? notices.length
+                  : pageSize[id] || PAGE_SIZE
+                return (
+                  <section
+                    key={id}
+                    className={styles.lane}
+                    aria-label={KIND_LABELS[id]}
+                  >
+                    <div className={styles.laneHead}>
+                      <h2>{KIND_LABELS[id]}</h2>
+                      <span className={styles.laneCount}>
+                        {initialPage
+                          ? pages.page?.counts[id] || 0
+                          : notices.length}
+                      </span>
+                    </div>
+                    {notices.slice(0, limit).map((o) => (
+                      <NoticeCard
+                        key={o.tweet_id}
+                        notice={o}
+                        loadTweet={loadTweet}
+                        badge={relationship(o, me, graph).label}
+                        expired={isPast(o, now)}
+                      />
+                    ))}
+                    {(initialPage
+                      ? pages.page?.cursors[id] &&
+                        !pages.loading[id] &&
+                        !pages.laneErrors[id]
+                      : notices.length > limit) && (
+                      <ScrollMore
+                        key={`${kind}:${side}:${search}:${past}:${recommended}`}
+                        label={KIND_LABELS[id]}
+                        count={limit}
+                        onMore={() =>
+                          initialPage
+                            ? void pages.loadMore(id)
+                            : setPageSize((size) => ({
+                                ...size,
+                                [id]: (size[id] || PAGE_SIZE) + PAGE_SIZE,
+                              }))
+                        }
+                      />
+                    )}
+                    {pages.loading[id] && (
+                      <p className={styles.empty}>Loading more…</p>
+                    )}
+                    {pages.laneErrors[id] && (
+                      <p className={styles.empty}>
+                        {pages.laneErrors[id]}{' '}
+                        <button onClick={() => void pages.loadMore(id)}>
+                          Retry
+                        </button>
+                      </p>
+                    )}
+                    {!notices.length && (
+                      <p className={styles.empty}>No matching notices.</p>
+                    )}
+                  </section>
+                )
+              })}
+          </div>
+        ))}
+      </div>
+      <footer className={styles.footer}>
+        <p role="status">
+          {count} of {total} notices
+          {shown < count ? ` · ${shown} shown` : ''}
+          {total === 2000 ? ' · Latest 2,000 only' : ''}
+        </p>
+        <p>
+          Thanks to <Link href="/user/maskys_">@maskys_</Link> for the first
+          prototype.
+        </p>
+        {isAdmin && <Link href="/admin/opportunities">Run dashboard →</Link>}
+        <details className={styles.options}>
+          <summary>Options & about this board</summary>
+          <div className={styles.optionFields}>
+            <label>
+              Sort{' '}
+              <select
+                value={recommended ? 'recommended' : 'newest'}
+                onChange={(e) =>
+                  setRecommended(e.target.value === 'recommended')
+                }
+              >
+                <option value="recommended">Recommended</option>
+                <option value="newest">Newest</option>
+              </select>
+            </label>
+            <label>
+              Category{' '}
+              <select value={kind} onChange={(e) => setKind(e.target.value)}>
+                <option value="all">All categories</option>
+                {Object.entries(KIND_LABELS).map(([id, label]) => (
+                  <option key={id} value={id}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              <input
+                type="checkbox"
+                checked={past}
+                onChange={(e) => setPast(e.target.checked)}
+              />
+              Show past notices
+            </label>
+          </div>
+          <p className={styles.method}>
+            {recommended
+              ? graph.available
+                ? 'Recommended puts your notices and people you interact with most first within each category, using your top 25 all-time outgoing interactions. Missing people are not necessarily strangers.'
+                : 'Top outgoing interactions are unavailable. Showing your notices first within each category, then newest.'
+              : 'Newest notices first within each category.'}{' '}
             Past notices appear last.
           </p>
           {me && (
-            <p className="my-2">
-              <strong>{username ? '@' + username : 'Your activity'}</strong> ·{' '}
-              {own.filter((o) => o.side === 'offer').length} offers ·{' '}
-              {own.filter((o) => o.side === 'ask').length} asks ·{' '}
+            <p className={styles.method}>
+              @{username || me} · {own.filter((o) => o.side === 'offer').length}{' '}
+              offers · {own.filter((o) => o.side === 'ask').length} asks ·{' '}
               {own.reduce((n, o) => n + (o.replies || 0) + (o.quotes || 0), 0)}{' '}
               public responses · Replied to {answered} other notices. Public
               archive activity within the loaded notices only.
             </p>
           )}
+          <p className={styles.method}>
+            After the daily archive refresh, phrase filters and AI find asks and
+            offers in recent original ClickHouse posts from participating
+            accounts. This is a selection, not a complete directory: replies,
+            reposts, late arrivals and notices without matching phrases may be
+            missed. Read the original before responding. Counts may adjust as
+            more posts are checked.
+          </p>
+          <p className={styles.method}>
+            The daily scan covers the previous two UTC days. Undated asks expire
+            after 14 days and offers after 60 days; standing offers stay open.
+            Post an “offer:”, “ask:”, or “standing offer:” on X with what you
+            need or offer and how to respond. Quote your own notice to renew an
+            undated notice when it reaches the archive.
+          </p>
         </details>
-      </div>
-      <div className="grid items-start gap-6 lg:grid-cols-2">
-        {(['offer', 'ask'] as const).map((side) => (
-          <section
-            key={side}
-            className="space-y-3"
-            aria-label={side === 'offer' ? 'Offers' : 'Asks'}
-          >
-            <h2 className="flex items-center justify-between border-b pb-2 text-xl font-semibold">
-              {side === 'offer' ? 'Offers' : 'Asks'}{' '}
-              <span className="text-base text-muted-foreground">
-                {visible.filter((o) => o.side === side).length}
-              </span>
-            </h2>
-            <div className="grid items-start gap-3 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2">
-              {visible
-                .filter((o) => o.side === side)
-                .slice(0, pageSize[side])
-                .map((o) => {
-                  const rel = relationship(o, me, graph)
-                  const expired = isPast(o, now)
-                  return (
-                    <article
-                      key={o.tweet_id}
-                      className={`min-w-0 overflow-hidden rounded-lg border bg-card ${expired ? 'opacity-60' : ''} ${rel.rank < 3 ? 'border-brand/40' : ''}`}
-                    >
-                      <Original notice={o} loadTweet={loadTweet} />
-                      <div className="h-24 space-y-1 border-t px-3 py-2">
-                        <div className="flex items-center justify-between gap-2 text-[11px] leading-4">
-                          <span className="rounded bg-muted px-1.5 py-0.5 font-medium text-muted-foreground">
-                            {KIND_LABELS[o.kind]}
-                          </span>
-                          {(rel.label || expired) && (
-                            <span className="rounded border bg-muted/40 px-1.5 py-0.5 text-right text-muted-foreground">
-                              {rel.label}
-                              {expired ? `${rel.label ? ' · ' : ''}Past` : ''}
-                            </span>
-                          )}
-                        </div>
-                        <p
-                          className="line-clamp-3 text-xs leading-[18px] text-foreground/80"
-                          title={o.summary}
-                        >
-                          {o.summary}
-                        </p>
-                      </div>
-                    </article>
-                  )
-                })}
-            </div>
-            {visible.filter((o) => o.side === side).length > pageSize[side] && (
-              <ScrollMore
-                key={`${kind}:${search}:${past}:${recommended}`}
-                side={side === 'offer' ? 'offers' : 'asks'}
-                count={pageSize[side]}
-                onMore={() =>
-                  setPageSize((size) => ({ ...size, [side]: size[side] + 6 }))
-                }
-              />
-            )}
-            {!visible.some((o) => o.side === side) && (
-              <p className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
-                No matching {side === 'offer' ? 'offers' : 'asks'}.
-              </p>
-            )}
-          </section>
-        ))}
-      </div>
-      <aside className="rounded-lg bg-muted/40 p-5 text-sm">
-        <strong>Put a notice on the board</strong>
-        <p className="mt-2 text-muted-foreground">
-          Post an “offer:”, “ask:”, or “standing offer:” on X. Say what you’re
-          offering or looking for and how to respond. Participating accounts are
-          checked after the daily refresh. Quote your own notice to renew an
-          undated notice when that quote reaches the archive.
-        </p>
-      </aside>
-    </div>
+      </footer>
+    </>
   )
 }

--- a/src/components/bulletin/RefreshButton.tsx
+++ b/src/components/bulletin/RefreshButton.tsx
@@ -4,12 +4,13 @@ import { useRouter } from 'next/navigation'
 import { RefreshCw } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 
-export function RefreshButton() {
+export function RefreshButton({ className }: { className?: string }) {
   const router = useRouter()
   const [pending, startTransition] = useTransition()
   return (
     <Button
       variant="outline"
+      className={className}
       disabled={pending}
       onClick={() => startTransition(() => router.refresh())}
     >

--- a/src/components/bulletin/useBoardPages.ts
+++ b/src/components/bulletin/useBoardPages.ts
@@ -1,0 +1,151 @@
+'use client'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  DEFAULT_BULLETIN_FILTERS,
+  type BulletinFilters,
+  type BulletinPage,
+} from '@/lib/bulletin/types'
+
+function filterKey(filters: BulletinFilters) {
+  return JSON.stringify([
+    filters.kind,
+    filters.side,
+    filters.search.trim(),
+    filters.past,
+    filters.recommended,
+  ])
+}
+function query(filters: BulletinFilters) {
+  return new URLSearchParams({
+    kind: filters.kind,
+    side: filters.side,
+    q: filters.search.trim(),
+    past: filters.past ? '1' : '0',
+    sort: filters.recommended ? 'recommended' : 'newest',
+  })
+}
+async function fetchPage(
+  params: URLSearchParams,
+  signal: AbortSignal,
+): Promise<BulletinPage> {
+  const response = await fetch(`/api/bulletin/board?${params}`, {
+    cache: 'no-store',
+    signal,
+  })
+  if (!response.ok)
+    throw new Error(
+      response.status === 409
+        ? 'The board changed. Refresh to continue.'
+        : 'Could not load notices. Please retry.',
+    )
+  return response.json()
+}
+
+export function useBoardPages(
+  initial: BulletinPage | undefined,
+  filters: BulletinFilters,
+  ready: boolean,
+) {
+  const key = filterKey(filters)
+  const [state, setState] = useState({
+    key: filterKey(DEFAULT_BULLETIN_FILTERS),
+    page: initial,
+  })
+  const [error, setError] = useState('')
+  const [retry, setRetry] = useState(0)
+  const [loading, setLoading] = useState<Record<string, boolean>>({})
+  const [laneErrors, setLaneErrors] = useState<Record<string, string>>({})
+  const requests = useRef(new Map<string, AbortController>())
+  const currentKey = useRef(key)
+  currentKey.current = key
+  const filtersRef = useRef(filters)
+  filtersRef.current = filters
+  const pending = !!initial && state.key !== key
+
+  useEffect(() => {
+    if (!initial || !ready) return
+    const controllers = requests.current
+    setLoading({})
+    setLaneErrors({})
+    setError('')
+    const controller = new AbortController()
+    // Debounce searches, while preserving the server-rendered default page.
+    const timer = pending
+      ? setTimeout(() => {
+          fetchPage(query(filtersRef.current), controller.signal)
+            .then((page) => {
+              if (!controller.signal.aborted && currentKey.current === key)
+                setState({ key, page })
+            })
+            .catch(() => {
+              if (!controller.signal.aborted)
+                setError('Could not load notices. Please retry.')
+            })
+        }, 200)
+      : undefined
+    return () => {
+      clearTimeout(timer)
+      controller.abort()
+      controllers.forEach((request) => request.abort())
+      controllers.clear()
+    }
+  }, [key, ready, initial, retry, pending])
+
+  const loadMore = useCallback(
+    async (kind: string) => {
+      const cursor = state.page?.cursors[kind]
+      if (!initial || pending || !cursor || requests.current.has(kind)) return
+      const controller = new AbortController()
+      requests.current.set(kind, controller)
+      setLoading((value) => ({ ...value, [kind]: true }))
+      setLaneErrors((value) => ({ ...value, [kind]: '' }))
+      const params = query({ ...filtersRef.current, kind })
+      params.set('after', cursor)
+      try {
+        const page = await fetchPage(params, controller.signal)
+        if (controller.signal.aborted || currentKey.current !== key) return
+        setState((value) => {
+          if (value.key !== key || !value.page) return value
+          const notices = new Map(
+            value.page.opportunities.map((o) => [o.tweet_id, o]),
+          )
+          for (const notice of page.opportunities)
+            notices.set(notice.tweet_id, notice)
+          return {
+            key,
+            page: {
+              ...value.page,
+              opportunities: Array.from(notices.values()),
+              counts: { ...value.page.counts, ...page.counts },
+              cursors: { ...value.page.cursors, ...page.cursors },
+            },
+          }
+        })
+      } catch (cause) {
+        if (!controller.signal.aborted)
+          setLaneErrors((value) => ({
+            ...value,
+            [kind]:
+              cause instanceof Error
+                ? cause.message
+                : 'Could not load notices.',
+          }))
+      } finally {
+        if (requests.current.get(kind) === controller) {
+          requests.current.delete(kind)
+          setLoading((value) => ({ ...value, [kind]: false }))
+        }
+      }
+    },
+    [initial, pending, state.page, key],
+  )
+  return {
+    page: state.page,
+    pending,
+    error,
+    loading,
+    laneErrors,
+    loadMore,
+    retry: () => setRetry((n) => n + 1),
+  }
+}

--- a/src/components/portal/TweetRow.tsx
+++ b/src/components/portal/TweetRow.tsx
@@ -6,14 +6,14 @@ import { useEffect, useRef, useState } from 'react'
 import type { KeyboardEvent, MouseEvent, ReactNode } from 'react'
 import { PiArrowSquareOut, PiHeart, PiQuotes, PiRepeat } from 'react-icons/pi'
 import ImageLightbox from '@/components/ImageLightbox'
-import TweetAvatarImage from '@/components/TweetAvatarImage'
+import { TweetAvatar } from '@/components/TweetAvatar'
+export { TweetAvatar, avatarHue } from '@/components/TweetAvatar'
 import {
   tweetPermalinkHref,
   userProfileHref,
   type TweetOrigin,
 } from '@/lib/navigation'
 import { decodeTweetText } from '@/lib/tweetText'
-import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import {
   Tooltip,
   TooltipContent,
@@ -25,17 +25,8 @@ import { capturePostHogEvent } from '@/lib/posthog'
 import { TweetLinkPreviews } from '@/components/TweetLinkPreviews'
 import { AddToProfileButton } from './AddToProfileButton'
 
-const HUES = [262, 32, 145, 4, 155, 200, 217, 88, 240, 190, 340, 45, 280, 20]
 const FEATURED_CARD_HOVER =
   'transition-[transform,border-color,box-shadow] duration-100 ease-out hover:-translate-y-0.5 hover:border-[#d4d4d7]/75 hover:shadow-[0_3px_9px_rgba(24,24,27,0.08)] motion-reduce:transition-none motion-reduce:hover:translate-y-0 dark:hover:border-[#404046]/80 dark:hover:shadow-[0_3px_9px_rgba(0,0,0,0.22)]'
-
-export const avatarHue = (username: string) => {
-  let h = 0
-  for (let i = 0; i < username.length; i++) {
-    h = (h * 31 + username.charCodeAt(i)) >>> 0
-  }
-  return HUES[h % HUES.length]
-}
 
 export const formatCount = (n: number) =>
   n >= 1000 ? (n / 1000).toFixed(1) + 'k' : String(n)
@@ -81,32 +72,6 @@ function CountMetric({
       <span aria-hidden="true">{formatCount(count)}</span>
       <span className="sr-only">{`${formatCount(count)} ${label}`}</span>
     </span>
-  )
-}
-
-export function TweetAvatar({
-  tweet,
-  size = 34,
-}: {
-  tweet: Pick<PortalTweet, 'id' | 'username' | 'avatar'>
-  size?: number
-}) {
-  const initials = tweet.username.slice(0, 2).toUpperCase()
-  return (
-    <Avatar className="flex-shrink-0" style={{ width: size, height: size }}>
-      <TweetAvatarImage
-        src={tweet.avatar}
-        alt=""
-        username={tweet.username}
-        tweetId={tweet.id}
-      />
-      <AvatarFallback
-        className="text-[12px] font-extrabold text-white"
-        style={{ background: `hsl(${avatarHue(tweet.username)},42%,42%)` }}
-      >
-        {initials}
-      </AvatarFallback>
-    </Avatar>
   )
 }
 

--- a/src/lib/bulletin/data.ts
+++ b/src/lib/bulletin/data.ts
@@ -22,7 +22,17 @@ export async function requireOpportunityUser() {
 }
 export async function loadOpportunities(): Promise<Opportunity[]> {
   await requireOpportunityUser()
-  const { notices, allowedAccounts } = await loadBulletinBoardState()
+  return hydrateBulletinNotices(await loadBulletinBoardState())
+}
+
+/** Hydrate only the selected notices, retaining the live source/policy checks. */
+export async function hydrateBulletinNotices({
+  notices,
+  allowedAccounts,
+}: {
+  notices: StoredNotice[]
+  allowedAccounts?: string[]
+}): Promise<Opportunity[]> {
   const result: Opportunity[] = []
   for (let offset = 0; offset < notices.length; offset += 100) {
     const batch = notices.slice(offset, offset + 100)

--- a/src/lib/bulletin/page.test.ts
+++ b/src/lib/bulletin/page.test.ts
@@ -1,0 +1,117 @@
+import { loadBulletinPage, BulletinCursorExpired } from './page'
+import {
+  hydrateBulletinNotices,
+  loadBulletinBoardState,
+  loadBulletinRelationships,
+  type StoredNotice,
+} from './data'
+import { DEFAULT_BULLETIN_FILTERS } from './types'
+jest.mock('./data', () => ({
+  hydrateBulletinNotices: jest.fn(),
+  loadBulletinBoardState: jest.fn(),
+  loadBulletinRelationships: jest.fn(),
+}))
+const filters = { ...DEFAULT_BULLETIN_FILTERS, kind: 'help' }
+const notice = (i: number): StoredNotice => ({
+  tweet_id: String(i),
+  account_id: '123',
+  username: 'alice',
+  posted_at: '2026-09-08T00:00:00Z',
+  kind: 'help',
+  side: 'offer',
+  summary: `Offer ${i}`,
+  topics: [],
+  standing: false,
+  expires_at: null,
+  place: null,
+  evidence: '',
+  respond: 'dm',
+  content_hash: 'hash',
+})
+beforeEach(() => {
+  jest.clearAllMocks()
+  jest.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-09-09T00:00:00Z'))
+  jest.mocked(loadBulletinBoardState).mockResolvedValue({
+    notices: Array.from({ length: 9 }, (_, i) => notice(i + 1)),
+  })
+  jest.mocked(loadBulletinRelationships).mockResolvedValue({
+    account_id: '',
+    username: '',
+    outgoing: {},
+    available: false,
+  })
+  jest.mocked(hydrateBulletinNotices).mockImplementation(async ({ notices }) =>
+    notices.map(({ content_hash, ...o }) => ({
+      ...o,
+      preview_text: `Current text ${o.tweet_id}`,
+    })),
+  )
+})
+afterEach(() => jest.restoreAllMocks())
+test('hydrates only four selected sources, keeps metadata private, and advances the cursor', async () => {
+  const first = await loadBulletinPage(filters)
+  expect(first.opportunities.map((o) => o.tweet_id)).toEqual([
+    '9',
+    '8',
+    '7',
+    '6',
+  ])
+  expect(hydrateBulletinNotices).toHaveBeenCalledTimes(1)
+  expect(
+    jest.mocked(hydrateBulletinNotices).mock.calls[0][0].notices,
+  ).toHaveLength(4)
+  expect(JSON.stringify(first)).not.toContain('content_hash')
+  expect(first.cursors.help).toBe('6')
+  const second = await loadBulletinPage(filters, first.cursors.help!)
+  expect(second.opportunities.map((o) => o.tweet_id)).toEqual([
+    '5',
+    '4',
+    '3',
+    '2',
+  ])
+  const third = await loadBulletinPage(filters, second.cursors.help!)
+  expect(third.opportunities.map((o) => o.tweet_id)).toEqual(['1'])
+  expect(third.cursors.help).toBeNull()
+})
+test('refills holes from removed sources and rejects missing cursors', async () => {
+  jest
+    .mocked(hydrateBulletinNotices)
+    .mockImplementation(async ({ notices }) =>
+      notices.filter((o) => o.tweet_id !== '9'),
+    )
+  const first = await loadBulletinPage(filters)
+  expect(first.opportunities.map((o) => o.tweet_id)).toEqual([
+    '8',
+    '7',
+    '6',
+    '5',
+  ])
+  expect(first.counts.help).toBe(8)
+  await expect(loadBulletinPage(filters, '999')).rejects.toBeInstanceOf(
+    BulletinCursorExpired,
+  )
+})
+test('preserves self-quote renewal and full-text search beyond the first page', async () => {
+  const expired = {
+    ...notice(1),
+    side: 'ask',
+    posted_at: '2026-08-01T00:00:00Z',
+  }
+  jest.mocked(loadBulletinBoardState).mockResolvedValue({
+    notices: [expired, ...Array.from({ length: 8 }, (_, i) => notice(i + 2))],
+  })
+  jest.mocked(hydrateBulletinNotices).mockImplementation(async ({ notices }) =>
+    notices.map((o) => ({
+      ...o,
+      preview_text: o.tweet_id === '1' ? 'Hidden needle' : 'other text',
+      renewed_at: o.tweet_id === '1' ? '2026-09-08T00:00:00Z' : null,
+    })),
+  )
+  const first = await loadBulletinPage(filters)
+  expect(first.counts.help).toBe(9)
+  expect(
+    jest.mocked(hydrateBulletinNotices).mock.calls[0][0].notices,
+  ).toHaveLength(5)
+  const result = await loadBulletinPage({ ...filters, search: 'needle' })
+  expect(result.opportunities.map((o) => o.tweet_id)).toEqual(['1'])
+})

--- a/src/lib/bulletin/page.ts
+++ b/src/lib/bulletin/page.ts
@@ -1,0 +1,147 @@
+import 'server-only'
+import {
+  hydrateBulletinNotices,
+  loadBulletinBoardState,
+  loadBulletinRelationships,
+  type StoredNotice,
+} from './data'
+import { isPast, sortNotices } from './board'
+import {
+  BULLETIN_PAGE_SIZE,
+  KIND_LABELS,
+  type BulletinFilters,
+  type BulletinPage,
+  type Opportunity,
+} from './types'
+
+export class BulletinCursorExpired extends Error {}
+
+/** Keep the directory server-side; only send source-verified card contents. */
+export async function loadBulletinPage(
+  filters: BulletinFilters,
+  after?: string,
+): Promise<BulletinPage> {
+  const now = Date.now()
+  const [state, personal] = await Promise.all([
+    loadBulletinBoardState(),
+    loadBulletinRelationships(),
+  ])
+  const kinds = Object.keys(KIND_LABELS).filter(
+    (id) => filters.kind === 'all' || id === filters.kind,
+  )
+  const eligible = state.notices.filter(
+    (o) =>
+      kinds.includes(o.kind) &&
+      (filters.side === 'all' || o.side === filters.side),
+  )
+  const verified = new Map<string, Opportunity>()
+  const rejected = new Set<string>()
+  async function hydrate(notices: StoredNotice[]) {
+    if (!notices.length) return
+    const rows = await hydrateBulletinNotices({ ...state, notices })
+    const found = new Set(rows.map((o) => o.tweet_id))
+    for (const o of notices)
+      if (!found.has(o.tweet_id)) rejected.add(o.tweet_id)
+    for (const o of rows) verified.set(o.tweet_id, o)
+  }
+  // A self-quote can renew an otherwise expired notice. Check those before
+  // selecting the active page, so pagination never silently loses renewals.
+  // Explicit deadlines cannot be renewed by self-quotes.
+  // Full-text search deliberately checks every candidate, not just page one.
+  const metadataOrder = sortNotices(
+    eligible,
+    filters.recommended,
+    personal.account_id,
+    personal,
+    now,
+  )
+  const first = kinds.flatMap((kind) => {
+    const rows = metadataOrder.filter(
+      (o) => o.kind === kind && (filters.past || !isPast(o, now)),
+    )
+    const start = after ? rows.findIndex((o) => o.tweet_id === after) + 1 : 0
+    return rows.slice(start, start + BULLETIN_PAGE_SIZE)
+  })
+  const preflight = new Map(
+    [...eligible.filter((o) => !o.expires_at && isPast(o, now)), ...first].map(
+      (o) => [o.tweet_id, o],
+    ),
+  )
+  await hydrate(
+    filters.search.trim()
+      ? eligible
+      : (Array.from(preflight.values()) as StoredNotice[]),
+  )
+  const candidates = sortNotices(
+    eligible
+      .map((o) => verified.get(o.tweet_id) || o)
+      .filter(
+        (o) =>
+          !rejected.has(o.tweet_id) &&
+          (filters.past || !isPast(o, now)) &&
+          [o.summary, o.preview_text, o.username, o.place, ...o.topics]
+            .filter(Boolean)
+            .join(' ')
+            .toLowerCase()
+            .includes(filters.search.trim().toLowerCase()),
+      ),
+    filters.recommended,
+    personal.account_id,
+    personal,
+    now,
+  )
+  const counts: Record<string, number> = {}
+  const cursors: Record<string, string | null> = {}
+  const lanes = kinds.map((kind) => {
+    const rows = candidates.filter((o) => o.kind === kind)
+    const index = after ? rows.findIndex((o) => o.tweet_id === after) : -1
+    if (after && index < 0)
+      throw new BulletinCursorExpired('The board changed. Refresh to continue.')
+    counts[kind] = rows.length
+    return { kind, rows, position: index + 1, selected: [] as Opportunity[] }
+  })
+  // Fill holes from removed/edited posts without returning unverified summaries.
+  while (
+    lanes.some(
+      (l) =>
+        l.selected.length < BULLETIN_PAGE_SIZE && l.position < l.rows.length,
+    )
+  ) {
+    const chunks = lanes.map((l) => ({
+      lane: l,
+      rows: l.rows.slice(
+        l.position,
+        l.position + BULLETIN_PAGE_SIZE - l.selected.length,
+      ),
+    }))
+    await hydrate(
+      chunks
+        .flatMap((c) => c.rows)
+        .filter(
+          (o) => !verified.has(o.tweet_id) && !rejected.has(o.tweet_id),
+        ) as StoredNotice[],
+    )
+    for (const { lane, rows } of chunks) {
+      for (const row of rows) {
+        const live = verified.get(row.tweet_id)
+        if (live && (filters.past || !isPast(live, now)))
+          lane.selected.push(live)
+        else counts[lane.kind]--
+      }
+      lane.position += rows.length
+    }
+  }
+  for (const lane of lanes)
+    cursors[lane.kind] =
+      lane.position < lane.rows.length
+        ? lane.rows[lane.position - 1].tweet_id
+        : null
+  return {
+    opportunities: lanes.flatMap((l) => l.selected),
+    counts,
+    cursors,
+    total: state.notices.length,
+    now,
+    personal,
+  }
+}

--- a/src/lib/bulletin/types.ts
+++ b/src/lib/bulletin/types.ts
@@ -118,3 +118,32 @@ export type PromptDashboard = {
   preview_note?: string
 }
 export type PromptSaveResult = { error?: string; version?: string }
+
+export type BulletinFilters = {
+  kind: string
+  side: string
+  search: string
+  past: boolean
+  recommended: boolean
+}
+export type BulletinPage = {
+  opportunities: Opportunity[]
+  counts: Record<string, number>
+  cursors: Record<string, string | null>
+  total: number
+  now: number
+  personal: {
+    account_id: string
+    username: string
+    outgoing: Record<string, number>
+    available: boolean
+  }
+}
+export const BULLETIN_PAGE_SIZE = 4
+export const DEFAULT_BULLETIN_FILTERS: BulletinFilters = {
+  kind: 'all',
+  side: 'all',
+  search: '',
+  past: false,
+  recommended: true,
+}


### PR DESCRIPTION
Replace the Opportunities board with the reviewed category-lane design, a compact header and explanation, real avatars, and inline “Read more” using the existing full tweet card.

Fetch four verified notices per category initially (22 cards in the current board), then fetch additional pages on scroll. Full tweet details load only on expansion. Search covers unloaded candidates, and authentication, source/hash validation, expiry and self-quote renewal checks remain in place. Counts can adjust as remaining sources are checked. No migrations, new gateway endpoints, or worker changes.

Validation: 24 focused tests passed; TypeScript and scoped lint passed. Browser checked avatars, inline expansion, infinite scroll and a search match outside the first batch. A warm local first-data request measured 1.8 seconds; this is not a production latency guarantee.
