### PR TITLE
Keep Bulletin tweets open while recommendations and context load

### DIFF
--- a/src/components/bulletin/BulletinBoard.test.tsx
+++ b/src/components/bulletin/BulletinBoard.test.tsx
@@ -485,12 +485,10 @@ test('shows cards before interactions finish, then replaces the page and cursor 
         resolve = r
       }),
   )
-  jest
-    .mocked(fetch)
-    .mockResolvedValueOnce({
-      ok: true,
-      json: async () => page([offer]),
-    } as Response)
+  jest.mocked(fetch).mockResolvedValueOnce({
+    ok: true,
+    json: async () => page([offer]),
+  } as Response)
   render(
     <BulletinBoard notices={[offer]} initialPage={initial} now={initial.now} />,
   )
@@ -518,4 +516,99 @@ test('shows cards before interactions finish, then replaces the page and cursor 
     ),
   )
   expect(String(jest.mocked(fetch).mock.calls[1][0])).toContain('after=2')
+})
+
+test('keeps an open tweet in place when background recommendations arrive', async () => {
+  const initial = { ...page([offer], '1'), recommendationsReady: false }
+  let recommend!: (response: Response) => void
+  let details!: (response: Response) => void
+  jest.mocked(fetch).mockImplementation(
+    (url) =>
+      new Promise((resolve) => {
+        if (String(url).includes('/board?')) recommend = resolve
+        else details = resolve
+      }),
+  )
+  render(
+    <BulletinBoard notices={[offer]} initialPage={initial} now={initial.now} />,
+  )
+  await act(async () => {
+    jest.advanceTimersByTime(200)
+  })
+  fireEvent.click(
+    screen.getByRole('button', { name: 'Read full tweet by @alice' }),
+  )
+  await act(async () => {
+    jest.advanceTimersByTime(20)
+  })
+  await act(async () =>
+    recommend({
+      ok: true,
+      json: async () => ({ ...page([ask]), recommendationsReady: true }),
+    } as Response),
+  )
+  expect(
+    screen.getByRole('button', { name: 'Collapse tweet by @alice' }),
+  ).toBeInTheDocument()
+  expect(screen.queryByText('Feedback on a garden')).not.toBeInTheDocument()
+  await act(async () =>
+    details({
+      ok: true,
+      json: async () => ({
+        tweets: [
+          {
+            id: '1',
+            text: 'Loaded original',
+            replies: [{ id: '10', text: 'Loaded reply' }],
+          },
+        ],
+      }),
+    } as Response),
+  )
+  expect(screen.getByText('Loaded original')).toBeInTheDocument()
+  expect(screen.getByText('Loaded reply')).toBeInTheDocument()
+  expect(
+    jest
+      .mocked(fetch)
+      .mock.calls.filter(([url]) => String(url).includes('/tweets?')),
+  ).toHaveLength(1)
+  fireEvent.click(
+    screen.getByRole('button', { name: 'Collapse tweet by @alice' }),
+  )
+  expect(screen.getByText('Feedback on a garden')).toBeInTheDocument()
+})
+
+test('keeps expansion when ranking moves a card between columns', async () => {
+  const props = {
+    notices: [offer, ask],
+    now: Date.parse('2026-09-09T00:00:00Z'),
+  }
+  const { rerender } = render(
+    <BulletinBoard
+      {...props}
+      graph={{ outgoing: { a: 10 }, available: true }}
+    />,
+  )
+  fireEvent.click(
+    screen.getByRole('button', { name: 'Read full tweet by @alice' }),
+  )
+  await act(async () => {
+    jest.advanceTimersByTime(20)
+  })
+  await act(async () => {
+    rerender(
+      <BulletinBoard
+        {...props}
+        graph={{ outgoing: { b: 10 }, available: true }}
+      />,
+    )
+  })
+  expect(
+    screen.getByRole('button', { name: 'Collapse tweet by @alice' }),
+  ).toBeInTheDocument()
+  expect(
+    jest
+      .mocked(fetch)
+      .mock.calls.filter(([url]) => String(url).includes('/tweets?')),
+  ).toHaveLength(1)
 })

--- a/src/components/bulletin/BulletinBoard.tsx
+++ b/src/components/bulletin/BulletinBoard.tsx
@@ -174,8 +174,12 @@ function NoticeCard({
   now,
   order,
   onKind,
+  open,
+  setOpen,
 }: {
   notice: Notice
+  open: boolean
+  setOpen: (open: boolean) => void
   loadTweet: (id: string) => Promise<BulletinTweet>
   badge: string
   replied: boolean
@@ -184,7 +188,6 @@ function NoticeCard({
   order: number
   onKind: (kind: string) => void
 }) {
-  const [open, setOpen] = useState(false)
   const [tweet, setTweet] = useState<BulletinTweet | null>(null)
   const [error, setError] = useState(false)
   const [attempt, setAttempt] = useState(0)
@@ -447,6 +450,7 @@ export function BulletinBoard({
   adminControls?: React.ReactNode
 }) {
   const loadTweet = useTweetBatch()
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({})
   const [limit, setLimit] = useState(BULLETIN_PAGE_SIZE)
   const [side, setSide] = useState('all')
   const [kinds, setKinds] = useState<string[]>([])
@@ -460,6 +464,7 @@ export function BulletinBoard({
     initialPage,
     { kind, side, search, past, recommended, ascending },
     hydrated,
+    Object.values(expanded).some(Boolean),
   )
   const graph = pages.page?.personal || initialGraph
   const viewerId = pages.page?.personal.account_id || me
@@ -540,6 +545,7 @@ export function BulletinBoard({
   )
   useEffect(() => {
     setLimit(BULLETIN_PAGE_SIZE)
+    setExpanded({})
   }, [kind, side, needle, past, recommended, ascending])
   // Counts under the other dimension's filter: server-provided when paging
   // server-side, otherwise derived from the notices in hand.
@@ -744,6 +750,10 @@ export function BulletinBoard({
                 <NoticeCard
                   key={o.tweet_id}
                   notice={o}
+                  open={!!expanded[o.tweet_id]}
+                  setOpen={(open) =>
+                    setExpanded((value) => ({ ...value, [o.tweet_id]: open }))
+                  }
                   order={index}
                   loadTweet={loadTweet}
                   badge={relationship(o, viewerId, graph).label}

--- a/src/components/bulletin/useBoardPages.ts
+++ b/src/components/bulletin/useBoardPages.ts
@@ -47,7 +47,11 @@ export function useBoardPages(
   initial: BulletinPage | undefined,
   filters: BulletinFilters,
   ready: boolean,
+  reading = false,
 ) {
+  const readingRef = useRef(reading)
+  readingRef.current = reading
+  const deferred = useRef<{ key: string; page: BulletinPage }>()
   const key = filterKey(filters)
   const [state, setState] = useState({
     key: filterKey(DEFAULT_BULLETIN_FILTERS),
@@ -69,7 +73,17 @@ export function useBoardPages(
     filters.recommended &&
     state.page?.recommendationsReady === false
 
+  // Apply a completed recommendation refresh only after the reader closes
+  // their tweet. Replacing the first page can otherwise remove that card.
   useEffect(() => {
+    if (!reading && deferred.current?.key === key) {
+      setState(deferred.current)
+      deferred.current = undefined
+    }
+  }, [reading, key])
+
+  useEffect(() => {
+    deferred.current = undefined
     if (!initial || !ready) return
     const controllers = requests.current
     setLoading({})
@@ -82,8 +96,11 @@ export function useBoardPages(
         ? setTimeout(() => {
             fetchPage(query(filtersRef.current), controller.signal)
               .then((page) => {
-                if (!controller.signal.aborted && currentKey.current === key)
-                  setState({ key, page })
+                if (!controller.signal.aborted && currentKey.current === key) {
+                  if (personalizing && readingRef.current)
+                    deferred.current = { key, page }
+                  else setState({ key, page })
+                }
               })
               .catch(() => {
                 if (!controller.signal.aborted)

--- a/src/lib/bulletin/tweet-route.test.ts
+++ b/src/lib/bulletin/tweet-route.test.ts
@@ -214,3 +214,17 @@ test('returns archived replies beneath the notice, oldest first, without placeho
   expect(body.replies.map((r: { id: string }) => r.id)).toEqual(['3', '2', '5'])
   expect(body.replies[0]).toMatchObject({ username: 'ray', text: 'Reply 3' })
 })
+
+test('asks ClickHouse for only the notice and 20 context tweets', async () => {
+  jest
+    .mocked(fetchClickHouseTweetThreadPageData)
+    .mockImplementation(async (id, fetcher) => {
+      await fetcher!(['tweet', id, 'thread'], new URLSearchParams())
+      return { tweet: detail, threadTree: null }
+    })
+  await call()
+  expect(fetchAnalyticsGatewayJson).toHaveBeenCalledWith(
+    ['tweet', '123', 'thread'],
+    new URLSearchParams({ limit: '21' }),
+  )
+})

--- a/src/lib/bulletin/tweets.ts
+++ b/src/lib/bulletin/tweets.ts
@@ -37,7 +37,7 @@ function replyCard(tweet: ThreadTweet): PortalTweet {
     })),
   }
 }
-/** Every archived reply beneath the notice, in posting order. */
+/** Replies beneath the notice from its bounded context, in posting order. */
 export function repliesTo(
   tweetId: string,
   tree: ConversationTree | null,
@@ -123,13 +123,13 @@ export async function loadBulletinTweets(ids: string[]) {
       for (let offset = 0; offset < ids.length; offset += 4) {
         details.push(
           ...(await Promise.all(
-            ids
-              .slice(offset, offset + 4)
-              .map((id) =>
-                fetchClickHouseTweetThreadPageData(id, (path, params) =>
-                  fetchAnalyticsGatewayJson(path, params),
-                ).catch(() => null),
-              ),
+            ids.slice(offset, offset + 4).map((id) =>
+              fetchClickHouseTweetThreadPageData(id, (path, params) => {
+                const bounded = new URLSearchParams(params)
+                bounded.set('limit', String(MAX_REPLIES + 1))
+                return fetchAnalyticsGatewayJson(path, bounded)
+              }).catch(() => null),
+            ),
           )),
         )
       }

--- a/src/lib/clickhouseGateway.test.ts
+++ b/src/lib/clickhouseGateway.test.ts
@@ -182,14 +182,14 @@ describe('ClickHouse analytics gateway requests', () => {
     ).toThrow('Unsupported ClickHouse analytics endpoint')
   })
 
-  test('allows only numeric tweet-thread paths and no query parameters', () => {
+  test('allows numeric tweet-thread paths and only the context limit', () => {
     const target = analyticsGatewayRequestUrl(
       ['tweet', '2085473085399150817', 'thread'],
-      new URLSearchParams('raw_sql=DROP'),
+      new URLSearchParams('raw_sql=DROP&limit=21'),
       'https://stream.example/analytics',
     )
     expect(target.toString()).toBe(
-      'https://stream.example/analytics/tweet/2085473085399150817/thread',
+      'https://stream.example/analytics/tweet/2085473085399150817/thread?limit=21',
     )
     expect(() =>
       analyticsGatewayRequestUrl(

--- a/src/lib/clickhouseGateway.ts
+++ b/src/lib/clickhouseGateway.ts
@@ -142,7 +142,7 @@ export function analyticsGatewayRequestUrl(
     /^\d{1,20}$/.test(cleanPath[1]) &&
     cleanPath[2] === 'thread'
   ) {
-    allowedParams = new Set()
+    allowedParams = new Set(['limit'])
   } else if (
     cleanPath.length === 2 &&
     cleanPath[0] === 'quote-posts' &&


### PR DESCRIPTION
A reader can open a Bulletin card before the background recommendations finish. The refreshed first page then replaces that card, or moves it into another column, resetting local expansion state and closing it. Hold the completed recommendation refresh until the reader closes their tweets, and keep expansion state on the board by tweet ID so column changes cannot collapse a card. Context loading continues while the current card stays visible.

Bulletin also displays at most 20 replies but previously requested context for up to 500 tweets. Request a 21-tweet context window, preserving main-tweet media and quoted context. Gateway dependency: https://github.com/TheExGenesis/community-archive-control-panel/pull/218 must deploy first to honor the limit. The full tweet page retains its larger context.

Validation: reproduced the closing bug with a failing regression test, then passed 48 focused component/route/gateway-client tests, TypeScript, scoped lint, and diff checks. Regression coverage includes a late recommendation response, late original/reply content, column reassignment without duplicate context requests, and the 21-tweet request parameter. Two targeted tests were rerun after their final assertion updates and passed.

One bounded production sample measured about 1.1 seconds for the current thread endpoint and 1.4 seconds for tweet detail, including network time. This change bounds expensive large-conversation work; no production latency improvement is claimed before deployment. No migrations or deployment performed.
