### PR TITLE
Show previous share in dark blue and gains in bright blue

### DIFF
--- a/src/components/portal/WeeklyKeywordRows.test.tsx
+++ b/src/components/portal/WeeklyKeywordRows.test.tsx
@@ -50,7 +50,9 @@ test('orders one list by absolute share change, preserving new terms and falls t
     'ai agents',
   ])
   const growth = screen.getByRole('img', { name: /model: 400 tweets/ })
-  expect(growth).toHaveAccessibleName(/green overlay shows the gain/)
+  expect(growth).toHaveAccessibleName(
+    /dark blue shows the previous share and bright blue shows the gain/,
+  )
   expect(growth.lastElementChild).toHaveStyle({ left: '50%', width: '50%' })
   expect(screen.queryByText(/Through Sep 6/)).not.toBeInTheDocument()
   const href = screen
@@ -137,5 +139,7 @@ test('makes the explanation available on keyboard focus', async () => {
   expect(tip).toHaveTextContent('Through Sep 6 (UTC).')
   expect(tip).toHaveTextContent('absolute change in author-weighted share')
   expect(tip).toHaveTextContent('faded blue extension')
-  expect(tip).toHaveTextContent('green overlay')
+  expect(tip).toHaveTextContent(
+    'dark blue shows the previous share and bright blue shows the gain',
+  )
 })

--- a/src/components/portal/WeeklyKeywordRows.tsx
+++ b/src/components/portal/WeeklyKeywordRows.tsx
@@ -58,7 +58,7 @@ export function WeeklyKeywordRows({
       : 'Tweet counts vs the previous week.',
     through ? `Through ${through} (UTC).` : '',
     `Ordered by the absolute change in ${weighted ? 'author-weighted share' : 'tweet count'}.`,
-    `Bars show ${weighted ? 'author-weighted share per 100k' : 'tweet counts'} on a shared linear scale. A green overlay shows activity gained this week; a faded blue extension shows activity lost since the previous week.`,
+    `Bars show ${weighted ? 'author-weighted share per 100k' : 'tweet counts'} on a shared linear scale. For growing terms, dark blue shows the previous share and bright blue shows the gain; a faded blue extension shows activity lost since the previous week.`,
   ]
     .filter(Boolean)
     .join(' ')
@@ -110,7 +110,7 @@ export function WeeklyKeywordRows({
         const falling = row.previous > row.current
         const rising = row.current > row.previous
         const details = `${row.last7.toLocaleString('en-US')} tweets${row.currentAuthors === undefined ? '' : ` from ${row.currentAuthors} authors`}; ${row.prev7.toLocaleString('en-US')} tweets in the previous week.`
-        const barDetails = `${row.term}: ${row.last7.toLocaleString('en-US')} tweets in the last seven days; ${weighted ? 'author-weighted share per 100k' : 'tweet count'} ${row.current.toLocaleString('en-US', { maximumFractionDigits: 1 })}, previously ${row.previous.toLocaleString('en-US', { maximumFractionDigits: 1 })}; linear scale${falling ? '; faded extension shows the previous week' : rising ? '; green overlay shows the gain since the previous week' : ''}`
+        const barDetails = `${row.term}: ${row.last7.toLocaleString('en-US')} tweets in the last seven days; ${weighted ? 'author-weighted share per 100k' : 'tweet count'} ${row.current.toLocaleString('en-US', { maximumFractionDigits: 1 })}, previously ${row.previous.toLocaleString('en-US', { maximumFractionDigits: 1 })}; linear scale${falling ? '; faded extension shows the previous week' : rising ? '; dark blue shows the previous share and bright blue shows the gain since the previous week' : ''}`
         return (
           <div
             key={row.term}
@@ -143,12 +143,12 @@ export function WeeklyKeywordRows({
                 />
               )}
               <div
-                className="relative h-full rounded bg-chart-accent"
+                className={`relative h-full rounded ${rising ? 'bg-[#10516B]' : 'bg-chart-accent'}`}
                 style={{ width: width(row.current) }}
               />
               {rising && (
                 <div
-                  className="absolute inset-y-0 rounded-r bg-emerald-500/70 dark:bg-emerald-400/70"
+                  className="absolute inset-y-0 rounded-r bg-chart-accent"
                   style={{
                     left: width(row.previous),
                     width: width(row.current - row.previous),


### PR DESCRIPTION
For growing homepage terms, show the previous share in dark blue and the gained portion in the existing bright chart blue. Replace the green overlay and update the info tooltip and accessible descriptions to match. Bar lengths stay linear and declines retain their faded extension.

Validation: all five focused WeeklyKeywordRows tests and changed-file ESLint pass. The unrelated database type-generation pre-commit hook was skipped; no schema changes.
