### PR TITLE
Preserve Bulletin expansion across server renders

### DIFF
--- a/src/app/bulletin/page.test.tsx
+++ b/src/app/bulletin/page.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { requireBulletinUser } from '@/lib/bulletin/data'
+import BulletinPage from './page'
+
+jest.mock('@/components/bulletin/BulletinBoard.module.css', () => ({}))
+jest.mock('@/lib/bulletin/data', () => ({
+  requireBulletinUser: jest.fn(),
+  isBulletinAdmin: jest.fn(async () => false),
+}))
+jest.mock('@/lib/bulletin/page', () => ({
+  loadBulletinPage: jest.fn(async () => ({ notices: [], personal: {} })),
+}))
+jest.mock('@/lib/bulletin/prompts', () => ({ loadPrompts: jest.fn() }))
+jest.mock('@/components/bulletin/RefreshControls', () => ({
+  RefreshControls: () => null,
+}))
+jest.mock('@/components/bulletin/BulletinBoard', () => ({
+  BulletinBoard: function Board() {
+    const [open, setOpen] = require('react').useState(false)
+    return (
+      <button onClick={() => setOpen(true)}>
+        {open ? 'Expanded tweet' : 'Read tweet'}
+      </button>
+    )
+  },
+}))
+
+afterEach(() => jest.restoreAllMocks())
+
+test('server refresh preserves board state but changing the viewer resets it', async () => {
+  jest.mocked(requireBulletinUser).mockResolvedValue({ id: 'alice' } as never)
+  const clock = jest.spyOn(Date, 'now').mockReturnValue(1000)
+  const { rerender } = render(await BulletinPage())
+  fireEvent.click(screen.getByRole('button', { name: 'Read tweet' }))
+  clock.mockReturnValue(16000)
+  rerender(await BulletinPage())
+  expect(
+    screen.getByRole('button', { name: 'Expanded tweet' }),
+  ).toBeInTheDocument()
+
+  jest.mocked(requireBulletinUser).mockResolvedValue({ id: 'bob' } as never)
+  rerender(await BulletinPage())
+  expect(screen.getByRole('button', { name: 'Read tweet' })).toBeInTheDocument()
+})

--- a/src/app/bulletin/page.tsx
+++ b/src/app/bulletin/page.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
 }
 
 export default async function BulletinBoardPage() {
-  await requireBulletinUser()
+  const user = await requireBulletinUser()
   const [isAdmin, page] = await Promise.all([
     isBulletinAdmin(),
     loadBulletinPage(DEFAULT_BULLETIN_FILTERS, undefined, false).catch(
@@ -29,7 +29,7 @@ export default async function BulletinBoardPage() {
         </div>
       ) : (
         <BulletinBoard
-          key={Date.now()}
+          key={user?.id ?? 'local-admin-preview'}
           notices={page.notices}
           initialPage={page}
           me={page.personal.account_id}


### PR DESCRIPTION
Expanded Bulletin tweets still collapsed after the first fix because the server page assigned the board a new timestamp key on every render. Admin status polling can return a new server tree and remount the entire board.

Key the board by the authenticated viewer instead, preserving expansion and pagination across server updates while resetting state when the viewer changes.

Validation: reproduced the reset in a failing server-page reconciliation test, then passed that regression and the board suite (18 tests). TypeScript, scoped ESLint, and diff checks pass. Production follow-up to #952; no gateway or database changes.
