### PR TITLE
Constrain bulletin model outputs and report validation reasons

### DIFF
--- a/services/bulletin/README.md
+++ b/services/bulletin/README.md
@@ -209,6 +209,11 @@ Unresolved work from an earlier run remains eligible after an hour, when the
 next run starts; there is no standalone retry timer.
 Model routing allows provider fallback for the same model while requiring the
 request's parameters and capping prices at $0.15 input / $0.50 output per million tokens.
+Requests use a strict JSON schema for label types, categories, response methods,
+and availability. Routing requires structured-output support. Python still checks
+all semantic constraints and exact source/author evidence before publication;
+schema compliance does not establish that a classification is correct. Logs
+include allowlisted validation codes, never arbitrary exception messages or text.
 
 An explicitly approved backfill can use `--backfill-budget-usd` (at most $1).
 Its cap is cumulative across runs of the exact same window. The monthly cap

--- a/services/bulletin/README.md
+++ b/services/bulletin/README.md
@@ -209,7 +209,8 @@ Unresolved work from an earlier run remains eligible after an hour, when the
 next run starts; there is no standalone retry timer.
 Model routing allows provider fallback for the same model while requiring the
 request's parameters and capping prices at $0.15 input / $0.50 output per million tokens.
-Requests use a strict JSON schema for label types, categories, response methods,
+Routing prioritizes low latency within those price ceilings. Requests use a
+strict JSON schema for label types, categories, response methods,
 and availability. Routing requires structured-output support. Python still checks
 all semantic constraints and exact source/author evidence before publication;
 schema compliance does not establish that a classification is correct. Logs

--- a/services/bulletin/output_schema.py
+++ b/services/bulletin/output_schema.py
@@ -1,0 +1,37 @@
+"""Wire-format constraints; semantic and source-evidence checks remain in Python."""
+from labels import KINDS
+
+RULES = '''Return the single top-level object required by the response schema.
+For a positive notice, side, kind, and respond must each be ONE listed value,
+never a combined value or display label. When several response methods are
+offered, choose the first explicitly mentioned supported method; otherwise unknown.
+For a negative, set is_notice=false, side/kind/summary/respond/evidence to null,
+topics to [], standing to false, expires_at/place to null, and availability to
+{"state":"unknown","tweet_id":null,"evidence":null}.'''
+
+PROPERTIES = {
+    'is_notice': {'type': 'boolean'},
+    'side': {'type': ['string', 'null'], 'enum': ['ask', 'offer', None]},
+    'kind': {'type': ['string', 'null'], 'enum': KINDS + [None]},
+    'summary': {'type': ['string', 'null']},
+    'topics': {'type': 'array', 'items': {'type': 'string'}},
+    'respond': {'type': ['string', 'null'], 'enum': ['dm', 'reply', 'link', 'like', 'unknown', None]},
+    'standing': {'type': 'boolean'},
+    'expires_at': {'type': ['string', 'null']},
+    'place': {'type': ['string', 'null']},
+    'evidence': {'type': ['string', 'null']},
+    'availability': {
+        'type': 'object', 'additionalProperties': False,
+        'properties': {
+            'state': {'type': 'string', 'enum': ['unknown', 'open', 'resolved']},
+            'tweet_id': {'type': ['string', 'null']},
+            'evidence': {'type': ['string', 'null']},
+        },
+        'required': ['state', 'tweet_id', 'evidence'],
+    },
+}
+FORMAT = {'type': 'json_schema', 'json_schema': {
+    'name': 'bulletin_notice', 'strict': True,
+    'schema': {'type': 'object', 'additionalProperties': False,
+        'properties': PROPERTIES, 'required': list(PROPERTIES)},
+}}

--- a/services/bulletin/test_retries.py
+++ b/services/bulletin/test_retries.py
@@ -40,5 +40,17 @@ class RetryTests(unittest.TestCase):
         self.assertEqual(event,dict(event='bulletin_error',run_id=14,call_id=2,attempt=1,
             stage='model_request',error_type='HTTPError',retry_seconds=2,http_status=503))
 
+    def test_validator_codes_are_allowlisted_and_unknown_messages_are_private(self):
+        for message, code in [('invalid response mode', 'invalid_response_mode'),
+                ('availability_requires_exact_author_evidence', 'availability_requires_exact_author_evidence'),
+                ('private tweet text https://secret.invalid', None)]:
+            with self.subTest(message=message):
+                out=io.StringIO()
+                with contextlib.redirect_stdout(out):
+                    worker.log_failure(ValueError(message),run_id=1,stage='model_validation')
+                event=json.loads(out.getvalue())
+                self.assertEqual(event.get('validation_code'),code)
+                self.assertNotIn('private tweet text',out.getvalue())
+
 
 if __name__=='__main__':unittest.main()

--- a/services/bulletin/test_tweet_context.py
+++ b/services/bulletin/test_tweet_context.py
@@ -124,7 +124,7 @@ class TweetContextTests(unittest.TestCase):
         self.assertNotIn('dm or reply', properties['respond']['enum'])
         self.assertNotIn('work', properties['kind']['enum'])
         self.assertEqual(json.loads(body)['provider'], {
-            'allow_fallbacks': True, 'require_parameters': True,
+            'allow_fallbacks': True, 'require_parameters': True, 'sort': 'latency',
             'max_price': {'prompt': 0.15, 'completion': 0.50},
         })
         messages = json.loads(body)['messages']

--- a/services/bulletin/test_tweet_context.py
+++ b/services/bulletin/test_tweet_context.py
@@ -116,6 +116,13 @@ class TweetContextTests(unittest.TestCase):
     def test_contract_keeps_joke_exclusion_and_seed_evidence(self):
         prepared = context.prepare(self.db, self.seed)
         body = worker.request_body(self.seed, SYSTEM, prepared)
+        response_format = json.loads(body)['response_format']
+        self.assertEqual(response_format['type'], 'json_schema')
+        self.assertTrue(response_format['json_schema']['strict'])
+        properties = response_format['json_schema']['schema']['properties']
+        self.assertEqual(properties['is_notice']['type'], 'boolean')
+        self.assertNotIn('dm or reply', properties['respond']['enum'])
+        self.assertNotIn('work', properties['kind']['enum'])
         self.assertEqual(json.loads(body)['provider'], {
             'allow_fallbacks': True, 'require_parameters': True,
             'max_price': {'prompt': 0.15, 'completion': 0.50},

--- a/services/bulletin/worker.py
+++ b/services/bulletin/worker.py
@@ -189,7 +189,7 @@ def request_body(tweet, prompt, context):
         {'role':'user','content':json.dumps(payload,ensure_ascii=False)}],
         'response_format':output_schema.FORMAT,'max_tokens':MAX_OUTPUT,
         'reasoning':{'effort':'low'},
-        'provider':{'allow_fallbacks':True,'require_parameters':True,
+        'provider':{'allow_fallbacks':True,'require_parameters':True,'sort':'latency',
           'max_price':{'prompt':0.15,'completion':0.50}}},ensure_ascii=False).encode()
 
 

--- a/services/bulletin/worker.py
+++ b/services/bulletin/worker.py
@@ -25,6 +25,7 @@ import upstream_filter as upstream
 import clickhouse_source
 import tweet_context
 import resolution
+import output_schema
 
 MODEL = 'z-ai/glm-5.3-flash'
 VERSION = 'bulletin-143dc2d-v3-resolution'
@@ -67,6 +68,17 @@ def log_failure(exc, *, run_id, call_id=None, attempt=None, stage, retry_seconds
         attempt=attempt, stage=stage, error_type=type(exc).__name__, retry_seconds=retry_seconds)
     if isinstance(exc, urllib.error.HTTPError):
         event['http_status'] = exc.code
+    reasons = {
+        'label must be an object', 'is_notice must be boolean',
+        'invalid side or category', 'invalid summary', 'standing must be boolean',
+        'invalid response mode', 'invalid topics', 'invalid expiry', 'invalid place',
+        'evidence must be an exact source substring', 'incomplete_output',
+        'invalid_availability', 'unknown_availability_has_evidence',
+        'availability_requires_exact_author_evidence',
+        'availability_evidence_not_in_reply_tree', 'availability_evidence_predates_notice',
+    }
+    if isinstance(exc, ValueError) and str(exc) in reasons:
+        event['validation_code'] = str(exc).replace(' ', '_')
     print(json.dumps(event), flush=True)
 
 
@@ -173,9 +185,9 @@ def request_body(tweet, prompt, context):
     payload={'author':'@'+tweet['username'],'posted_at':tweet['created_at'].isoformat(),
         'text':tweet['full_text'], 'context':context.text}
     return json.dumps({'model':MODEL,'messages':[{'role':'system','content':prompt},
-        {'role':'system','content':tweet_context.CONTEXT_RULES+'\n'+resolution.RULES},
+        {'role':'system','content':tweet_context.CONTEXT_RULES+'\n'+resolution.RULES+'\n'+output_schema.RULES},
         {'role':'user','content':json.dumps(payload,ensure_ascii=False)}],
-        'response_format':{'type':'json_object'},'max_tokens':MAX_OUTPUT,
+        'response_format':output_schema.FORMAT,'max_tokens':MAX_OUTPUT,
         'reasoning':{'effort':'low'},
         'provider':{'allow_fallbacks':True,'require_parameters':True,
           'max_price':{'prompt':0.15,'completion':0.50}}},ensure_ascii=False).encode()


### PR DESCRIPTION
The resolution rollout exposed valid JSON with invalid label types, categories and response methods. These outputs failed validation and left notices queued even though model requests succeeded. Request a strict JSON schema and route only to providers supporting that format, retaining same-model fallback, price ceilings and all source/evidence checks. Negative outputs follow the same wire shape but normalize to the existing negative decision.

Add allowlisted validation codes to structured error logs so operators can distinguish output-shape errors from evidence failures without logging arbitrary exception messages, model bodies or tweet text.

Validation: 14 focused retry/context tests passed, including routing/schema serialization and private-error redaction. Checked the schema with a JSON Schema validator: positive/negative fixtures pass; invalid boolean, response mode, category and numeric evidence ID fail. Three formerly failing entries passed the strict-schema live pilot ($0.00167947 actual). The negative control also passed both semantic and JSON Schema validation through Makora ($0.00027549 actual). Routing also prioritizes low latency within existing price ceilings after a slow provider was observed during the pilot. No migration or frontend change.
