### PR TITLE
Retry transient Bulletin failures promptly and log HTTP status

### DIFF
--- a/services/bulletin/README.md
+++ b/services/bulletin/README.md
@@ -97,8 +97,18 @@ metadata say so rather than inventing attribution.
 
 Normal admission limits are $0.10/day and $1/calendar month, UTC, with 10%
 headroom. Calls reserve a conservative maximum first; ambiguous or timed-out
-calls retain that reservation. Retries wait an hour and stop after three
-attempts per unchanged input. Model routing forbids fallback or price escalation
+calls retain that reservation. Transient model-request failures (HTTP 408, 429,
+5xx, network errors and timeouts) retry within the same run after 2 then 5 seconds,
+plus up to one second of jitter. Respect a provider's `Retry-After` up to 60 seconds;
+longer waits are deferred to a later run. Authentication, payment, validation and
+publication errors do not trigger immediate model retries. Retries stop after
+three total attempts per unchanged input, including attempts from earlier runs.
+Every retry rechecks current source/policy and reserves budget again; it counts
+toward the run's 50-call cap and must fit within the remaining time allowance.
+Successful recovery makes the run `ok`; `failed` still counts failed attempts.
+Unresolved work from an earlier run remains eligible after an hour, when the
+next run starts; there is no standalone retry timer.
+Model routing forbids fallback or price escalation
 and caps prices at $0.15 input / $0.50 output per million tokens.
 
 An explicitly approved backfill can use `--backfill-budget-usd` (at most $1).
@@ -121,6 +131,16 @@ Owner: Community Archive backend. Existing worker host: `ca-autorefresh`
 The wrapper never reruns scraping to retry Bulletin. Service failure invokes the
 existing journal failure unit. Inspect unit status, last-success age, queue and
 run dashboard; investigate non-complete status or freshness older than 36 hours.
+
+Failures emit a JSON `bulletin_error` event to the systemd journal with run/call
+IDs, attempt, processing stage, exception class, HTTP status when available, and
+the scheduled retry delay. The private call ledger also retains HTTP status in
+`failed:HTTPError:<status>`. These diagnostics intentionally omit exception
+messages, request URLs, provider bodies, tweet content, credentials and headers.
+Inspect them with `journalctl -u ca-bulletin.service --since today -o cat`.
+Grafana Alloy can forward this unit's journal to Loki; worker installation alone
+does not configure log shipping or external alerts. Alert on the final failed
+run or stale last success, rather than every recovered attempt.
 
 The immutable release lives beneath `/opt/community-archive-bulletin/releases/`
 with a `current` symlink. PostgreSQL policy/state settings are read at runtime
@@ -160,7 +180,7 @@ that explicit local preview guard. Tweet reads still use ClickHouse.
 ```sh
 BULLETIN_TEST_DSN='host=127.0.0.1 port=55439 dbname=bulletin_test user=frsc' \
   uv run --with 'psycopg[binary]==3.2.9' --with duckdb==1.5.5 \
-  python -m unittest -v test_worker.py test_clickhouse_worker.py
+  python -m unittest -v test_worker.py test_retries.py test_clickhouse_worker.py
 ```
 
 These tests require a named disposable local database. They exercise a fake

--- a/services/bulletin/test_clickhouse_worker.py
+++ b/services/bulletin/test_clickhouse_worker.py
@@ -6,6 +6,7 @@ import json
 import os
 from pathlib import Path
 import unittest
+import urllib.error
 from unittest.mock import patch
 import psycopg
 from psycopg.rows import dict_row
@@ -126,6 +127,76 @@ class ClickHouseWorkerTests(unittest.TestCase):
         result,calls=self.run_worker(backfill_budget=Decimal('.05'))
         self.assertEqual((result['status'],calls),('ok',1))
         self.assertEqual(self.db.execute('SELECT attempts FROM bulletin.decisions').fetchone()['attempts'],2)
+
+    def http_error(self,code=503):
+        return urllib.error.HTTPError('https://example.invalid/secret',code,'private provider message',{},None)
+
+    def test_transient_errors_retry_in_same_run_and_recover(self):
+        with patch.object(worker,'call_model',side_effect=[self.http_error(),self.http_error(429),self.response(None)]) as model, \
+                patch.object(worker.time,'sleep') as sleep:
+            result=worker.run(self.db,window=self.window)
+        self.assertEqual((result['status'],result['calls'],result['failed'],result['pending']),('ok',3,2,0))
+        self.assertEqual(model.call_count,3)
+        self.assertEqual(sleep.call_count,2)
+        self.assertEqual(self.db.execute('SELECT attempts FROM bulletin.decisions').fetchone()['attempts'],3)
+        calls=self.db.execute('SELECT status,actual_usd FROM bulletin.calls ORDER BY id').fetchall()
+        self.assertEqual([c['status'] for c in calls],['failed:HTTPError:503','failed:HTTPError:429','validated'])
+        self.assertIsNone(calls[0]['actual_usd'])
+        self.assertIsNone(calls[1]['actual_usd'])
+
+    def test_transient_failure_stops_at_durable_attempt_limit(self):
+        with patch.object(worker,'call_model',side_effect=self.http_error()) as model,patch.object(worker.time,'sleep'):
+            result=worker.run(self.db,window=self.window)
+        self.assertEqual((result['status'],result['calls'],result['pending']),('classification_failed',3,1))
+        self.db.execute("UPDATE bulletin.decisions SET last_attempt_at=now()-interval '2 hours'")
+        self.assertEqual(self.run_worker()[1],0)
+
+    def test_auth_error_does_not_immediately_retry(self):
+        with patch.object(worker,'call_model',side_effect=self.http_error(401)),patch.object(worker.time,'sleep') as sleep:
+            result=worker.run(self.db,window=self.window)
+        self.assertEqual(result['calls'],1)
+        sleep.assert_not_called()
+
+    def test_retries_obey_call_limit(self):
+        with patch.object(worker,'call_model',side_effect=self.http_error()),patch.object(worker.time,'sleep'):
+            result=worker.run(self.db,window=self.window,limit=2)
+        self.assertEqual((result['calls'],result['pending']),(2,1))
+
+    def test_retry_must_reserve_budget_again(self):
+        body=worker.request_body(self.source,SYSTEM)
+        cap=worker.reservation(body)*Decimal('1.5')
+        with patch.object(worker,'call_model',side_effect=self.http_error()),patch.object(worker.time,'sleep'):
+            result=worker.run(self.db,window=self.window,backfill_budget=cap)
+        self.assertEqual((result['status'],result['calls']),('budget_limit',1))
+
+    def test_retry_does_not_start_near_deadline(self):
+        with patch.object(worker.time,'monotonic',return_value=0) as clock, \
+                patch.object(worker.time,'sleep') as sleep,patch.object(worker,'MAX_SECONDS',65):
+            def fail(body):
+                clock.return_value=10
+                raise self.http_error()
+            with patch.object(worker,'call_model',side_effect=fail):
+                result=worker.run(self.db,window=self.window)
+        self.assertEqual(result['calls'],1)
+        sleep.assert_not_called()
+
+    def test_publication_error_does_not_repeat_paid_model_call(self):
+        with patch.object(worker,'call_model',side_effect=self.response) as model, \
+                patch.object(worker,'publish',side_effect=self.http_error()), \
+                patch.object(worker.time,'sleep') as sleep:
+            result=worker.run(self.db,window=self.window)
+        self.assertEqual((result['status'],model.call_count),('classification_failed',1))
+        self.assertIsNotNone(self.db.execute('SELECT actual_usd FROM bulletin.calls').fetchone()['actual_usd'])
+        sleep.assert_not_called()
+
+    def test_policy_change_before_retry_suppresses_call(self):
+        def optout(_):
+            self.db.execute("INSERT INTO public.optin VALUES ('10','alice',true)")
+        with patch.object(worker,'call_model',side_effect=self.http_error()) as model, \
+                patch.object(worker.time,'sleep',side_effect=optout):
+            result=worker.run(self.db,window=self.window)
+        self.assertEqual((result['status'],result['calls'],result['suppressed'],result['pending']),('ok',1,1,0))
+        self.assertEqual(model.call_count,1)
 
     def test_browser_cannot_read_state_and_backfill_does_not_touch_daily_cursor(self):
         old=self.db.execute('SELECT cursor_at,cursor_id FROM bulletin.worker_state').fetchone()

--- a/services/bulletin/test_retries.py
+++ b/services/bulletin/test_retries.py
@@ -1,0 +1,44 @@
+"""Retry policy and allowlisted diagnostics, without network calls."""
+import contextlib
+import datetime as dt
+from email.utils import format_datetime
+import io
+import json
+import unittest
+import urllib.error
+from unittest.mock import patch
+
+import worker
+
+
+class RetryTests(unittest.TestCase):
+    def error(self,code=503,headers=None):
+        return urllib.error.HTTPError('https://private.invalid/token',code,'secret body',headers or {},None)
+
+    def test_backoff_and_retry_after(self):
+        with patch.object(worker.random,'uniform',return_value=0):
+            self.assertEqual(worker.retry_wait(self.error(),1),2)
+            self.assertEqual(worker.retry_wait(self.error(),2),5)
+            self.assertEqual(worker.retry_wait(self.error(429,{'Retry-After':'20'}),1),20)
+            future=format_datetime(dt.datetime.now(dt.timezone.utc)+dt.timedelta(seconds=30))
+            self.assertGreater(worker.retry_wait(self.error(429,{'Retry-After':future}),1),28)
+            self.assertEqual(worker.retry_wait(self.error(429,{'Retry-After':'invalid'}),1),2)
+            self.assertIsNone(worker.retry_wait(self.error(429,{'Retry-After':'120'}),1))
+
+    def test_transient_errors_only_and_three_attempts(self):
+        for exc in (self.error(408),self.error(429),self.error(502),TimeoutError(),urllib.error.URLError('timeout')):
+            self.assertIsNotNone(worker.retry_wait(exc,1))
+            self.assertIsNone(worker.retry_wait(exc,3))
+        for exc in (self.error(400),self.error(401),self.error(402),self.error(403),ValueError('invalid label')):
+            self.assertIsNone(worker.retry_wait(exc,1))
+
+    def test_log_has_only_safe_structured_metadata(self):
+        out=io.StringIO()
+        with contextlib.redirect_stdout(out):
+            worker.log_failure(self.error(),run_id=14,call_id=2,attempt=1,stage='model_request',retry_seconds=2)
+        event=json.loads(out.getvalue())
+        self.assertEqual(event,dict(event='bulletin_error',run_id=14,call_id=2,attempt=1,
+            stage='model_request',error_type='HTTPError',retry_seconds=2,http_status=503))
+
+
+if __name__=='__main__':unittest.main()

--- a/services/bulletin/worker.py
+++ b/services/bulletin/worker.py
@@ -4,11 +4,15 @@
 # ///
 """Incremental, bounded Bulletin worker. Run after a successful autorefresh."""
 import argparse
+from collections import deque
 import datetime as dt
+from email.utils import parsedate_to_datetime
 from decimal import Decimal
 import json
 import os
+import random
 import time
+import urllib.error
 import urllib.request
 
 import duckdb
@@ -29,6 +33,39 @@ MAX_CALLS = 50
 MAX_PAGES = 100
 MAX_SECONDS = 900
 LOCK = 712606570
+
+
+def retry_wait(exc, attempt):
+    """Short provider retries; a longer Retry-After is deferred to a later run."""
+    if attempt >= 3:
+        return None
+    if isinstance(exc, urllib.error.HTTPError):
+        if exc.code not in (408, 429) and not 500 <= exc.code < 600:
+            return None
+    elif not isinstance(exc, (urllib.error.URLError, TimeoutError)):
+        return None
+    delay = (2 if attempt == 1 else 5) + random.uniform(0, 1)
+    if isinstance(exc, urllib.error.HTTPError):
+        value = exc.headers.get('Retry-After') if exc.headers else None
+        if value:
+            try:
+                seconds = int(value)
+            except ValueError:
+                try:
+                    seconds = (parsedate_to_datetime(value) - dt.datetime.now(dt.timezone.utc)).total_seconds()
+                except (ValueError, TypeError, OverflowError):
+                    seconds = 0
+            delay = max(delay, seconds)
+    return delay if delay <= 60 else None
+
+
+def log_failure(exc, *, run_id, call_id=None, attempt=None, stage, retry_seconds=None):
+    # Allowlist metadata: never serialize exceptions, URLs, bodies, headers or locals.
+    event = dict(event='bulletin_error', run_id=run_id, call_id=call_id,
+        attempt=attempt, stage=stage, error_type=type(exc).__name__, retry_seconds=retry_seconds)
+    if isinstance(exc, urllib.error.HTTPError):
+        event['http_status'] = exc.code
+    print(json.dumps(event), flush=True)
 
 
 def connect():
@@ -244,10 +281,13 @@ def run(db, limit=MAX_CALLS, enqueue_only=False, window=None, backfill_budget=No
             if not os.environ.get('OPENROUTER_API_KEY'):
                 raise RuntimeError('missing_model_key')
             retry_delay=dt.timedelta(minutes=1 if backfill_budget is not None else 60)
-            jobs=db.execute('''SELECT * FROM bulletin.decisions WHERE status IN ('pending','failed')
+            jobs=deque(db.execute('''SELECT * FROM bulletin.decisions WHERE status IN ('pending','failed')
               AND attempts<3 AND (last_attempt_at IS NULL OR last_attempt_at<now()-%s)
-              ORDER BY updated_at LIMIT %s''',(retry_delay,limit)).fetchall()
-            for job in jobs:
+              ORDER BY updated_at LIMIT %s''',(retry_delay,limit)).fetchall())
+            while jobs:
+                if counts['calls'] >= limit:
+                    status='call_limit';break
+                job=jobs.popleft()
                 if time.monotonic()-started>MAX_SECONDS:
                     status='time_limit';break
                 source=current(db,job['tweet_id'])
@@ -262,28 +302,45 @@ def run(db, limit=MAX_CALLS, enqueue_only=False, window=None, backfill_budget=No
                 if call_id is None:
                     status='budget_limit';break
                 counts['calls']+=1
+                job['attempts']+=1
+                stage='model_request'
                 try:
                     result=call_model(body)
+                    stage='model_validation'
                     db.execute("UPDATE bulletin.calls SET actual_usd=%s,status='responded' WHERE id=%s",
                         (actual_cost(result),call_id))
                     choice=result['choices'][0]
                     if choice.get('finish_reason')!='stop':
                         raise ValueError('incomplete_output')
                     label=validate_label(json.loads(choice['message']['content']),{'text':source['full_text']})
+                    stage='publish'
                     stored=publish(db,job,label)
                     counts['positive' if label['is_notice'] else 'negative']+=int(stored)
                     counts['suppressed']+=int(not stored)
                     db.execute('UPDATE bulletin.calls SET status=%s WHERE id=%s',
                         ('validated' if stored else 'suppressed',call_id))
                 except Exception as exc:
-                    # Never persist provider bodies, prompts, authored text or credentials in logs.
+                    delay=retry_wait(exc,job['attempts']) if stage=='model_request' else None
+                    if delay is not None and (counts['calls']>=limit or
+                            time.monotonic()-started+delay+60>MAX_SECONDS):
+                        delay=None
+                    log_failure(exc,run_id=run_id,call_id=call_id,attempt=job['attempts'],
+                        stage=stage,retry_seconds=delay)
+                    failure='failed:'+type(exc).__name__
+                    if isinstance(exc,urllib.error.HTTPError):
+                        failure+=':'+str(exc.code)
                     db.execute('UPDATE bulletin.calls SET status=%s WHERE id=%s',
-                        ('failed:'+type(exc).__name__,call_id))
+                        (failure,call_id))
                     counts['failed']+=1
                     status='classification_failed'
+                    if delay is not None:
+                        time.sleep(delay)
+                        jobs.appendleft(job)
                 progress(db,run_id,counts)
         pending=db.execute("SELECT count(*) AS n FROM bulletin.decisions WHERE status IN ('pending','failed')").fetchone()['n']
         counts['pending']=pending
+        if not pending and status=='classification_failed':
+            status='ok'
         if enqueue_only:
             status='enqueued_only'
         elif pending and status=='ok':
@@ -294,6 +351,7 @@ def run(db, limit=MAX_CALLS, enqueue_only=False, window=None, backfill_budget=No
         progress(db,run_id,counts,status,finished=True)
         return {'status':status,**counts}
     except Exception as exc:
+        log_failure(exc,run_id=run_id,stage='worker')
         if run_id is not None:
             progress(db,run_id,counts,'failed:'+type(exc).__name__,finished=True)
         db.execute('''UPDATE bulletin.worker_state SET last_finished_at=now(),status=%s,counts=%s WHERE id=1''',


### PR DESCRIPTION
Bulletin currently leaves a transient model HTTP failure unresolved until another run, and records only `HTTPError`. Retry transient model requests in the same run after 2 then 5 seconds plus jitter, and record safe structured diagnostics with HTTP status, stage, run/call ID and attempt.

Retries honor `Retry-After` up to 60 seconds (longer delays defer), the existing three-attempt limit, per-run call/time limits and cost reservations. Every attempt rechecks current source and policy. Authentication, payment, validation and publication failures do not trigger immediate model retries. A recovered run finishes `ok` while preserving failed-attempt counts. Existing cross-run cooldowns remain unchanged.

Validation: 21 focused Python tests passed against an isolated local UTF-8 PostgreSQL database with mocked model and ClickHouse requests. Coverage includes recovery, exhaustion, HTTP/auth policy, Retry-After, deadline/call/budget limits, privacy-safe logs, consent changes, publication errors and existing worker behavior. `git diff --check` passed. The worktree lacks the Husky bootstrap; the commit used a per-command hook bypass after these focused checks.

Deployment: worker-only change; no schema, website or systemd configuration changes. Production is unchanged. After explicit rollout approval, install an immutable worker release while `ca-bulletin.service` is idle, preserve its previous `current` target, and run a bounded service check. Rollback restores the previous `current` symlink; retain the cost and decision ledger. Loki shipping and external alerts are separate monitoring work.
