### PR TITLE
Handle HTML entities in exact bulletin evidence checks

### DIFF
--- a/services/bulletin/README.md
+++ b/services/bulletin/README.md
@@ -85,6 +85,11 @@ or logs. Every printed source's hash and current consent are checked again befor
 saving; a change leaves the decision pending without repeating the paid call
 immediately or removing its cost from the ledger.
 
+Evidence comparisons decode HTML entities once on both sides, so archived
+`&gt;` and visible `>` match. Case, whitespace and wording must still match exactly.
+Raw source text, hashes and stored model evidence are unchanged. This applies
+to label evidence and author availability evidence; author/reply-tree checks remain.
+
 The graph endpoint may cache reply discovery for an hour. The classifier version
 bump reconsiders encountered candidates in newly scanned windows; it does not
 trigger a historical backfill. Candidate phrase filters are unchanged.

--- a/services/bulletin/labels.py
+++ b/services/bulletin/labels.py
@@ -1,5 +1,6 @@
 """Bulletin classification prompt and strict output validation."""
 import datetime as dt
+import html
 import re
 
 KINDS = ['help', 'feedback', 'intro', 'free', 'invite', 'opportunity']
@@ -8,6 +9,10 @@ KINDS = ['help', 'feedback', 'intro', 'free', 'invite', 'opportunity']
 import json
 from pathlib import Path
 SYSTEM = json.loads(Path(__file__).with_name('default-prompt.json').read_text())
+
+def evidence_matches(evidence, text):
+    """Compare visible characters; do not relax case, spacing or wording."""
+    return html.unescape(evidence) in html.unescape(text)
 
 def validate_label(label, tweet, reference=False):
     if not isinstance(label, dict):
@@ -38,7 +43,7 @@ def validate_label(label, tweet, reference=False):
     if place is not None and (not isinstance(place, str) or len(place) > 160):
         raise ValueError('invalid place')
     evidence = label.get('evidence')
-    if not reference and (not isinstance(evidence, str) or not evidence.strip() or evidence not in tweet['text']):
+    if not reference and (not isinstance(evidence, str) or not evidence.strip() or not evidence_matches(evidence, tweet['text'])):
         raise ValueError('evidence must be an exact source substring')
     return {'is_notice': True, 'side': label['side'], 'kind': label['kind'],
             'summary': summary.strip(), 'topics': topics, 'respond': label['respond'],

--- a/services/bulletin/labels.py
+++ b/services/bulletin/labels.py
@@ -12,7 +12,8 @@ SYSTEM = json.loads(Path(__file__).with_name('default-prompt.json').read_text())
 
 def evidence_matches(evidence, text):
     """Compare visible characters; do not relax case, spacing or wording."""
-    return html.unescape(evidence) in html.unescape(text)
+    decoded = html.unescape(evidence)
+    return bool(decoded.strip()) and decoded in html.unescape(text)
 
 def validate_label(label, tweet, reference=False):
     if not isinstance(label, dict):

--- a/services/bulletin/resolution.py
+++ b/services/bulletin/resolution.py
@@ -3,6 +3,7 @@ import hashlib
 import datetime as dt
 
 import tweet_context
+from labels import evidence_matches
 
 RULES = '''For every positive notice, also return an availability object, for example:
 {"state":"unknown","tweet_id":null,"evidence":null}.
@@ -35,7 +36,7 @@ def validate(value, seed, context):
     row = context.records.get(ident) if isinstance(ident, str) else None
     if (not row or row['account_id'] != seed['account_id']
             or not isinstance(evidence, str) or not evidence.strip()
-            or len(evidence) > 1000 or evidence not in row['full_text']):
+            or len(evidence) > 1000 or not evidence_matches(evidence, row['full_text'])):
         raise ValueError('availability_requires_exact_author_evidence')
     # A quote or unrelated post by the same author cannot close this notice.
     node, seen = ident, set()

--- a/services/bulletin/test_evidence_entities.py
+++ b/services/bulletin/test_evidence_entities.py
@@ -1,0 +1,30 @@
+"""HTML entity spelling must not reject an otherwise exact source quote."""
+import unittest
+from labels import evidence_matches, validate_label
+
+
+class EvidenceEntityTests(unittest.TestCase):
+    def test_encoded_source_and_visible_quote_are_equivalent(self):
+        for evidence, text in [('> 400 sqft', 'sublet for &gt; 400 sqft'),
+                ('A & B', 'A &amp; B'), ('"yes"', 'said &#34;yes&#34;'),
+                ('&gt; 400 sqft', 'sublet for > 400 sqft')]:
+            with self.subTest(evidence=evidence):
+                self.assertTrue(evidence_matches(evidence,text))
+
+    def test_paraphrase_spacing_case_and_double_decoding_still_fail(self):
+        for evidence, text in [('over 400 sqft', '&gt; 400 sqft'),
+                ('>  400 sqft', '&gt; 400 sqft'), ('ALL CLAIMED', 'all claimed'),
+                ('> 400 sqft', '&amp;gt; 400 sqft')]:
+            with self.subTest(evidence=evidence):
+                self.assertFalse(evidence_matches(evidence,text))
+
+    def test_real_sublet_label_keeps_source_and_evidence_unchanged(self):
+        text='does anyone in SF i know have sublet industrial for &gt; 400 sqft or so? friend is asking'
+        label=dict(is_notice=True,side='ask',kind='help',summary='Seeking a sublet.',
+            topics=[],respond='unknown',standing=False,expires_at=None,place='SF',
+            evidence='sublet industrial for > 400 sqft')
+        self.assertEqual(validate_label(label,{'text':text})['evidence'],label['evidence'])
+        self.assertIn('&gt;',text)
+
+
+if __name__=='__main__':unittest.main()

--- a/services/bulletin/test_evidence_entities.py
+++ b/services/bulletin/test_evidence_entities.py
@@ -26,5 +26,10 @@ class EvidenceEntityTests(unittest.TestCase):
         self.assertEqual(validate_label(label,{'text':text})['evidence'],label['evidence'])
         self.assertIn('&gt;',text)
 
+    def test_entities_that_decode_to_empty_or_whitespace_are_not_evidence(self):
+        for evidence in ['&#x0b;', '&#32;', '&NewLine;']:
+            with self.subTest(evidence=evidence):
+                self.assertFalse(evidence_matches(evidence,'Any source text.\n'))
+
 
 if __name__=='__main__':unittest.main()

--- a/services/bulletin/test_resolution.py
+++ b/services/bulletin/test_resolution.py
@@ -31,6 +31,13 @@ class ResolutionTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError,'reply_tree'):
             resolution.validate(self.value,self.seed,self.context)
 
+    def test_entity_equivalent_author_evidence_keeps_raw_source_hash(self):
+        self.reply['full_text']='All claimed &amp; closed.'
+        self.context.sources['2']=fingerprint(self.reply)
+        self.value['evidence']='All claimed & closed.'
+        result=resolution.validate(self.value,self.seed,self.context)
+        self.assertEqual(result['content_hash'],fingerprint(self.reply)[1])
+
     def test_invented_evidence_unknown_and_missing_output(self):
         self.value['evidence']='The role is filled'
         with self.assertRaisesRegex(ValueError,'exact_author_evidence'):


### PR DESCRIPTION
A sublet notice repeatedly failed exact-evidence validation while its archived source contains `&gt;` where the visible tweet has `>`. Compare label and availability evidence after one HTML-entity decoding pass on each side. Case, spacing and wording remain exact; paraphrases, repeated decoding, wrong authors and unrelated reply trees remain invalid. Source text/hashes and stored model evidence are unchanged.

Validation: 18 focused evidence, resolution and context tests passed. Regressions cover the sublet example, named/numeric entities, rejection of paraphrases/case/spacing changes and double decoding, and retention of the raw source hash for author evidence. Live pilot confirmed the defect: model evidence failed raw substring matching but passed entity-equivalent matching; the positive label and unknown availability validated ($0.0002385 actual). An additional regression rejects entities that decode to empty text or whitespace; the four focused entity tests passed after that guard. No migration or frontend change.
