### PR TITLE
Inspect bulletin decisions and explain queue and recommendations

### DIFF
--- a/services/bulletin/README.md
+++ b/services/bulletin/README.md
@@ -243,3 +243,23 @@ ClickHouse source against real PostgreSQL policy/job state, including a tweet
 that does not exist in PostgreSQL, replay, edits, failure recovery, opt-out,
 private grants, budgets and prompt pinning. Gateway and website tests cover the
 corresponding read and ranking contracts. No production corpus reset is needed.
+
+### Admin decision browser
+
+`/admin/bulletin/decisions` inspects the latest stored candidate decisions by
+status, with keyset pagination. It does not reconstruct per-run labels, include
+posts rejected before the model, or include private experimental ledgers.
+Negative decisions have no persisted detailed rejection rationale. Full tweet
+expansion uses the shared source/hash verification and canonical tweet card.
+
+The read-only `20260911204733_bulletin_admin_decisions.sql` migration is required
+before deploying this UI. It grants execution only to the backend service role;
+application reads additionally require bulletin admin authorization. Current
+membership policy is checked in PostgreSQL and live source identity, hash,
+reply/repost status and availability are checked before display. Expired accepted
+notices remain inspectable; acceptance is distinct from live board visibility.
+
+Focused SQL verification on a disposable empty local PostgreSQL database:
+`psql -v ON_ERROR_STOP=1 -f services/bulletin/test_admin_decisions.sql`.
+The fixture and assertions roll back all changes. Server regression tests live
+in `src/lib/bulletin/decisions.test.ts` and `src/lib/bulletin/tweets.test.ts`.

--- a/services/bulletin/test_admin_decisions.sql
+++ b/services/bulletin/test_admin_decisions.sql
@@ -1,0 +1,53 @@
+-- Run with psql -v ON_ERROR_STOP=1 -f services/bulletin/test_admin_decisions.sql
+-- against a disposable, empty local PostgreSQL database only. No live data.
+BEGIN;
+CREATE ROLE anon;
+CREATE ROLE authenticated;
+CREATE ROLE service_role;
+CREATE SCHEMA bulletin;
+CREATE TABLE bulletin.decisions (
+ tweet_id text PRIMARY KEY, account_id text, posted_at timestamptz,
+ content_hash text, status text, attempts integer DEFAULT 0,
+ updated_at timestamptz, last_attempt_at timestamptz, version text
+);
+CREATE TABLE bulletin.opportunities (
+ tweet_id text PRIMARY KEY, content_hash text, summary text, evidence text, side text, kind text
+);
+-- Fixtures represent the output of the existing authoritative policy view.
+CREATE TABLE bulletin.allowed_accounts (account_id text PRIMARY KEY, username text);
+GRANT USAGE ON SCHEMA bulletin TO service_role;
+GRANT SELECT ON ALL TABLES IN SCHEMA bulletin TO service_role;
+\ir ../../supabase/migrations/20260911204733_bulletin_admin_decisions.sql
+INSERT INTO bulletin.allowed_accounts VALUES ('42','member');
+INSERT INTO bulletin.decisions(tweet_id,account_id,content_hash,status,updated_at)
+VALUES ('101','42','a','positive','2026-09-11 10:00Z'),
+ ('102','42','b','negative','2026-09-11 10:00Z'),
+ ('103','42','c','failed','2026-09-11 10:00Z'),
+ ('104','42','d','pending','2026-09-11 10:00Z'),
+ ('105','99','e','positive','2026-09-11 10:00Z');
+INSERT INTO bulletin.opportunities VALUES
+ ('101','a','Accepted summary','Evidence','ask','help'),
+ ('102','b','Stale rejected summary','Evidence','ask','help'),
+ ('103','old','Stale failed summary','Evidence','ask','help');
+DO $$ BEGIN
+ IF has_function_privilege('anon','public.get_bulletin_decisions(text,timestamptz,text,integer,text)','execute')
+   OR has_function_privilege('authenticated','public.get_bulletin_decisions(text,timestamptz,text,integer,text)','execute')
+ THEN RAISE EXCEPTION 'browser roles must not execute'; END IF;
+END $$;
+SET LOCAL ROLE service_role;
+DO $$ BEGIN
+ IF jsonb_array_length(public.get_bulletin_decisions())<>4 THEN RAISE EXCEPTION 'policy filtering'; END IF;
+ IF public.get_bulletin_decisions('positive')->0->>'summary'<>'Accepted summary' THEN RAISE EXCEPTION 'positive label'; END IF;
+ IF public.get_bulletin_decisions('negative')->0->>'summary' IS NOT NULL THEN RAISE EXCEPTION 'stale label leak'; END IF;
+ IF public.get_bulletin_decisions('failed')->0->>'summary' IS NOT NULL THEN RAISE EXCEPTION 'failed label leak'; END IF;
+ IF public.get_bulletin_decisions(NULL,'2026-09-11 10:00Z','103')->0->>'tweet_id'<>'102' THEN RAISE EXCEPTION 'cursor tie'; END IF;
+ IF jsonb_array_length(public.get_bulletin_decisions(max_results=>2))<>2 THEN RAISE EXCEPTION 'page bound'; END IF;
+ IF public.get_bulletin_decisions(selected_tweet_id=>'105')<>'[]'::jsonb THEN RAISE EXCEPTION 'single lookup policy'; END IF;
+ IF public.get_bulletin_decisions('invalid')<>'[]'::jsonb THEN RAISE EXCEPTION 'invalid status'; END IF;
+END $$;
+RESET ROLE;
+DELETE FROM bulletin.allowed_accounts WHERE account_id='42';
+DO $$ BEGIN
+ IF public.get_bulletin_decisions()<>'[]'::jsonb THEN RAISE EXCEPTION 'revoked policy'; END IF;
+END $$;
+ROLLBACK;

--- a/src/app/admin/bulletin/decisions/page.tsx
+++ b/src/app/admin/bulletin/decisions/page.tsx
@@ -1,0 +1,167 @@
+import Link from 'next/link'
+import { requireBulletinAdmin } from '@/lib/bulletin/data'
+import {
+  DECISION_LABELS,
+  decisionStatus,
+  loadDecisions,
+} from '@/lib/bulletin/decisions'
+import { formatTimestamp } from '@/lib/bulletin/types'
+import { DecisionTweet } from '@/components/bulletin/DecisionTweet'
+import { decodeTweetText } from '@/lib/tweetText'
+import { RefreshButton } from '@/components/bulletin/RefreshButton'
+
+export const dynamic = 'force-dynamic'
+export const metadata = {
+  title: 'Bulletin decisions | CA admin',
+  robots: { index: false, follow: false },
+}
+export default async function DecisionsPage({
+  searchParams,
+}: {
+  searchParams?: { status?: string; before?: string }
+}) {
+  await requireBulletinAdmin()
+  const status = decisionStatus(searchParams?.status)
+  const data = await loadDecisions(status, searchParams?.before).catch(
+    () => null,
+  )
+  return (
+    <main className="mx-auto min-h-[70vh] max-w-4xl space-y-6 px-4 py-10 sm:px-6">
+      <Link
+        href="/admin/bulletin"
+        className="text-sm text-brand hover:underline"
+      >
+        ← Bulletin admin
+      </Link>
+      <header className="space-y-3">
+        <h1 className="text-3xl font-semibold">Tweet decisions</h1>
+        <p>
+          Inspect the latest saved outcome for each candidate. Accepted means
+          the AI found a notice; rejected means it did not. Acceptance does not
+          guarantee a notice is still active or visible on the board.
+        </p>
+        <p className="text-sm text-muted-foreground">
+          Posts skipped by the candidate filters never reach this queue. This is
+          current decision state, not an immutable per-run history. Private
+          comparison experiments are not included.
+        </p>
+      </header>
+      <nav aria-label="Decision filters" className="flex flex-wrap gap-2">
+        {Object.entries(DECISION_LABELS).map(([key, label]) => (
+          <Link
+            key={key}
+            href={`/admin/bulletin/decisions?status=${key}`}
+            aria-current={status === key ? 'page' : undefined}
+            className={`rounded-full border px-4 py-2 text-sm ${status === key ? 'bg-foreground text-background' : 'hover:bg-muted'}`}
+          >
+            {label}
+          </Link>
+        ))}
+      </nav>
+      {!data ? (
+        <div role="alert" className="space-y-3 rounded-lg border p-5">
+          <p>
+            Decisions could not be loaded. The decision-browser database
+            migration must be installed.
+          </p>
+          <RefreshButton />
+        </div>
+      ) : (
+        <>
+          {!!data.hidden && (
+            <p className="text-sm text-muted-foreground">
+              {data.hidden} records omitted because their current source could
+              not be verified. Deleted, changed or no-longer-permitted posts are
+              not shown.
+            </p>
+          )}
+          {!data.decisions.length && (
+            <p className="rounded-lg border p-6">
+              No available tweets on this page.
+            </p>
+          )}
+          {data.decisions.map((row) => (
+            <article
+              key={row.tweet_id}
+              className="space-y-4 rounded-lg border bg-card p-5"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <a
+                  href={`https://x.com/${encodeURIComponent(row.username)}/status/${row.tweet_id}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="font-medium text-brand hover:underline"
+                >
+                  @{row.username} ↗
+                </a>
+                <span className="rounded-full bg-muted px-3 py-1 text-xs font-medium">
+                  {row.status === 'failed' && row.attempts >= 3
+                    ? 'Retries exhausted'
+                    : DECISION_LABELS[row.status]}
+                </span>
+              </div>
+              <p className="whitespace-pre-wrap break-words">
+                {decodeTweetText(row.text)}
+              </p>
+              {row.summary && (
+                <p className="text-sm">
+                  <strong>AI notice:</strong> {row.summary}
+                </p>
+              )}
+              {row.evidence && (
+                <p className="text-sm text-muted-foreground">
+                  <strong>Matched evidence:</strong> {row.evidence}
+                </p>
+              )}
+              {row.status === 'negative' && (
+                <p className="text-sm text-muted-foreground">
+                  The AI returned “not a notice.” A detailed rejection reason
+                  was not stored.
+                </p>
+              )}
+              {row.status === 'pending' && (
+                <p className="text-sm text-muted-foreground">
+                  Waiting for classification. This can also be an unchanged post
+                  queued for a requested recheck.
+                </p>
+              )}
+              {row.status === 'failed' && (
+                <p className="text-sm text-muted-foreground">
+                  {row.attempts >= 3
+                    ? 'Reached the automatic retry limit; no successful decision.'
+                    : 'No successful decision yet; may be in progress or awaiting a retry.'}
+                </p>
+              )}
+              <p className="text-xs text-muted-foreground">
+                Posted {formatTimestamp(row.posted_at)} · Updated{' '}
+                {formatTimestamp(row.updated_at)} · {row.attempts} attempts ·
+                Classifier {row.version}
+              </p>
+              <DecisionTweet id={row.tweet_id} />
+            </article>
+          ))}
+          <nav aria-label="Decision pages" className="flex justify-between">
+            {searchParams?.before ? (
+              <Link
+                href={`/admin/bulletin/decisions?status=${status}`}
+                className="text-brand"
+              >
+                Latest decisions
+              </Link>
+            ) : (
+              <span />
+            )}
+            {data.next && (
+              <Link
+                href={`/admin/bulletin/decisions?${new URLSearchParams({ status, before: data.next })}`}
+                className="text-brand"
+              >
+                Older decisions →
+              </Link>
+            )}
+          </nav>
+        </>
+      )}
+    </main>
+  )
+}

--- a/src/app/admin/bulletin/page.tsx
+++ b/src/app/admin/bulletin/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { loadRunDashboard, requireBulletinAdmin } from '@/lib/bulletin/data'
 import { RunDashboard } from '@/components/bulletin/RunDashboard'
 import { RefreshButton } from '@/components/bulletin/RefreshButton'
+import { RecommendationExplainer } from '@/components/bulletin/RecommendationExplainer'
 import { CandidateFilters } from '@/components/bulletin/CandidateFilters'
 
 export const dynamic = 'force-dynamic'
@@ -45,7 +46,14 @@ export default async function BulletinRunsPage({
           found and what still needs attention.
         </p>
       </header>
+      <Link
+        href="/admin/bulletin/decisions"
+        className="inline-flex rounded-lg border px-4 py-3 text-sm font-medium text-brand hover:bg-muted"
+      >
+        Browse accepted, rejected and queued tweets →
+      </Link>
       <CandidateFilters />
+      <RecommendationExplainer />
       {prompts ? (
         <PromptEditor data={prompts} olderThan={searchParams?.prompts_before} />
       ) : (

--- a/src/app/api/admin/bulletin/tweet/route.ts
+++ b/src/app/api/admin/bulletin/tweet/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server'
+import { requireBulletinAdmin } from '@/lib/bulletin/data'
+import { loadDecisionTweet } from '@/lib/bulletin/decisions'
+
+export const dynamic = 'force-dynamic'
+export async function GET(request: Request) {
+  await requireBulletinAdmin()
+  const headers = { 'Cache-Control': 'private, no-store' }
+  const id = new URL(request.url).searchParams.get('id') || ''
+  if (!/^\d{1,20}$/.test(id))
+    return NextResponse.json(
+      { error: 'Invalid tweet ID' },
+      { status: 400, headers },
+    )
+  try {
+    const tweet = await loadDecisionTweet(id)
+    return NextResponse.json({ tweet }, { status: tweet ? 200 : 404, headers })
+  } catch {
+    return NextResponse.json(
+      { error: 'Post unavailable. Try again.' },
+      { status: 503, headers },
+    )
+  }
+}

--- a/src/components/bulletin/DecisionTweet.tsx
+++ b/src/components/bulletin/DecisionTweet.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { useState } from 'react'
+import dynamic from 'next/dynamic'
+import type { BulletinTweet } from '@/lib/bulletin/tweets'
+const TweetCard = dynamic(() =>
+  import('@/components/TweetCard').then((m) => m.TweetCard),
+)
+
+export function DecisionTweet({ id }: { id: string }) {
+  const [tweet, setTweet] = useState<BulletinTweet | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(false)
+  async function load() {
+    if (loading || tweet) return
+    setLoading(true)
+    setError(false)
+    try {
+      const response = await fetch(`/api/admin/bulletin/tweet?id=${id}`, {
+        cache: 'no-store',
+      })
+      if (!response.ok) throw new Error('Unavailable')
+      const result = await response.json()
+      if (!result.tweet) throw new Error('Unavailable')
+      setTweet(result.tweet)
+    } catch {
+      setError(true)
+    } finally {
+      setLoading(false)
+    }
+  }
+  return (
+    <details
+      onToggle={(event) => {
+        if (event.currentTarget.open) void load()
+      }}
+    >
+      <summary className="cursor-pointer text-sm text-brand">
+        View full tweet, media and quoted post
+      </summary>
+      <div className="mt-3">
+        {loading && <p role="status">Loading post…</p>}
+        {error && (
+          <p role="alert">
+            Post unavailable or changed.{' '}
+            <button className="underline" onClick={() => void load()}>
+              Try again
+            </button>
+          </p>
+        )}
+        {tweet && (
+          <TweetCard
+            tweet={tweet}
+            clickable={false}
+            noClamp
+            showDate
+            returnTo="/admin/bulletin/decisions"
+          />
+        )}
+      </div>
+    </details>
+  )
+}

--- a/src/components/bulletin/RecommendationExplainer.tsx
+++ b/src/components/bulletin/RecommendationExplainer.tsx
@@ -1,0 +1,46 @@
+export function RecommendationExplainer() {
+  return (
+    <section className="space-y-3 rounded-lg border bg-card p-5 text-sm leading-6 sm:p-6">
+      <h2 className="text-xl font-semibold">
+        How personal recommendations work
+      </h2>
+      <p>
+        Recommended changes the order of accepted notices. It does not change
+        which tweets the AI accepts, and it does not use an LLM to infer your
+        interests.
+      </p>
+      <ol className="list-decimal space-y-2 pl-5">
+        <li>
+          Active notices come before past notices. Past notices are hidden
+          unless you include them.
+        </li>
+        <li>
+          Your own notices come first, then notices from your top 25 interaction
+          partners, then everyone else.
+        </li>
+        <li>
+          Among loaded cards in each group, asks with no recorded replies or
+          quotes are lifted first. Higher interaction counts come next, followed
+          by newer posts.
+        </li>
+      </ol>
+      <p>
+        Interaction partners come from your outgoing mentions, replies, quotes
+        and reposts available in the archive, across all available years. Follow
+        lists, likes, topic similarity and private messages are not used.
+        Missing archive data can make these signals incomplete.
+      </p>
+      <p>
+        If your identity or interaction data is unavailable, that part of
+        personalization is skipped. The board can load before personal
+        recommendations arrive. “Newest” sorts by posting time instead;
+        reversing the sort reverses the order within the active and past groups.
+      </p>
+      <p className="text-muted-foreground">
+        Reply and quote counts cover archived community members, so “unanswered”
+        does not guarantee nobody has responded on X. This is a lightweight
+        ranking of the accepted pool, not a prediction of what you will like.
+      </p>
+    </section>
+  )
+}

--- a/src/components/bulletin/RunDashboard.tsx
+++ b/src/components/bulletin/RunDashboard.tsx
@@ -16,7 +16,7 @@ const columns = [
   ['positive', 'Notices'],
   ['negative', 'Not notices'],
   ['failed', 'Failed'],
-  ['pending', 'Left in queue'],
+  ['pending', 'Unresolved at finish'],
 ] as const
 
 export function RunDashboard({
@@ -236,15 +236,21 @@ export function RunDashboard({
           earlier scans. <strong>Notices</strong> counts positive decisions
           saved during this run, before expiry and later consent changes. It is
           not the number currently visible on the website.{' '}
-          <strong>Left in queue</strong> includes waiting, failed and exhausted
-          decisions at the end of that run.
+          <strong>Unresolved at finish</strong> (previously “Left in queue”)
+          counts candidates without a successful decision when that run ended:
+          waiting, failed, or out of retries. It can include leftovers from
+          earlier scans. It is not a manual approval queue, and later retries do
+          not change this historical count. The cards above show the current
+          queue across runs; refresh runs count only their own request queue.
         </p>
         <p>
           Running and interrupted rows may have partial counts. Costs show
           reported charges plus reservations for requests whose final cost is
           unknown. Limits: $0.10/day, $1/calendar month, at most 50 calls per
-          run. Failed decisions wait at least an hour and retry on a later run,
-          up to three attempts.
+          run for normal daily scans. Transient provider failures can retry
+          within the run after roughly 2 then 5 seconds, plus jitter, up to
+          three total attempts. Otherwise eligible failures wait at least an
+          hour for a later run. Exhausted items do not retry automatically.
         </p>
         {latest && (
           <p>

--- a/src/database-types.ts
+++ b/src/database-types.ts
@@ -2037,6 +2037,16 @@ export type Database = {
           archive_upload_id: number
         }[]
       }
+      get_bulletin_decisions: {
+        Args: {
+          decision_status?: string
+          before_updated_at?: string
+          before_tweet_id?: string
+          max_results?: number
+          selected_tweet_id?: string
+        }
+        Returns: Json
+      }
       get_bulletin_board_state: {
         Args: {
           max_results?: number

--- a/src/database-types.ts
+++ b/src/database-types.ts
@@ -2037,6 +2037,12 @@ export type Database = {
           archive_upload_id: number
         }[]
       }
+      get_bulletin_board_state: {
+        Args: {
+          max_results?: number
+        }
+        Returns: Json
+      }
       get_bulletin_decisions: {
         Args: {
           decision_status?: string
@@ -2044,12 +2050,6 @@ export type Database = {
           before_tweet_id?: string
           max_results?: number
           selected_tweet_id?: string
-        }
-        Returns: Json
-      }
-      get_bulletin_board_state: {
-        Args: {
-          max_results?: number
         }
         Returns: Json
       }

--- a/src/lib/bulletin/decisions.test.ts
+++ b/src/lib/bulletin/decisions.test.ts
@@ -1,0 +1,151 @@
+import { createHash } from 'crypto'
+import { getAdminClient } from '@/app/admin/data'
+import { getLocalAdminPreview } from '@/lib/localAdminPreview'
+import { fetchAnalyticsGatewayJson } from '@/lib/clickhouseGateway'
+import { hydrateBulletinTweets } from './tweets'
+import {
+  loadDecisions,
+  loadDecisionTweet,
+  decisionStatus,
+  type StoredDecision,
+} from './decisions'
+
+jest.mock('@/app/admin/data', () => ({ getAdminClient: jest.fn() }))
+jest.mock('@/lib/localAdminPreview', () => ({
+  getLocalAdminPreview: jest.fn(),
+}))
+jest.mock('@/utils/supabase', () => ({
+  createServerServiceRoleClient: jest.fn(),
+}))
+jest.mock('@/lib/clickhouseGateway', () => ({
+  fetchAnalyticsGatewayJson: jest.fn(),
+}))
+jest.mock('./tweets', () => ({ hydrateBulletinTweets: jest.fn() }))
+const rpc = jest.fn()
+const hash = (text: string) => createHash('sha256').update(text).digest('hex')
+const row: StoredDecision = {
+  tweet_id: '123',
+  account_id: '42',
+  posted_at: '2026-09-11T10:00:00Z',
+  content_hash: hash('Original post'),
+  status: 'negative',
+  attempts: 1,
+  updated_at: '2026-09-11T11:00:00+00:00',
+  last_attempt_at: null,
+  version: 'v1',
+  username: 'person',
+  summary: null,
+  evidence: null,
+  side: null,
+  kind: null,
+}
+const source = {
+  tweet_id: '123',
+  account_id: '42',
+  full_text: 'Original post',
+  reply_to_tweet_id: null,
+  retweet: false,
+}
+beforeEach(() => {
+  jest.resetAllMocks()
+  jest.mocked(getLocalAdminPreview).mockResolvedValue(null)
+  jest
+    .mocked(getAdminClient)
+    .mockResolvedValue({ rpc } as unknown as Awaited<
+      ReturnType<typeof getAdminClient>
+    >)
+  rpc.mockResolvedValue({ data: [row], error: null })
+  jest.mocked(fetchAnalyticsGatewayJson).mockResolvedValue({ data: [source] })
+})
+test('both admin reads authorize before fetching private records or sources', async () => {
+  jest.mocked(getAdminClient).mockRejectedValue(new Error('not authorized'))
+  await expect(loadDecisions()).rejects.toThrow('not authorized')
+  await expect(loadDecisionTweet('123')).rejects.toThrow('not authorized')
+  expect(rpc).not.toHaveBeenCalled()
+  expect(fetchAnalyticsGatewayJson).not.toHaveBeenCalled()
+  expect(hydrateBulletinTweets).not.toHaveBeenCalled()
+})
+test('returns source-verified rejected text, without leaking its hash', async () => {
+  const result = await loadDecisions('negative')
+  expect(result.decisions).toHaveLength(1)
+  expect(result.decisions[0]).toMatchObject({
+    status: 'negative',
+    text: 'Original post',
+  })
+  expect(result.decisions[0]).not.toHaveProperty('content_hash')
+  expect(rpc).toHaveBeenCalledWith(
+    'get_bulletin_decisions',
+    expect.objectContaining({ decision_status: 'negative', max_results: 26 }),
+  )
+})
+test.each([
+  { data: [] },
+  { data: [{ ...source, account_id: '99' }] },
+  { data: [{ ...source, full_text: 'Edited' }] },
+  { data: [{ ...source, reply_to_tweet_id: '1' }] },
+  { data: [{ ...source, retweet: true }] },
+])(
+  'omits unavailable, changed, mismatched and non-original sources',
+  async ({ data }) => {
+    jest.mocked(fetchAnalyticsGatewayJson).mockResolvedValue({ data })
+    const result = await loadDecisions()
+    expect(result.decisions).toEqual([])
+    expect(result.hidden).toBe(1)
+  },
+)
+test('empty policy-filtered results do not fetch content', async () => {
+  rpc.mockResolvedValue({ data: [], error: null })
+  expect((await loadDecisions()).decisions).toEqual([])
+  expect(await loadDecisionTweet('123')).toBeNull()
+  expect(fetchAnalyticsGatewayJson).not.toHaveBeenCalled()
+  expect(hydrateBulletinTweets).not.toHaveBeenCalled()
+})
+test('preserves keyset pagination even if source checks remove every row', async () => {
+  rpc.mockResolvedValue({
+    data: Array.from({ length: 26 }, (_, i) => ({
+      ...row,
+      tweet_id: String(1000 - i),
+    })),
+    error: null,
+  })
+  jest.mocked(fetchAnalyticsGatewayJson).mockResolvedValue({ data: [] })
+  const result = await loadDecisions()
+  expect(result.decisions).toEqual([])
+  expect(result.next).toBe(`${row.updated_at}|976`)
+  await loadDecisions('positive', result.next!)
+  expect(rpc).toHaveBeenLastCalledWith(
+    'get_bulletin_decisions',
+    expect.objectContaining({
+      before_updated_at: row.updated_at,
+      before_tweet_id: '976',
+    }),
+  )
+})
+test('rejects invalid filters and cursors without a database query', async () => {
+  expect(() => decisionStatus('constructor')).toThrow('Invalid')
+  for (const before of ['bad', '2026-09-11|1', `${row.updated_at}|1|extra`])
+    await expect(loadDecisions('all', before)).rejects.toThrow('Invalid')
+  expect(rpc).not.toHaveBeenCalled()
+})
+test('passes only policy-authorized candidate records to full-fidelity hydration', async () => {
+  jest
+    .mocked(hydrateBulletinTweets)
+    .mockResolvedValue({ tweets: [], errors: { '123': 503 } })
+  expect(await loadDecisionTweet('123')).toBeNull()
+  expect(rpc).toHaveBeenCalledWith(
+    'get_bulletin_decisions',
+    expect.objectContaining({ selected_tweet_id: '123' }),
+  )
+  expect(hydrateBulletinTweets).toHaveBeenCalledWith(['123'], {
+    notices: [row],
+  })
+})
+test('upstream failures stay distinct from an empty decision list', async () => {
+  rpc.mockResolvedValue({ data: null, error: { code: 'PGRST202' } })
+  await expect(loadDecisions()).rejects.toThrow('could not be loaded')
+  rpc.mockResolvedValue({ data: [row], error: null })
+  jest
+    .mocked(fetchAnalyticsGatewayJson)
+    .mockRejectedValue(new Error('upstream unavailable'))
+  await expect(loadDecisions()).rejects.toThrow('upstream unavailable')
+})

--- a/src/lib/bulletin/decisions.ts
+++ b/src/lib/bulletin/decisions.ts
@@ -1,0 +1,121 @@
+import 'server-only'
+import { createHash } from 'crypto'
+import { getAdminClient } from '@/app/admin/data'
+import { createServerServiceRoleClient } from '@/utils/supabase'
+import { getLocalAdminPreview } from '@/lib/localAdminPreview'
+import { fetchAnalyticsGatewayJson } from '@/lib/clickhouseGateway'
+import { hydrateBulletinTweets } from './tweets'
+
+export const DECISION_PAGE_SIZE = 25
+export const DECISION_LABELS = {
+  all: 'All candidates',
+  positive: 'Accepted',
+  negative: 'Rejected',
+  pending: 'Waiting',
+  failed: 'Failed / retrying',
+} as const
+export type DecisionStatus = keyof typeof DECISION_LABELS
+export type StoredDecision = {
+  tweet_id: string
+  account_id: string
+  posted_at: string
+  content_hash: string
+  status: Exclude<DecisionStatus, 'all'>
+  attempts: number
+  updated_at: string
+  last_attempt_at: string | null
+  version: string
+  username: string
+  summary: string | null
+  evidence: string | null
+  side: string | null
+  kind: string | null
+}
+export type Decision = Omit<StoredDecision, 'content_hash'> & { text: string }
+
+export function decisionStatus(value = 'all'): DecisionStatus {
+  if (!Object.hasOwn(DECISION_LABELS, value))
+    throw new Error('Invalid decision filter')
+  return value as DecisionStatus
+}
+function cursor(value?: string) {
+  if (!value) return {}
+  const [updated, id, extra] = value.split('|')
+  if (
+    extra !== undefined ||
+    !/^\d{1,20}$/.test(id || '') ||
+    !/^\d{4}-\d{2}-\d{2}T[\d:.]+(?:Z|[+-]\d{2}:\d{2})$/.test(updated) ||
+    !Number.isFinite(Date.parse(updated))
+  )
+    throw new Error('Invalid decision cursor')
+  return { before_updated_at: updated, before_tweet_id: id }
+}
+async function records(status: DecisionStatus, before?: string, id?: string) {
+  const admin =
+    (await getLocalAdminPreview()) === 'admin'
+      ? createServerServiceRoleClient()
+      : await getAdminClient()
+  const { data, error } = await admin.rpc('get_bulletin_decisions', {
+    decision_status: status === 'all' ? undefined : status,
+    ...cursor(before),
+    max_results: DECISION_PAGE_SIZE + 1,
+    selected_tweet_id: id,
+  })
+  if (error || !Array.isArray(data))
+    throw new Error('Decisions could not be loaded')
+  return data as unknown as StoredDecision[]
+}
+export async function loadDecisions(
+  status: DecisionStatus = 'all',
+  before?: string,
+) {
+  const rows = await records(decisionStatus(status), before)
+  const page = rows.slice(0, DECISION_PAGE_SIZE)
+  const decisions: Decision[] = []
+  if (page.length) {
+    const response = await fetchAnalyticsGatewayJson<{
+      data: {
+        tweet_id: string
+        account_id: string
+        full_text: string
+        reply_to_tweet_id: string | null
+        retweet: boolean
+      }[]
+    }>(
+      ['bulletin-sources'],
+      new URLSearchParams({ ids: page.map((r) => r.tweet_id).join(',') }),
+    )
+    const sources = new Map(response.data.map((row) => [row.tweet_id, row]))
+    for (const row of page) {
+      const source = sources.get(row.tweet_id)
+      if (
+        !source ||
+        source.account_id !== row.account_id ||
+        source.reply_to_tweet_id ||
+        source.retweet ||
+        source.full_text.startsWith('RT @') ||
+        createHash('sha256').update(source.full_text).digest('hex') !==
+          row.content_hash
+      )
+        continue
+      const { content_hash: _hash, ...decision } = row
+      decisions.push({ ...decision, text: source.full_text })
+    }
+  }
+  const last = page[page.length - 1]
+  return {
+    decisions,
+    hidden: page.length - decisions.length,
+    next:
+      rows.length > DECISION_PAGE_SIZE
+        ? `${last.updated_at}|${last.tweet_id}`
+        : null,
+  }
+}
+export async function loadDecisionTweet(id: string) {
+  if (!/^\d{1,20}$/.test(id)) throw new Error('Invalid tweet ID')
+  const rows = await records('all', undefined, id)
+  if (!rows.some((row) => row.tweet_id === id)) return null
+  const { tweets } = await hydrateBulletinTweets([id], { notices: rows })
+  return tweets[0] || null
+}

--- a/src/lib/bulletin/tweets.test.ts
+++ b/src/lib/bulletin/tweets.test.ts
@@ -38,12 +38,10 @@ const detail = {
 beforeEach(() => {
   jest.resetAllMocks()
   jest.mocked(fetchAnalyticsGatewayJson).mockResolvedValue({ data: [source] })
-  jest
-    .mocked(fetchClickHouseTweetThreadPageData)
-    .mockResolvedValue({
-      tweet: detail,
-      threadTree: null,
-    } as unknown as ClickHouseTweetThreadPageData)
+  jest.mocked(fetchClickHouseTweetThreadPageData).mockResolvedValue({
+    tweet: detail,
+    threadTree: null,
+  } as unknown as ClickHouseTweetThreadPageData)
 })
 test('full-fidelity admin hydration preserves media and quoted context', async () => {
   const result = await hydrateBulletinTweets(['123'], { notices: [record] })
@@ -58,12 +56,10 @@ test('full-fidelity admin hydration preserves media and quoted context', async (
 })
 test('full details cannot expose another account or an edited source', async () => {
   for (const change of [{ account_id: '99' }, { full_text: 'Edited' }]) {
-    jest
-      .mocked(fetchClickHouseTweetThreadPageData)
-      .mockResolvedValue({
-        tweet: { ...detail, ...change },
-        threadTree: null,
-      } as unknown as ClickHouseTweetThreadPageData)
+    jest.mocked(fetchClickHouseTweetThreadPageData).mockResolvedValue({
+      tweet: { ...detail, ...change },
+      threadTree: null,
+    } as unknown as ClickHouseTweetThreadPageData)
     expect(
       (await hydrateBulletinTweets(['123'], { notices: [record] })).tweets,
     ).toEqual([])

--- a/src/lib/bulletin/tweets.test.ts
+++ b/src/lib/bulletin/tweets.test.ts
@@ -1,0 +1,85 @@
+import { createHash } from 'crypto'
+import { hydrateBulletinTweets, loadBulletinTweets } from './tweets'
+import { loadBulletinBoardState } from './data'
+import { fetchAnalyticsGatewayJson } from '@/lib/clickhouseGateway'
+import { fetchClickHouseTweetThreadPageData } from '@/lib/clickhouseTweetPage'
+import type { ClickHouseTweetThreadPageData } from '@/lib/clickhouseTweetPage'
+jest.mock('./data', () => ({ loadBulletinBoardState: jest.fn() }))
+jest.mock('@/lib/clickhouseGateway', () => ({
+  fetchAnalyticsGatewayJson: jest.fn(),
+}))
+jest.mock('@/lib/clickhouseTweetPage', () => ({
+  fetchClickHouseTweetThreadPageData: jest.fn(),
+}))
+const hash = createHash('sha256').update('Original').digest('hex')
+const record = { tweet_id: '123', account_id: '42', content_hash: hash }
+const source = {
+  ...record,
+  full_text: 'Original',
+  reply_to_tweet_id: null,
+  retweet: false,
+}
+const detail = {
+  tweet_id: '123',
+  account_id: '42',
+  username: 'member',
+  account_display_name: 'Member',
+  full_text: 'Original',
+  created_at: '2026-09-11T00:00:00Z',
+  media: [{ media_url: 'https://example.com/photo.png', media_type: 'photo' }],
+  quoted_tweet: {
+    tweet_id: '456',
+    full_text: 'Quoted context',
+    media: [
+      { media_url: 'https://example.com/quote.png', media_type: 'photo' },
+    ],
+  },
+}
+beforeEach(() => {
+  jest.resetAllMocks()
+  jest.mocked(fetchAnalyticsGatewayJson).mockResolvedValue({ data: [source] })
+  jest
+    .mocked(fetchClickHouseTweetThreadPageData)
+    .mockResolvedValue({
+      tweet: detail,
+      threadTree: null,
+    } as unknown as ClickHouseTweetThreadPageData)
+})
+test('full-fidelity admin hydration preserves media and quoted context', async () => {
+  const result = await hydrateBulletinTweets(['123'], { notices: [record] })
+  expect(result.tweets[0]).toMatchObject({
+    text: 'Original',
+    media: [{ url: 'https://example.com/photo.png' }],
+    quotedTweet: {
+      text: 'Quoted context',
+      media: [{ url: 'https://example.com/quote.png' }],
+    },
+  })
+})
+test('full details cannot expose another account or an edited source', async () => {
+  for (const change of [{ account_id: '99' }, { full_text: 'Edited' }]) {
+    jest
+      .mocked(fetchClickHouseTweetThreadPageData)
+      .mockResolvedValue({
+        tweet: { ...detail, ...change },
+        threadTree: null,
+      } as unknown as ClickHouseTweetThreadPageData)
+    expect(
+      (await hydrateBulletinTweets(['123'], { notices: [record] })).tweets,
+    ).toEqual([])
+  }
+})
+test('missing source is not resurrected by available thread details', async () => {
+  jest.mocked(fetchAnalyticsGatewayJson).mockResolvedValue({ data: [] })
+  expect(
+    (await hydrateBulletinTweets(['123'], { notices: [record] })).tweets,
+  ).toEqual([])
+})
+test('the public reader still requires board authorization before source queries', async () => {
+  jest
+    .mocked(loadBulletinBoardState)
+    .mockRejectedValue(new Error('login required'))
+  await expect(loadBulletinTweets(['123'])).rejects.toThrow('login required')
+  expect(fetchAnalyticsGatewayJson).not.toHaveBeenCalled()
+  expect(fetchClickHouseTweetThreadPageData).not.toHaveBeenCalled()
+})

--- a/src/lib/bulletin/tweets.ts
+++ b/src/lib/bulletin/tweets.ts
@@ -1,6 +1,6 @@
 import 'server-only'
 import { createHash } from 'crypto'
-import { loadBulletinBoardState } from './data'
+import { loadBulletinBoardState, type StoredNotice } from './data'
 import { fetchAnalyticsGatewayJson } from '@/lib/clickhouseGateway'
 import {
   fetchClickHouseTweetThreadPageData,
@@ -104,9 +104,18 @@ function card(tweet: TweetData): PortalTweet {
 }
 
 export async function loadBulletinTweets(ids: string[]) {
-  // Share the live notice/policy read and source check across a small batch.
-  const [state, current, details] = await Promise.all([
-    loadBulletinBoardState(),
+  return hydrateBulletinTweets(ids, await loadBulletinBoardState())
+}
+
+/** Call only with records from an authorized, current-policy read. */
+export async function hydrateBulletinTweets(
+  ids: string[],
+  state: {
+    notices: Pick<StoredNotice, 'tweet_id' | 'account_id' | 'content_hash'>[]
+    allowedAccounts?: string[]
+  },
+) {
+  const [current, details] = await Promise.all([
     fetchAnalyticsGatewayJson<{
       data: Array<{
         tweet_id: string

--- a/supabase/migrations/20260911204733_bulletin_admin_decisions.sql
+++ b/supabase/migrations/20260911204733_bulletin_admin_decisions.sql
@@ -1,0 +1,30 @@
+CREATE INDEX bulletin_decisions_recent_idx ON bulletin.decisions(updated_at DESC,tweet_id DESC);
+CREATE INDEX bulletin_decisions_status_recent_idx ON bulletin.decisions(status,updated_at DESC,tweet_id DESC);
+-- Read-only, server-only decision inspection. Live tweet text is hydrated separately.
+CREATE FUNCTION public.get_bulletin_decisions(
+  decision_status text DEFAULT NULL,
+  before_updated_at timestamptz DEFAULT NULL,
+  before_tweet_id text DEFAULT NULL,
+  max_results integer DEFAULT 26,
+  selected_tweet_id text DEFAULT NULL
+)
+RETURNS jsonb LANGUAGE sql STABLE SECURITY INVOKER SET search_path='' AS $$
+ SELECT coalesce(jsonb_agg(to_jsonb(row) ORDER BY row.updated_at DESC,row.tweet_id DESC),'[]'::jsonb)
+ FROM (
+   SELECT d.tweet_id,d.account_id,d.posted_at,d.content_hash,d.status,d.attempts,
+     d.updated_at,d.last_attempt_at,d.version,a.username,
+     o.summary,o.evidence,o.side,o.kind
+   FROM bulletin.decisions d
+   JOIN bulletin.allowed_accounts a ON a.account_id=d.account_id
+   LEFT JOIN bulletin.opportunities o ON o.tweet_id=d.tweet_id
+     AND o.content_hash=d.content_hash AND d.status='positive'
+   WHERE (decision_status IS NULL OR d.status=decision_status)
+     AND (selected_tweet_id IS NULL OR d.tweet_id=selected_tweet_id)
+     AND ((before_updated_at IS NULL AND before_tweet_id IS NULL)
+       OR (d.updated_at,d.tweet_id)<(before_updated_at,before_tweet_id))
+   ORDER BY d.updated_at DESC,d.tweet_id DESC
+   LIMIT greatest(0,least(coalesce(max_results,26),26))
+ ) row
+$$;
+REVOKE ALL ON FUNCTION public.get_bulletin_decisions(text,timestamptz,text,integer,text) FROM PUBLIC,anon,authenticated;
+GRANT EXECUTE ON FUNCTION public.get_bulletin_decisions(text,timestamptz,text,integer,text) TO service_role;

--- a/supabase/schemas/030_indexes.sql
+++ b/supabase/schemas/030_indexes.sql
@@ -159,3 +159,6 @@ CREATE INDEX IF NOT EXISTS "community_project_likes_project_id_idx"
   ON "public"."community_project_likes" ("project_id");
 CREATE INDEX IF NOT EXISTS "community_project_comments_project_id_created_at_idx"
   ON "public"."community_project_comments" ("project_id", "created_at");
+
+CREATE INDEX bulletin_decisions_recent_idx ON bulletin.decisions(updated_at DESC,tweet_id DESC);
+CREATE INDEX bulletin_decisions_status_recent_idx ON bulletin.decisions(status,updated_at DESC,tweet_id DESC);

--- a/supabase/schemas/070_functions.sql
+++ b/supabase/schemas/070_functions.sql
@@ -3811,3 +3811,30 @@ RETURNS jsonb LANGUAGE sql STABLE SECURITY INVOKER SET search_path='' AS $$
     ORDER BY r.created_at DESC LIMIT 10
   ) item
 $$;
+
+-- Read-only, server-only decision inspection. Live tweet text is hydrated separately.
+CREATE FUNCTION public.get_bulletin_decisions(
+  decision_status text DEFAULT NULL,
+  before_updated_at timestamptz DEFAULT NULL,
+  before_tweet_id text DEFAULT NULL,
+  max_results integer DEFAULT 26,
+  selected_tweet_id text DEFAULT NULL
+)
+RETURNS jsonb LANGUAGE sql STABLE SECURITY INVOKER SET search_path='' AS $$
+ SELECT coalesce(jsonb_agg(to_jsonb(row) ORDER BY row.updated_at DESC,row.tweet_id DESC),'[]'::jsonb)
+ FROM (
+   SELECT d.tweet_id,d.account_id,d.posted_at,d.content_hash,d.status,d.attempts,
+     d.updated_at,d.last_attempt_at,d.version,a.username,
+     o.summary,o.evidence,o.side,o.kind
+   FROM bulletin.decisions d
+   JOIN bulletin.allowed_accounts a ON a.account_id=d.account_id
+   LEFT JOIN bulletin.opportunities o ON o.tweet_id=d.tweet_id
+     AND o.content_hash=d.content_hash AND d.status='positive'
+   WHERE (decision_status IS NULL OR d.status=decision_status)
+     AND (selected_tweet_id IS NULL OR d.tweet_id=selected_tweet_id)
+     AND ((before_updated_at IS NULL AND before_tweet_id IS NULL)
+       OR (d.updated_at,d.tweet_id)<(before_updated_at,before_tweet_id))
+   ORDER BY d.updated_at DESC,d.tweet_id DESC
+   LIMIT greatest(0,least(coalesce(max_results,26),26))
+ ) row
+$$;

--- a/supabase/schemas/090_policy_grants.sql
+++ b/supabase/schemas/090_policy_grants.sql
@@ -211,3 +211,6 @@ REVOKE ALL ON FUNCTION public.request_bulletin_refresh(uuid,text,bigint,numeric,
 REVOKE ALL ON FUNCTION public.get_bulletin_refreshes() FROM PUBLIC,anon,authenticated;
 GRANT EXECUTE ON FUNCTION public.request_bulletin_refresh(uuid,text,bigint,numeric,uuid) TO service_role;
 GRANT EXECUTE ON FUNCTION public.get_bulletin_refreshes() TO service_role;
+
+REVOKE ALL ON FUNCTION public.get_bulletin_decisions(text,timestamptz,text,integer,text) FROM PUBLIC,anon,authenticated;
+GRANT EXECUTE ON FUNCTION public.get_bulletin_decisions(text,timestamptz,text,integer,text) TO service_role;


### PR DESCRIPTION
Admins can now inspect the latest accepted, rejected, waiting and failed candidate tweets from the bulletin dashboard, with 25-row pagination and on-demand full tweet/media/quote rendering. The page distinguishes AI rejection from posts skipped by prefilters and makes clear that rejection explanations were not stored.

The dashboard renames “Left in queue” to “Unresolved at finish,” explains historical versus current queue counts, corrects the fast-retry description, and explains the existing interaction-based personal ranking.

Data access remains admin-only. A service-role-only RPC checks current authoritative membership; source hydration checks identity, original-post status and content hashes before returning content. Expired accepted notices remain inspectable.

**Requires production migration before frontend merge:** `20260911204733_bulletin_admin_decisions.sql`. Production has not been migrated. The migration is additive (read function and two indexes), with aligned declarative schema and client types. This PR does not change filtering, classification or ranking behavior.

Validation: TypeScript and scoped ESLint passed; 16 focused server tests passed; the actual SQL migration passed policy, role-access, stale-label and pagination checks in a disposable local PostgreSQL database. Browser inspection was attempted with synthetic fixtures, but the in-app browser timed out before a usable preview; visual verification remains outstanding.
