### PR TITLE
Add admin navigation and bounded Bulletin prompt reruns

### DIFF
--- a/services/bulletin/README.md
+++ b/services/bulletin/README.md
@@ -126,6 +126,54 @@ uv run worker.py --start 2026-08-26 --end 2026-09-09 --backfill-budget-usd 1
 
 ## Runtime and rollout
 
+### Admin refresh controls
+
+Admins can open **Refresh notices** in the bulletin header, or use the controls
+under the prompt editor. Save a draft first, then choose the latest run's exact
+window or the previous 14 complete UTC days and a per-request cap ($0.01–$1,
+default $0.10). This reclassifies all phrase-filter candidates, including cached
+positive/negative decisions, with the saved prompt version pinned at submission.
+It does not rerun scraping or bypass the upstream phrase filters.
+
+The server checks the existing admin identity gate and rejects local read-preview
+writes. The service-only RPC records an idempotent request and allows only one
+active refresh. `ca-bulletin-refresh.timer` checks the queue once per minute;
+`worker.py --queued-only` processes one bounded batch under the same advisory lock
+as the daily worker. An empty queue makes no model calls. Intake and call/time
+limits automatically continue on the next tick, using the same cursor, pinned
+prompt, attempts and cumulative spending cap. The existing monthly cap and
+conservative reservations also apply. Budget exhaustion or model errors stop the
+request visibly; there is no automatic budget increase or retry-counter reset.
+Only a new, explicitly submitted refresh resets attempts once for its candidates.
+Daily classification does not consume refresh-owned pending decisions.
+
+Unchanged existing notices remain visible while reclassification is pending or
+fails. A successful positive replaces the notice; a successful negative removes
+it. Current source-hash and consent checks still suppress stale/private sources.
+The UI polls status and shows the latest batch plus cumulative spending; reload
+the board to see newly classified results. Stopped requests can be investigated
+in run history before explicitly requesting another refresh.
+
+Production activation is separate from shipping this code:
+
+1. Apply `20260911014857_bulletin_refresh_requests.sql` and verify service-role
+   RPC access and denial for browser roles. This migration is required by the
+   updated daily worker as well as the refresh worker.
+2. While the daily unit is idle, install the tested worker release and the new
+   refresh service/timer beside the existing unit, retaining the same runtime
+   credentials and previous release. Enable the timer. An empty-queue smoke
+   requires no model calls. Verify timer health before exposing the controls.
+3. Set server-only `BULLETIN_REFRESH_ENABLED=true` for the intended website
+   environment. Leave it unset on previews unless their worker/DB queue is
+   separately configured. Local admin preview always remains read-only.
+4. Any production classification smoke needs its own approved window/cap.
+
+To disable new requests, remove `BULLETIN_REFRESH_ENABLED`. Stop the refresh
+timer/service before rolling back the worker. Keep schema, requests, prompts,
+derived data and cost history. An older daily worker does not understand refresh
+ownership; do not resume it with pending refresh-owned decisions until those
+requests have been reconciled. Never clear billing history to make a rerun fit.
+
 Owner: Community Archive backend. Existing worker host: `ca-autorefresh`
 (`95.217.12.23`), unit `ca-bulletin.service`, invoked after autorefresh succeeds.
 The wrapper never reruns scraping to retry Bulletin. Service failure invokes the

--- a/services/bulletin/ca-bulletin-refresh.service
+++ b/services/bulletin/ca-bulletin-refresh.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Community Archive admin Bulletin refresh queue
+After=network-online.target
+Wants=network-online.target
+OnFailure=ca-bulletin-failure.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=/opt/community-archive-bulletin/current
+Environment=PATH=/root/.local/bin:/usr/local/bin:/usr/bin:/bin
+LoadCredentialEncrypted=openrouter_api_key:/etc/credstore.encrypted/ca-bulletin-openrouter
+LoadCredentialEncrypted=clickhouse_api_token:/etc/credstore.encrypted/ca-bulletin-clickhouse
+Environment=CLICKHOUSE_ANALYTICS_API_URL=https://analytics.community-archive.org/analytics
+ExecStart=/usr/bin/python3 /opt/community-archive-bulletin/current/run_service.py --queued-only
+TimeoutStartSec=20min
+MemoryMax=512M
+CPUQuota=100%
+UMask=0077
+NoNewPrivileges=true
+PrivateTmp=true
+

--- a/services/bulletin/ca-bulletin-refresh.timer
+++ b/services/bulletin/ca-bulletin-refresh.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Check for explicitly requested Bulletin refreshes
+
+[Timer]
+OnBootSec=1min
+OnUnitInactiveSec=1min
+Unit=ca-bulletin-refresh.service
+
+[Install]
+WantedBy=timers.target

--- a/services/bulletin/test_clickhouse_worker.py
+++ b/services/bulletin/test_clickhouse_worker.py
@@ -23,12 +23,12 @@ class ClickHouseWorkerTests(unittest.TestCase):
             raise RuntimeError('Tests require a named local disposable database')
         cls.db.execute('DROP SCHEMA IF EXISTS bulletin CASCADE; DROP SCHEMA IF EXISTS tes CASCADE; DROP SCHEMA public CASCADE; CREATE SCHEMA public')
         cls.db.execute(FIXTURE)
-        for name in ('opportunities','run_history','prompt_versions','clickhouse'):
+        for name in ('opportunities','run_history','prompt_versions','clickhouse','refresh_requests'):
             cls.db.execute(next((ROOT/'supabase/migrations').glob('*_bulletin_'+name+'.sql')).read_text())
     @classmethod
     def tearDownClass(cls): cls.db.close()
     def setUp(self):
-        self.db.execute('TRUNCATE bulletin.decisions,bulletin.calls,bulletin.runs,bulletin.scans,bulletin.prompt_versions,public.all_account,public.members,public.optin,tes.blocked_scraping_users RESTART IDENTITY CASCADE')
+        self.db.execute('TRUNCATE bulletin.decisions,bulletin.calls,bulletin.runs,bulletin.scans,bulletin.refresh_requests,bulletin.prompt_versions,public.all_account,public.members,public.optin,tes.blocked_scraping_users RESTART IDENTITY CASCADE')
         self.db.execute("INSERT INTO public.all_account VALUES ('10','alice',false); INSERT INTO public.members VALUES ('10')")
         self.db.execute("INSERT INTO bulletin.prompt_versions(body,note) VALUES (%s,'Initial')",(SYSTEM,))
         self.window=(dt.datetime(2026,9,1,tzinfo=dt.timezone.utc),dt.datetime(2026,9,2,tzinfo=dt.timezone.utc))
@@ -72,6 +72,123 @@ class ClickHouseWorkerTests(unittest.TestCase):
             self.assertEqual(older['versions'][0]['id'],'1')
             self.assertEqual(older['active']['body'],'updated')
         finally:self.db.execute('RESET ROLE')
+
+    def queue_refresh(self,request_id='00000000-0000-4000-8000-000000000001',budget='.10',selection='latest',prompt=1):
+        return self.db.execute('SELECT public.request_bulletin_refresh(%s,%s,%s,%s,%s) id',
+            (request_id,selection,prompt,Decimal(budget),'00000000-0000-0000-0000-000000000001')).fetchone()['id']
+
+    def run_refresh(self,**kwargs):
+        with patch.object(worker,'call_model',side_effect=self.response) as model:
+            result=worker.run(self.db,queued_only=True,**kwargs)
+        return result,model.call_count
+
+    def test_refresh_reclassifies_and_removes_notice_with_pinned_prompt(self):
+        self.run_worker()
+        self.db.execute("INSERT INTO bulletin.prompt_versions(body,note) VALUES ('Changed prompt','Change')")
+        request=self.queue_refresh(prompt=2)
+        self.db.execute("INSERT INTO bulletin.prompt_versions(body,note) VALUES ('Later prompt','Later')")
+        self.label={'is_notice':False}
+        original=self.response
+        def respond(body):
+            self.assertEqual(json.loads(body)['messages'][0]['content'],'Changed prompt')
+            return original(body)
+        self.response=respond
+        result,calls=self.run_refresh()
+        self.assertEqual((result['status'],calls),('ok',1))
+        self.assertEqual(self.db.execute('SELECT count(*) n FROM bulletin.opportunities').fetchone()['n'],0)
+        self.assertEqual(self.db.execute('SELECT status FROM bulletin.refresh_requests WHERE id=%s',(request,)).fetchone()['status'],'complete')
+        self.assertEqual(self.run_refresh()[0]['status'],'queue_empty')
+
+    def test_refresh_updates_positive_and_preserves_notice_on_model_failure(self):
+        self.run_worker();self.queue_refresh()
+        self.label['summary']='Updated offer.'
+        self.run_refresh()
+        self.assertEqual(self.db.execute('SELECT summary FROM bulletin.opportunities').fetchone()['summary'],'Updated offer.')
+        self.queue_refresh('00000000-0000-4000-8000-000000000002')
+        with patch.object(worker,'call_model',side_effect=self.http_error(401)):
+            self.assertEqual(worker.run(self.db,queued_only=True)['status'],'classification_failed')
+        self.assertEqual(self.db.execute('SELECT summary FROM bulletin.opportunities').fetchone()['summary'],'Updated offer.')
+
+    def test_refresh_resumes_without_resetting_attempts_or_cost_cap(self):
+        self.run_worker();self.queue_refresh(budget='.01')
+        with patch.object(worker,'MAX_PAGES',1):
+            self.assertEqual(self.run_refresh()[0]['status'],'intake_backlog')
+        self.db.execute("UPDATE bulletin.decisions SET attempts=2,last_attempt_at=now()-interval '2 minutes'")
+        result,calls=self.run_refresh()
+        self.assertEqual((result['status'],calls),('ok',1))
+        self.assertEqual(self.db.execute('SELECT attempts FROM bulletin.decisions').fetchone()['attempts'],3)
+        self.assertEqual(self.db.execute('SELECT count(*) n FROM bulletin.calls').fetchone()['n'],2)
+
+    def test_refresh_budget_and_monthly_limit_stop_without_losing_notice(self):
+        self.run_worker();request=self.queue_refresh(budget='.01')
+        with patch.object(worker,'MAX_PAGES',1):self.run_refresh()
+        self.db.execute("INSERT INTO bulletin.calls(reserved_usd,run_id) SELECT .01,id FROM bulletin.runs ORDER BY id DESC LIMIT 1")
+        result,calls=self.run_refresh()
+        self.assertEqual((result['status'],calls),('budget_limit',0))
+        self.assertEqual(self.db.execute('SELECT count(*) n FROM bulletin.opportunities').fetchone()['n'],1)
+        dashboard=self.db.execute('SELECT public.get_bulletin_refreshes() data').fetchone()['data']
+        self.assertEqual((dashboard[0]['status'],dashboard[0]['spent_usd']),('stopped',.01))
+        self.queue_refresh('00000000-0000-4000-8000-000000000002',budget='1')
+        self.db.execute('INSERT INTO bulletin.calls(reserved_usd) VALUES (.90)')
+        self.assertEqual(self.run_refresh()[0]['status'],'budget_limit')
+
+    def test_refresh_is_idempotent_serialized_and_private(self):
+        self.run_worker();request=self.queue_refresh()
+        self.assertEqual(self.queue_refresh(),request)
+        with self.assertRaises(psycopg.errors.ObjectNotInPrerequisiteState):
+            self.queue_refresh('00000000-0000-4000-8000-000000000002')
+        for role in ('anon','authenticated'):
+            self.db.execute('SET ROLE '+role)
+            try:
+                with self.assertRaises(psycopg.errors.InsufficientPrivilege):self.queue_refresh()
+                with self.assertRaises(psycopg.errors.InsufficientPrivilege):
+                    self.db.execute('SELECT public.get_bulletin_refreshes()')
+            finally:self.db.execute('RESET ROLE')
+
+    def test_service_role_can_queue_and_read_but_not_delete_refresh_history(self):
+        self.run_worker()
+        self.db.execute('SET ROLE service_role')
+        try:
+            request=self.queue_refresh()
+            dashboard=self.db.execute('SELECT public.get_bulletin_refreshes() data').fetchone()['data']
+            self.assertEqual(dashboard[0]['id'],request)
+            with self.assertRaises(psycopg.errors.InsufficientPrivilege):
+                self.db.execute('DELETE FROM bulletin.refresh_requests')
+        finally:self.db.execute('RESET ROLE')
+
+    def test_refresh_waits_for_daily_lock_without_changing_request(self):
+        self.run_worker();self.queue_refresh()
+        with psycopg.connect(os.environ['BULLETIN_TEST_DSN'],autocommit=True) as other:
+            other.execute('SELECT pg_advisory_lock(%s)',(worker.LOCK,))
+            self.assertEqual(self.run_refresh()[0]['status'],'already_running')
+            self.assertEqual(self.db.execute('SELECT status FROM bulletin.refresh_requests').fetchone()['status'],'queued')
+        self.assertEqual(self.run_refresh()[0]['status'],'ok')
+
+    def test_refresh_rejects_stale_prompt_and_invalid_cap_and_covers_fourteen_days(self):
+        with self.assertRaises(psycopg.errors.SerializationFailure):self.queue_refresh(prompt=2)
+        with self.assertRaises(psycopg.errors.InvalidParameterValue):self.queue_refresh(budget='1.01')
+        with self.assertRaises(psycopg.errors.InvalidParameterValue):self.queue_refresh()
+        self.queue_refresh(selection='two_weeks')
+        request=self.db.execute('SELECT * FROM bulletin.refresh_requests').fetchone()
+        self.assertEqual(request['window_end']-request['window_start'],dt.timedelta(days=14))
+        self.assertEqual(request['window_end'].hour,0)
+
+    def test_daily_run_does_not_consume_refresh_candidates(self):
+        self.run_worker();self.queue_refresh()
+        with patch.object(worker,'MAX_PAGES',1):self.run_refresh()
+        self.assertEqual(self.run_worker()[1],0)
+        self.assertEqual(self.run_refresh()[1],1)
+
+    def test_refresh_rechecks_policy_and_recovers_abandoned_running_request(self):
+        self.run_worker();self.queue_refresh()
+        self.db.execute("UPDATE bulletin.refresh_requests SET status='running'")
+        original=self.response
+        def optout(body):
+            self.db.execute("INSERT INTO public.optin VALUES ('10','alice',true)")
+            return original(body)
+        self.response=optout
+        self.assertEqual(self.run_refresh()[0]['suppressed'],1)
+        self.assertEqual(self.db.execute('SELECT count(*) n FROM bulletin.opportunities').fetchone()['n'],0)
 
     def test_clickhouse_only_tweet_publishes_and_replay_reuses_decision(self):
         result,calls=self.run_worker()

--- a/services/bulletin/worker.py
+++ b/services/bulletin/worker.py
@@ -92,11 +92,13 @@ def candidates(engine, rows):
         and upstream.side_of(upstream.clean_text(r['full_text'])) is not None]
 
 
-def intake(db, engine, counts, started, run_id, window=None, rescan=False):
+def intake(db, engine, counts, started, run_id, window=None, rescan=False, refresh=None):
     now=dt.datetime.now(dt.timezone.utc)
     end=window[1] if window else now.replace(hour=0,minute=0,second=0,microsecond=0)
     start=window[0] if window else end-dt.timedelta(days=2)
     key=('backfill:' if window else 'daily:')+start.isoformat()+':'+end.isoformat()
+    if refresh:
+        key='refresh:'+str(refresh['id'])
     db.execute("INSERT INTO bulletin.scans(scan_key,window_start,window_end) VALUES(%s,%s,%s) ON CONFLICT DO NOTHING",(key,start,end))
     if rescan:
         db.execute("UPDATE bulletin.scans SET cursor_id='0',complete=false WHERE scan_key=%s",(key,))
@@ -132,6 +134,13 @@ def intake(db, engine, counts, started, run_id, window=None, rescan=False):
                   SET account_id=excluded.account_id,posted_at=excluded.posted_at''',
                   (VERSION,Jsonb([{'tweet_id':r['tweet_id'],'account_id':r['account_id'],
                     'posted_at':r['created_at'].isoformat(),'content_hash':r['content_hash']} for r in shortlist])))
+                if refresh:
+                    # Reset once per explicit refresh, never on a resumed page.
+                    # Preserve the previous notice until a new decision succeeds.
+                    db.execute('''UPDATE bulletin.decisions SET status='pending',attempts=0,
+                      last_attempt_at=NULL,refresh_request_id=%s,updated_at=now()
+                      WHERE tweet_id=ANY(%s) AND refresh_request_id IS DISTINCT FROM %s''',
+                      (refresh['id'],[r['tweet_id'] for r in shortlist],refresh['id']))
             next_id=page['next']
             if page['scanned'] and (not next_id or int(next_id)<=int(after)):
                 raise RuntimeError('invalid_clickhouse_cursor')
@@ -230,10 +239,15 @@ def publish(db, job, label):
             db.execute('''INSERT INTO bulletin.opportunities
               (tweet_id,content_hash,side,kind,summary,evidence,topics,respond,standing,expires_at,place,model)
               VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
-              ON CONFLICT(tweet_id) DO NOTHING''',
+              ON CONFLICT(tweet_id) DO UPDATE SET content_hash=excluded.content_hash,
+                side=excluded.side,kind=excluded.kind,summary=excluded.summary,evidence=excluded.evidence,
+                topics=excluded.topics,respond=excluded.respond,standing=excluded.standing,
+                expires_at=excluded.expires_at,place=excluded.place,model=excluded.model''',
               (job['tweet_id'],job['content_hash'],label['side'],label['kind'],label['summary'],
                label['evidence'],label['topics'],label['respond'],label['standing'],
                label['expires_at'],label['place'],MODEL))
+        else:
+            db.execute('DELETE FROM bulletin.opportunities WHERE tweet_id=%s',(job['tweet_id'],))
     return True
 
 
@@ -245,7 +259,7 @@ def progress(db, run_id, counts, status='running', finished=False):
           (Jsonb(counts),status,finished,run_id))
 
 
-def run(db, limit=MAX_CALLS, enqueue_only=False, window=None, backfill_budget=None, rescan=False):
+def run(db, limit=MAX_CALLS, enqueue_only=False, window=None, backfill_budget=None, rescan=False, queued_only=False):
     if backfill_budget is not None and (window is None or not Decimal(0)<backfill_budget<=Decimal(1)):
         raise ValueError('backfill_budget_requires_window_and_at_most_one_dollar')
     if not db.execute('SELECT pg_try_advisory_lock(%s) AS locked',(LOCK,)).fetchone()['locked']:
@@ -255,11 +269,22 @@ def run(db, limit=MAX_CALLS, enqueue_only=False, window=None, backfill_budget=No
     if backfill_budget is not None:
         counts['backfill_budget_usd']=str(backfill_budget)
     run_id=None
+    refresh=None
     try:
+        if queued_only:
+            refresh=db.execute("SELECT * FROM bulletin.refresh_requests WHERE status IN ('queued','running') ORDER BY created_at LIMIT 1").fetchone()
+            if not refresh:
+                return {'status':'queue_empty'}
+            window=(refresh['window_start'],refresh['window_end'])
+            backfill_budget=refresh['budget_usd']
+            counts.update(refresh_request_id=str(refresh['id']),backfill_budget_usd=str(backfill_budget))
+            db.execute("UPDATE bulletin.refresh_requests SET status='running',updated_at=now() WHERE id=%s",(refresh['id'],))
         # Owning the lock proves earlier 'running' rows no longer have a live worker.
         with db.transaction():
             db.execute("UPDATE bulletin.runs SET status='interrupted' WHERE status='running'")
-            prompt=db.execute('SELECT id,body FROM bulletin.prompt_versions ORDER BY id DESC LIMIT 1').fetchone()
+            prompt=(db.execute('SELECT id,body FROM bulletin.prompt_versions WHERE id=%s',
+                (refresh['prompt_version_id'],)).fetchone() if refresh else
+                db.execute('SELECT id,body FROM bulletin.prompt_versions ORDER BY id DESC LIMIT 1').fetchone())
             if not prompt:
                 raise RuntimeError('missing_active_prompt')
             run_id=db.execute('INSERT INTO bulletin.runs(model,classifier_version,prompt_version_id) VALUES(%s,%s,%s) RETURNING id',
@@ -273,7 +298,7 @@ def run(db, limit=MAX_CALLS, enqueue_only=False, window=None, backfill_budget=No
         engine.execute('SET threads=1')
         engine.execute("SET memory_limit='128MB'")
         try:
-            complete=intake(db,engine,counts,started,run_id,window,rescan)
+            complete=intake(db,engine,counts,started,run_id,window,rescan,refresh)
         finally:
             engine.close()
         status='ok' if complete else 'intake_backlog'
@@ -282,8 +307,9 @@ def run(db, limit=MAX_CALLS, enqueue_only=False, window=None, backfill_budget=No
                 raise RuntimeError('missing_model_key')
             retry_delay=dt.timedelta(minutes=1 if backfill_budget is not None else 60)
             jobs=deque(db.execute('''SELECT * FROM bulletin.decisions WHERE status IN ('pending','failed')
+              AND refresh_request_id IS NOT DISTINCT FROM %s::uuid
               AND attempts<3 AND (last_attempt_at IS NULL OR last_attempt_at<now()-%s)
-              ORDER BY updated_at LIMIT %s''',(retry_delay,limit)).fetchall())
+              ORDER BY updated_at LIMIT %s''',(refresh['id'] if refresh else None,retry_delay,limit)).fetchall())
             while jobs:
                 if counts['calls'] >= limit:
                     status='call_limit';break
@@ -337,7 +363,10 @@ def run(db, limit=MAX_CALLS, enqueue_only=False, window=None, backfill_budget=No
                         time.sleep(delay)
                         jobs.appendleft(job)
                 progress(db,run_id,counts)
-        pending=db.execute("SELECT count(*) AS n FROM bulletin.decisions WHERE status IN ('pending','failed')").fetchone()['n']
+        remaining=db.execute("""SELECT count(*) AS n,count(*) FILTER (WHERE attempts>=3) AS exhausted
+          FROM bulletin.decisions WHERE status IN ('pending','failed')
+          AND refresh_request_id IS NOT DISTINCT FROM %s::uuid""",(refresh['id'] if refresh else None,)).fetchone()
+        pending=remaining['n']
         counts['pending']=pending
         if not pending and status=='classification_failed':
             status='ok'
@@ -349,11 +378,20 @@ def run(db, limit=MAX_CALLS, enqueue_only=False, window=None, backfill_budget=No
           last_success_at=CASE WHEN %s='ok' THEN now() ELSE last_success_at END WHERE id=1''',
           (status,Jsonb(counts),status))
         progress(db,run_id,counts,status,finished=True)
+        if refresh:
+            request_status=('complete' if status=='ok' else 'queued'
+                if status in ('intake_backlog','call_limit','time_limit','pending_review') and not remaining['exhausted']
+                else 'stopped')
+            db.execute('''UPDATE bulletin.refresh_requests SET status=%s,last_status=%s,updated_at=now()
+              WHERE id=%s''',(request_status,status,refresh['id']))
         return {'status':status,**counts}
     except Exception as exc:
         log_failure(exc,run_id=run_id,stage='worker')
         if run_id is not None:
             progress(db,run_id,counts,'failed:'+type(exc).__name__,finished=True)
+        if refresh:
+            db.execute("UPDATE bulletin.refresh_requests SET status='stopped',last_status=%s,updated_at=now() WHERE id=%s",
+                ('failed:'+type(exc).__name__,refresh['id']))
         db.execute('''UPDATE bulletin.worker_state SET last_finished_at=now(),status=%s,counts=%s WHERE id=1''',
             ('failed:'+type(exc).__name__,Jsonb(counts)))
         raise
@@ -369,6 +407,7 @@ if __name__=='__main__':
     parser.add_argument('--end',help='Backfill UTC date, exclusive (at most 15 days)')
     parser.add_argument('--backfill-budget-usd',type=Decimal,help='Explicit one-time cap, at most $1; requires start/end')
     parser.add_argument('--rescan',action='store_true',help='Revisit the window from the start; keep cached decisions and spending')
+    parser.add_argument('--queued-only',action='store_true',help='Process one bounded pass of an admin refresh; otherwise do nothing')
     args=parser.parse_args()
     window=None
     if args.start or args.end:
@@ -380,11 +419,14 @@ if __name__=='__main__':
             parser.error('start/end must form a UTC window of at most 15 days')
     if not 0<=args.limit<=MAX_CALLS:
         parser.error('limit must be between 0 and 50')
+    if args.queued_only and (window or args.enqueue_only or args.rescan or args.backfill_budget_usd is not None):
+        parser.error('queued-only cannot be combined with manual scan options')
     try:
         with connect() as db:
-            result=run(db,args.limit,args.enqueue_only,window,args.backfill_budget_usd,args.rescan)
+            result=run(db,args.limit,args.enqueue_only,window,args.backfill_budget_usd,args.rescan,args.queued_only)
         print(json.dumps(result),flush=True)
-        raise SystemExit(0 if result['status'] in ('ok','already_running','enqueued_only') else 1)
+        raise SystemExit(0 if result['status'] in ('ok','already_running','enqueued_only','queue_empty') or
+            (args.queued_only and result['status'] in ('intake_backlog','call_limit','time_limit','pending_review')) else 1)
     except Exception as exc:
         print(json.dumps({'status':'failed','error_type':type(exc).__name__}),flush=True)
         raise SystemExit(1)

--- a/src/app/admin/bulletin/refreshActions.test.ts
+++ b/src/app/admin/bulletin/refreshActions.test.ts
@@ -1,0 +1,91 @@
+import { getRefreshState, requestRefresh } from './refreshActions'
+import { requireAdmin } from '@/app/admin/data'
+import { getLocalAdminPreview } from '@/lib/localAdminPreview'
+import { createServerServiceRoleClient } from '@/utils/supabase'
+
+jest.mock('@/app/admin/data', () => ({ requireAdmin: jest.fn() }))
+jest.mock('@/lib/localAdminPreview', () => ({
+  getLocalAdminPreview: jest.fn(),
+}))
+jest.mock('@/utils/supabase', () => ({
+  createServerServiceRoleClient: jest.fn(),
+}))
+const rpc = jest.fn()
+const id = '00000000-0000-4000-8000-000000000001'
+const originalEnabled = process.env.BULLETIN_REFRESH_ENABLED
+function form() {
+  const data = new FormData()
+  Object.entries({
+    selection: 'two_weeks',
+    prompt_id: '2',
+    budget: '0.10',
+    request_id: id,
+    actor_id: 'forged',
+  }).forEach(([key, value]) => data.set(key, value))
+  return data
+}
+beforeEach(() => {
+  jest.resetAllMocks()
+  process.env.BULLETIN_REFRESH_ENABLED = 'true'
+  jest
+    .mocked(requireAdmin)
+    .mockResolvedValue({ user: { id: 'verified' } } as Awaited<
+      ReturnType<typeof requireAdmin>
+    >)
+  jest
+    .mocked(createServerServiceRoleClient)
+    .mockReturnValue({ rpc } as unknown as ReturnType<
+      typeof createServerServiceRoleClient
+    >)
+  rpc.mockResolvedValue({ data: id, error: null })
+})
+afterAll(() => {
+  if (originalEnabled === undefined) delete process.env.BULLETIN_REFRESH_ENABLED
+  else process.env.BULLETIN_REFRESH_ENABLED = originalEnabled
+})
+test('gates both submission and status on verified admin auth', async () => {
+  jest.mocked(requireAdmin).mockRejectedValue(new Error('not admin'))
+  await expect(requestRefresh(form())).rejects.toThrow('not admin')
+  await expect(getRefreshState()).rejects.toThrow('not admin')
+  expect(rpc).not.toHaveBeenCalled()
+})
+test('disabled rollout and read preview cannot queue work', async () => {
+  process.env.BULLETIN_REFRESH_ENABLED = 'false'
+  expect(await requestRefresh(form())).toHaveProperty('error')
+  process.env.BULLETIN_REFRESH_ENABLED = 'true'
+  jest.mocked(getLocalAdminPreview).mockResolvedValue('admin')
+  expect(await requestRefresh(form())).toHaveProperty('error')
+  expect(rpc).not.toHaveBeenCalled()
+})
+test('pins expected prompt and uses verified actor and idempotency key', async () => {
+  expect(await requestRefresh(form())).toEqual({ id })
+  expect(rpc).toHaveBeenCalledWith('request_bulletin_refresh', {
+    request_id: id,
+    selection: 'two_weeks',
+    expected_prompt_id: 2,
+    budget_usd: 0.1,
+    actor_id: 'verified',
+  })
+})
+test.each([
+  ['selection', 'all'],
+  ['budget', '1.01'],
+  ['budget', 'NaN'],
+  ['budget', '0'],
+  ['prompt_id', '2e1'],
+  ['request_id', 'invalid'],
+])('rejects invalid %s', async (key, value) => {
+  const data = form()
+  data.set(key, value)
+  expect(await requestRefresh(data)).toHaveProperty('error')
+  expect(rpc).not.toHaveBeenCalled()
+})
+test('conflicts surface a useful error without internal details', async () => {
+  rpc.mockResolvedValue({
+    data: null,
+    error: { code: '40001', message: 'private' },
+  })
+  expect(await requestRefresh(form())).toEqual({
+    error: expect.stringContaining('saved prompt changed'),
+  })
+})

--- a/src/app/admin/bulletin/refreshActions.ts
+++ b/src/app/admin/bulletin/refreshActions.ts
@@ -1,0 +1,78 @@
+'use server'
+
+import { requireAdmin } from '@/app/admin/data'
+import { getLocalAdminPreview } from '@/lib/localAdminPreview'
+import { createServerServiceRoleClient } from '@/utils/supabase'
+import type { RefreshState } from '@/lib/bulletin/refresh'
+
+async function enabled() {
+  return (
+    process.env.BULLETIN_REFRESH_ENABLED === 'true' &&
+    (await getLocalAdminPreview()) !== 'admin'
+  )
+}
+
+export async function getRefreshState(): Promise<RefreshState> {
+  if (!(await enabled())) return { enabled: false, requests: [] }
+  await requireAdmin('/admin/bulletin')
+  const { data, error } = await createServerServiceRoleClient().rpc(
+    'get_bulletin_refreshes',
+  )
+  return error
+    ? {
+        enabled: true,
+        requests: [],
+        error: 'Refresh status could not be loaded.',
+      }
+    : { enabled: true, requests: data as unknown as RefreshState['requests'] }
+}
+
+export async function requestRefresh(
+  form: FormData,
+): Promise<{ id?: string; error?: string }> {
+  if (!(await enabled()))
+    return {
+      error: 'Refreshes are unavailable here. Local preview is read-only.',
+    }
+  const { user } = await requireAdmin('/admin/bulletin')
+  const selection = form.get('selection')
+  const prompt = form.get('prompt_id')
+  const budget = form.get('budget')
+  const request = form.get('request_id')
+  if (
+    (selection !== 'latest' && selection !== 'two_weeks') ||
+    typeof prompt !== 'string' ||
+    !/^[1-9]\d*$/.test(prompt) ||
+    !Number.isSafeInteger(Number(prompt)) ||
+    typeof budget !== 'string' ||
+    !/^(?:0\.[0-9]{1,2}|1(?:\.0{1,2})?)$/.test(budget) ||
+    Number(budget) <= 0 ||
+    typeof request !== 'string' ||
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      request,
+    )
+  )
+    return { error: 'Choose a window and a spending cap between $0.01 and $1.' }
+  const { data, error } = await createServerServiceRoleClient().rpc(
+    'request_bulletin_refresh',
+    {
+      request_id: request,
+      selection,
+      expected_prompt_id: Number(prompt),
+      budget_usd: Number(budget),
+      actor_id: user.id,
+    },
+  )
+  if (error || !data)
+    return {
+      error:
+        error?.code === '40001'
+          ? 'The saved prompt changed. Reload before requesting a refresh.'
+          : error?.code === '55000'
+            ? 'A refresh is already queued or running. Check its status below.'
+            : error?.code === '22023'
+              ? 'No previous scan window is available. Choose the last two weeks.'
+              : 'Refresh could not be queued. Retry to check the same request.',
+    }
+  return { id: data }
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -162,6 +162,16 @@ export default async function AdminPage({
         </Link>
 
         <Link
+          href="/admin/digest"
+          className="rounded-lg border bg-card p-5 transition-colors hover:bg-accent"
+        >
+          <h2 className="font-semibold">Digest admin →</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Generate, edit, review, and publish daily digest editions.
+          </p>
+        </Link>
+
+        <Link
           href="/admin/bulletin"
           className="rounded-lg border bg-card p-5 transition-colors hover:bg-accent"
         >

--- a/src/app/bulletin/page.tsx
+++ b/src/app/bulletin/page.tsx
@@ -4,6 +4,8 @@ import { isBulletinAdmin, requireBulletinUser } from '@/lib/bulletin/data'
 import { loadBulletinPage } from '@/lib/bulletin/page'
 import { DEFAULT_BULLETIN_FILTERS } from '@/lib/bulletin/types'
 import { BulletinBoard } from '@/components/bulletin/BulletinBoard'
+import { loadPrompts } from '@/lib/bulletin/prompts'
+import { RefreshControls } from '@/components/bulletin/RefreshControls'
 export const dynamic = 'force-dynamic'
 export const metadata: Metadata = {
   title: 'Bulletin | Community Archive',
@@ -18,6 +20,7 @@ export default async function BulletinBoardPage() {
       () => null,
     ),
   ])
+  const prompt = isAdmin ? await loadPrompts().catch(() => null) : null
   return (
     <main className={styles.page}>
       {page === null ? (
@@ -34,6 +37,9 @@ export default async function BulletinBoardPage() {
           graph={page.personal}
           now={page.now}
           isAdmin={isAdmin}
+          adminControls={
+            prompt ? <RefreshControls promptId={prompt.active.id} /> : undefined
+          }
         />
       )}
     </main>

--- a/src/components/bulletin/BulletinBoard.module.css
+++ b/src/components/bulletin/BulletinBoard.module.css
@@ -47,8 +47,18 @@
 }
 .titleRow {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 10px;
+}
+.adminLink {
+  margin-left: auto;
+  color: var(--accent);
+  font-size: 13px;
+  white-space: nowrap;
+}
+.adminLink:hover {
+  text-decoration: underline;
 }
 .about {
   position: relative;

--- a/src/components/bulletin/BulletinBoard.tsx
+++ b/src/components/bulletin/BulletinBoard.tsx
@@ -590,6 +590,11 @@ export function BulletinBoard({
               </Link>
             </div>
           </details>
+          {isAdmin && (
+            <Link href="/admin/bulletin" className={styles.adminLink}>
+              Bulletin admin →
+            </Link>
+          )}
         </div>
         <p className={styles.lede}>
           Asks and offers that members posted on Twitter, gathered from the
@@ -778,7 +783,6 @@ export function BulletinBoard({
           Thanks to <Link href="/user/maskys_">@maskys_</Link> for the first
           prototype.
         </p>
-        {isAdmin && <Link href="/admin/bulletin">Run dashboard →</Link>}
       </footer>
     </>
   )

--- a/src/components/bulletin/BulletinBoard.tsx
+++ b/src/components/bulletin/BulletinBoard.tsx
@@ -435,6 +435,7 @@ export function BulletinBoard({
   graph: initialGraph = EMPTY_GRAPH,
   now = Date.now(),
   isAdmin = false,
+  adminControls,
 }: {
   notices: Notice[]
   initialPage?: BulletinPage
@@ -443,6 +444,7 @@ export function BulletinBoard({
   graph?: BulletinRelationships
   now?: number
   isAdmin?: boolean
+  adminControls?: React.ReactNode
 }) {
   const loadTweet = useTweetBatch()
   const [limit, setLimit] = useState(BULLETIN_PAGE_SIZE)
@@ -600,6 +602,14 @@ export function BulletinBoard({
           Asks and offers that members posted on Twitter, gathered from the
           archive each day.
         </p>
+        {isAdmin && adminControls ? (
+          <details className="mt-4">
+            <summary className="cursor-pointer text-sm text-brand">
+              Refresh notices
+            </summary>
+            <div className="mt-3">{adminControls}</div>
+          </details>
+        ) : null}
       </header>
       <div className={styles.sticky}>
         <div className={styles.controlRow}>

--- a/src/components/bulletin/PromptEditor.test.tsx
+++ b/src/components/bulletin/PromptEditor.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { PromptEditor } from './PromptEditor'
 import { savePrompt } from '@/app/admin/bulletin/actions'
 import type { PromptDashboard } from '@/lib/bulletin/types'
+jest.mock('./RefreshControls', () => ({ RefreshControls: () => null }))
 jest.mock('@/app/admin/bulletin/actions', () => ({
   savePrompt: jest.fn(),
 }))

--- a/src/components/bulletin/PromptEditor.tsx
+++ b/src/components/bulletin/PromptEditor.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { savePrompt } from '@/app/admin/bulletin/actions'
 import { formatTimestamp, type PromptDashboard } from '@/lib/bulletin/types'
+import { RefreshControls } from './RefreshControls'
 
 export function PromptEditor({
   data,
@@ -136,6 +137,10 @@ export function PromptEditor({
         restart a running job or recheck old decisions. Phrase filters, JSON
         validation, and spending limits stay in place.
       </p>
+      <RefreshControls
+        promptId={active.id}
+        dirty={saving || body !== active.body}
+      />
       <details>
         <summary className="cursor-pointer text-sm font-medium">
           Prompt version history

--- a/src/components/bulletin/RefreshControls.test.tsx
+++ b/src/components/bulletin/RefreshControls.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { RefreshControls } from './RefreshControls'
+import {
+  getRefreshState,
+  requestRefresh,
+} from '@/app/admin/bulletin/refreshActions'
+
+jest.mock('@/app/admin/bulletin/refreshActions', () => ({
+  getRefreshState: jest.fn(),
+  requestRefresh: jest.fn(),
+}))
+beforeEach(() => {
+  jest.resetAllMocks()
+  Object.defineProperty(crypto, 'randomUUID', {
+    configurable: true,
+    value: jest.fn(() => '00000000-0000-4000-8000-000000000001'),
+  })
+  jest
+    .mocked(getRefreshState)
+    .mockResolvedValue({ enabled: true, requests: [] })
+})
+test('blocks unsaved prompt edits and submits the selected window after saving', async () => {
+  jest.mocked(requestRefresh).mockResolvedValue({ id: 'request' })
+  const { rerender } = render(<RefreshControls promptId="2" dirty />)
+  await waitFor(() => expect(getRefreshState).toHaveBeenCalled())
+  expect(screen.getByRole('button', { name: 'Queue refresh' })).toBeDisabled()
+  rerender(<RefreshControls promptId="3" />)
+  fireEvent.change(screen.getByLabelText('Window'), {
+    target: { value: 'two_weeks' },
+  })
+  fireEvent.click(screen.getByRole('button', { name: 'Queue refresh' }))
+  await waitFor(() => expect(requestRefresh).toHaveBeenCalledTimes(1))
+  const data = jest.mocked(requestRefresh).mock.calls[0][0]
+  expect(data.get('prompt_id')).toBe('3')
+  expect(data.get('selection')).toBe('two_weeks')
+  expect(data.get('budget')).toBe('0.10')
+  await screen.findByText(/Refresh queued/)
+})
+test('ambiguous network failures retry the same request ID', async () => {
+  jest.mocked(requestRefresh).mockRejectedValue(new Error('network'))
+  render(<RefreshControls promptId="2" />)
+  const button = screen.getByRole('button', { name: 'Queue refresh' })
+  await waitFor(() => expect(button).toBeEnabled())
+  fireEvent.click(button)
+  await screen.findByText(/Could not confirm/)
+  fireEvent.click(button)
+  await waitFor(() => expect(requestRefresh).toHaveBeenCalledTimes(2))
+  expect(
+    jest
+      .mocked(requestRefresh)
+      .mock.calls.map(([data]) => data.get('request_id')),
+  ).toEqual([
+    '00000000-0000-4000-8000-000000000001',
+    '00000000-0000-4000-8000-000000000001',
+  ])
+})
+test('an active request blocks duplicate submissions and displays progress', async () => {
+  jest.mocked(getRefreshState).mockResolvedValue({
+    enabled: true,
+    requests: [
+      {
+        id: 'r',
+        status: 'running',
+        prompt_id: '2',
+        budget_usd: 0.1,
+        spent_usd: 0.02,
+        created_at: '2026-09-10T00:00:00Z',
+        window_start: '2026-09-08T00:00:00Z',
+        window_end: '2026-09-10T00:00:00Z',
+        last_status: null,
+        counts: { rows_seen: 500, pending: 4 },
+      },
+    ],
+  })
+  render(<RefreshControls promptId="2" />)
+  expect(
+    await screen.findByRole('button', { name: 'Refresh in progress' }),
+  ).toBeDisabled()
+  expect(screen.getByText(/4 candidates remaining/)).toBeInTheDocument()
+  expect(requestRefresh).not.toHaveBeenCalled()
+})

--- a/src/components/bulletin/RefreshControls.tsx
+++ b/src/components/bulletin/RefreshControls.tsx
@@ -1,0 +1,186 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import {
+  getRefreshState,
+  requestRefresh,
+} from '@/app/admin/bulletin/refreshActions'
+import { formatTimestamp } from '@/lib/bulletin/types'
+import type { RefreshState } from '@/lib/bulletin/refresh'
+
+export function RefreshControls({
+  promptId,
+  dirty = false,
+}: {
+  promptId: string
+  dirty?: boolean
+}) {
+  const [state, setState] = useState<RefreshState | null>(null)
+  const [selection, setSelection] = useState('latest')
+  const [budget, setBudget] = useState('0.10')
+  const [busy, setBusy] = useState(false)
+  const [message, setMessage] = useState('')
+  const requestId = useRef<string>()
+  const active = state?.requests.some(
+    (r) => r.status === 'queued' || r.status === 'running',
+  )
+
+  useEffect(() => {
+    let cancelled = false
+    const refresh = async () => {
+      try {
+        const next = await getRefreshState()
+        if (!cancelled) setState(next)
+      } catch {
+        if (!cancelled) setMessage('Refresh status could not be loaded.')
+      }
+    }
+    void refresh()
+    const timer = setInterval(() => {
+      if (document.visibilityState === 'visible') void refresh()
+    }, 15000)
+    return () => {
+      cancelled = true
+      clearInterval(timer)
+    }
+  }, [])
+
+  async function submit(event: React.FormEvent) {
+    event.preventDefault()
+    if (busy) return
+    setBusy(true)
+    setMessage('')
+    requestId.current ??= crypto.randomUUID()
+    const form = new FormData()
+    form.set('selection', selection)
+    form.set('budget', budget)
+    form.set('prompt_id', promptId)
+    form.set('request_id', requestId.current)
+    try {
+      const result = await requestRefresh(form)
+      if (result.error) setMessage(result.error)
+      else {
+        requestId.current = undefined
+        setMessage(
+          'Refresh queued. The board updates as new decisions finish; reload it to see changes.',
+        )
+        setState(await getRefreshState())
+      }
+    } catch {
+      setMessage(
+        'Could not confirm the request. Retry to check the same request without duplicating it.',
+      )
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <section className="space-y-4 rounded-lg border bg-card p-4 text-sm">
+      <div>
+        <h3 className="font-semibold">Refresh bulletin notices</h3>
+        <p className="mt-1 text-muted-foreground">
+          Reclassify all candidates in the selected window with saved prompt
+          version {promptId}. Successful decisions can update or remove notices.
+          Failed checks keep the previous notice.
+        </p>
+      </div>
+      {dirty && (
+        <p role="status">Save your prompt changes before starting a refresh.</p>
+      )}
+      {state && !state.enabled && (
+        <p>Refreshes are not enabled here. Local preview is read-only.</p>
+      )}
+      <form onSubmit={submit} className="flex flex-wrap items-end gap-3">
+        <label className="grid gap-1">
+          Window
+          <select
+            value={selection}
+            onChange={(e) => {
+              setSelection(e.target.value)
+              requestId.current = undefined
+            }}
+            disabled={busy || active}
+            className="rounded-md border bg-background p-2"
+          >
+            <option value="latest">Latest run’s window</option>
+            <option value="two_weeks">Last 14 complete UTC days</option>
+          </select>
+        </label>
+        <label className="grid gap-1">
+          Maximum spend (USD)
+          <input
+            type="number"
+            min="0.01"
+            max="1"
+            step="0.01"
+            required
+            value={budget}
+            onChange={(e) => {
+              setBudget(e.target.value)
+              requestId.current = undefined
+            }}
+            disabled={busy || active}
+            className="w-32 rounded-md border bg-background p-2"
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={busy || active || dirty || !state?.enabled || !!state.error}
+          className="rounded-md bg-primary px-4 py-2 font-medium text-primary-foreground disabled:opacity-50"
+        >
+          {busy
+            ? 'Queueing…'
+            : active
+              ? 'Refresh in progress'
+              : 'Queue refresh'}
+        </button>
+      </form>
+      <p className="text-xs text-muted-foreground">
+        Starts within about a minute when the worker is free. Larger windows
+        continue in batches. The cap covers the whole request, including
+        retries; the $1 monthly limit also applies. A budget or model failure
+        can stop a refresh before the full window finishes.
+      </p>
+      <p role="status">{message || state?.error}</p>
+      {state?.requests.length ? (
+        <ul className="space-y-3" aria-label="Recent refresh requests">
+          {state.requests.map((r) => (
+            <li key={r.id} className="rounded-md border p-3">
+              <p className="font-medium">
+                {r.status === 'complete'
+                  ? 'Complete'
+                  : r.status === 'stopped'
+                    ? 'Stopped before completion'
+                    : r.status === 'running'
+                      ? 'Running'
+                      : 'Queued'}{' '}
+                · Prompt {r.prompt_id}
+              </p>
+              <p>
+                {formatTimestamp(r.window_start)} →{' '}
+                {formatTimestamp(r.window_end)} (end exclusive)
+              </p>
+              <p>
+                ${Number(r.spent_usd).toFixed(4)} charged or reserved / $
+                {Number(r.budget_usd).toFixed(2)} cap
+              </p>
+              {r.counts && (
+                <p>
+                  Latest batch: {r.counts.rows_seen ?? 0} tweets scanned ·{' '}
+                  {r.counts.pending ?? '—'} candidates remaining
+                </p>
+              )}
+              {r.status === 'stopped' && (
+                <p>
+                  Reason: {r.last_status?.replaceAll('_', ' ')}. Check run
+                  history before requesting another refresh.
+                </p>
+              )}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </section>
+  )
+}

--- a/src/database-types.ts
+++ b/src/database-types.ts
@@ -2071,6 +2071,10 @@ export type Database = {
         }
         Returns: Json
       }
+      get_bulletin_refreshes: {
+        Args: Record<PropertyKey, never>
+        Returns: Json
+      }
       get_bulletin_relationships: {
         Args: {
           viewer_username?: string
@@ -2496,6 +2500,16 @@ export type Database = {
       refresh_global_activity_summary: {
         Args: Record<PropertyKey, never>
         Returns: undefined
+      }
+      request_bulletin_refresh: {
+        Args: {
+          request_id: string
+          selection: string
+          expected_prompt_id: number
+          budget_usd: number
+          actor_id: string
+        }
+        Returns: string
       }
       save_bulletin_prompt: {
         Args: {

--- a/src/lib/bulletin/refresh.ts
+++ b/src/lib/bulletin/refresh.ts
@@ -1,0 +1,18 @@
+export type BulletinRefresh = {
+  id: string
+  created_at: string
+  window_start: string
+  window_end: string
+  prompt_id: string
+  budget_usd: number
+  spent_usd: number
+  status: 'queued' | 'running' | 'complete' | 'stopped'
+  last_status: string | null
+  counts: { rows_seen?: number; pending?: number } | null
+}
+
+export type RefreshState = {
+  enabled: boolean
+  requests: BulletinRefresh[]
+  error?: string
+}

--- a/supabase/migrations/20260911014857_bulletin_refresh_requests.sql
+++ b/supabase/migrations/20260911014857_bulletin_refresh_requests.sql
@@ -1,0 +1,87 @@
+-- Admin-triggered refreshes are durable, bounded jobs consumed by the worker.
+CREATE TABLE bulletin.refresh_requests (
+  id uuid PRIMARY KEY,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  created_by uuid NOT NULL,
+  window_start timestamptz NOT NULL,
+  window_end timestamptz NOT NULL,
+  prompt_version_id bigint NOT NULL REFERENCES bulletin.prompt_versions(id),
+  budget_usd numeric NOT NULL CHECK (budget_usd > 0 AND budget_usd <= 1),
+  status text NOT NULL DEFAULT 'queued' CHECK (status IN ('queued','running','complete','stopped')),
+  last_status text,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CHECK (window_end > window_start AND window_end-window_start <= interval '15 days')
+);
+CREATE UNIQUE INDEX bulletin_one_active_refresh ON bulletin.refresh_requests ((true))
+  WHERE status IN ('queued','running');
+ALTER TABLE bulletin.decisions ADD COLUMN refresh_request_id uuid REFERENCES bulletin.refresh_requests(id);
+CREATE INDEX bulletin_refresh_pending_idx ON bulletin.decisions(refresh_request_id,updated_at)
+  WHERE status IN ('pending','failed');
+
+CREATE FUNCTION public.request_bulletin_refresh(request_id uuid, selection text, expected_prompt_id bigint, budget_usd numeric, actor_id uuid)
+RETURNS text LANGUAGE plpgsql SECURITY INVOKER SET search_path='' AS $$
+DECLARE start_at timestamptz; end_at timestamptz; active_id bigint;
+BEGIN
+  -- Share the prompt-save lock so the version shown at submission is pinned.
+  PERFORM pg_advisory_xact_lock(712606571);
+  IF actor_id IS NULL OR request_id IS NULL OR selection IS NULL OR selection NOT IN ('latest','two_weeks')
+    OR budget_usd IS NULL OR NOT (budget_usd > 0 AND budget_usd <= 1) THEN
+    RAISE EXCEPTION 'Invalid refresh request' USING ERRCODE='22023';
+  END IF;
+  -- Retries of the same submission never create another billable job.
+  IF EXISTS (SELECT 1 FROM bulletin.refresh_requests r WHERE r.id=request_id AND r.created_by=actor_id) THEN
+    RETURN request_id::text;
+  END IF;
+  SELECT id INTO active_id FROM bulletin.prompt_versions ORDER BY id DESC LIMIT 1;
+  IF expected_prompt_id IS DISTINCT FROM active_id OR active_id IS NULL THEN
+    RAISE EXCEPTION 'Prompt changed; reload' USING ERRCODE='40001';
+  END IF;
+  IF EXISTS (SELECT 1 FROM bulletin.refresh_requests WHERE status IN ('queued','running')) THEN
+    RAISE EXCEPTION 'A refresh is already active' USING ERRCODE='55000';
+  END IF;
+  IF selection='latest' THEN
+    SELECT (counts->>'window_start')::timestamptz,(counts->>'window_end')::timestamptz
+      INTO start_at,end_at FROM bulletin.runs
+      WHERE counts->>'source'='clickhouse' AND counts ? 'window_start' AND counts ? 'window_end'
+      ORDER BY id DESC LIMIT 1;
+    IF start_at IS NULL OR end_at IS NULL THEN
+      RAISE EXCEPTION 'No previous scan window' USING ERRCODE='22023';
+    END IF;
+  ELSE
+    end_at := date_trunc('day',now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC';
+    start_at := end_at-interval '14 days';
+  END IF;
+  INSERT INTO bulletin.refresh_requests(id,created_by,window_start,window_end,prompt_version_id,budget_usd)
+    VALUES(request_id,actor_id,start_at,end_at,active_id,budget_usd);
+  RETURN request_id::text;
+END
+$$;
+
+CREATE FUNCTION public.get_bulletin_refreshes()
+RETURNS jsonb LANGUAGE sql STABLE SECURITY INVOKER SET search_path='' AS $$
+  SELECT coalesce(jsonb_agg(to_jsonb(item) ORDER BY item.created_at DESC),'[]'::jsonb) FROM (
+    SELECT r.*,r.prompt_version_id::text AS prompt_id,
+      coalesce(cost.spent,0) AS spent_usd,latest.counts
+    FROM bulletin.refresh_requests r
+    LEFT JOIN LATERAL (
+      SELECT sum(coalesce(c.actual_usd,c.reserved_usd)) AS spent
+      FROM bulletin.runs run JOIN bulletin.calls c ON c.run_id=run.id
+      WHERE run.counts->>'refresh_request_id'=r.id::text
+    ) cost ON true
+    LEFT JOIN LATERAL (
+      SELECT run.counts FROM bulletin.runs run
+      WHERE run.counts->>'refresh_request_id'=r.id::text ORDER BY run.id DESC LIMIT 1
+    ) latest ON true
+    ORDER BY r.created_at DESC LIMIT 10
+  ) item
+$$;
+CREATE INDEX bulletin_runs_refresh_idx ON bulletin.runs ((counts->>'refresh_request_id'))
+  WHERE counts ? 'refresh_request_id';
+
+ALTER TABLE bulletin.refresh_requests ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON bulletin.refresh_requests FROM PUBLIC,anon,authenticated,service_role;
+GRANT SELECT,INSERT,UPDATE ON bulletin.refresh_requests TO service_role;
+REVOKE ALL ON FUNCTION public.request_bulletin_refresh(uuid,text,bigint,numeric,uuid) FROM PUBLIC,anon,authenticated;
+REVOKE ALL ON FUNCTION public.get_bulletin_refreshes() FROM PUBLIC,anon,authenticated;
+GRANT EXECUTE ON FUNCTION public.request_bulletin_refresh(uuid,text,bigint,numeric,uuid) TO service_role;
+GRANT EXECUTE ON FUNCTION public.get_bulletin_refreshes() TO service_role;

--- a/supabase/schemas/020_tables.sql
+++ b/supabase/schemas/020_tables.sql
@@ -730,3 +730,26 @@ CREATE TABLE bulletin.scans (
   updated_at timestamptz NOT NULL DEFAULT now(),
   CHECK (window_end>window_start AND window_end-window_start<=interval '15 days')
 );
+
+-- Admin-triggered refreshes are durable, bounded jobs consumed by the worker.
+CREATE TABLE bulletin.refresh_requests (
+  id uuid PRIMARY KEY,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  created_by uuid NOT NULL,
+  window_start timestamptz NOT NULL,
+  window_end timestamptz NOT NULL,
+  prompt_version_id bigint NOT NULL REFERENCES bulletin.prompt_versions(id),
+  budget_usd numeric NOT NULL CHECK (budget_usd > 0 AND budget_usd <= 1),
+  status text NOT NULL DEFAULT 'queued' CHECK (status IN ('queued','running','complete','stopped')),
+  last_status text,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CHECK (window_end > window_start AND window_end-window_start <= interval '15 days')
+);
+CREATE UNIQUE INDEX bulletin_one_active_refresh ON bulletin.refresh_requests ((true))
+  WHERE status IN ('queued','running');
+ALTER TABLE bulletin.decisions ADD COLUMN refresh_request_id uuid REFERENCES bulletin.refresh_requests(id);
+CREATE INDEX bulletin_refresh_pending_idx ON bulletin.decisions(refresh_request_id,updated_at)
+  WHERE status IN ('pending','failed');
+
+CREATE INDEX bulletin_runs_refresh_idx ON bulletin.runs ((counts->>'refresh_request_id'))
+  WHERE counts ? 'refresh_request_id';

--- a/supabase/schemas/070_functions.sql
+++ b/supabase/schemas/070_functions.sql
@@ -3753,3 +3753,61 @@ RETURNS jsonb LANGUAGE sql STABLE SECURITY INVOKER SET search_path='' AS $$
    'following',(SELECT coalesce(jsonb_agg(a.account_id),'[]'::jsonb) FROM outgoing o JOIN bulletin.allowed_accounts a USING(account_id)),
    'followers',(SELECT coalesce(jsonb_agg(a.account_id),'[]'::jsonb) FROM incoming i JOIN bulletin.allowed_accounts a USING(account_id))) FROM viewer v
 $$;
+
+CREATE FUNCTION public.request_bulletin_refresh(request_id uuid, selection text, expected_prompt_id bigint, budget_usd numeric, actor_id uuid)
+RETURNS text LANGUAGE plpgsql SECURITY INVOKER SET search_path='' AS $$
+DECLARE start_at timestamptz; end_at timestamptz; active_id bigint;
+BEGIN
+  -- Share the prompt-save lock so the version shown at submission is pinned.
+  PERFORM pg_advisory_xact_lock(712606571);
+  IF actor_id IS NULL OR request_id IS NULL OR selection IS NULL OR selection NOT IN ('latest','two_weeks')
+    OR budget_usd IS NULL OR NOT (budget_usd > 0 AND budget_usd <= 1) THEN
+    RAISE EXCEPTION 'Invalid refresh request' USING ERRCODE='22023';
+  END IF;
+  -- Retries of the same submission never create another billable job.
+  IF EXISTS (SELECT 1 FROM bulletin.refresh_requests r WHERE r.id=request_id AND r.created_by=actor_id) THEN
+    RETURN request_id::text;
+  END IF;
+  SELECT id INTO active_id FROM bulletin.prompt_versions ORDER BY id DESC LIMIT 1;
+  IF expected_prompt_id IS DISTINCT FROM active_id OR active_id IS NULL THEN
+    RAISE EXCEPTION 'Prompt changed; reload' USING ERRCODE='40001';
+  END IF;
+  IF EXISTS (SELECT 1 FROM bulletin.refresh_requests WHERE status IN ('queued','running')) THEN
+    RAISE EXCEPTION 'A refresh is already active' USING ERRCODE='55000';
+  END IF;
+  IF selection='latest' THEN
+    SELECT (counts->>'window_start')::timestamptz,(counts->>'window_end')::timestamptz
+      INTO start_at,end_at FROM bulletin.runs
+      WHERE counts->>'source'='clickhouse' AND counts ? 'window_start' AND counts ? 'window_end'
+      ORDER BY id DESC LIMIT 1;
+    IF start_at IS NULL OR end_at IS NULL THEN
+      RAISE EXCEPTION 'No previous scan window' USING ERRCODE='22023';
+    END IF;
+  ELSE
+    end_at := date_trunc('day',now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC';
+    start_at := end_at-interval '14 days';
+  END IF;
+  INSERT INTO bulletin.refresh_requests(id,created_by,window_start,window_end,prompt_version_id,budget_usd)
+    VALUES(request_id,actor_id,start_at,end_at,active_id,budget_usd);
+  RETURN request_id::text;
+END
+$$;
+
+CREATE FUNCTION public.get_bulletin_refreshes()
+RETURNS jsonb LANGUAGE sql STABLE SECURITY INVOKER SET search_path='' AS $$
+  SELECT coalesce(jsonb_agg(to_jsonb(item) ORDER BY item.created_at DESC),'[]'::jsonb) FROM (
+    SELECT r.*,r.prompt_version_id::text AS prompt_id,
+      coalesce(cost.spent,0) AS spent_usd,latest.counts
+    FROM bulletin.refresh_requests r
+    LEFT JOIN LATERAL (
+      SELECT sum(coalesce(c.actual_usd,c.reserved_usd)) AS spent
+      FROM bulletin.runs run JOIN bulletin.calls c ON c.run_id=run.id
+      WHERE run.counts->>'refresh_request_id'=r.id::text
+    ) cost ON true
+    LEFT JOIN LATERAL (
+      SELECT run.counts FROM bulletin.runs run
+      WHERE run.counts->>'refresh_request_id'=r.id::text ORDER BY run.id DESC LIMIT 1
+    ) latest ON true
+    ORDER BY r.created_at DESC LIMIT 10
+  ) item
+$$;

--- a/supabase/schemas/090_policy_grants.sql
+++ b/supabase/schemas/090_policy_grants.sql
@@ -203,3 +203,11 @@ GRANT EXECUTE ON FUNCTION public.get_bulletin_board_state(integer) TO service_ro
 
 REVOKE ALL ON FUNCTION public.get_bulletin_relationships(text,text) FROM PUBLIC,anon,authenticated;
 GRANT EXECUTE ON FUNCTION public.get_bulletin_relationships(text,text) TO service_role;
+
+ALTER TABLE bulletin.refresh_requests ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON bulletin.refresh_requests FROM PUBLIC,anon,authenticated,service_role;
+GRANT SELECT,INSERT,UPDATE ON bulletin.refresh_requests TO service_role;
+REVOKE ALL ON FUNCTION public.request_bulletin_refresh(uuid,text,bigint,numeric,uuid) FROM PUBLIC,anon,authenticated;
+REVOKE ALL ON FUNCTION public.get_bulletin_refreshes() FROM PUBLIC,anon,authenticated;
+GRANT EXECUTE ON FUNCTION public.request_bulletin_refresh(uuid,text,bigint,numeric,uuid) TO service_role;
+GRANT EXECUTE ON FUNCTION public.get_bulletin_refreshes() TO service_role;


### PR DESCRIPTION
Admins need to reach the digest tools and rerun Bulletin after changing its classifier prompt. This adds a Digest admin card to `/admin`, moves the admin-only Bulletin link into the board header, and adds refresh controls to both the bulletin and its prompt editor.

Refreshes target the latest run's exact window or the last 14 complete UTC days. Submitting pins the saved prompt and a cumulative spending cap ($0.01–$1, default $0.10). Unsaved prompt edits block submission. The existing monthly budget and model/source/consent checks remain in force.

The service-only queue uses idempotent request IDs, one active request, and the daily worker's advisory lock. A new timer processes bounded batches and resumes their cursor, attempt counters and cumulative cap. It reclassifies cached decisions; successful positives replace notices and successful negatives remove them. Existing notices remain during pending or failed classification. Budget/model errors stop the request visibly. Status polling reports the latest batch and cumulative charged/reserved cost.

Production activation required before use:

- Apply `20260911014857_bulletin_refresh_requests.sql`; the updated daily worker also depends on it.
- Install the worker release and `ca-bulletin-refresh.service`/timer with the existing runtime credentials; verify empty-queue behavior and timer health.
- Then enable server-only `BULLETIN_REFRESH_ENABLED=true` for the website environment. Leave unset on previews without an isolated worker/queue. Local admin read-preview never grants writes.
- No production migration, worker deployment, scraping, or paid classification was performed. Activation and any paid smoke remain separate. Rollout/rollback details are in `services/bulletin/README.md`.

Validation:

- 30 focused Python worker/database/retry tests passed using an isolated local PostgreSQL database with fake ClickHouse/model responses. Includes reclassification/removal, failure preservation, prompt pinning, scope isolation, resume/caps, idempotency, queue lock contention, policy changes, and service/browser grants.
- 31 UI/server-action tests passed, including prompt editor and bulletin regressions. The existing board test emitted a jsdom navigation-not-implemented message.
- TypeScript, changed-path lint, formatting and diff whitespace checks passed. New RPC types match the local SQL contract; staging automation will regenerate the full client types.
- No real-browser verification. Commit hooks were bypassed because the isolated worktree lacks its Husky bootstrap; focused checks ran directly without unrelated database/API regeneration.
