### PR TITLE
Track resolved bulletin notices from author replies

### DIFF
--- a/services/bulletin/README.md
+++ b/services/bulletin/README.md
@@ -107,15 +107,17 @@ unknown in that response. Confirmed resolved notices are hidden by default;
 `Show resolved` includes them independently of `Show past`, with a badge linking
 to the author update. An explicit reopening restores default visibility.
 
-Each regular daily run checks at most **20** saved positive notices, oldest check
-first, that have not been checked for a day. It covers notices posted in the past
-60 days, unexpired dated notices, and standing notices, including resolved ones.
+Each regular daily run checks **all active saved notices** not yet checked that
+UTC day, oldest check first. Active follows the board's lifetime: 14 days for
+undated asks, 60 for offers, explicit dates, standing notices, and self-quote
+renewals. This includes resolved notices still within that lifetime so they can reopen.
 Unchanged rendered context updates the check time without a model call. Changed
 context joins the existing durable queue; existing call, day/month budget, retry,
 and run-time limits still apply. Fresh candidates precede newly queued rechecks.
-More than 20 due notices rotate across runs; this is periodic checking, not a
-guarantee that all author updates appear within 24 hours. Backfills and explicit
-refresh jobs do not start unrelated availability checks.
+There is no per-run item cap. If the run-time limit prevents finishing context
+checks, the run reports a failure and keeps completed checkpoints for resumption.
+Model-call and spending limits can still defer changed-context classifications.
+Backfills and explicit refresh jobs do not start unrelated availability checks.
 
 New intake and rechecks use the same classifier/output validator. Failed or
 ambiguous rechecks do not silently mark a notice resolved, and unknown does not

--- a/services/bulletin/README.md
+++ b/services/bulletin/README.md
@@ -207,8 +207,8 @@ toward the run's 50-call cap and must fit within the remaining time allowance.
 Successful recovery makes the run `ok`; `failed` still counts failed attempts.
 Unresolved work from an earlier run remains eligible after an hour, when the
 next run starts; there is no standalone retry timer.
-Model routing forbids fallback or price escalation
-and caps prices at $0.15 input / $0.50 output per million tokens.
+Model routing allows provider fallback for the same model while requiring the
+request's parameters and capping prices at $0.15 input / $0.50 output per million tokens.
 
 An explicitly approved backfill can use `--backfill-budget-usd` (at most $1).
 Its cap is cumulative across runs of the exact same window. The monthly cap

--- a/services/bulletin/README.md
+++ b/services/bulletin/README.md
@@ -64,7 +64,7 @@ skill installation. There are no extra runtime packages or image-model calls.
 The existing gateway thread endpoint fetches at most 500 conversation tweets.
 The renderer selects a reply-edge radius of two plus one outgoing quote hop,
 then limits input to 21 tweets and a soft 12,000-character target. It prioritizes
-the seed and the author's replies, keeps the seed whole, and explicitly marks
+the seed and the author's newest replies, keeps the seed whole, and explicitly marks
 omissions. The existing 64 KiB request ceiling and byte-based cost reservation
 still apply to the complete model request, including context.
 
@@ -85,14 +85,52 @@ or logs. Every printed source's hash and current consent are checked again befor
 saving; a change leaves the decision pending without repeating the paid call
 immediately or removing its cost from the ledger.
 
-Context is a bounded snapshot, not continuous reply monitoring. New replies do
-not automatically invalidate an already saved decision; the graph endpoint may
-cache reply discovery for an hour. The classifier version bump reconsiders
-encountered candidates in newly scanned windows. It does not trigger a historical
-backfill. Candidate phrase filters are unchanged.
+The graph endpoint may cache reply discovery for an hour. The classifier version
+bump reconsiders encountered candidates in newly scanned windows; it does not
+trigger a historical backfill. Candidate phrase filters are unchanged.
+
+### Resolution and reopening
+
+Positive labels include `availability` with `state` (`unknown`, `open`, or
+`resolved`), `tweet_id`, and exact `evidence`. Unknown has null evidence fields.
+An explicit author statement can resolve or reopen a notice. Evidence must occur
+in the seed or a printed descendant reply by the same author; unrelated posts,
+quotes, other participants' interest, generic thanks, silence, and partial uptake
+do not establish closure. The model uses the latest applicable author statement.
+A resolved notice remains a positive notice, preserving it for later viewing.
+
+The database stores only the availability state and evidence tweet ID/hash, plus
+the checked context digest/time. It does not store reply text. Before displaying
+resolved status (or hiding the card by default), the board verifies the evidence's
+current author and content hash. Missing or changed evidence makes the status
+unknown in that response. Confirmed resolved notices are hidden by default;
+`Show resolved` includes them independently of `Show past`, with a badge linking
+to the author update. An explicit reopening restores default visibility.
+
+Each regular daily run checks at most **20** saved positive notices, oldest check
+first, that have not been checked for a day. It covers notices posted in the past
+60 days, unexpired dated notices, and standing notices, including resolved ones.
+Unchanged rendered context updates the check time without a model call. Changed
+context joins the existing durable queue; existing call, day/month budget, retry,
+and run-time limits still apply. Fresh candidates precede newly queued rechecks.
+More than 20 due notices rotate across runs; this is periodic checking, not a
+guarantee that all author updates appear within 24 hours. Backfills and explicit
+refresh jobs do not start unrelated availability checks.
+
+New intake and rechecks use the same classifier/output validator. Failed or
+ambiguous rechecks do not silently mark a notice resolved, and unknown does not
+erase an earlier confirmed resolution. Older evidence cannot override a newer
+author update. A failed recheck preserves its prior card
+and cost history. Context changes during a model call retain the normal pending
+retry behavior rather than publishing stale results.
 
 Deployment requires the complete `services/bulletin` directory, including the
-vendored helpers. The existing gateway endpoints and database schema suffice.
+vendored helpers. The existing gateway endpoints suffice. Apply
+`20260911222035_bulletin_resolution_status.sql` before deploying this worker;
+it adds private opportunity metadata and a recheck index. The public RPC remains
+JSON, so its generated TypeScript signature is unchanged. Old frontend/worker
+releases tolerate the added columns; rollback the worker and frontend separately
+while retaining the resolution metadata and cost ledger.
 Before production rollout, inspect a small, separately budgeted model pilot for
 real asks, jokes, vague posts, and clarifying replies. Worker deployment and any
 historical reclassification remain separate from merging the web access gate.
@@ -287,7 +325,7 @@ that explicit local preview guard. Tweet reads still use ClickHouse.
 ```sh
 BULLETIN_TEST_DSN='host=127.0.0.1 port=55439 dbname=bulletin_test user=frsc' \
   uv run --with 'psycopg[binary]==3.2.9' --with duckdb==1.5.5 \
-  python -m unittest -v test_worker.py test_retries.py test_tweet_context.py test_clickhouse_worker.py
+  python -m unittest -v test_worker.py test_retries.py test_tweet_context.py test_resolution.py test_clickhouse_worker.py
 ```
 
 These tests require a named disposable local database. They exercise a fake

--- a/services/bulletin/resolution.py
+++ b/services/bulletin/resolution.py
@@ -1,9 +1,9 @@
 """Conservative author-evidenced availability and bounded daily rechecks."""
 import hashlib
+import datetime as dt
 
 import tweet_context
 
-MAX_RECHECKS = 20
 RULES = '''For every positive notice, also return an availability object, for example:
 {"state":"unknown","tweet_id":null,"evidence":null}.
 State must be exactly unknown, open, or resolved.
@@ -52,20 +52,31 @@ def validate(value, seed, context):
 
 def enqueue_rechecks(db, started, max_seconds, current, clock):
     """Only daily runs revisit saved notices; all paid work uses the normal queue."""
-    rows = db.execute('''SELECT o.tweet_id,o.context_digest,d.content_hash
+    rows = db.execute('''SELECT o.tweet_id,o.context_digest,d.content_hash,
+        o.standing,o.expires_at,o.side,d.posted_at
       FROM bulletin.opportunities o JOIN bulletin.decisions d USING(tweet_id)
       LEFT JOIN bulletin.refresh_requests r ON r.id=d.refresh_request_id
       WHERE d.status='positive'
         AND (d.refresh_request_id IS NULL OR r.status IN ('complete','stopped'))
-        AND (o.context_checked_at IS NULL OR o.context_checked_at<now()-interval '1 day')
-        AND (o.standing OR o.expires_at>=CURRENT_DATE
-          OR d.posted_at>=now()-interval '60 days')
-      ORDER BY o.context_checked_at ASC NULLS FIRST,o.tweet_id LIMIT %s''',
-      (MAX_RECHECKS,)).fetchall()
+        AND (o.context_checked_at IS NULL OR o.context_checked_at<date_trunc('day',now()))
+      ORDER BY o.context_checked_at ASC NULLS FIRST,o.tweet_id''').fetchall()
     prepared = {}
     for row in rows:
         if clock()-started > max_seconds:
-            break
+            raise RuntimeError('resolution_checks_time_limit')
+        now = dt.datetime.now(dt.timezone.utc)
+        if row['expires_at']:
+            if row['expires_at'] < now.date():
+                continue
+        elif not row['standing']:
+            duration = dt.timedelta(days=14 if row['side']=='ask' else 60)
+            if row['posted_at']+duration <= now:
+                # Self-quotes renew undated cards in the UI. Check that live
+                # signal before skipping a notice whose original date is old.
+                sources=tweet_context.clickhouse_source.get('bulletin-sources',ids=row['tweet_id'],enrich='true')['data']
+                renewed=sources[0].get('renewed_at') if sources else None
+                if not renewed or dt.datetime.fromisoformat(renewed.replace(' ','T').replace('Z','+00:00')).replace(tzinfo=dt.timezone.utc)+duration <= now:
+                    continue
         seed = current(db, row['tweet_id'])
         if not seed or seed['content_hash'] != row['content_hash']:
             db.execute('DELETE FROM bulletin.decisions WHERE tweet_id=%s', (row['tweet_id'],))

--- a/services/bulletin/resolution.py
+++ b/services/bulletin/resolution.py
@@ -1,0 +1,81 @@
+"""Conservative author-evidenced availability and bounded daily rechecks."""
+import hashlib
+
+import tweet_context
+
+MAX_RECHECKS = 20
+RULES = '''For every positive notice, also return an availability object, for example:
+{"state":"unknown","tweet_id":null,"evidence":null}.
+State must be exactly unknown, open, or resolved.
+A resolved opportunity remains is_notice=true: it was a genuine ask or offer.
+Use resolved only for an explicit statement from the seed's author that this
+specific ask/offer is complete, filled, claimed, cancelled, or no longer available.
+Use open only for an explicit author statement that it remains available or has
+reopened. Use the latest applicable author update when statements conflict.
+The evidence must be an exact substring of the seed or a visible descendant reply
+by that same author, with its tweet_id. For unknown, both fields must be null.
+A thank-you alone, someone offering help, interest, an answer from another person,
+elapsed time, or silence does not establish resolution. Partial uptake does not
+close remaining openings. Jokes, ambiguous gratitude, unrelated replies, and
+quoted posts do not establish availability. Never guess that a request is done.'''
+
+
+def digest(context):
+    return hashlib.sha256(context.text.encode()).hexdigest()
+
+
+def validate(value, seed, context):
+    if not isinstance(value, dict) or value.get('state') not in ('unknown', 'open', 'resolved'):
+        raise ValueError('invalid_availability')
+    state, ident, evidence = value['state'], value.get('tweet_id'), value.get('evidence')
+    if state == 'unknown':
+        if ident is not None or evidence is not None:
+            raise ValueError('unknown_availability_has_evidence')
+        return dict(state=state, tweet_id=None, content_hash=None)
+    row = context.records.get(ident) if isinstance(ident, str) else None
+    if (not row or row['account_id'] != seed['account_id']
+            or not isinstance(evidence, str) or not evidence.strip()
+            or len(evidence) > 1000 or evidence not in row['full_text']):
+        raise ValueError('availability_requires_exact_author_evidence')
+    # A quote or unrelated post by the same author cannot close this notice.
+    node, seen = ident, set()
+    while node != seed['tweet_id']:
+        if node in seen or node not in context.records:
+            raise ValueError('availability_evidence_not_in_reply_tree')
+        seen.add(node)
+        node = context.records[node].get('reply_to_tweet_id')
+    if row['created_at'] < seed['created_at']:
+        raise ValueError('availability_evidence_predates_notice')
+    return dict(state=state, tweet_id=ident,
+        content_hash=context.sources[ident][1])
+
+
+def enqueue_rechecks(db, started, max_seconds, current, clock):
+    """Only daily runs revisit saved notices; all paid work uses the normal queue."""
+    rows = db.execute('''SELECT o.tweet_id,o.context_digest,d.content_hash
+      FROM bulletin.opportunities o JOIN bulletin.decisions d USING(tweet_id)
+      LEFT JOIN bulletin.refresh_requests r ON r.id=d.refresh_request_id
+      WHERE d.status='positive'
+        AND (d.refresh_request_id IS NULL OR r.status IN ('complete','stopped'))
+        AND (o.context_checked_at IS NULL OR o.context_checked_at<now()-interval '1 day')
+        AND (o.standing OR o.expires_at>=CURRENT_DATE
+          OR d.posted_at>=now()-interval '60 days')
+      ORDER BY o.context_checked_at ASC NULLS FIRST,o.tweet_id LIMIT %s''',
+      (MAX_RECHECKS,)).fetchall()
+    prepared = {}
+    for row in rows:
+        if clock()-started > max_seconds:
+            break
+        seed = current(db, row['tweet_id'])
+        if not seed or seed['content_hash'] != row['content_hash']:
+            db.execute('DELETE FROM bulletin.decisions WHERE tweet_id=%s', (row['tweet_id'],))
+            continue
+        context = tweet_context.prepare(db, seed)
+        with db.transaction():
+            db.execute('UPDATE bulletin.opportunities SET context_checked_at=now() WHERE tweet_id=%s',
+                (row['tweet_id'],))
+            if digest(context) != row['context_digest']:
+                db.execute('''UPDATE bulletin.decisions SET status='pending',attempts=0,refresh_request_id=NULL,
+                  last_attempt_at=NULL,updated_at=now() WHERE tweet_id=%s''', (row['tweet_id'],))
+                prepared[row['tweet_id']] = context
+    return prepared

--- a/services/bulletin/test_clickhouse_worker.py
+++ b/services/bulletin/test_clickhouse_worker.py
@@ -98,6 +98,30 @@ class ClickHouseWorkerTests(unittest.TestCase):
         row=self.db.execute('SELECT status,refresh_request_id FROM bulletin.decisions').fetchone()
         self.assertEqual(row,dict(status='pending',refresh_request_id=None))
 
+    def test_resolution_checks_all_due_items_beyond_twenty(self):
+        self.run_worker()
+        self.db.execute('''INSERT INTO bulletin.decisions(tweet_id,account_id,posted_at,content_hash,version,status)
+          SELECT n::text,d.account_id,d.posted_at,d.content_hash,d.version,'positive'
+          FROM bulletin.decisions d CROSS JOIN generate_series(2,27) n WHERE d.tweet_id='1' ''')
+        self.db.execute('''INSERT INTO bulletin.opportunities(tweet_id,content_hash,side,kind,summary,evidence,topics,respond,standing,model)
+          SELECT n::text,o.content_hash,o.side,o.kind,o.summary,o.evidence,o.topics,o.respond,o.standing,o.model
+          FROM bulletin.opportunities o CROSS JOIN generate_series(2,27) n WHERE o.tweet_id='1' ''')
+        prepared=worker.tweet_context.prepare(self.db,self.source)
+        with patch.object(worker.tweet_context,'prepare',return_value=prepared) as check:
+            result=worker.resolution.enqueue_rechecks(self.db,0,900,
+                lambda db,ident:dict(self.source,tweet_id=ident),lambda:0)
+        self.assertEqual((len(result),check.call_count),(26,26))
+
+    def test_expired_ask_is_skipped_unless_renewed_by_self_quote(self):
+        self.run_worker()
+        self.db.execute("UPDATE bulletin.decisions SET posted_at=now()-interval '20 days'")
+        self.db.execute("UPDATE bulletin.opportunities SET side='ask',context_checked_at=NULL,context_digest=NULL")
+        with patch.object(worker.clickhouse_source,'get',return_value={'data':[]}) as fetch:
+            self.assertEqual(worker.resolution.enqueue_rechecks(self.db,0,900,worker.current,lambda:0),{})
+        fetch.assert_called_once_with('bulletin-sources',ids='1',enrich='true')
+        with patch.object(worker.clickhouse_source,'get',return_value={'data':[{'renewed_at':dt.datetime.now(dt.timezone.utc).isoformat()}]}):
+            self.assertEqual(list(worker.resolution.enqueue_rechecks(self.db,0,900,worker.current,lambda:0)),['1'])
+
     def test_invalid_resolution_evidence_does_not_hide_notice(self):
         self.run_worker()
         self.queue_refresh()

--- a/services/bulletin/test_clickhouse_worker.py
+++ b/services/bulletin/test_clickhouse_worker.py
@@ -23,7 +23,7 @@ class ClickHouseWorkerTests(unittest.TestCase):
             raise RuntimeError('Tests require a named local disposable database')
         cls.db.execute('DROP SCHEMA IF EXISTS bulletin CASCADE; DROP SCHEMA IF EXISTS tes CASCADE; DROP SCHEMA public CASCADE; CREATE SCHEMA public')
         cls.db.execute(FIXTURE)
-        for name in ('opportunities','run_history','prompt_versions','clickhouse','refresh_requests'):
+        for name in ('opportunities','run_history','prompt_versions','clickhouse','refresh_requests','resolution_status'):
             cls.db.execute(next((ROOT/'supabase/migrations').glob('*_bulletin_'+name+'.sql')).read_text())
     @classmethod
     def tearDownClass(cls): cls.db.close()
@@ -35,7 +35,8 @@ class ClickHouseWorkerTests(unittest.TestCase):
         text='Happy to help anyone with their Python project; DM me.'
         self.source=dict(tweet_id='1',account_id='10',created_at=self.window[0],updated_at=self.window[0],
           full_text=text,content_hash=hashlib.sha256(text.encode()).hexdigest(),reply_to_tweet_id=None,is_tombstone=0,retweet=False,allowed=True,username='alice')
-        self.label=dict(is_notice=True,side='offer',kind='help',summary='Offers Python help.',evidence='Happy to help',topics=['python'],respond='dm',standing=False,expires_at=None,place=None)
+        self.label=dict(is_notice=True,side='offer',kind='help',summary='Offers Python help.',evidence='Happy to help',topics=['python'],respond='dm',standing=False,expires_at=None,place=None,
+            availability=dict(state='unknown',tweet_id=None,evidence=None))
         self.context_rows=[]
         self.patches=[patch.object(worker.clickhouse_source,'page',side_effect=self.page),
           patch.object(worker.clickhouse_source,'current',side_effect=lambda _:dict(self.source) if self.source else None),
@@ -54,6 +55,57 @@ class ClickHouseWorkerTests(unittest.TestCase):
         self.db.execute("INSERT INTO public.all_account VALUES ('20','bob',false); INSERT INTO public.members VALUES ('20')")
         self.context_rows=[dict(self.source,tweet_id='2',account_id='20',username='bob',
             reply_to_tweet_id='1',full_text='The example project uses Python 3.11.')]
+
+    def test_resolution_persists_and_rechecks_only_changed_context(self):
+        self.context_rows=[dict(self.source,tweet_id='2',reply_to_tweet_id='1',
+            full_text='All places are filled now, thank you.')]
+        self.label['availability']=dict(state='resolved',tweet_id='2',evidence='All places are filled now')
+        result,calls=self.run_worker()
+        self.assertEqual((result['positive'],calls),(1,1))
+        saved=self.db.execute('SELECT * FROM bulletin.opportunities').fetchone()
+        self.assertEqual((saved['resolution_state'],saved['resolution_tweet_id']),('resolved','2'))
+        self.assertEqual(saved['resolution_content_hash'],hashlib.sha256(self.context_rows[0]['full_text'].encode()).hexdigest())
+        # An old seed statement cannot reopen a later author-confirmed closure.
+        self.db.execute("UPDATE bulletin.decisions SET status='pending',attempts=0,last_attempt_at=NULL")
+        self.label['availability']=dict(state='open',tweet_id='1',evidence='Happy to help')
+        self.run_worker()
+        self.assertEqual(self.db.execute('SELECT resolution_state FROM bulletin.opportunities').fetchone()['resolution_state'],'resolved')
+        self.db.execute("UPDATE bulletin.opportunities SET context_checked_at=now()-interval '2 days'")
+        prepared=worker.resolution.enqueue_rechecks(self.db,0,900,worker.current,lambda:0)
+        self.assertEqual(prepared,{})
+        self.assertEqual(self.db.execute('SELECT status FROM bulletin.decisions').fetchone()['status'],'positive')
+        self.context_rows.append(dict(self.source,tweet_id='3',reply_to_tweet_id='1',
+            full_text='One place has reopened. Still available!',created_at=self.source['created_at']+dt.timedelta(hours=2)))
+        self.db.execute("UPDATE bulletin.opportunities SET context_checked_at=now()-interval '2 days'")
+        self.label['availability']=dict(state='open',tweet_id='3',evidence='One place has reopened')
+        with patch.object(worker,'intake',return_value=True),patch.object(worker,'call_model',side_effect=self.response) as model:
+            result=worker.run(self.db)
+        self.assertEqual((result['positive'],model.call_count,result['resolution_rechecks_queued']),(1,1,1))
+        self.assertEqual(self.db.execute('SELECT resolution_state FROM bulletin.opportunities').fetchone()['resolution_state'],'open')
+
+    def test_completed_refresh_notices_can_join_daily_resolution_queue(self):
+        self.run_worker()
+        request=self.queue_refresh()
+        self.run_refresh()
+        self.assertEqual(self.db.execute('SELECT status FROM bulletin.refresh_requests').fetchone()['status'],'complete')
+        self.context_rows=[dict(self.source,tweet_id='2',reply_to_tweet_id='1',full_text='All filled now.')]
+        self.db.execute("UPDATE bulletin.opportunities SET context_checked_at=now()-interval '2 days'")
+        self.db.execute("UPDATE bulletin.refresh_requests SET status='running' WHERE id=%s",(request,))
+        self.assertEqual(worker.resolution.enqueue_rechecks(self.db,0,900,worker.current,lambda:0),{})
+        self.db.execute("UPDATE bulletin.refresh_requests SET status='complete' WHERE id=%s",(request,))
+        prepared=worker.resolution.enqueue_rechecks(self.db,0,900,worker.current,lambda:0)
+        self.assertEqual(list(prepared),['1'])
+        row=self.db.execute('SELECT status,refresh_request_id FROM bulletin.decisions').fetchone()
+        self.assertEqual(row,dict(status='pending',refresh_request_id=None))
+
+    def test_invalid_resolution_evidence_does_not_hide_notice(self):
+        self.run_worker()
+        self.queue_refresh()
+        self.add_context_reply()
+        self.label['availability']=dict(state='resolved',tweet_id='2',evidence='Python 3.11')
+        result,calls=self.run_refresh()
+        self.assertEqual((result['status'],calls),('classification_failed',1))
+        self.assertEqual(self.db.execute('SELECT resolution_state FROM bulletin.opportunities').fetchone()['resolution_state'],'unknown')
 
     def test_automated_call_uses_attributed_plaintext_context(self):
         self.add_context_reply()

--- a/services/bulletin/test_resolution.py
+++ b/services/bulletin/test_resolution.py
@@ -1,0 +1,48 @@
+"""Strict resolution provenance, independent of model quality."""
+import datetime as dt
+import unittest
+import resolution
+from tweet_context import PreparedContext, fingerprint
+
+
+class ResolutionTests(unittest.TestCase):
+    def setUp(self):
+        now = dt.datetime(2026, 9, 11, tzinfo=dt.timezone.utc)
+        self.seed = dict(tweet_id='1', account_id='10', full_text='Who wants a spare ticket?', created_at=now)
+        self.reply = dict(tweet_id='2', account_id='10', full_text='All claimed now, thanks!',
+            reply_to_tweet_id='1', created_at=now+dt.timedelta(hours=1))
+        self.records = {'1': self.seed, '2': self.reply}
+        self.context = PreparedContext('context', {i:fingerprint(r) for i,r in self.records.items()}, self.records)
+        self.value = dict(state='resolved',tweet_id='2',evidence='All claimed now')
+
+    def test_exact_author_reply_can_resolve_or_reopen(self):
+        self.assertEqual(resolution.validate(self.value,self.seed,self.context)['state'],'resolved')
+        self.value.update(state='open',evidence='Still available')
+        self.reply['full_text']='Still available, looking for a taker.'
+        self.context.sources['2']=fingerprint(self.reply)
+        self.assertEqual(resolution.validate(self.value,self.seed,self.context)['state'],'open')
+
+    def test_other_participants_and_quotes_cannot_resolve_seed(self):
+        self.reply['account_id']='20'
+        with self.assertRaisesRegex(ValueError,'author_evidence'):
+            resolution.validate(self.value,self.seed,self.context)
+        self.reply['account_id']='10'
+        self.reply['reply_to_tweet_id']=None
+        with self.assertRaisesRegex(ValueError,'reply_tree'):
+            resolution.validate(self.value,self.seed,self.context)
+
+    def test_invented_evidence_unknown_and_missing_output(self):
+        self.value['evidence']='The role is filled'
+        with self.assertRaisesRegex(ValueError,'exact_author_evidence'):
+            resolution.validate(self.value,self.seed,self.context)
+        with self.assertRaisesRegex(ValueError,'invalid_availability'):
+            resolution.validate(None,self.seed,self.context)
+        self.assertEqual(resolution.validate(dict(state='unknown',tweet_id=None,evidence=None),
+            self.seed,self.context),dict(state='unknown',tweet_id=None,content_hash=None))
+
+    def test_prompt_rejects_ambiguous_uptake_and_keeps_resolved_notices(self):
+        for rule in ['remains is_notice=true','thank-you alone','Partial uptake','latest applicable author update']:
+            self.assertIn(rule,resolution.RULES)
+
+
+if __name__ == '__main__': unittest.main()

--- a/services/bulletin/test_tweet_context.py
+++ b/services/bulletin/test_tweet_context.py
@@ -116,6 +116,10 @@ class TweetContextTests(unittest.TestCase):
     def test_contract_keeps_joke_exclusion_and_seed_evidence(self):
         prepared = context.prepare(self.db, self.seed)
         body = worker.request_body(self.seed, SYSTEM, prepared)
+        self.assertEqual(json.loads(body)['provider'], {
+            'allow_fallbacks': True, 'require_parameters': True,
+            'max_price': {'prompt': 0.15, 'completion': 0.50},
+        })
         messages = json.loads(body)['messages']
         self.assertEqual(messages[0]['content'], SYSTEM)
         self.assertIn('Keep excluding jokes', messages[1]['content'])

--- a/services/bulletin/tweet_context.py
+++ b/services/bulletin/tweet_context.py
@@ -1,5 +1,5 @@
 """Policy-safe prompt context using the pinned tweet-plaintext skill helpers."""
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import hashlib
 import os
 from pathlib import Path
@@ -35,6 +35,7 @@ reply, or quoted tweet. Missing context is unknown, not proof of deletion or res
 class PreparedContext:
     text: str
     sources: dict[str, tuple[str, str]]
+    records: dict = field(default_factory=dict)
 
 
 def fingerprint(row):
@@ -72,7 +73,9 @@ def prepare(db, seed):
         records, primary, _ = plaintext.normalize_payload([seed])
         notes.append('Cached seed differs or is absent; reply/quote context omitted.')
     ids, missing = plaintext.select_context(records, primary, seed_id, 'radius', 2)
-    # Prefer the author's clarifications, retaining stable order within each group.
+    # Prefer the author's newest clarifications; the renderer restores parent
+    # order. Old discussion must not crowd out a recent resolution/reopening.
+    ids.sort(key=lambda ident: str(records[ident].get('created_at') or ''), reverse=True)
     ids.sort(key=lambda ident: (ident != seed_id,
         str(records[ident].get('account_id')) != str(seed['account_id'])))
     if len(ids) > MAX_TWEETS:
@@ -109,8 +112,9 @@ def prepare(db, seed):
                 break
     text, omitted = plaintext.render_context(safe, list(safe), seed_id,
         max_characters=MAX_CHARACTERS, notes=list(dict.fromkeys(notes)))
-    return PreparedContext(text, {ident: fingerprint(safe[ident])
-        for ident in safe if ident not in omitted})
+    printed = {ident: safe[ident] for ident in safe if ident not in omitted}
+    return PreparedContext(text, {ident: fingerprint(row)
+        for ident, row in printed.items()}, printed)
 
 
 def still_current(db, prepared):

--- a/services/bulletin/worker.py
+++ b/services/bulletin/worker.py
@@ -24,9 +24,10 @@ from labels import validate_label
 import upstream_filter as upstream
 import clickhouse_source
 import tweet_context
+import resolution
 
 MODEL = 'z-ai/glm-5.3-flash'
-VERSION = 'bulletin-143dc2d-v2-context'
+VERSION = 'bulletin-143dc2d-v3-resolution'
 DAY_BUDGET = Decimal('0.10')
 MONTH_BUDGET = Decimal('1.00')
 MAX_OUTPUT = 2048
@@ -172,7 +173,7 @@ def request_body(tweet, prompt, context):
     payload={'author':'@'+tweet['username'],'posted_at':tweet['created_at'].isoformat(),
         'text':tweet['full_text'], 'context':context.text}
     return json.dumps({'model':MODEL,'messages':[{'role':'system','content':prompt},
-        {'role':'system','content':tweet_context.CONTEXT_RULES},
+        {'role':'system','content':tweet_context.CONTEXT_RULES+'\n'+resolution.RULES},
         {'role':'user','content':json.dumps(payload,ensure_ascii=False)}],
         'response_format':{'type':'json_object'},'max_tokens':MAX_OUTPUT,
         'reasoning':{'effort':'low'},
@@ -229,7 +230,7 @@ def actual_cost(result):
     return cost if cost.is_finite() and cost>=0 else None
 
 
-def publish(db, job, label, context):
+def publish(db, job, label, context, availability=None):
     with db.transaction():
         source=current(db,job['tweet_id'],lock=True)
         if not source or source['content_hash']!=job['content_hash']:
@@ -255,6 +256,25 @@ def publish(db, job, label, context):
               (job['tweet_id'],job['content_hash'],label['side'],label['kind'],label['summary'],
                label['evidence'],label['topics'],label['respond'],label['standing'],
                label['expires_at'],label['place'],MODEL))
+            availability = availability or dict(state='unknown',tweet_id=None,content_hash=None)
+            previous=db.execute('SELECT resolution_tweet_id FROM bulletin.opportunities WHERE tweet_id=%s',
+                (job['tweet_id'],)).fetchone()
+            # Tweet IDs are chronological snowflakes. Truncated context must
+            # not let an older "still available" override a newer resolution.
+            if (availability['state']!='unknown' and previous['resolution_tweet_id']
+                    and int(availability['tweet_id'])<int(previous['resolution_tweet_id'])):
+                availability=dict(state='unknown',tweet_id=None,content_hash=None)
+            # Unknown is not evidence that a confirmed resolution has reopened.
+            # Its existing evidence is still verified on every board read.
+            db.execute('''UPDATE bulletin.opportunities SET
+              context_digest=%s,context_checked_at=now(),
+              resolution_state=CASE WHEN %s='unknown' THEN resolution_state ELSE %s END,
+              resolution_tweet_id=CASE WHEN %s='unknown' THEN resolution_tweet_id ELSE %s END,
+              resolution_content_hash=CASE WHEN %s='unknown' THEN resolution_content_hash ELSE %s END
+              WHERE tweet_id=%s''',
+              (resolution.digest(context),availability['state'],availability['state'],
+               availability['state'],availability['tweet_id'],
+               availability['state'],availability['content_hash'],job['tweet_id']))
         else:
             db.execute('DELETE FROM bulletin.opportunities WHERE tweet_id=%s',(job['tweet_id'],))
     return True
@@ -314,6 +334,9 @@ def run(db, limit=MAX_CALLS, enqueue_only=False, window=None, backfill_budget=No
         if not enqueue_only and complete:
             if not os.environ.get('OPENROUTER_API_KEY'):
                 raise RuntimeError('missing_model_key')
+            contexts = (resolution.enqueue_rechecks(db,started,MAX_SECONDS,current,time.monotonic)
+                if window is None and refresh is None else {})
+            counts['resolution_rechecks_queued'] = len(contexts)
             retry_delay=dt.timedelta(minutes=1 if backfill_budget is not None else 60)
             jobs=deque(db.execute('''SELECT * FROM bulletin.decisions WHERE status IN ('pending','failed')
               AND refresh_request_id IS NOT DISTINCT FROM %s::uuid
@@ -330,7 +353,9 @@ def run(db, limit=MAX_CALLS, enqueue_only=False, window=None, backfill_budget=No
                     db.execute('DELETE FROM bulletin.decisions WHERE tweet_id=%s',(job['tweet_id'],))
                     counts['suppressed']+=1;continue
                 try:
-                    context=tweet_context.prepare(db,source)
+                    context=contexts.pop(job['tweet_id'],None)
+                    if context is None or not tweet_context.still_current(db,context):
+                        context=tweet_context.prepare(db,source)
                 except Exception as exc:
                     log_failure(exc,run_id=run_id,stage='context_preparation')
                     raise
@@ -354,9 +379,12 @@ def run(db, limit=MAX_CALLS, enqueue_only=False, window=None, backfill_budget=No
                     choice=result['choices'][0]
                     if choice.get('finish_reason')!='stop':
                         raise ValueError('incomplete_output')
-                    label=validate_label(json.loads(choice['message']['content']),{'text':source['full_text']})
+                    raw_label=json.loads(choice['message']['content'])
+                    label=validate_label(raw_label,{'text':source['full_text']})
+                    availability=(resolution.validate(raw_label.get('availability'),source,context)
+                        if label['is_notice'] else None)
                     stage='publish'
-                    stored=publish(db,job,label,context)
+                    stored=publish(db,job,label,context,availability)
                     counts['positive' if label['is_notice'] else 'negative']+=int(stored)
                     counts['suppressed']+=int(not stored)
                     db.execute('UPDATE bulletin.calls SET status=%s WHERE id=%s',

--- a/services/bulletin/worker.py
+++ b/services/bulletin/worker.py
@@ -177,7 +177,7 @@ def request_body(tweet, prompt, context):
         {'role':'user','content':json.dumps(payload,ensure_ascii=False)}],
         'response_format':{'type':'json_object'},'max_tokens':MAX_OUTPUT,
         'reasoning':{'effort':'low'},
-        'provider':{'allow_fallbacks':False,'require_parameters':True,
+        'provider':{'allow_fallbacks':True,'require_parameters':True,
           'max_price':{'prompt':0.15,'completion':0.50}}},ensure_ascii=False).encode()
 
 

--- a/src/app/api/bulletin/board/route.ts
+++ b/src/app/api/bulletin/board/route.ts
@@ -29,6 +29,7 @@ export async function GET(request: Request) {
           side,
           search,
           past: p.get('past') === '1',
+          resolved: p.get('resolved') === '1',
           recommended: p.get('sort') !== 'newest',
           ascending: p.get('dir') === 'asc',
         },

--- a/src/app/bulletin/about/page.tsx
+++ b/src/app/bulletin/about/page.tsx
@@ -53,6 +53,20 @@ export default function BulletinAboutPage() {
           </p>
         </section>
         <section>
+          <h2 className="text-base font-semibold text-foreground">
+            Resolved notices
+          </h2>
+          <p className="mt-2">
+            An explicit author update can mark a notice resolved—for example,
+            when a role is filled or an item is claimed. Replies, thank-yous, or
+            silence alone do not mean it is resolved. These notices stay
+            available under &quot;Show resolved&quot;; their badge links to the
+            author update. An explicit reopening can return them to the board.
+            Checks are periodic and use available archived replies, so updates
+            may take time to appear.
+          </p>
+        </section>
+        <section>
           <h2 className="text-base font-semibold text-foreground">Ordering</h2>
           <p className="mt-2">
             Relevance puts your own notices first, then people you reply to and

--- a/src/components/bulletin/BulletinBoard.module.css
+++ b/src/components/bulletin/BulletinBoard.module.css
@@ -491,6 +491,17 @@
   text-decoration: underline;
   text-underline-offset: 2px;
 }
+.resolvedPill {
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  padding: 1px 6px;
+  font-size: 10px;
+  font-weight: 600;
+  text-decoration: none;
+}
+.resolvedPill:hover {
+  text-decoration: underline;
+}
 .newPill {
   flex-shrink: 0;
   border-radius: 999px;

--- a/src/components/bulletin/BulletinBoard.test.tsx
+++ b/src/components/bulletin/BulletinBoard.test.tsx
@@ -164,6 +164,33 @@ test('past toggle includes expired notices and preserves filters in the URL', ()
   expect(screen.getByText('Help with Python')).toBeInTheDocument()
   expect(screen.getByText('ended Sep 1')).toBeInTheDocument()
 })
+test('resolved notices have their own toggle and link to the author evidence', () => {
+  render(
+    <BulletinBoard
+      notices={[
+        {
+          ...offer,
+          resolution_state: 'resolved',
+          resolution_tweet_id: '987',
+          expires_at: '2026-01-01',
+        },
+      ]}
+      now={Date.parse('2026-09-09T00:00:00Z')}
+    />,
+  )
+  expect(screen.getByRole('status')).toHaveTextContent('0 notices')
+  fireEvent.click(screen.getByLabelText('Show past notices'))
+  expect(screen.getByRole('status')).toHaveTextContent('0 notices')
+  fireEvent.click(screen.getByLabelText('Show resolved notices'))
+  expect(screen.getByRole('status')).toHaveTextContent('1 notice')
+  expect(window.location.hash).toContain('resolved=1')
+  expect(screen.getByRole('link', { name: 'Resolved' })).toHaveAttribute(
+    'href',
+    `https://x.com/${offer.username}/status/987`,
+  )
+  fireEvent.click(screen.getByLabelText('Show resolved notices'))
+  expect(screen.getByRole('status')).toHaveTextContent('0 notices')
+})
 test('shows the ledger and relationship words only from own account and outgoing counts', () => {
   render(
     <BulletinBoard

--- a/src/components/bulletin/BulletinBoard.tsx
+++ b/src/components/bulletin/BulletinBoard.tsx
@@ -38,6 +38,8 @@ import {
 import {
   expiry,
   isPast,
+  isResolved,
+  visibleStatus,
   relationship,
   sortNotices,
   uptake,
@@ -219,6 +221,7 @@ function NoticeCard({
     rts: 0,
   }
   const past = isPast(notice, now)
+  const resolved = isResolved(notice)
   const postAge = now - Date.parse(notice.posted_at)
   const isNew = postAge >= 0 && postAge < 24 * 60 * 60 * 1000
   const tweetUrl = `https://twitter.com/${encodeURIComponent(notice.username)}/status/${notice.tweet_id}`
@@ -245,7 +248,18 @@ function NoticeCard({
         <KindIcon kind={notice.kind} size={13} />
         {cardLabel(notice)}
       </button>
-      {isNew && (
+      {resolved && (
+        <a
+          className={styles.resolvedPill}
+          href={`https://x.com/${encodeURIComponent(notice.username)}/status/${notice.resolution_tweet_id || notice.tweet_id}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          title="Resolved based on an author update. Open the evidence on X."
+        >
+          Resolved
+        </a>
+      )}
+      {isNew && !resolved && (
         <span
           className={styles.newPill}
           title="Posted within the last 24 hours"
@@ -259,7 +273,7 @@ function NoticeCard({
   )
   return (
     <article
-      className={`${styles.notice} ${past ? styles.past : ''} ${open ? styles.open : ''}`}
+      className={`${styles.notice} ${past || resolved ? styles.past : ''} ${open ? styles.open : ''}`}
       style={{ order }}
       onClick={(event) => {
         if (open) return
@@ -467,12 +481,13 @@ export function BulletinBoard({
   const kind = kindKey(kinds)
   const [search, setSearch] = useState('')
   const [past, setPast] = useState(false)
+  const [resolved, setResolved] = useState(false)
   const [recommended, setRecommended] = useState(true)
   const [ascending, setAscending] = useState(false)
   const [hydrated, setHydrated] = useState(false)
   const pages = useBoardPages(
     initialPage,
-    { kind, side, search, past, recommended, ascending },
+    { kind, side, search, past, resolved, recommended, ascending },
     hydrated,
     Object.values(expanded).some(Boolean),
   )
@@ -496,6 +511,7 @@ export function BulletinBoard({
       ['ask', 'offer'].includes(p.get('side') || '') ? p.get('side')! : 'all',
     )
     setPast(p.get('past') === '1')
+    setResolved(p.get('resolved') === '1')
     setRecommended(p.get('sort') !== 'newest')
     setAscending(p.get('dir') === 'asc')
     setHydrated(true)
@@ -506,6 +522,7 @@ export function BulletinBoard({
     if (kind !== 'all') p.set('kind', kind)
     if (side !== 'all') p.set('side', side)
     if (past) p.set('past', '1')
+    if (resolved) p.set('resolved', '1')
     if (!recommended) p.set('sort', 'newest')
     if (ascending) p.set('dir', 'asc')
     window.history.replaceState(
@@ -515,10 +532,10 @@ export function BulletinBoard({
         window.location.search +
         (p.toString() ? '#' + p.toString() : ''),
     )
-  }, [kind, side, past, recommended, ascending, hydrated])
+  }, [kind, side, past, resolved, recommended, ascending, hydrated])
   const needle = search.trim().toLowerCase()
   const matches = (o: Notice) =>
-    (past || !isPast(o, now)) &&
+    visibleStatus(o, now, past, resolved) &&
     [o.summary, o.preview_text, o.username, o.place, ...o.topics]
       .filter(Boolean)
       .join(' ')
@@ -545,6 +562,7 @@ export function BulletinBoard({
       kind,
       side,
       past,
+      resolved,
       needle,
       recommended,
       ascending,
@@ -556,7 +574,7 @@ export function BulletinBoard({
   useEffect(() => {
     setLimit(BULLETIN_PAGE_SIZE)
     setExpanded({})
-  }, [kind, side, needle, past, recommended, ascending])
+  }, [kind, side, needle, past, resolved, recommended, ascending])
   // Counts under the other dimension's filter: server-provided when paging
   // server-side, otherwise derived from the notices in hand.
   const count = (key: string) => {
@@ -693,6 +711,15 @@ export function BulletinBoard({
             />
             Show past
           </label>
+          <label className={styles.pastToggle}>
+            <input
+              type="checkbox"
+              aria-label="Show resolved notices"
+              checked={resolved}
+              onChange={(e) => setResolved(e.target.checked)}
+            />
+            Show resolved
+          </label>
           <div className={styles.sortLinks} role="group" aria-label="Sort">
             <button
               type="button"
@@ -792,7 +819,7 @@ export function BulletinBoard({
           ? cursor && !pages.loading[kind] && !pages.laneErrors[kind]
           : visible.length > limit) && (
           <ScrollMore
-            key={`${kind}:${side}:${needle}:${past}:${recommended}`}
+            key={`${kind}:${side}:${needle}:${past}:${resolved}:${recommended}`}
             count={shown}
             onMore={() =>
               initialPage

--- a/src/components/bulletin/useBoardPages.ts
+++ b/src/components/bulletin/useBoardPages.ts
@@ -12,6 +12,7 @@ function filterKey(filters: BulletinFilters) {
     filters.side,
     filters.search.trim(),
     filters.past,
+    filters.resolved,
     filters.recommended,
     filters.ascending,
   ])
@@ -22,6 +23,7 @@ function query(filters: BulletinFilters) {
     side: filters.side,
     q: filters.search.trim(),
     past: filters.past ? '1' : '0',
+    resolved: filters.resolved ? '1' : '0',
     sort: filters.recommended ? 'recommended' : 'newest',
     dir: filters.ascending ? 'asc' : 'desc',
   })

--- a/src/lib/bulletin/board.ts
+++ b/src/lib/bulletin/board.ts
@@ -18,6 +18,17 @@ export function isPast(notice: Notice, now: number) {
   const until = expiry(notice)
   return until !== null && until <= now
 }
+export function isResolved(notice: Notice) {
+  return notice.resolution_state === 'resolved'
+}
+export function visibleStatus(
+  notice: Notice,
+  now: number,
+  past: boolean,
+  resolved: boolean,
+) {
+  return isResolved(notice) ? resolved : past || !isPast(notice, now)
+}
 /** Public replies plus quote posts by archived members, once hydrated. */
 export function uptake(notice: Notice): number | null {
   if (notice.replies === undefined && notice.quotes === undefined) return null
@@ -64,6 +75,7 @@ export function sortNotices(
     b.tweet_id.localeCompare(a.tweet_id)
   return [...notices].sort(
     (a, b) =>
+      Number(isResolved(a)) - Number(isResolved(b)) ||
       Number(isPast(a, now)) - Number(isPast(b, now)) ||
       (ascending ? -inner(a, b) : inner(a, b)),
   )

--- a/src/lib/bulletin/data.test.ts
+++ b/src/lib/bulletin/data.test.ts
@@ -78,6 +78,47 @@ test('run history always requires admin authorization', async () => {
   await expect(loadRunDashboard()).rejects.toThrow('not authorized')
   expect(rpc).not.toHaveBeenCalled()
 })
+test.each(['valid', 'edited', 'missing', 'other-author'])(
+  'resolution evidence is verified before default filtering: %s',
+  async (state) => {
+    jest.mocked(getCurrentUser).mockResolvedValue({ id: 'member' } as User)
+    rpc.mockResolvedValue({
+      data: [
+        {
+          tweet_id: '1',
+          account_id: '10',
+          resolution_state: 'resolved',
+          resolution_tweet_id: '2',
+          resolution_content_hash: createHash('sha256')
+            .update('All claimed.')
+            .digest('hex'),
+        },
+      ],
+      error: null,
+    })
+    jest.mocked(fetchAnalyticsGatewayJson).mockResolvedValue({
+      data:
+        state === 'missing'
+          ? []
+          : [
+              {
+                tweet_id: '2',
+                account_id: state === 'other-author' ? '20' : '10',
+                full_text:
+                  state === 'edited' ? 'Still available.' : 'All claimed.',
+              },
+            ],
+    })
+    const result = await loadBulletinBoardState()
+    expect(result.notices[0].resolution_state).toBe(
+      state === 'valid' ? 'resolved' : 'unknown',
+    )
+    expect(fetchAnalyticsGatewayJson).toHaveBeenCalledWith(
+      ['bulletin-sources'],
+      new URLSearchParams({ ids: '2' }),
+    )
+  },
+)
 
 test.each([
   { data: null, error: null },

--- a/src/lib/bulletin/data.ts
+++ b/src/lib/bulletin/data.ts
@@ -102,6 +102,8 @@ export async function hydrateBulletinNotices({
         quotes: source.quotes,
         reply_account_ids: source.reply_account_ids,
         renewed_at: source.renewed_at ? utc(source.renewed_at) : null,
+        resolution_state: notice.resolution_state,
+        resolution_tweet_id: notice.resolution_tweet_id,
       })
     }
   }
@@ -252,5 +254,43 @@ export async function loadBulletinBoardState(): Promise<{
     { max_results: BULLETIN_LIMIT },
   )
   if (error) throw new Error('Bulletin notices could not be loaded')
-  return { notices: (data ?? []) as unknown as StoredNotice[] }
+  const notices = (data ?? []) as unknown as StoredNotice[]
+  // Verify resolution evidence even for notices hidden by the default filter.
+  // A deleted/edited update must not leave a notice silently hidden forever.
+  const resolved = notices.filter((o) => o.resolution_state === 'resolved')
+  for (let offset = 0; offset < resolved.length; offset += 100) {
+    const batch = resolved.slice(offset, offset + 100)
+    const ids = Array.from(
+      new Set(
+        batch
+          .map((o) => o.resolution_tweet_id)
+          .filter((id): id is string => !!id && /^\d{1,20}$/.test(id)),
+      ),
+    )
+    const sources = ids.length
+      ? (
+          await fetchAnalyticsGatewayJson<{
+            data: Array<{
+              tweet_id: string
+              account_id: string
+              full_text: string
+            }>
+          }>(['bulletin-sources'], new URLSearchParams({ ids: ids.join(',') }))
+        ).data
+      : []
+    const byId = new Map(sources.map((o) => [o.tweet_id, o]))
+    for (const notice of batch) {
+      const evidence = byId.get(notice.resolution_tweet_id || '')
+      if (
+        !evidence ||
+        evidence.account_id !== notice.account_id ||
+        createHash('sha256').update(evidence.full_text).digest('hex') !==
+          notice.resolution_content_hash
+      ) {
+        notice.resolution_state = 'unknown'
+        notice.resolution_tweet_id = null
+      }
+    }
+  }
+  return { notices }
 }

--- a/src/lib/bulletin/page.test.ts
+++ b/src/lib/bulletin/page.test.ts
@@ -46,14 +46,12 @@ beforeEach(() => {
     outgoing: {},
     available: false,
   })
-  jest
-    .mocked(loadBulletinViewer)
-    .mockResolvedValue({
-      account_id: '42',
-      username: 'alice',
-      outgoing: {},
-      available: false,
-    })
+  jest.mocked(loadBulletinViewer).mockResolvedValue({
+    account_id: '42',
+    username: 'alice',
+    outgoing: {},
+    available: false,
+  })
   jest.mocked(hydrateBulletinNotices).mockImplementation(async ({ notices }) =>
     notices.map(({ content_hash, ...o }) => ({
       ...o,
@@ -62,6 +60,29 @@ beforeEach(() => {
   )
 })
 afterEach(() => jest.restoreAllMocks())
+test('resolved notices are hidden by default and independently included even when expired', async () => {
+  jest
+    .mocked(loadBulletinBoardState)
+    .mockResolvedValue({
+      notices: [
+        notice(1),
+        {
+          ...notice(2),
+          resolution_state: 'resolved',
+          resolution_tweet_id: '3',
+          expires_at: '2026-01-01',
+        },
+      ],
+    })
+  const normal = await loadBulletinPage(filters)
+  expect(normal.notices.map((o) => o.tweet_id)).toEqual(['1'])
+  expect(normal.counts.help).toBe(1)
+  const pastOnly = await loadBulletinPage({ ...filters, past: true })
+  expect(pastOnly.notices.map((o) => o.tweet_id)).toEqual(['1'])
+  const resolved = await loadBulletinPage({ ...filters, resolved: true })
+  expect(resolved.notices.map((o) => o.tweet_id)).toEqual(['1', '2'])
+  expect(resolved.counts.help).toBe(2)
+})
 test('hydrates only one page of sources, keeps metadata private, and advances a single cursor', async () => {
   expect(BULLETIN_PAGE_SIZE).toBe(18)
   const first = await loadBulletinPage(filters)

--- a/src/lib/bulletin/page.ts
+++ b/src/lib/bulletin/page.ts
@@ -6,7 +6,7 @@ import {
   loadBulletinViewer,
   type StoredNotice,
 } from './data'
-import { isPast, sortNotices } from './board'
+import { isPast, sortNotices, visibleStatus } from './board'
 import {
   BULLETIN_PAGE_SIZE,
   KIND_LABELS,
@@ -74,7 +74,7 @@ export async function loadBulletinPage(
   const live = (o: StoredNotice): Notice => verified.get(o.tweet_id) || o
   const shown = (o: Notice) =>
     !rejected.has(o.tweet_id) &&
-    (filters.past || !isPast(o, now)) &&
+    visibleStatus(o, now, filters.past, filters.resolved) &&
     matches(o, search)
 
   // Select the first page from metadata order, then verify it against the
@@ -90,7 +90,9 @@ export async function loadBulletinPage(
     filters.ascending,
     false, // Live uptake ranks loaded cards in the client, never a partial server cursor.
   )
-  const active = metadataOrder.filter((o) => filters.past || !isPast(o, now))
+  const active = metadataOrder.filter((o) =>
+    visibleStatus(o, now, filters.past, filters.resolved),
+  )
   const start = after ? active.findIndex((o) => o.tweet_id === after) + 1 : 0
   const first = active.slice(start, start + BULLETIN_PAGE_SIZE)
   const preflight = new Map(

--- a/src/lib/bulletin/types.ts
+++ b/src/lib/bulletin/types.ts
@@ -15,6 +15,9 @@ export type Notice = Omit<
   quotes?: number
   reply_account_ids?: string[]
   renewed_at?: string | null
+  resolution_state?: 'unknown' | 'open' | 'resolved'
+  resolution_tweet_id?: string | null
+  resolution_content_hash?: string | null
 }
 export type RunCounts = Partial<
   Record<
@@ -152,6 +155,7 @@ export type BulletinFilters = {
   side: string
   search: string
   past: boolean
+  resolved: boolean
   recommended: boolean
   ascending: boolean
 }
@@ -184,6 +188,7 @@ export const DEFAULT_BULLETIN_FILTERS: BulletinFilters = {
   side: 'all',
   search: '',
   past: false,
+  resolved: false,
   recommended: true,
   ascending: false,
 }

--- a/supabase/migrations/20260911222035_bulletin_resolution_status.sql
+++ b/supabase/migrations/20260911222035_bulletin_resolution_status.sql
@@ -1,0 +1,17 @@
+-- Private derived availability: retain only a source ID/hash, not reply text.
+ALTER TABLE bulletin.opportunities
+  ADD COLUMN resolution_state text NOT NULL DEFAULT 'unknown'
+    CHECK (resolution_state IN ('unknown','open','resolved')),
+  ADD COLUMN resolution_tweet_id text,
+  ADD COLUMN resolution_content_hash text,
+  ADD COLUMN context_digest text,
+  ADD COLUMN context_checked_at timestamptz,
+  ADD CONSTRAINT bulletin_resolution_evidence CHECK (
+    (resolution_state='unknown' AND resolution_tweet_id IS NULL AND resolution_content_hash IS NULL)
+    OR (resolution_state IN ('open','resolved') AND resolution_tweet_id ~ '^[0-9]{1,20}$'
+      AND resolution_content_hash ~ '^[0-9a-f]{64}$'
+      AND resolution_tweet_id IS NOT NULL AND resolution_content_hash IS NOT NULL));
+CREATE INDEX bulletin_resolution_recheck_idx
+  ON bulletin.opportunities(context_checked_at NULLS FIRST,tweet_id);
+-- get_bulletin_board_state already returns o.* as JSON. Existing private RLS
+-- and service-role grants apply; there is no new browser-accessible RPC.

--- a/supabase/schemas/020_tables.sql
+++ b/supabase/schemas/020_tables.sql
@@ -673,8 +673,21 @@ CREATE TABLE bulletin.opportunities (
   expires_at date,
   place text,
   model text NOT NULL,
+  resolution_state text NOT NULL DEFAULT 'unknown'
+    CHECK (resolution_state IN ('unknown','open','resolved')),
+  resolution_tweet_id text,
+  resolution_content_hash text,
+  context_digest text,
+  context_checked_at timestamptz,
+  CONSTRAINT bulletin_resolution_evidence CHECK (
+    (resolution_state='unknown' AND resolution_tweet_id IS NULL AND resolution_content_hash IS NULL)
+    OR (resolution_state IN ('open','resolved') AND resolution_tweet_id ~ '^[0-9]{1,20}$'
+      AND resolution_content_hash ~ '^[0-9a-f]{64}$'
+      AND resolution_tweet_id IS NOT NULL AND resolution_content_hash IS NOT NULL)),
   created_at timestamptz NOT NULL DEFAULT now()
 );
+CREATE INDEX bulletin_resolution_recheck_idx
+  ON bulletin.opportunities(context_checked_at NULLS FIRST,tweet_id);
 
 -- Usage survives tweet deletion; it contains no tweet IDs, text or author data.
 CREATE TABLE bulletin.calls (


### PR DESCRIPTION
Bulletin notices remain visible after an author says they are filled or claimed. Track author-evidenced availability and hide confirmed resolved notices by default. A separate Show resolved toggle displays them with an evidence link; an explicit reopening restores visibility.

Positive labels include availability. Evidence must be an exact substring of the seed or a descendant reply by the same author. Jokes, generic thanks, other people's interest, silence, and partial uptake do not establish closure. Unknown or older evidence cannot overwrite a newer confirmed update. Store only status and evidence ID/hash, and verify current evidence before hiding a notice.

Daily runs check all active saved notices not checked that UTC day, using the board's lifetime and renewal rules. Unchanged context costs no model call; changed context joins the normal queue. Existing spending, model-call, retry and time limits remain. Reply discovery is limited to available archive context and may be cached for an hour. Rechecks include completed admin refreshes without taking over running jobs.

Allow fallback between providers of the same model, retaining parameter requirements and the existing price ceilings. The production pilot reproduced HTTP 429 with fallback disabled; with fallback enabled, three requests succeeded via Relace, Together and Parasail. An author reply reading “Resolved” correctly closed its parent request. Two additional negative controls (a joke and a narrative) were correctly rejected. Actual cost for all five successful pilot calls was $0.001064114.

Validation: 47 focused Python and 58 focused frontend/server tests passed for the feature. Four targeted database checks cover all-active scheduling, renewal and refresh ownership; ten context tests cover request routing and rendering. TypeScript, scoped ESLint, candidate-filter snapshot and diff checks passed. No browser visual verification.

Production migration 20260911222035_bulletin_resolution_status.sql is applied and the migration ledger is synchronized. It adds private metadata and a recheck index; public RPC signatures remain unchanged. Deploy the complete worker directory after merge; previous frontend/worker releases tolerate the additive schema. Plaintext integration was merged separately in #961.
