### PR TITLE
Load bulletin directly into recommendations with fewer waits

### DIFF
--- a/src/app/bulletin/page.test.tsx
+++ b/src/app/bulletin/page.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import { requireBulletinUser } from '@/lib/bulletin/data'
+import { isBulletinAdmin, requireBulletinUser } from '@/lib/bulletin/data'
 import { loadBulletinPage } from '@/lib/bulletin/page'
+import { loadPrompts } from '@/lib/bulletin/prompts'
 import { DEFAULT_BULLETIN_FILTERS } from '@/lib/bulletin/types'
 import BulletinPage from './page'
 
@@ -28,6 +29,16 @@ jest.mock('@/components/bulletin/BulletinBoard', () => ({
 }))
 
 afterEach(() => jest.restoreAllMocks())
+
+test('admin prompt loading cannot delay the first recommended cards', async () => {
+  jest.mocked(requireBulletinUser).mockResolvedValue({ id: 'alice' } as never)
+  jest.mocked(isBulletinAdmin).mockResolvedValueOnce(true)
+  jest.mocked(loadPrompts).mockImplementationOnce(() => new Promise(() => {}))
+  render(await BulletinPage())
+  expect(screen.getByRole('button', { name: 'Read tweet' })).toBeInTheDocument()
+  // The optional server child runs in its own streaming boundary.
+  expect(loadPrompts).not.toHaveBeenCalled()
+})
 
 test('initial server page requests recommendations before rendering the board', async () => {
   jest.mocked(requireBulletinUser).mockResolvedValue({ id: 'alice' } as never)

--- a/src/app/bulletin/page.test.tsx
+++ b/src/app/bulletin/page.test.tsx
@@ -1,5 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { requireBulletinUser } from '@/lib/bulletin/data'
+import { loadBulletinPage } from '@/lib/bulletin/page'
+import { DEFAULT_BULLETIN_FILTERS } from '@/lib/bulletin/types'
 import BulletinPage from './page'
 
 jest.mock('@/components/bulletin/BulletinBoard.module.css', () => ({}))
@@ -26,6 +28,15 @@ jest.mock('@/components/bulletin/BulletinBoard', () => ({
 }))
 
 afterEach(() => jest.restoreAllMocks())
+
+test('initial server page requests recommendations before rendering the board', async () => {
+  jest.mocked(requireBulletinUser).mockResolvedValue({ id: 'alice' } as never)
+  jest.mocked(loadBulletinPage).mockClear()
+  render(await BulletinPage())
+  expect(loadBulletinPage).toHaveBeenCalledTimes(1)
+  expect(loadBulletinPage).toHaveBeenCalledWith(DEFAULT_BULLETIN_FILTERS)
+  expect(screen.getByRole('button', { name: 'Read tweet' })).toBeInTheDocument()
+})
 
 test('server refresh preserves board state but changing the viewer resets it', async () => {
   jest.mocked(requireBulletinUser).mockResolvedValue({ id: 'alice' } as never)

--- a/src/app/bulletin/page.tsx
+++ b/src/app/bulletin/page.tsx
@@ -1,11 +1,12 @@
 import type { Metadata } from 'next'
+import { Suspense } from 'react'
 import styles from '@/components/bulletin/BulletinBoard.module.css'
 import { isBulletinAdmin, requireBulletinUser } from '@/lib/bulletin/data'
 import { loadBulletinPage } from '@/lib/bulletin/page'
 import { DEFAULT_BULLETIN_FILTERS } from '@/lib/bulletin/types'
 import { BulletinBoard } from '@/components/bulletin/BulletinBoard'
-import { loadPrompts } from '@/lib/bulletin/prompts'
-import { RefreshControls } from '@/components/bulletin/RefreshControls'
+import { BulletinRefreshControls } from './refresh-controls'
+import { measureServerRead } from '@/lib/performance/server'
 export const dynamic = 'force-dynamic'
 export const metadata: Metadata = {
   title: 'Bulletin | Community Archive',
@@ -13,13 +14,14 @@ export const metadata: Metadata = {
 }
 
 export default async function BulletinBoardPage() {
-  const user = await requireBulletinUser()
-  const [isAdmin, page] = await Promise.all([
+  const [user, isAdmin, page] = await Promise.all([
+    requireBulletinUser(),
     isBulletinAdmin(),
     // Resolve recommendations before showing cards so the first selection stays put.
-    loadBulletinPage(DEFAULT_BULLETIN_FILTERS).catch(() => null),
+    measureServerRead('bulletin.page', () =>
+      loadBulletinPage(DEFAULT_BULLETIN_FILTERS),
+    ).catch(() => null),
   ])
-  const prompt = isAdmin ? await loadPrompts().catch(() => null) : null
   return (
     <main className={styles.page}>
       {page === null ? (
@@ -37,7 +39,11 @@ export default async function BulletinBoardPage() {
           now={page.now}
           isAdmin={isAdmin}
           adminControls={
-            prompt ? <RefreshControls promptId={prompt.active.id} /> : undefined
+            isAdmin ? (
+              <Suspense fallback={null}>
+                <BulletinRefreshControls />
+              </Suspense>
+            ) : undefined
           }
         />
       )}

--- a/src/app/bulletin/page.tsx
+++ b/src/app/bulletin/page.tsx
@@ -16,9 +16,8 @@ export default async function BulletinBoardPage() {
   const user = await requireBulletinUser()
   const [isAdmin, page] = await Promise.all([
     isBulletinAdmin(),
-    loadBulletinPage(DEFAULT_BULLETIN_FILTERS, undefined, false).catch(
-      () => null,
-    ),
+    // Resolve recommendations before showing cards so the first selection stays put.
+    loadBulletinPage(DEFAULT_BULLETIN_FILTERS).catch(() => null),
   ])
   const prompt = isAdmin ? await loadPrompts().catch(() => null) : null
   return (

--- a/src/app/bulletin/refresh-controls.test.tsx
+++ b/src/app/bulletin/refresh-controls.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react'
+import { loadPrompts } from '@/lib/bulletin/prompts'
+import { BulletinRefreshControls } from './refresh-controls'
+
+jest.mock('@/lib/bulletin/prompts', () => ({ loadPrompts: jest.fn() }))
+jest.mock('@/components/bulletin/RefreshControls', () => ({
+  RefreshControls: ({ promptId }: { promptId: string }) => (
+    <button>Refresh with prompt {promptId}</button>
+  ),
+}))
+
+test('streams refresh controls with the active prompt', async () => {
+  jest.mocked(loadPrompts).mockResolvedValue({ active: { id: '2' } } as never)
+  render(await BulletinRefreshControls())
+  expect(
+    screen.getByRole('button', { name: 'Refresh with prompt 2' }),
+  ).toBeInTheDocument()
+})
+
+test('an unavailable admin prompt does not fail the board', async () => {
+  jest.mocked(loadPrompts).mockRejectedValue(new Error('unavailable'))
+  expect(await BulletinRefreshControls()).toBeNull()
+})

--- a/src/app/bulletin/refresh-controls.tsx
+++ b/src/app/bulletin/refresh-controls.tsx
@@ -1,0 +1,11 @@
+import { RefreshControls } from '@/components/bulletin/RefreshControls'
+import { loadPrompts } from '@/lib/bulletin/prompts'
+import { measureServerRead } from '@/lib/performance/server'
+
+/** Optional admin tools must not hold up the recommended cards. */
+export async function BulletinRefreshControls() {
+  const prompt = await measureServerRead('bulletin.admin-controls', () =>
+    loadPrompts(),
+  ).catch(() => null)
+  return prompt ? <RefreshControls promptId={prompt.active.id} /> : null
+}

--- a/src/components/NavigationAudience.test.tsx
+++ b/src/components/NavigationAudience.test.tsx
@@ -30,6 +30,10 @@ describe('NavigationAudience', () => {
     )
 
     expect(screen.getByRole('link', { name: 'Docs' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Bulletin' })).toHaveAttribute(
+      'href',
+      '/bulletin',
+    )
     expect(
       screen.getByRole('link', { name: 'Upload archive' }),
     ).toBeInTheDocument()

--- a/src/components/bulletin/BulletinBoard.test.tsx
+++ b/src/components/bulletin/BulletinBoard.test.tsx
@@ -503,6 +503,20 @@ test('deals cards round-robin into three stacks and keeps rank order via style o
   })
 })
 
+test('server recommendations are visible immediately without fetching a replacement page', async () => {
+  const initial = { ...page([ask], '2'), recommendationsReady: true }
+  render(
+    <BulletinBoard notices={[ask]} initialPage={initial} now={initial.now} />,
+  )
+  expect(screen.getByText('Feedback on a garden')).toBeInTheDocument()
+  await act(async () => {
+    jest.advanceTimersByTime(1000)
+  })
+  expect(screen.getByText('Feedback on a garden')).toBeInTheDocument()
+  expect(screen.getByLabelText('Load more notices')).toBeInTheDocument()
+  expect(fetch).not.toHaveBeenCalled()
+})
+
 test('shows cards before interactions finish, then replaces the page and cursor together', async () => {
   const initial = { ...page([offer], '1'), recommendationsReady: false }
   let resolve!: (value: Response) => void

--- a/src/lib/bulletin/data.ts
+++ b/src/lib/bulletin/data.ts
@@ -1,5 +1,6 @@
 import { getSessionTwitterUsername } from '@/lib/sessionTwitterUsername'
 import 'server-only'
+import { cache } from 'react'
 import { redirect } from 'next/navigation'
 import { getCurrentUser } from '@/lib/portal/auth'
 import { getOptInStatus } from '@/lib/auth-utils'
@@ -8,12 +9,13 @@ import { getAdminClient, requireAdmin, checkIsAdmin } from '@/app/admin/data'
 import { createServerServiceRoleClient } from '@/utils/supabase'
 import { fetchAnalyticsGatewayJson } from '@/lib/clickhouseGateway'
 import { createHash } from 'crypto'
+import { measureServerRead } from '@/lib/performance/server'
 import type { Notice, RunDashboard } from './types'
 
 export const BULLETIN_LIMIT = 2000
 export const RUN_PAGE_SIZE = 25
 
-export async function requireBulletinUser() {
+async function readBulletinUser() {
   if ((await getLocalAdminPreview()) === 'admin') return null
   // Member-preview cookies never authorize reads. The explicit loopback-only
   // local admin read preview follows the same convention as Birdseye.
@@ -28,6 +30,13 @@ export async function requireBulletinUser() {
     redirect('/opt-in?redirect=/bulletin')
   return user
 }
+
+// Share one live consent check within this server render, never across requests.
+// React 18's non-RSC test runtime does not provide cache().
+const requestCache = cache ?? ((read: typeof readBulletinUser) => read)
+export const requireBulletinUser = requestCache(() =>
+  measureServerRead('bulletin.access', readBulletinUser),
+)
 
 /** Hydrate only the selected notices, retaining the live source/policy checks. */
 export async function hydrateBulletinNotices({
@@ -230,7 +239,7 @@ export async function loadBulletinRelationships() {
 }
 
 export type StoredNotice = Notice & { content_hash: string }
-export async function loadBulletinBoardState(): Promise<{
+export async function loadBulletinBoardState(verifyResolution = true): Promise<{
   notices: StoredNotice[]
   allowedAccounts?: string[]
 }> {
@@ -255,6 +264,12 @@ export async function loadBulletinBoardState(): Promise<{
   )
   if (error) throw new Error('Bulletin notices could not be loaded')
   const notices = (data ?? []) as unknown as StoredNotice[]
+  if (verifyResolution) await verifyBulletinResolutions(notices)
+  return { notices }
+}
+
+/** Callers deferring this check must await it before selecting visible cards. */
+export async function verifyBulletinResolutions(notices: StoredNotice[]) {
   // Verify resolution evidence even for notices hidden by the default filter.
   // A deleted/edited update must not leave a notice silently hidden forever.
   const resolved = notices.filter((o) => o.resolution_state === 'resolved')
@@ -292,5 +307,4 @@ export async function loadBulletinBoardState(): Promise<{
       }
     }
   }
-  return { notices }
 }

--- a/src/lib/bulletin/page.test.ts
+++ b/src/lib/bulletin/page.test.ts
@@ -4,6 +4,7 @@ import {
   loadBulletinBoardState,
   loadBulletinRelationships,
   loadBulletinViewer,
+  verifyBulletinResolutions,
   type StoredNotice,
 } from './data'
 import { BULLETIN_PAGE_SIZE, DEFAULT_BULLETIN_FILTERS } from './types'
@@ -12,6 +13,7 @@ jest.mock('./data', () => ({
   loadBulletinBoardState: jest.fn(),
   loadBulletinRelationships: jest.fn(),
   loadBulletinViewer: jest.fn(),
+  verifyBulletinResolutions: jest.fn(),
 }))
 const filters = { ...DEFAULT_BULLETIN_FILTERS, kind: 'help' }
 const notice = (i: number): StoredNotice => ({
@@ -36,6 +38,7 @@ const ids = (from: number, to: number) =>
   Array.from({ length: from - to + 1 }, (_, i) => String(from - i))
 beforeEach(() => {
   jest.clearAllMocks()
+  jest.mocked(verifyBulletinResolutions).mockResolvedValue(undefined)
   jest.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-09-09T00:00:00Z'))
   jest.mocked(loadBulletinBoardState).mockResolvedValue({
     notices: Array.from({ length: 40 }, (_, i) => notice(i + 1)),
@@ -60,20 +63,66 @@ beforeEach(() => {
   )
 })
 afterEach(() => jest.restoreAllMocks())
-test('resolved notices are hidden by default and independently included even when expired', async () => {
-  jest
-    .mocked(loadBulletinBoardState)
-    .mockResolvedValue({
-      notices: [
-        notice(1),
-        {
-          ...notice(2),
-          resolution_state: 'resolved',
-          resolution_tweet_id: '3',
-          expires_at: '2026-01-01',
-        },
-      ],
+test.each([false, true])(
+  'source hydration overlaps resolution checks and uses their final result (show resolved: %s)',
+  async (resolved) => {
+    const reopened = {
+      ...notice(2),
+      resolution_state: 'resolved' as const,
+      resolution_tweet_id: '3',
+    }
+    jest.mocked(loadBulletinBoardState).mockResolvedValue({
+      notices: [notice(1), reopened],
     })
+    let finish!: () => void
+    jest.mocked(verifyBulletinResolutions).mockImplementationOnce(
+      (notices) =>
+        new Promise<void>((resolve) => {
+          finish = () => {
+            notices[1].resolution_state = 'unknown'
+            notices[1].resolution_tweet_id = null
+            resolve()
+          }
+        }),
+    )
+    let completed = false
+    const pending = loadBulletinPage({ ...filters, resolved }).then((page) => {
+      completed = true
+      return page
+    })
+    await new Promise<void>((resolve) => setImmediate(resolve))
+    expect(hydrateBulletinNotices).toHaveBeenCalledTimes(1)
+    expect(completed).toBe(false)
+    finish()
+    const page = await pending
+    expect(page.notices.map((o) => o.tweet_id)).toEqual(['2', '1'])
+    expect(page.notices[0]).toMatchObject({
+      resolution_state: 'unknown',
+      resolution_tweet_id: null,
+    })
+    expect(page.counts.help).toBe(2)
+  },
+)
+
+test('resolution verification outages still fail the page', async () => {
+  jest
+    .mocked(verifyBulletinResolutions)
+    .mockRejectedValueOnce(new Error('source unavailable'))
+  await expect(loadBulletinPage(filters)).rejects.toThrow('source unavailable')
+})
+
+test('resolved notices are hidden by default and independently included even when expired', async () => {
+  jest.mocked(loadBulletinBoardState).mockResolvedValue({
+    notices: [
+      notice(1),
+      {
+        ...notice(2),
+        resolution_state: 'resolved',
+        resolution_tweet_id: '3',
+        expires_at: '2026-01-01',
+      },
+    ],
+  })
   const normal = await loadBulletinPage(filters)
   expect(normal.notices.map((o) => o.tweet_id)).toEqual(['1'])
   expect(normal.counts.help).toBe(1)

--- a/src/lib/bulletin/page.ts
+++ b/src/lib/bulletin/page.ts
@@ -1,9 +1,11 @@
 import 'server-only'
+import { measureServerRead } from '@/lib/performance/server'
 import {
   hydrateBulletinNotices,
   loadBulletinBoardState,
   loadBulletinRelationships,
   loadBulletinViewer,
+  verifyBulletinResolutions,
   type StoredNotice,
 } from './data'
 import { isPast, sortNotices, visibleStatus } from './board'
@@ -46,9 +48,9 @@ export async function loadBulletinPage(
   const now = Date.now()
   const search = filters.search.trim().toLowerCase()
   const [state, personal] = await Promise.all([
-    loadBulletinBoardState(),
+    measureServerRead('bulletin.state', () => loadBulletinBoardState(false)),
     personalize && filters.recommended
-      ? loadBulletinRelationships()
+      ? measureServerRead('bulletin.recommendations', loadBulletinRelationships)
       : loadBulletinViewer(),
   ])
   const me = personal.account_id
@@ -65,13 +67,26 @@ export async function loadBulletinPage(
   const rejected = new Set<string>()
   async function hydrate(notices: StoredNotice[]) {
     if (!notices.length) return
-    const rows = await hydrateBulletinNotices({ ...state, notices })
+    const rows = await measureServerRead('bulletin.sources', () =>
+      hydrateBulletinNotices({ ...state, notices }),
+    )
     const found = new Set(rows.map((o) => o.tweet_id))
     for (const o of notices)
       if (!found.has(o.tweet_id)) rejected.add(o.tweet_id)
     for (const o of rows) verified.set(o.tweet_id, o)
   }
-  const live = (o: StoredNotice): Notice => verified.get(o.tweet_id) || o
+  const live = (o: StoredNotice | Notice): Notice => {
+    const source = verified.get(o.tweet_id)
+    // Resolution verification runs alongside hydration, which may finish first.
+    // Always use the verified resolution state when selecting visible cards.
+    return source
+      ? {
+          ...source,
+          resolution_state: o.resolution_state,
+          resolution_tweet_id: o.resolution_tweet_id,
+        }
+      : o
+  }
   const shown = (o: Notice) =>
     !rejected.has(o.tweet_id) &&
     visibleStatus(o, now, filters.past, filters.resolved) &&
@@ -100,9 +115,14 @@ export async function loadBulletinPage(
       (o) => [o.tweet_id, o],
     ),
   )
-  await hydrate(
-    search ? eligible : (Array.from(preflight.values()) as StoredNotice[]),
-  )
+  await Promise.all([
+    measureServerRead('bulletin.resolutions', () =>
+      verifyBulletinResolutions(state.notices),
+    ),
+    hydrate(
+      search ? eligible : (Array.from(preflight.values()) as StoredNotice[]),
+    ),
+  ])
 
   const rows = sortNotices(
     eligible.map(live).filter(shown),
@@ -130,7 +150,7 @@ export async function loadBulletinPage(
       ) as StoredNotice[],
     )
     for (const row of chunk) {
-      const current = verified.get(row.tweet_id)
+      const current = verified.has(row.tweet_id) ? live(row) : undefined
       if (current && shown(current)) selected.push(current)
     }
     position += chunk.length

--- a/src/lib/navigation.test.ts
+++ b/src/lib/navigation.test.ts
@@ -163,14 +163,12 @@ describe('tweet detail navigation', () => {
   })
 })
 
-test('bulletin navigation is signed-in only and preserves the source return link', () => {
-  expect(getPrimaryNav(false).some((item) => item.href === '/bulletin')).toBe(
-    false,
-  )
-  expect(getMobileNav(true)).toContainEqual({
-    href: '/bulletin',
-    label: 'Bulletin',
-  })
+test('bulletin navigation is visible to every audience and preserves the source return link', () => {
+  for (const isMember of [false, true]) {
+    for (const nav of [getPrimaryNav(isMember), getMobileNav(isMember)]) {
+      expect(nav).toContainEqual({ href: '/bulletin', label: 'Bulletin' })
+    }
+  }
   expect(navAnalyticsDestination('/bulletin')).toBe('opportunities')
   expect(getTweetBackLink({ from: 'opportunities' }).href).toBe('/bulletin')
 })

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -168,6 +168,7 @@ export const getPrimaryNav = (
     : [
         { href: BANGERS_WEEK_HREF, label: 'Bangers' },
         { href: '/digest', label: 'Digest' },
+        { href: '/bulletin', label: 'Bulletin' },
         { href: '/user-dir', label: 'Users' },
         { href: '/community', label: 'Apps' },
         { href: '/trends', label: 'Trends' },


### PR DESCRIPTION
Opening the bulletin currently shows a generic page, then replaces its cards after a browser request for recommendations. Render the recommended selection from the server and remove unnecessary waits on the initial load. Show Bulletin in both desktop and mobile navigation for signed-out visitors as well; the existing page gate sends them to sign-in with a return link to the bulletin, and still requires opt-in afterward.

- Share the live opt-in check within each server render. Consent is checked again on the next request; no cross-request authorization cache is introduced.
- Run resolution-evidence verification and card-source hydration together, awaiting both before selecting cards. Apply the final verified resolution state even when source hydration finishes first; missing or edited resolution evidence can restore a notice, and verification outages still fail the board.
- Stream optional admin refresh controls separately so prompt loading cannot delay the cards.
- Record fixed-stage timings using the existing website performance logger, without tweet text, user identifiers, or credentials.

Validation: 72 focused tests pass across the route, refresh controls, loader, authorization/source checks, board, and public navigation. New coverage checks that admin tools cannot delay the board, initial recommendations do not trigger a replacement fetch, and concurrent resolution checks correctly restore notices with either resolved-filter setting. Type-check, scoped lint, and diff checks pass.

Local browser verification against live read-only data services rendered 18 recommended cards with no console errors. One warm measured load reached visible cards in 2.28 seconds; server data preparation was 1.57 seconds versus 2.19 seconds before parallelizing source and resolution checks. Timings vary with network and development compilation; this is a spot check, not a production percentile comparison. The current production warm-load spot check was 3.59 seconds, but local preview skips signed-in auth and is not directly comparable. Production after-timings remain to be measured after an approved deployment.

No database migrations, worker changes, or gateway deployment. Not merged or deployed.

