### PR TITLE
Simplify trending terms, add log chart controls, and fix footer overflow

### DIFF
--- a/src/components/portal/TrendsExplorer.tsx
+++ b/src/components/portal/TrendsExplorer.tsx
@@ -33,7 +33,6 @@ export default function TrendsExplorer({
   initialSearch?: string
 }) {
   const {
-    weekly,
     configuredTerms,
     granularity,
     buckets,
@@ -44,6 +43,8 @@ export default function TrendsExplorer({
     setFeedFilters,
     scale,
     setScale,
+    axis,
+    setAxis,
     termInput,
     setTermInput,
     isAdding,
@@ -109,64 +110,9 @@ export default function TrendsExplorer({
 
         <ExtensionInstallPrompt surface="trends" className="mb-5" />
 
-        <section
-          aria-label="Live trending words"
-          className={`${CARD} mb-5 p-4 sm:p-5`}
-        >
-          <h2 className="text-sm font-bold">Trending this week</h2>
-          <p className={`mt-1 text-xs ${MUTED}`}>
-            Default chart terms come from the same daily discovery as the
-            homepage. Growth below uses author-weighted member activity; the
-            historical chart uses full-corpus tweet counts.
-          </p>
-          <div className="mt-3 grid gap-4 sm:grid-cols-3">
-            {(
-              [
-                { lane: 'emerging', label: 'Breaking out' },
-                { lane: 'rising', label: 'Big & rising' },
-                { lane: 'falling', label: 'Cooling off' },
-              ] as const
-            ).map((group) => (
-              <div key={group.lane}>
-                <h3 className={`mb-2 text-xs font-semibold ${MUTED}`}>
-                  {group.label}
-                </h3>
-                <div className="flex flex-wrap gap-2">
-                  {weekly
-                    .filter((row) => row.lane === group.lane)
-                    .map((row) => (
-                      <Link
-                        key={row.term}
-                        href={`/trends?${new URLSearchParams({ q: row.term, granularity: 'month' })}`}
-                        className="rounded border px-2.5 py-1.5 text-xs text-brand hover:bg-accent"
-                      >
-                        {row.term}{' '}
-                        <span className={MUTED}>
-                          {row.deltaPct === null
-                            ? 'New'
-                            : `${row.deltaPct >= 0 ? '+' : ''}${Math.round(row.deltaPct)}%`}
-                        </span>
-                      </Link>
-                    ))}
-                </div>
-              </div>
-            ))}
-          </div>
-          {weekly.some((row) => row.untilDate) && (
-            <p className={`mt-3 text-xs ${MUTED}`}>
-              Complete week through{' '}
-              {weekly.find((row) => row.untilDate)?.untilDate} (UTC). Click a
-              word to open its monthly history.
-            </p>
-          )}
-          {!weekly.some((row) => row.lane) && (
-            <p className={`mt-3 text-xs ${MUTED}`}>
-              {initialLoadFailed
-                ? 'Live keywords are temporarily unavailable. Retry defaults below.'
-                : 'No dynamic movers are available yet.'}
-            </p>
-          )}
-        </section>
+        <p className={`mb-4 text-xs ${MUTED}`}>
+          Default terms are trending this week in the community.
+        </p>
 
         <div className="grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(360px,0.8fr)]">
           <section className="min-w-0">
@@ -267,9 +213,34 @@ export default function TrendsExplorer({
                       </button>
                     ))}
                   </div>
+                  <div
+                    className="inline-flex rounded-[4px] border border-zinc-300 p-0.5 dark:border-[#34343a]"
+                    aria-label="Chart axis"
+                  >
+                    {(['linear', 'log'] as const).map((option) => (
+                      <button
+                        key={option}
+                        type="button"
+                        aria-pressed={axis === option}
+                        onClick={() => setAxis(option)}
+                        className={`rounded-[3px] px-2.5 py-1.5 text-[11.5px] font-semibold transition-colors ${
+                          axis === option
+                            ? 'bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900'
+                            : `${MUTED} hover:text-foreground`
+                        }`}
+                      >
+                        {option === 'linear' ? 'Linear' : 'Log'}
+                      </button>
+                    ))}
+                  </div>
                 </div>
               </div>
 
+              {axis === 'log' && (
+                <p className={`px-4 pt-2 text-[11px] ${MUTED}`}>
+                  Log scale compresses large peaks while keeping zero visible.
+                </p>
+              )}
               {chartError && (
                 <div
                   className="mx-4 mt-4 flex flex-wrap items-center justify-between gap-3 rounded-[4px] border border-amber-300 bg-amber-50 px-3 py-2.5 text-amber-950 dark:border-amber-700/70 dark:bg-amber-950/30 dark:text-amber-100 sm:mx-5"
@@ -298,6 +269,7 @@ export default function TrendsExplorer({
                 enabledSeries={enabledSeries}
                 granularity={granularity}
                 scale={scale}
+                axis={axis}
                 selectedRange={selectedRange}
                 setSelectedRange={setSelectedRange}
                 isLoadingSeries={isLoadingSeries}
@@ -489,7 +461,7 @@ export default function TrendsExplorer({
 
             <div
               ref={evidenceScrollRef}
-              className={`${CARD} max-h-[760px] overflow-y-auto`}
+              className={`${CARD} relative max-h-[760px] overflow-y-auto`}
               aria-label="Matching tweets"
               aria-live="polite"
               onScroll={(event) => {

--- a/src/components/portal/WeeklyKeywordRows.test.tsx
+++ b/src/components/portal/WeeklyKeywordRows.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, within } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { WeeklyKeywordRows } from './WeeklyKeywordRows'
 import type { TermWeek } from '@/lib/portal/types'
 
@@ -6,6 +7,8 @@ const words: TermWeek[] = [
   {
     term: 'ai agents',
     lane: 'emerging',
+    currentPer100k: 2000,
+    previousPer100k: 0,
     last7: 80,
     prev7: 0,
     deltaPct: null,
@@ -16,6 +19,8 @@ const words: TermWeek[] = [
   {
     term: 'model',
     lane: 'rising',
+    currentPer100k: 10000,
+    previousPer100k: 5000,
     last7: 400,
     prev7: 200,
     deltaPct: 100,
@@ -24,6 +29,8 @@ const words: TermWeek[] = [
   {
     term: 'dolly',
     lane: 'falling',
+    currentPer100k: 0,
+    previousPer100k: 3000,
     last7: 0,
     prev7: 100,
     deltaPct: -100,
@@ -31,20 +38,18 @@ const words: TermWeek[] = [
   },
 ]
 
-test('shows all groups, date-scoped phrase links, new terms, and falls to zero', () => {
+test('orders one list by absolute share change, preserving new terms and falls to zero', () => {
   render(<WeeklyKeywordRows weekly={words} failed={false} />)
-  expect(
-    within(screen.getByRole('region', { name: 'Breaking out' })).getByText(
-      'New',
-    ),
-  ).toBeVisible()
-  expect(
-    within(screen.getByRole('region', { name: 'Cooling off' })).getByText(
-      '−100%',
-    ),
-  ).toBeVisible()
+  expect(screen.getByText('New')).toBeVisible()
+  expect(screen.getByText('−100%')).toBeVisible()
   expect(screen.getByText('Share change')).toBeVisible()
-  expect(screen.getByText(/Through Sep 6 \(UTC\)/)).toBeVisible()
+  expect(screen.queryByRole('region')).not.toBeInTheDocument()
+  expect(screen.getAllByRole('link').map((link) => link.textContent)).toEqual([
+    'model',
+    'dolly',
+    'ai agents',
+  ])
+  expect(screen.queryByText(/Through Sep 6/)).not.toBeInTheDocument()
   const href = screen
     .getByRole('link', { name: 'ai agents' })
     .getAttribute('href')!
@@ -55,13 +60,13 @@ test('shows all groups, date-scoped phrase links, new terms, and falls to zero',
     untilDate: '2026-09-06',
   })
   expect(
-    screen.getByRole('img', { name: /dolly: 0 tweets/ }).firstElementChild,
+    screen.getByRole('img', { name: /dolly: 0 tweets/ }).lastElementChild,
   ).toHaveStyle({ width: '0%' })
 })
 
 test('renders empty groups honestly and hides stale rows on failure', () => {
   const { rerender } = render(<WeeklyKeywordRows weekly={[]} failed={false} />)
-  expect(screen.getAllByText('No clear movers this week.')).toHaveLength(3)
+  expect(screen.getAllByText('No clear movers this week.')).toHaveLength(1)
   rerender(<WeeklyKeywordRows weekly={words} failed={true} />)
   expect(screen.getByRole('status')).toHaveTextContent(
     'temporarily unavailable',
@@ -81,4 +86,52 @@ test('does not label the legacy watchlist as share-normalized discovery', () => 
   expect(
     screen.queryByRole('region', { name: 'Breaking out' }),
   ).not.toBeInTheDocument()
+})
+
+test('shows previous share behind declines even when raw tweet counts increased', () => {
+  render(
+    <WeeklyKeywordRows
+      weekly={[
+        {
+          ...words[1],
+          last7: 500,
+          prev7: 100,
+          currentPer100k: 50,
+          previousPer100k: 100,
+          deltaPct: -50,
+        },
+        words[0],
+      ]}
+      failed={false}
+    />,
+  )
+  const decline = screen.getByRole('img', { name: /model: 500 tweets/ })
+  expect(decline).toHaveAccessibleName(
+    /faded extension shows the previous week/,
+  )
+  expect(decline.children).toHaveLength(2)
+  const previousWidth = parseFloat(
+    (decline.firstElementChild as HTMLElement).style.width,
+  )
+  const currentWidth = parseFloat(
+    (decline.lastElementChild as HTMLElement).style.width,
+  )
+  expect(previousWidth).toBeGreaterThan(currentWidth)
+  expect(currentWidth).toBeGreaterThan(0)
+  expect(screen.getByRole('img', { name: /ai agents:/ }).children).toHaveLength(
+    1,
+  )
+})
+
+test('makes the explanation available on keyboard focus', async () => {
+  const user = userEvent.setup()
+  render(<WeeklyKeywordRows weekly={words} failed={false} />)
+  await user.tab()
+  expect(
+    screen.getByRole('button', { name: 'About trending terms' }),
+  ).toHaveFocus()
+  const tip = await screen.findByRole('tooltip')
+  expect(tip).toHaveTextContent('Through Sep 6 (UTC).')
+  expect(tip).toHaveTextContent('absolute change in author-weighted share')
+  expect(tip).toHaveTextContent('faded extension')
 })

--- a/src/components/portal/WeeklyKeywordRows.tsx
+++ b/src/components/portal/WeeklyKeywordRows.tsx
@@ -1,26 +1,15 @@
+'use client'
+
 import Link from 'next/link'
+import { Info } from '@phosphor-icons/react'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import type { TermWeek } from '@/lib/portal/types'
 import { MUTED } from './styles'
-
-const GROUPS = [
-  {
-    lane: 'emerging',
-    title: 'Breaking out',
-    description:
-      'Previously uncommon terms with a strong rise across several authors.',
-  },
-  {
-    lane: 'rising',
-    title: 'Big and rising',
-    description: 'Established terms gaining the most share of conversation.',
-  },
-  {
-    lane: 'falling',
-    title: 'Cooling off',
-    description:
-      'Terms previously in the top 20 breakouts or risers, now losing share.',
-  },
-] as const
 
 export function WeeklyKeywordRows({
   weekly,
@@ -36,26 +25,26 @@ export function WeeklyKeywordRows({
       </p>
     )
   const dynamic = weekly.length === 0 || weekly.every((row) => row.lane)
-  const groups = dynamic
-    ? GROUPS.map((group) => ({
-        ...group,
-        rows: weekly.filter((row) => row.lane === group.lane),
-      }))
-    : [
-        {
-          lane: 'tracked',
-          title: 'Tracked terms',
-          description: 'Terms from the original watchlist.',
-          rows: weekly
-            .filter((row) => row.last7 > 0)
-            .sort((a, b) => b.last7 - a.last7)
-            .slice(0, 6),
-        },
-      ]
-  const max = Math.max(
-    1,
-    ...groups.flatMap((group) => group.rows.map((row) => row.last7)),
+  const weighted = weekly.every(
+    (row) =>
+      row.currentPer100k !== undefined && row.previousPer100k !== undefined,
   )
+  const activity = (row: TermWeek) => ({
+    current: weighted ? row.currentPer100k! : row.last7,
+    previous: weighted ? row.previousPer100k! : row.prev7,
+  })
+  const rows = weekly
+    .map((row) => ({ ...row, ...activity(row) }))
+    .sort(
+      (a, b) =>
+        Math.abs(b.current - b.previous) - Math.abs(a.current - a.previous) ||
+        b.current - a.current ||
+        a.term.localeCompare(b.term),
+    )
+    .slice(0, 6)
+  const max = Math.max(1, ...rows.flatMap((row) => [row.current, row.previous]))
+  const width = (value: number) =>
+    `${(Math.log1p(value) / Math.log1p(max)) * 100}%`
   const until = weekly[0]?.untilDate
   const through =
     until &&
@@ -64,102 +53,109 @@ export function WeeklyKeywordRows({
       day: 'numeric',
       timeZone: 'UTC',
     }).format(new Date(`${until}T00:00:00Z`))
+  const explanation = [
+    dynamic
+      ? 'Author-weighted share vs the previous week; excludes retweets.'
+      : 'Tweet counts vs the previous week.',
+    through ? `Through ${through} (UTC).` : '',
+    `Ordered by the absolute change in ${weighted ? 'author-weighted share' : 'tweet count'}.`,
+    `Bars show ${weighted ? 'author-weighted share per 100k' : 'tweet counts'} on a shared logarithmic scale. A faded extension shows the previous week when activity has declined.`,
+  ]
+    .filter(Boolean)
+    .join(' ')
   return (
     <div className="flex flex-1 flex-col px-4 pb-3 pt-2">
       <div
-        className={`grid grid-cols-[minmax(0,1fr)_46px_minmax(35px,0.6fr)_68px] items-end gap-2 pb-1 text-[9px] uppercase tracking-wide ${MUTED}`}
+        className={`grid grid-cols-[minmax(0,1fr)_46px_minmax(35px,0.6fr)_68px] items-end gap-2 pb-2 text-[9px] uppercase tracking-wide ${MUTED}`}
       >
-        <span>Term</span>
-        <span className="text-right">Tweets</span>
-        <span title="Bar widths use log(1 + tweet count), on the same scale across all terms.">
-          Volume (log)
+        <span className="inline-flex items-center gap-1">
+          Term
+          <TooltipProvider delayDuration={100}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label="About trending terms"
+                  className="inline-flex rounded hover:text-brand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/30"
+                >
+                  <Info aria-hidden="true" className="h-3.5 w-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent
+                side="bottom"
+                className="max-w-[300px] text-[12px] normal-case tracking-normal"
+              >
+                {explanation}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         </span>
-        <span
-          className="text-right"
-          title={
-            dynamic
-              ? 'Change in author-weighted share: each author contributes the square root of their posts mentioning the term. Compared with the previous complete week.'
-              : undefined
-          }
-        >
+        <span className="text-right">Tweets</span>
+        <span>Volume (log)</span>
+        <span className="text-right">
           {dynamic ? 'Share change' : 'Change'}
         </span>
       </div>
-      {groups.map((group) => (
-        <section key={group.lane} aria-label={group.title} className="py-1.5">
-          {dynamic && (
-            <h3
-              title={group.description}
-              className={`mb-1 text-[10px] font-semibold ${MUTED}`}
+      {rows.length === 0 && (
+        <p className={`py-3 text-[11px] ${MUTED}`}>
+          No clear movers this week.
+        </p>
+      )}
+      {rows.map((row) => {
+        const change =
+          row.status === 'new'
+            ? 'New'
+            : row.deltaPct === null
+              ? '—'
+              : `${row.deltaPct >= 0 ? '+' : '−'}${Math.abs(row.deltaPct).toLocaleString('en-US')}%`
+        const falling = row.previous > row.current
+        const details = `${row.last7.toLocaleString('en-US')} tweets${row.currentAuthors === undefined ? '' : ` from ${row.currentAuthors} authors`}; ${row.prev7.toLocaleString('en-US')} tweets in the previous week.`
+        const barDetails = `${row.term}: ${row.last7.toLocaleString('en-US')} tweets in the last seven days; ${weighted ? 'author-weighted share per 100k' : 'tweet count'} ${row.current.toLocaleString('en-US', { maximumFractionDigits: 1 })}, previously ${row.previous.toLocaleString('en-US', { maximumFractionDigits: 1 })}; logarithmic scale${falling ? '; faded extension shows the previous week' : ''}`
+        return (
+          <div
+            key={row.term}
+            className="grid grid-cols-[minmax(0,1fr)_46px_minmax(35px,0.6fr)_68px] items-center gap-2 py-[5px]"
+          >
+            <Link
+              href={`/search?${new URLSearchParams({
+                q: row.term,
+                ...(row.sinceDate ? { sinceDate: row.sinceDate } : {}),
+                ...(row.untilDate ? { untilDate: row.untilDate } : {}),
+              })}`}
+              title={`Search tweets mentioning ${row.term}`}
+              className="truncate text-[12px] font-semibold text-brand underline-offset-2 hover:underline"
             >
-              {group.title}
-            </h3>
-          )}
-          {group.rows.length === 0 ? (
-            <p className={`py-1 text-[11px] ${MUTED}`}>
-              No clear movers this week.
-            </p>
-          ) : (
-            group.rows.map((row) => {
-              const change =
-                row.status === 'new'
-                  ? 'New'
-                  : row.deltaPct === null
-                    ? '—'
-                    : `${row.deltaPct >= 0 ? '+' : '−'}${Math.abs(row.deltaPct).toLocaleString('en-US')}%`
-              const details = `${row.last7.toLocaleString('en-US')} tweets${row.currentAuthors === undefined ? '' : ` from ${row.currentAuthors} authors`}; ${row.prev7.toLocaleString('en-US')} tweets in the previous week. ${dynamic ? 'Percentage compares author-weighted shares, excluding retweets.' : ''}`
-              return (
+              {row.term}
+            </Link>
+            <span className={`text-right text-[11px] tabular-nums ${MUTED}`}>
+              {row.last7.toLocaleString('en-US')}
+            </span>
+            <div
+              role="img"
+              aria-label={barDetails}
+              title={barDetails}
+              className="relative h-2 overflow-hidden rounded bg-zinc-100 dark:bg-[#26262a]"
+            >
+              {falling && (
                 <div
-                  key={row.term}
-                  className="grid grid-cols-[minmax(0,1fr)_46px_minmax(35px,0.6fr)_68px] items-center gap-2 py-[5px]"
-                >
-                  <Link
-                    href={`/search?${new URLSearchParams({
-                      q: row.term,
-                      ...(row.sinceDate ? { sinceDate: row.sinceDate } : {}),
-                      ...(row.untilDate ? { untilDate: row.untilDate } : {}),
-                    })}`}
-                    title={`Search tweets mentioning ${row.term}`}
-                    className="truncate text-[12px] font-semibold text-brand underline-offset-2 hover:underline"
-                  >
-                    {row.term}
-                  </Link>
-                  <span
-                    className={`text-right text-[11px] tabular-nums ${MUTED}`}
-                  >
-                    {row.last7.toLocaleString('en-US')}
-                  </span>
-                  <div
-                    role="img"
-                    aria-label={`${row.term}: ${row.last7.toLocaleString('en-US')} tweets in the last seven days; logarithmic volume scale`}
-                    title={`${row.last7.toLocaleString('en-US')} tweets; all bars use the same logarithmic scale.`}
-                    className="h-2 overflow-hidden rounded bg-zinc-100 dark:bg-[#26262a]"
-                  >
-                    <div
-                      className="h-full rounded bg-chart-accent"
-                      style={{
-                        width: `${(Math.log1p(row.last7) / Math.log1p(max)) * 100}%`,
-                      }}
-                    />
-                  </div>
-                  <span
-                    title={details}
-                    className={`text-right text-[11px] font-bold tabular-nums ${row.deltaPct !== null && row.deltaPct < 0 ? 'text-[#dc2626] dark:text-[#f87171]' : row.status === 'inactive' ? MUTED : 'text-[#16a34a] dark:text-[#2acf80]'}`}
-                  >
-                    {change}
-                  </span>
-                </div>
-              )
-            })
-          )}
-        </section>
-      ))}
-      <p className={`mt-auto pt-2 text-[10px] leading-relaxed ${MUTED}`}>
-        {dynamic
-          ? 'Author-weighted share vs the previous week; excludes retweets.'
-          : 'Tweet counts vs the previous week.'}
-        {through && <> Through {through} (UTC).</>}
-      </p>
+                  className="absolute inset-y-0 left-0 rounded bg-chart-accent opacity-25"
+                  style={{ width: width(row.previous) }}
+                />
+              )}
+              <div
+                className="relative h-full rounded bg-chart-accent"
+                style={{ width: width(row.current) }}
+              />
+            </div>
+            <span
+              title={details}
+              className={`text-right text-[11px] font-bold tabular-nums ${row.deltaPct !== null && row.deltaPct < 0 ? 'text-[#dc2626] dark:text-[#f87171]' : row.status === 'inactive' ? MUTED : 'text-[#16a34a] dark:text-[#2acf80]'}`}
+            >
+              {change}
+            </span>
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/src/components/portal/WeeklyKeywordRows.tsx
+++ b/src/components/portal/WeeklyKeywordRows.tsx
@@ -71,7 +71,9 @@ export function WeeklyKeywordRows({
       >
         <span>Term</span>
         <span className="text-right">Tweets</span>
-        <span>Volume</span>
+        <span title="Bar widths use log(1 + tweet count), on the same scale across all terms.">
+          Volume (log)
+        </span>
         <span
           className="text-right"
           title={
@@ -129,13 +131,15 @@ export function WeeklyKeywordRows({
                   </span>
                   <div
                     role="img"
-                    aria-label={`${row.term}: ${row.last7.toLocaleString('en-US')} tweets in the last seven days`}
-                    title={`${row.last7.toLocaleString('en-US')} tweets; all bars use the same scale.`}
+                    aria-label={`${row.term}: ${row.last7.toLocaleString('en-US')} tweets in the last seven days; logarithmic volume scale`}
+                    title={`${row.last7.toLocaleString('en-US')} tweets; all bars use the same logarithmic scale.`}
                     className="h-2 overflow-hidden rounded bg-zinc-100 dark:bg-[#26262a]"
                   >
                     <div
                       className="h-full rounded bg-chart-accent"
-                      style={{ width: `${(row.last7 / max) * 100}%` }}
+                      style={{
+                        width: `${(Math.log1p(row.last7) / Math.log1p(max)) * 100}%`,
+                      }}
                     />
                   </div>
                   <span

--- a/src/components/portal/trends/TrendChart.test.tsx
+++ b/src/components/portal/trends/TrendChart.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react'
+import { TrendChart } from './TrendChart'
+
+const props = {
+  buckets: ['2026-01', '2026-02', '2026-03'],
+  enabledSeries: [
+    {
+      term: 'astra',
+      color: '#0088cc',
+      tweetsPerBucket: [0, 10, 10000],
+      perBucket: [0, 1, 1000],
+    },
+  ],
+  granularity: 'month' as const,
+  scale: 'raw' as const,
+  selectedRange: null,
+  setSelectedRange: jest.fn(),
+  isLoadingSeries: false,
+  seriesCount: 1,
+  captureExplorerAction: jest.fn(),
+  onSelectingRangeChange: jest.fn(),
+}
+
+test('log axis reveals small values, keeps zero finite, and preserves actual count labels', () => {
+  const { rerender } = render(<TrendChart {...props} axis="linear" />)
+  const points = () =>
+    Array.from(screen.getByRole('img').querySelectorAll('circle'))
+  const linearY = Number(points()[1].getAttribute('cy'))
+  const zeroY = points()[0].getAttribute('cy')
+  rerender(<TrendChart {...props} axis="log" />)
+  expect(Number(points()[1].getAttribute('cy'))).toBeLessThan(linearY - 50)
+  expect(points()[0].getAttribute('cy')).toBe(zeroY)
+  expect(
+    points().every((point) =>
+      Number.isFinite(Number(point.getAttribute('cy'))),
+    ),
+  ).toBe(true)
+  expect(points()[1]).toHaveAttribute(
+    'aria-label',
+    'astra · Feb 2026 · 10 tweets',
+  )
+  rerender(<TrendChart {...props} axis="log" scale="normalized" />)
+  expect(points()[1]).toHaveAttribute(
+    'aria-label',
+    'astra · Feb 2026 · 1 per 100k',
+  )
+})

--- a/src/components/portal/trends/TrendChart.tsx
+++ b/src/components/portal/trends/TrendChart.tsx
@@ -43,6 +43,7 @@ export function TrendChart({
   enabledSeries,
   granularity,
   scale,
+  axis = 'linear',
   selectedRange,
   setSelectedRange,
   isLoadingSeries,
@@ -54,6 +55,7 @@ export function TrendChart({
   enabledSeries: TrendBucketSeries[]
   granularity: TrendGranularity
   scale: TrendExplorerUrlState['scale']
+  axis?: 'linear' | 'log'
   selectedRange: TrendRange | null
   setSelectedRange: Dispatch<SetStateAction<TrendRange | null>>
   isLoadingSeries: boolean
@@ -70,13 +72,17 @@ export function TrendChart({
     ...enabledSeries.flatMap((item) => valuesFor(item)),
   )
   const chartMax = niceCeiling(maxValue)
-  const gridValues = [
-    0,
-    chartMax / 4,
-    chartMax / 2,
-    (chartMax * 3) / 4,
-    chartMax,
-  ]
+  const gridValues =
+    axis === 'log'
+      ? [
+          0,
+          ...Array.from(
+            { length: Math.ceil(Math.log10(chartMax)) + 1 },
+            (_, i) => 10 ** i,
+          ).filter((value) => value < chartMax),
+          chartMax,
+        ]
+      : [0, chartMax / 4, chartMax / 2, (chartMax * 3) / 4, chartMax]
   const W = 760
   const H = 360
   const X0 = 62
@@ -95,7 +101,12 @@ export function TrendChart({
         index === buckets.length - 1 ||
         index % 12 === 0,
     )
-  const yPosition = (value: number) => Y0 - (value / chartMax) * (Y0 - Y1)
+  const yPosition = (value: number) =>
+    Y0 -
+    (axis === 'log'
+      ? Math.log1p(value) / Math.log1p(chartMax)
+      : value / chartMax) *
+      (Y0 - Y1)
   const selectedStartIndex = selectedRange
     ? buckets.indexOf(selectedRange.start)
     : -1
@@ -156,7 +167,7 @@ export function TrendChart({
           viewBox={`0 0 ${W} ${H}`}
           className="block w-full touch-none select-none"
           role="img"
-          aria-label={`${granularity === 'year' ? 'Yearly' : 'Monthly'} term trends shown as ${scale === 'normalized' ? 'occurrences per 100,000 tweets' : 'raw tweet counts'}`}
+          aria-label={`${granularity === 'year' ? 'Yearly' : 'Monthly'} term trends shown as ${scale === 'normalized' ? 'occurrences per 100,000 tweets' : 'raw tweet counts'}${axis === 'log' ? ' on a logarithmic axis' : ''}`}
         >
           {gridValues.map((value) => (
             <g key={value}>

--- a/src/components/portal/trends/useTrendExplorer.ts
+++ b/src/components/portal/trends/useTrendExplorer.ts
@@ -98,6 +98,9 @@ export function useTrendExplorer({
       ),
   )
   const [scale, setScale] = useState(initialUrlState.scale)
+  const [axis, setAxis] = useState<'linear' | 'log'>(
+    initialUrlState.axis ?? 'linear',
+  )
   const [termInput, setTermInput] = useState('')
   const [isAdding, setIsAdding] = useState(false)
   const [isLoadingSeries, setIsLoadingSeries] = useState(
@@ -184,10 +187,12 @@ export function useTrendExplorer({
       shown: configuredTerms.filter((term) => chartEnabled[term]),
       included: includeTerms,
       scale,
+      axis,
       granularity,
       range: selectedRange,
     }),
     [
+      axis,
       chartEnabled,
       configuredTerms,
       granularity,
@@ -429,6 +434,8 @@ export function useTrendExplorer({
     setFeedFilters,
     scale,
     setScale,
+    axis,
+    setAxis,
     termInput,
     setTermInput,
     isAdding,

--- a/src/lib/portal/TrendsExplorerResilience.test.tsx
+++ b/src/lib/portal/TrendsExplorerResilience.test.tsx
@@ -637,7 +637,7 @@ describe('TrendsExplorer request isolation', () => {
   })
 })
 
-test('charts the six live keyword defaults monthly and shows their categories', async () => {
+test('charts six live monthly defaults with a brief note and independent log toggle', async () => {
   const terms = [
     'astra',
     'navier stokes',
@@ -695,8 +695,11 @@ test('charts the six live keyword defaults monthly and shows their categories', 
     'true',
   )
   expect(
-    screen.getByRole('region', { name: 'Live trending words' }),
-  ).toHaveTextContent('Cooling off')
+    screen.queryByRole('region', { name: 'Live trending words' }),
+  ).not.toBeInTheDocument()
+  expect(
+    screen.getByText('Default terms are trending this week in the community.'),
+  ).toBeVisible()
   expect(screen.getByText('6/12 trends')).toBeVisible()
   expect(
     calls
@@ -708,10 +711,20 @@ test('charts the six live keyword defaults monthly and shows their categories', 
       .find((url) => url.searchParams.get('view') === 'series')
       ?.searchParams.get('granularity'),
   ).toBe('month')
-  expect(screen.getByRole('link', { name: /navier stokes/ })).toHaveAttribute(
-    'href',
-    '/trends?q=navier+stokes&granularity=month',
+  const requestsBeforeAxisChange = calls.length
+  fireEvent.click(screen.getByRole('button', { name: 'Log' }))
+  expect(
+    screen.getByRole('button', { name: 'Log' }),
+  ).toHaveAttribute('aria-pressed', 'true')
+  expect(
+    screen.getByRole('img', { name: /Monthly term trends/ }),
+  ).toHaveAccessibleName(/logarithmic axis/)
+  expect(screen.getByRole('button', { name: 'Per 100k' })).toHaveAttribute(
+    'aria-pressed',
+    'true',
   )
+  expect(new URLSearchParams(window.location.search).get('axis')).toBe('log')
+  expect(calls).toHaveLength(requestsBeforeAxisChange)
   await act(async () => {
     await Promise.resolve()
   })

--- a/src/lib/portal/trendExplorerState.test.ts
+++ b/src/lib/portal/trendExplorerState.test.ts
@@ -13,6 +13,7 @@ describe('trend explorer URL state', () => {
       shown: ['ai agents'],
       included: ['tpot'],
       scale: 'raw',
+      axis: 'log',
       granularity: 'month',
       range: { start: '2025-03', end: '2026-08' },
     })
@@ -22,6 +23,7 @@ describe('trend explorer URL state', () => {
       shown: ['ai agents'],
       included: ['tpot'],
       scale: 'raw',
+      axis: 'log',
       granularity: 'month',
       range: { start: '2025-03', end: '2026-08' },
     })

--- a/src/lib/portal/trendExplorerState.ts
+++ b/src/lib/portal/trendExplorerState.ts
@@ -12,6 +12,7 @@ export interface TrendExplorerUrlState {
   shown: string[]
   included: string[]
   scale: TrendScale
+  axis?: 'linear' | 'log'
   granularity: TrendGranularity
   range: TrendRange | null
 }
@@ -84,6 +85,7 @@ export function parseTrendExplorerState(
         ? selectedTerms(includedParams, resolvedTerms)
         : resolvedTerms.slice(0, 1),
     scale: params.get('scale') === 'raw' ? 'raw' : 'normalized',
+    ...(params.get('axis') === 'log' ? { axis: 'log' as const } : {}),
     granularity,
     range: validRange ? { start: from, end: to } : null,
   }
@@ -97,6 +99,7 @@ export function serializeTrendExplorerState(
   state.shown.forEach((term) => params.append('show', term))
   state.included.forEach((term) => params.append('include', term))
   params.set('scale', state.scale)
+  if (state.axis === 'log') params.set('axis', 'log')
   params.set('granularity', state.granularity)
   if (state.range) {
     params.set('from', state.range.start)

--- a/src/lib/portal/types.ts
+++ b/src/lib/portal/types.ts
@@ -81,6 +81,8 @@ export interface TermWeek {
   /** Present for automatically discovered, share-normalized homepage terms. */
   lane?: 'emerging' | 'rising' | 'falling'
   currentAuthors?: number
+  currentPer100k?: number
+  previousPer100k?: number
   previousAuthors?: number
   sinceDate?: string
   untilDate?: string

--- a/src/lib/portal/weeklyKeywords.test.ts
+++ b/src/lib/portal/weeklyKeywords.test.ts
@@ -48,6 +48,8 @@ test('maps discovered terms and complete date windows to the homepage', async ()
       prev7: 0,
       currentAuthors: 20,
       previousAuthors: 0,
+      currentPer100k: 200,
+      previousPer100k: 0,
       sinceDate: '2026-08-31',
       untilDate: '2026-09-06',
       deltaPct: null,
@@ -118,4 +120,15 @@ test('gateway exposes a structured HTTP status for deployment fallback', async (
       fetchImpl,
     }),
   ).rejects.toMatchObject({ status: 404 })
+})
+
+test('rejects invalid shares before using them for bar widths or effect ordering', () => {
+  for (const currentPer100k of [-1, NaN, Infinity]) {
+    expect(() =>
+      mapWeeklyKeywords({
+        ...response,
+        data: [{ ...response.data[0], currentPer100k }],
+      }),
+    ).toThrow('invalid')
+  }
 })

--- a/src/lib/portal/weeklyKeywords.ts
+++ b/src/lib/portal/weeklyKeywords.ts
@@ -83,6 +83,9 @@ export function mapWeeklyKeywords(
         row.currentAuthors,
         row.previousAuthors,
       ].some((count) => !Number.isSafeInteger(count) || count < 0) ||
+      [row.currentPer100k, row.previousPer100k].some(
+        (share) => !Number.isFinite(share) || share < 0,
+      ) ||
       row.currentAuthors > row.currentTweets ||
       row.previousAuthors > row.previousTweets ||
       (row.changePct !== null &&
@@ -97,6 +100,8 @@ export function mapWeeklyKeywords(
       last7: row.currentTweets,
       prev7: row.previousTweets,
       currentAuthors: row.currentAuthors,
+      currentPer100k: row.currentPer100k,
+      previousPer100k: row.previousPer100k,
       previousAuthors: row.previousAuthors,
       sinceDate,
       untilDate,


### PR DESCRIPTION
The homepage trending widget now presents one list ordered by absolute change in author-weighted share. Log-scaled share bars show a faded previous-week extension for declines, including falls to zero, while exact tweet counts remain visible. An info icon replaces the explanatory footer and exposes the date, metric and scale on hover or keyboard focus.

The Trends explorer replaces the large weekly category section with a short note about its default terms. A separate Linear / Log axis switch works with both raw counts and normalized frequency, handles zero with log1p, preserves actual labels, and round-trips in shared URLs without another data request.

The scrolling tweet panel establishes a positioning context so absolutely positioned screen-reader labels stay inside its overflow boundary. On the reported page those labels extended the document to 8,152 pixels even though the footer ended at 2,414 pixels.

Validation: 29 focused tests pass across weekly mapping/rendering, chart geometry, URL state and explorer interaction. Focused ESLint and TypeScript checks pass. The unrelated Supabase type-generation commit hook was skipped. No gateway or database changes are required.
