### PR TITLE
Require active opt-in for bulletin access

### DIFF
--- a/services/bulletin/README.md
+++ b/services/bulletin/README.md
@@ -1,7 +1,8 @@
 # Community Bulletin
 
-Signed-in members use `/bulletin`; the existing admin allowlist controls
-`/admin/bulletin`. The worker runs after the daily autorefresh succeeds.
+Signed-in users with an active streaming opt-in use `/bulletin`; the existing
+admin allowlist controls `/admin/bulletin`. The worker runs after the daily
+autorefresh succeeds.
 
 ## Data and privacy
 
@@ -20,7 +21,13 @@ The decisions table no longer requires a matching PostgreSQL tweet row.
 Only derived notices and source hashes are stored, not a second tweet corpus.
 
 Browser roles cannot access the `bulletin` schema or its service-only RPCs.
-Server routes verify the session before fetching private state. Opt-outs during
+The board and tweet API routes verify the session and current PostgreSQL
+`optin` record before fetching private state: `opted_in` must be true and
+`explicit_optout` must not be true. Archive membership alone does not grant
+viewer access. Signed-out visitors go to login; other visitors without consent
+go to the opt-in page with a return link after opting in. Consent lookup failures
+deny access. The existing loopback-only local admin preview remains available.
+Opt-outs during
 a model call suppress publication. Every board read verifies current ClickHouse
 content, author, original-post status and hash. Missing, edited or deleted sources
 are hidden. Derived records may remain privately stored until reconciliation;

--- a/src/app/opt-in/page.test.tsx
+++ b/src/app/opt-in/page.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import OptInPage from './page'
+import { getOptInStatus, requireAuth } from '@/lib/auth-utils'
+import { isStagingOptInPreviewEnabled } from '@/lib/stagingOptInPreview'
+
+jest.mock('@/lib/auth-utils', () => ({
+  requireAuth: jest.fn(),
+  getOptInStatus: jest.fn(),
+}))
+jest.mock('@/lib/stagingOptInPreview', () => ({
+  isStagingOptInPreviewEnabled: jest.fn(),
+}))
+jest.mock('@/components/OptInForm', () => ({
+  __esModule: true,
+  default: () => <div>Opt-in form</div>,
+}))
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  jest.mocked(requireAuth).mockResolvedValue({
+    user: { id: 'member' },
+  } as Awaited<ReturnType<typeof requireAuth>>)
+  jest.mocked(isStagingOptInPreviewEnabled).mockReturnValue(false)
+  jest.mocked(getOptInStatus).mockResolvedValue({ data: null, error: null })
+})
+
+test('explains the bulletin requirement and preserves the destination through login', async () => {
+  render(await OptInPage({ searchParams: { redirect: '/bulletin' } }))
+  expect(requireAuth).toHaveBeenCalledWith('/opt-in?redirect=/bulletin')
+  expect(screen.getByText(/choose whether to opt in/i)).toBeInTheDocument()
+  expect(
+    screen.queryByRole('link', { name: /continue to the bulletin/i }),
+  ).not.toBeInTheDocument()
+})
+
+test.each([false, true])(
+  'only active consent offers the return link (opt-out: %s)',
+  async (optedOut) => {
+    jest.mocked(getOptInStatus).mockResolvedValue({
+      data: { opted_in: true, explicit_optout: optedOut },
+      error: null,
+    } as Awaited<ReturnType<typeof getOptInStatus>>)
+    render(await OptInPage({ searchParams: { redirect: '/bulletin' } }))
+    const link = screen.queryByRole('link', {
+      name: /continue to the bulletin/i,
+    })
+    if (optedOut) expect(link).not.toBeInTheDocument()
+    else expect(link).toHaveAttribute('href', '/bulletin')
+  },
+)
+
+test.each([undefined, 'https://example.com', ['/bulletin']])(
+  'ignores unrelated or malformed redirect destinations: %s',
+  async (redirect) => {
+    render(await OptInPage({ searchParams: { redirect } }))
+    expect(requireAuth).toHaveBeenCalledWith('/opt-in')
+    expect(
+      screen.queryByText(/the bulletin is available/i),
+    ).not.toBeInTheDocument()
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+  },
+)
+
+test('mock opt-in never enables bulletin access', async () => {
+  jest.mocked(isStagingOptInPreviewEnabled).mockReturnValue(true)
+  render(
+    await OptInPage({
+      searchParams: { redirect: '/bulletin', mockOptIn: '1' },
+    }),
+  )
+  expect(getOptInStatus).not.toHaveBeenCalled()
+  expect(
+    screen.queryByRole('link', { name: /continue to the bulletin/i }),
+  ).not.toBeInTheDocument()
+})

--- a/src/app/opt-in/page.tsx
+++ b/src/app/opt-in/page.tsx
@@ -1,23 +1,45 @@
 import { requireAuth, getOptInStatus } from '@/lib/auth-utils'
 import OptInForm from '@/components/OptInForm'
 import { isStagingOptInPreviewEnabled } from '@/lib/stagingOptInPreview'
+import Link from 'next/link'
 
 interface OptInPageProps {
   searchParams?: {
     mockOptIn?: string | string[]
+    redirect?: string | string[]
   }
 }
 
 export default async function OptInPage({ searchParams }: OptInPageProps) {
-  const { user } = await requireAuth()
+  const fromBulletin = searchParams?.redirect === '/bulletin'
+  const { user } = await requireAuth(
+    fromBulletin ? '/opt-in?redirect=/bulletin' : '/opt-in',
+  )
   const mockOptIn = isStagingOptInPreviewEnabled(
     searchParams?.mockOptIn === '1',
   )
   const optInData = mockOptIn ? null : (await getOptInStatus(user.id)).data
+  const canVisitBulletin =
+    optInData?.opted_in === true && optInData.explicit_optout !== true
 
   return (
     <main className="min-h-screen bg-card dark:bg-background">
       <div className="mx-auto max-w-5xl px-4 py-12 sm:px-6 lg:px-8">
+        {fromBulletin && (
+          <div className="mb-8 rounded-lg border p-4">
+            {canVisitBulletin ? (
+              <Link href="/bulletin" className="font-medium underline">
+                Continue to the bulletin
+              </Link>
+            ) : (
+              <p>
+                The bulletin is available to people who have opted in to
+                Community Archive. Review the data policy below and choose
+                whether to opt in.
+              </p>
+            )}
+          </div>
+        )}
         <OptInForm
           userId={user.id}
           initialOptInStatus={optInData}

--- a/src/components/OptInForm.test.tsx
+++ b/src/components/OptInForm.test.tsx
@@ -51,6 +51,21 @@ jest.mock('@/hooks/useAuthAndArchive', () => ({
 }))
 
 describe('OptInForm opted-in experience', () => {
+  it('lets an explicitly opted-out user opt back in despite a stale positive flag', () => {
+    render(
+      <OptInForm
+        userId="user-1"
+        initialOptInStatus={{ opted_in: true, explicit_optout: true }}
+      />,
+    )
+    expect(
+      screen.getByRole('button', { name: /opt in to tweet streaming/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('heading', { name: 'Thanks for opting in!' }),
+    ).not.toBeInTheDocument()
+  })
+
   it('celebrates the opt-in and offers archive and exploration next steps', () => {
     render(
       <OptInForm userId="user-1" initialOptInStatus={{ opted_in: true }} />,

--- a/src/components/OptInForm.tsx
+++ b/src/components/OptInForm.tsx
@@ -44,7 +44,8 @@ export default function OptInForm({
   const router = useRouter()
   const { userMetadata } = useAuthAndArchive()
   const [isOptedIn, setIsOptedIn] = useState(
-    initialOptInStatus?.opted_in || false,
+    initialOptInStatus?.opted_in === true &&
+      initialOptInStatus.explicit_optout !== true,
   )
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState('')

--- a/src/lib/bulletin/data.test.ts
+++ b/src/lib/bulletin/data.test.ts
@@ -7,9 +7,11 @@ import {
   loadRunDashboard,
   loadBulletinRelationships,
   loadBulletinViewer,
+  requireBulletinUser,
 } from './data'
 import { getLocalAdminPreview } from '@/lib/localAdminPreview'
 import { getCurrentUser } from '@/lib/portal/auth'
+import { getOptInStatus } from '@/lib/auth-utils'
 import { getAdminClient } from '@/app/admin/data'
 import { createServerServiceRoleClient } from '@/utils/supabase'
 jest.mock('@/lib/clickhouseGateway', () => ({
@@ -19,6 +21,7 @@ jest.mock('@/lib/localAdminPreview', () => ({
   getLocalAdminPreview: jest.fn(),
 }))
 jest.mock('@/lib/portal/auth', () => ({ getCurrentUser: jest.fn() }))
+jest.mock('@/lib/auth-utils', () => ({ getOptInStatus: jest.fn() }))
 jest.mock('@/app/admin/data', () => ({ getAdminClient: jest.fn() }))
 jest.mock('@/utils/supabase', () => ({
   createServerServiceRoleClient: jest.fn(),
@@ -34,6 +37,10 @@ const loadNotices = async () =>
   hydrateBulletinNotices(await loadBulletinBoardState())
 beforeEach(() => {
   jest.clearAllMocks()
+  jest.mocked(getOptInStatus).mockResolvedValue({
+    data: { opted_in: true, explicit_optout: false },
+    error: null,
+  } as Awaited<ReturnType<typeof getOptInStatus>>)
   jest.mocked(getLocalAdminPreview).mockResolvedValue(null)
   jest
     .mocked(createServerServiceRoleClient)
@@ -49,9 +56,10 @@ test.each([null, { is_anonymous: true }])(
       'redirect:/login?redirect=/bulletin',
     )
     expect(createServerServiceRoleClient).not.toHaveBeenCalled()
+    expect(getOptInStatus).not.toHaveBeenCalled()
   },
 )
-test('verified members read the policy-aware RPC, with upstream errors kept distinct from empty results', async () => {
+test('opted-in users read the policy-aware RPC, with upstream errors kept distinct from empty results', async () => {
   jest
     .mocked(getCurrentUser)
     .mockResolvedValue({ id: 'member', is_anonymous: false } as User)
@@ -59,6 +67,7 @@ test('verified members read the policy-aware RPC, with upstream errors kept dist
     .mockResolvedValueOnce({ data: [], error: null })
     .mockResolvedValueOnce({ data: null, error: { message: 'unavailable' } })
   await expect(loadNotices()).resolves.toEqual([])
+  expect(getOptInStatus).toHaveBeenCalledWith('member')
   expect(rpc).toHaveBeenCalledWith('get_bulletin_board_state', {
     max_results: 2000,
   })
@@ -68,6 +77,62 @@ test('run history always requires admin authorization', async () => {
   jest.mocked(getAdminClient).mockRejectedValueOnce(new Error('not authorized'))
   await expect(loadRunDashboard()).rejects.toThrow('not authorized')
   expect(rpc).not.toHaveBeenCalled()
+})
+
+test.each([
+  { data: null, error: null },
+  { data: null, error: { code: 'PGRST116' } },
+  { data: { opted_in: false, explicit_optout: false }, error: null },
+  { data: { opted_in: null, explicit_optout: null }, error: null },
+  { data: { opted_in: true, explicit_optout: true }, error: null },
+])(
+  'users without active consent cannot read bulletin data: %j',
+  async (status) => {
+    jest.mocked(getCurrentUser).mockResolvedValue({
+      id: 'signed-in-user',
+      user_metadata: { opted_in: true, is_member: true },
+    } as unknown as User)
+    jest
+      .mocked(getOptInStatus)
+      .mockResolvedValue(status as Awaited<ReturnType<typeof getOptInStatus>>)
+    for (const read of [
+      loadNotices,
+      loadBulletinViewer,
+      loadBulletinRelationships,
+    ])
+      await expect(read()).rejects.toThrow(
+        'redirect:/opt-in?redirect=/bulletin',
+      )
+    expect(getOptInStatus).toHaveBeenCalledWith('signed-in-user')
+    expect(createServerServiceRoleClient).not.toHaveBeenCalled()
+    expect(fetchAnalyticsGatewayJson).not.toHaveBeenCalled()
+  },
+)
+
+test('consent lookup failures deny access without pretending the user has not opted in', async () => {
+  jest.mocked(getCurrentUser).mockResolvedValue({ id: 'member' } as User)
+  jest.mocked(getOptInStatus).mockResolvedValue({
+    data: null,
+    error: { code: '08006', message: 'Connection unavailable' },
+  } as Awaited<ReturnType<typeof getOptInStatus>>)
+  await expect(loadNotices()).rejects.toThrow(
+    'opt-in status could not be checked',
+  )
+  expect(createServerServiceRoleClient).not.toHaveBeenCalled()
+  expect(fetchAnalyticsGatewayJson).not.toHaveBeenCalled()
+})
+
+test('consent is checked again after opt-out, even with the same authenticated session', async () => {
+  jest.mocked(getCurrentUser).mockResolvedValue({ id: 'member' } as User)
+  await expect(requireBulletinUser()).resolves.toMatchObject({ id: 'member' })
+  jest.mocked(getOptInStatus).mockResolvedValue({
+    data: { opted_in: false, explicit_optout: true },
+    error: null,
+  } as Awaited<ReturnType<typeof getOptInStatus>>)
+  await expect(requireBulletinUser()).rejects.toThrow(
+    'redirect:/opt-in?redirect=/bulletin',
+  )
+  expect(getOptInStatus).toHaveBeenCalledTimes(2)
 })
 test('run history uses bounded keyset pagination and rejects malformed cursors', async () => {
   jest
@@ -99,6 +164,7 @@ test('explicit local admin read preview does not fabricate an Auth user', async 
   rpc.mockResolvedValue({ data: [], error: null })
   await expect(loadNotices()).resolves.toEqual([])
   expect(getCurrentUser).not.toHaveBeenCalled()
+  expect(getOptInStatus).not.toHaveBeenCalled()
 })
 test('signed-out local preview still requires login', async () => {
   jest.mocked(getLocalAdminPreview).mockResolvedValue('signed-out')

--- a/src/lib/bulletin/data.ts
+++ b/src/lib/bulletin/data.ts
@@ -2,6 +2,7 @@ import { getSessionTwitterUsername } from '@/lib/sessionTwitterUsername'
 import 'server-only'
 import { redirect } from 'next/navigation'
 import { getCurrentUser } from '@/lib/portal/auth'
+import { getOptInStatus } from '@/lib/auth-utils'
 import { getLocalAdminPreview } from '@/lib/localAdminPreview'
 import { getAdminClient, requireAdmin, checkIsAdmin } from '@/app/admin/data'
 import { createServerServiceRoleClient } from '@/utils/supabase'
@@ -18,6 +19,13 @@ export async function requireBulletinUser() {
   // local admin read preview follows the same convention as Birdseye.
   const user = await getCurrentUser()
   if (!user || user.is_anonymous) redirect('/login?redirect=/bulletin')
+  // Read current consent from PostgreSQL, never session metadata or archive
+  // membership. An explicit opt-out overrides even a stale positive flag.
+  const { data: consent, error } = await getOptInStatus(user.id)
+  if (error && error.code !== 'PGRST116')
+    throw new Error('Bulletin opt-in status could not be checked. Try again.')
+  if (error || consent?.opted_in !== true || consent.explicit_optout === true)
+    redirect('/opt-in?redirect=/bulletin')
   return user
 }
 


### PR DESCRIPTION
Signed-in visitors could read the bulletin without opting in. Require a current PostgreSQL opt-in record before the bulletin page or tweet APIs serve private data. Explicit opt-out overrides a positive flag; missing consent redirects to opt-in, and lookup failures deny access.

The opt-in page explains the requirement and offers a fixed return link after consent is saved. It also handles a stale positive flag with explicit opt-out. The existing local admin preview and separate admin authorization remain intact.

Validation: 32 focused tests passed (consent denial, revocation, forged metadata, lookup failure, and opt-in return states), TypeScript and scoped ESLint passed. Browser visual verification was not performed. No database migration or classifier/prompt change.
