### PR TITLE
Show share gains in trending volume bars

### DIFF
--- a/src/components/portal/WeeklyKeywordRows.test.tsx
+++ b/src/components/portal/WeeklyKeywordRows.test.tsx
@@ -49,6 +49,9 @@ test('orders one list by absolute share change, preserving new terms and falls t
     'dolly',
     'ai agents',
   ])
+  const growth = screen.getByRole('img', { name: /model: 400 tweets/ })
+  expect(growth).toHaveAccessibleName(/green overlay shows the gain/)
+  expect(growth.lastElementChild).toHaveStyle({ left: '50%', width: '50%' })
   expect(screen.queryByText(/Through Sep 6/)).not.toBeInTheDocument()
   const href = screen
     .getByRole('link', { name: 'ai agents' })
@@ -118,9 +121,9 @@ test('shows previous share behind declines even when raw tweet counts increased'
   )
   expect(previousWidth).toBe(5)
   expect(currentWidth).toBe(2.5)
-  expect(screen.getByRole('img', { name: /ai agents:/ }).children).toHaveLength(
-    1,
-  )
+  expect(
+    screen.getByRole('img', { name: /ai agents:/ }).lastElementChild,
+  ).toHaveStyle({ left: '0%', width: '100%' })
 })
 
 test('makes the explanation available on keyboard focus', async () => {
@@ -133,5 +136,6 @@ test('makes the explanation available on keyboard focus', async () => {
   const tip = await screen.findByRole('tooltip')
   expect(tip).toHaveTextContent('Through Sep 6 (UTC).')
   expect(tip).toHaveTextContent('absolute change in author-weighted share')
-  expect(tip).toHaveTextContent('faded extension')
+  expect(tip).toHaveTextContent('faded blue extension')
+  expect(tip).toHaveTextContent('green overlay')
 })

--- a/src/components/portal/WeeklyKeywordRows.tsx
+++ b/src/components/portal/WeeklyKeywordRows.tsx
@@ -58,7 +58,7 @@ export function WeeklyKeywordRows({
       : 'Tweet counts vs the previous week.',
     through ? `Through ${through} (UTC).` : '',
     `Ordered by the absolute change in ${weighted ? 'author-weighted share' : 'tweet count'}.`,
-    `Bars show ${weighted ? 'author-weighted share per 100k' : 'tweet counts'} on a shared linear scale. A faded extension shows the previous week when activity has declined.`,
+    `Bars show ${weighted ? 'author-weighted share per 100k' : 'tweet counts'} on a shared linear scale. A green overlay shows activity gained this week; a faded blue extension shows activity lost since the previous week.`,
   ]
     .filter(Boolean)
     .join(' ')
@@ -108,8 +108,9 @@ export function WeeklyKeywordRows({
               ? '—'
               : `${row.deltaPct >= 0 ? '+' : '−'}${Math.abs(row.deltaPct).toLocaleString('en-US')}%`
         const falling = row.previous > row.current
+        const rising = row.current > row.previous
         const details = `${row.last7.toLocaleString('en-US')} tweets${row.currentAuthors === undefined ? '' : ` from ${row.currentAuthors} authors`}; ${row.prev7.toLocaleString('en-US')} tweets in the previous week.`
-        const barDetails = `${row.term}: ${row.last7.toLocaleString('en-US')} tweets in the last seven days; ${weighted ? 'author-weighted share per 100k' : 'tweet count'} ${row.current.toLocaleString('en-US', { maximumFractionDigits: 1 })}, previously ${row.previous.toLocaleString('en-US', { maximumFractionDigits: 1 })}; linear scale${falling ? '; faded extension shows the previous week' : ''}`
+        const barDetails = `${row.term}: ${row.last7.toLocaleString('en-US')} tweets in the last seven days; ${weighted ? 'author-weighted share per 100k' : 'tweet count'} ${row.current.toLocaleString('en-US', { maximumFractionDigits: 1 })}, previously ${row.previous.toLocaleString('en-US', { maximumFractionDigits: 1 })}; linear scale${falling ? '; faded extension shows the previous week' : rising ? '; green overlay shows the gain since the previous week' : ''}`
         return (
           <div
             key={row.term}
@@ -145,6 +146,15 @@ export function WeeklyKeywordRows({
                 className="relative h-full rounded bg-chart-accent"
                 style={{ width: width(row.current) }}
               />
+              {rising && (
+                <div
+                  className="absolute inset-y-0 rounded-r bg-emerald-500/70 dark:bg-emerald-400/70"
+                  style={{
+                    left: width(row.previous),
+                    width: width(row.current - row.previous),
+                  }}
+                />
+              )}
             </div>
             <span
               title={details}


### PR DESCRIPTION
Highlight the gained portion of a rising term's homepage volume bar with a green overlay, spanning from its previous share to its current share. New terms show the whole bar as gained activity. Declines retain the faded blue extension, and bar lengths remain linear.

Update the info tooltip and accessible bar descriptions to explain both treatments. Validation: all five focused WeeklyKeywordRows tests pass, including proportional growth and decline widths, new terms, and keyboard tooltip access; changed-file ESLint passes. Skipped the unrelated database type-generation pre-commit hook; no schema changes.
